### PR TITLE
Feature/vendor dashboard 4a

### DIFF
--- a/web/modules/custom/myeventlane_event/src/EventCard/EventCardViewModel.php
+++ b/web/modules/custom/myeventlane_event/src/EventCard/EventCardViewModel.php
@@ -405,6 +405,15 @@ final class EventCardViewModel {
     return [(string) (int) date('j', $startTimestamp), date('M', $startTimestamp)];
   }
 
+  /**
+   * Single-line primary location label (venue entity, venue name, or locality).
+   *
+   * Shared by public event cards, heroes, and Event Studio summaries.
+   */
+  public function getLocationLabel(NodeInterface $node): ?string {
+    return $this->locationLabel($node);
+  }
+
   private function locationLabel(NodeInterface $node): ?string {
     if ($node->hasField('field_venue') && !$node->get('field_venue')->isEmpty()) {
       $venue = $node->get('field_venue')->entity;

--- a/web/modules/custom/myeventlane_event/src/EventCard/EventCardViewModel.php
+++ b/web/modules/custom/myeventlane_event/src/EventCard/EventCardViewModel.php
@@ -429,6 +429,10 @@ final class EventCardViewModel {
         if ($locality) {
           return $administrativeArea ? $locality . ', ' . $administrativeArea : $locality;
         }
+        $line1 = trim((string) $locationItem->get('address_line1')->getValue());
+        if ($line1 !== '') {
+          return $line1;
+        }
       }
     }
     return NULL;

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -3354,6 +3354,42 @@
   gap: 16px;
 }
 
+.mel-event-studio .mel-es-location-summary {
+  margin: 0 0 4px;
+  padding: 14px 16px;
+  border: 1px solid rgba(244, 114, 182, 0.18);
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(255, 247, 237, 0.72) 0%, rgba(250, 245, 255, 0.82) 100%);
+}
+
+.mel-event-studio .mel-es-location-summary__title {
+  margin: 0 0 8px;
+  color: #64748b;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.mel-event-studio .mel-es-location-summary__line {
+  margin: 0;
+  color: #475569;
+  font-size: 0.875rem;
+  line-height: 1.45;
+}
+
+.mel-event-studio .mel-es-location-summary__line + .mel-es-location-summary__line {
+  margin-top: 2px;
+}
+
+.mel-event-studio .mel-es-location-summary__line--secondary {
+  padding-left: 1.35rem;
+}
+
+.mel-event-studio .mel-es-location-summary__line--warning {
+  color: #92400e;
+}
+
 .mel-event-studio .mel-es-field-group__body--datetime,
 .mel-event-studio .mel-es-field-group__body--two-column {
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -2120,6 +2120,41 @@
   overflow-wrap: anywhere;
 }
 
+.mel-event-studio-topbar__location {
+  margin: 6px 0 0;
+  color: #475569;
+  font-size: 0.875rem;
+  line-height: 1.45;
+}
+
+.mel-event-studio-topbar__location-line {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  margin: 0;
+}
+
+.mel-event-studio-topbar__location-line + .mel-event-studio-topbar__location-line {
+  margin-top: 2px;
+}
+
+.mel-event-studio-topbar__location-line--secondary {
+  padding-left: 1.35rem;
+}
+
+.mel-event-studio-topbar__location-line--warning {
+  color: #92400e;
+}
+
+.mel-event-studio-topbar__location-icon {
+  flex: 0 0 auto;
+  line-height: 1.45;
+}
+
+.mel-event-studio-topbar__location-text {
+  min-width: 0;
+}
+
 .mel-event-studio-topbar__meta,
 .mel-event-studio-topbar__actions {
   display: flex;

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
@@ -347,6 +347,66 @@
     stateEl?.remove();
   }
 
+  function syncTopbarLocation(shell, location) {
+    const container = shell.querySelector('[data-mel-topbar-location]');
+    if (!container) {
+      return;
+    }
+    const primary = container.querySelector('[data-mel-topbar-location-primary]');
+    const secondary = container.querySelector('[data-mel-topbar-location-secondary]');
+    const warning = container.querySelector('[data-mel-topbar-location-warning]');
+    if (!location || !location.configured) {
+      container.querySelectorAll('.mel-event-studio-topbar__location-line--primary, .mel-event-studio-topbar__location-line--secondary').forEach((line) => {
+        line.remove();
+      });
+      let warningLine = container.querySelector('.mel-event-studio-topbar__location-line--warning');
+      if (!warningLine) {
+        warningLine = document.createElement('p');
+        warningLine.className = 'mel-event-studio-topbar__location-line mel-event-studio-topbar__location-line--warning';
+        warningLine.innerHTML = '<span class="mel-event-studio-topbar__location-icon" aria-hidden="true">⚠</span><span class="mel-event-studio-topbar__location-text" data-mel-topbar-location-warning></span>';
+        container.appendChild(warningLine);
+      }
+      const warningText = warningLine.querySelector('[data-mel-topbar-location-warning]');
+      if (warningText) {
+        warningText.textContent = location?.warning || 'Venue not yet configured';
+      }
+      return;
+    }
+    container.querySelector('.mel-event-studio-topbar__location-line--warning')?.remove();
+    if (location.primary_line) {
+      let primaryLine = container.querySelector('.mel-event-studio-topbar__location-line--primary');
+      if (!primaryLine) {
+        primaryLine = document.createElement('p');
+        primaryLine.className = 'mel-event-studio-topbar__location-line mel-event-studio-topbar__location-line--primary';
+        primaryLine.innerHTML = '<span class="mel-event-studio-topbar__location-icon" aria-hidden="true">📍</span><span class="mel-event-studio-topbar__location-text" data-mel-topbar-location-primary></span>';
+        container.prepend(primaryLine);
+      }
+      const primaryText = primaryLine.querySelector('[data-mel-topbar-location-primary]');
+      if (primaryText) {
+        primaryText.textContent = location.primary_line;
+      }
+    }
+    else {
+      container.querySelector('.mel-event-studio-topbar__location-line--primary')?.remove();
+    }
+    if (location.secondary_line) {
+      let secondaryLine = container.querySelector('.mel-event-studio-topbar__location-line--secondary');
+      if (!secondaryLine) {
+        secondaryLine = document.createElement('p');
+        secondaryLine.className = 'mel-event-studio-topbar__location-line mel-event-studio-topbar__location-line--secondary';
+        secondaryLine.innerHTML = '<span class="mel-event-studio-topbar__location-text" data-mel-topbar-location-secondary></span>';
+        container.appendChild(secondaryLine);
+      }
+      const secondaryText = secondaryLine.querySelector('[data-mel-topbar-location-secondary]');
+      if (secondaryText) {
+        secondaryText.textContent = location.secondary_line;
+      }
+    }
+    else {
+      container.querySelector('.mel-event-studio-topbar__location-line--secondary')?.remove();
+    }
+  }
+
   function updateTopbar(shell, result) {
     if (!result || !result.topbar) {
       return;
@@ -358,6 +418,9 @@
     setText(shell, '[data-mel-publish-status]', result.topbar.status || '');
     syncTopbarState(shell, result.topbar.state || '');
     setText(shell, '[data-mel-publish-last-saved]', result.topbar.lastSaved || '');
+    if (result.topbar.location) {
+      syncTopbarLocation(shell, result.topbar.location);
+    }
     const buttons = shell.querySelectorAll('[data-mel-publish-action], [data-mel-card-publish-action], [data-mel-unpublish-action]');
     if (result.changed !== undefined && result.changed !== null) {
       const changed = String(result.changed);

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-workspace-location.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-workspace-location.js
@@ -1,0 +1,51 @@
+/**
+ * @file
+ * Event Studio workspace information — location search hidden-field sync.
+ *
+ * Legacy wizard bundles this in mel-event-studio.js; workspace routes attach this
+ * library instead so address autocomplete and place selection still work.
+ */
+(function (Drupal, once) {
+  'use strict';
+
+  Drupal.behaviors.melEventStudioWorkspaceLocation = {
+    attach: function (context) {
+      once('mel-event-studio-workspace-location', '.mel-location-search', context).forEach(function (input) {
+        input.addEventListener('place_selected', function (e) {
+          var detail = e.detail || {};
+          var components = detail.components || {};
+          var place = detail.place || {};
+          var formatted =
+            place.formatted_address ||
+            (place.formattedAddressLines && place.formattedAddressLines.length
+              ? place.formattedAddressLines.join(', ')
+              : '');
+          var row = {
+            address_line1: components.address_line1 || formatted || '',
+            address_line2: components.address_line2 || '',
+            locality: components.locality || '',
+            administrative_area: components.administrative_area || '',
+            postal_code: components.postal_code || '',
+            country_code: components.country_code || 'AU',
+          };
+          var form = input.closest('form');
+          if (!form) {
+            return;
+          }
+          var locationField = form.querySelector('input[name="mel[field_location]"]');
+          var latitudeField = form.querySelector('input[name="mel[field_location_latitude]"]');
+          var longitudeField = form.querySelector('input[name="mel[field_location_longitude]"]');
+          if (locationField) {
+            locationField.value = JSON.stringify(row);
+          }
+          if (latitudeField && detail.lat != null) {
+            latitudeField.value = String(detail.lat);
+          }
+          if (longitudeField && detail.lng != null) {
+            longitudeField.value = String(detail.lng);
+          }
+        });
+      });
+    },
+  };
+})(Drupal, once);

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -161,3 +161,12 @@ mel_event_studio_shell_only:
     - core/drupal
     - core/drupalSettings
     - core/once
+
+mel_event_studio_workspace_location:
+  version: 1.0
+  js:
+    js/mel-event-studio-workspace-location.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
+    - myeventlane_location/address_autocomplete

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -26,6 +26,7 @@ services:
     arguments:
       - '@date.formatter'
       - '@myeventlane_event.featured_readiness_render'
+      - '@myeventlane_event.event_card_view_model'
       - '@string_translation'
 
   myeventlane_event_studio.preprocess:

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
@@ -395,6 +395,7 @@ final class EventStudioController extends ControllerBase {
 
     return [
       'title' => $node->label(),
+      'location' => $this->workspacePresentation->buildTopbarLocation($node),
       'status' => $node->isPublished() ? $this->t('Published') : $this->t('Draft'),
       'state' => $state,
       'show_last_saved' => FALSE,

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPublishController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPublishController.php
@@ -282,6 +282,7 @@ final class EventStudioPublishController {
         'state' => ($node->isPublished() && $publish_result->ready)
           ? ''
           : $this->workspacePresentation->operationalState($publish_result),
+        'location' => $this->workspacePresentation->buildTopbarLocation($node),
         'lastSaved' => $node->getChangedTime() > 0 ? (string) $this->t('Last saved @time', [
           '@time' => $this->dateFormatter->format($node->getChangedTime(), 'short'),
         ]) : (string) $this->t('Not saved yet'),

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
@@ -198,9 +198,41 @@ final class EventBrandingForm extends EventStudioBaseForm {
     if ($hero['fid'] > 0 && $hero['alt'] === '') {
       $form_state->setErrorByName(
         'mel][field_event_image_alt',
-        $this->t('Alt text is required for the cover image.')
+        $this->t('Add alt text for your cover image before saving. Describe what appears in the image for screen readers and search.')
       );
     }
+
+    $this->validateBrandingHeroUploadResolution($form_state, $mel_for_hero);
+  }
+
+  /**
+   * Surfaces widget sync failures before save when an upload cannot be resolved.
+   *
+   * @param array<string, mixed> $mel_for_hero
+   */
+  private function validateBrandingHeroUploadResolution(FormStateInterface $form_state, array $mel_for_hero): void {
+    $user_mel = $form_state->getUserInput()['mel'] ?? NULL;
+    if (!is_array($user_mel)) {
+      return;
+    }
+    $input_fragment = $user_mel['field_event_image'] ?? NULL;
+    if (!is_array($input_fragment)) {
+      return;
+    }
+    $input_fid = EventStudioMelPayloadService::normalizeHeroFromMelFragment([
+      'field_event_image' => $input_fragment,
+    ])['fid'];
+    if ($input_fid < 1) {
+      return;
+    }
+    $resolved_fid = EventStudioMelPayloadService::normalizeHeroFromMelFragment($mel_for_hero)['fid'];
+    if ($resolved_fid > 0) {
+      return;
+    }
+    $form_state->setErrorByName(
+      'mel][field_event_image',
+      $this->t('The event image could not be saved. Please reselect the image.')
+    );
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventInformationForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventInformationForm.php
@@ -33,11 +33,17 @@ final class EventInformationForm extends EventStudioBaseForm {
   }
 
   protected function onWizardStepSaveSuccess(NodeInterface $saved, FormStateInterface $form_state): void {
-    $this->messenger()->addStatus($this->t('Event information saved.'));
+    $has_location = ($saved->hasField('field_venue') && !$saved->get('field_venue')->isEmpty())
+      || ($saved->hasField('field_location') && !$saved->get('field_location')->isEmpty());
+    $this->messenger()->addStatus($has_location
+      ? $this->t('Event information and venue saved.')
+      : $this->t('Event information saved.'));
     $form_state->setRedirect('myeventlane_event_studio.workspace_information', ['node' => $saved->id()]);
   }
 
   protected function buildWizardStepContent(array &$form, FormStateInterface $form_state, NodeInterface $node, array $melDefaults): void {
+    $form['#attached']['library'][] = 'myeventlane_event_studio/mel_event_studio_workspace_location';
+
     $form['mel']['title'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Event title'),

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventInformationForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventInformationForm.php
@@ -5,12 +5,36 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_event_studio\Form;
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\myeventlane_event_studio\Service\EventStudioWorkspacePresentation;
 use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Isolated Event Studio form for event information.
  */
 final class EventInformationForm extends EventStudioBaseForm {
+
+  private ?EventStudioWorkspacePresentation $workspacePresentation = NULL;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    $instance = parent::create($container);
+    $instance->ensureInjectedServices();
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function ensureInjectedServices(): void {
+    parent::ensureInjectedServices();
+    if ($this->workspacePresentation instanceof EventStudioWorkspacePresentation) {
+      return;
+    }
+    $this->workspacePresentation = \Drupal::getContainer()->get('myeventlane_event_studio.workspace_presentation');
+  }
 
   public function getFormId(): string {
     return 'myeventlane_event_studio_information_form';
@@ -105,6 +129,10 @@ final class EventInformationForm extends EventStudioBaseForm {
       '#default_value' => $melDefaults['venue_mode'] ?? 'one_off',
       '#prefix' => '<section class="mel-es-field-group mel-es-field-group--location" aria-labelledby="mel-es-location-title"><header class="mel-es-field-group__header"><h3 class="mel-es-field-group__title" id="mel-es-location-title">' . $this->t('Location') . '</h3><p class="mel-es-field-group__hint">' . $this->t('Choose a saved venue, create a venue, or add a one-off address for this event.') . '</p></header><div class="mel-es-field-group__body">',
     ];
+
+    $this->ensureInjectedServices();
+    $form['mel']['location_saved_summary'] = $this->workspacePresentation->buildSavedLocationSummaryRenderArray($node);
+    $form['mel']['location_saved_summary']['#weight'] = -20;
 
     $form['mel']['venue_saved'] = [
       '#type' => 'entity_autocomplete',

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
@@ -172,6 +172,10 @@ final class EventStudioMelPayloadService {
     if ($fids === NULL || $fids === '') {
       return 0;
     }
+    if (is_int($fids) || is_float($fids)) {
+      $candidate = (int) $fids;
+      return $candidate > 0 ? $candidate : 0;
+    }
     if (is_array($fids)) {
       foreach ($fids as $value) {
         $candidate = (int) $value;

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
@@ -321,6 +321,7 @@ final class EventStudioMelPayloadService {
       'attendee_questions' => $attendee_questions,
       'field_event_visibility' => trim((string) ($mel['field_event_visibility'] ?? '')),
       'event_passcode' => trim((string) ($mel['event_passcode'] ?? '')),
+      'studio_section' => trim((string) ($form_state->getValue('mel_studio_section') ?? '')),
     ];
 
     if ($this->operationalCapabilityStudioManager !== NULL
@@ -352,7 +353,13 @@ final class EventStudioMelPayloadService {
     if (is_array($raw)) {
       $ids = [];
       foreach ($raw as $item) {
-        if (is_array($item) && isset($item['target_id'])) {
+        if ($item instanceof EntityInterface) {
+          $tid = (int) $item->id();
+          if ($tid > 0) {
+            $ids[] = $tid;
+          }
+        }
+        elseif (is_array($item) && isset($item['target_id'])) {
           $tid = (int) $item['target_id'];
           if ($tid > 0) {
             $ids[] = $tid;

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -1023,18 +1023,30 @@ final class EventStudioSaveService {
       $mel_values = [];
     }
 
-    $synced_hero_fid = EventStudioMelPayloadService::normalizeHeroFromMelFragment($mel_values)['fid'];
     $user_input = $form_state->getUserInput();
     $input_fragment = is_array($user_input['mel'] ?? NULL)
       ? ($user_input['mel']['field_event_image'] ?? NULL)
       : NULL;
     $values_fragment = $mel_values['field_event_image'] ?? NULL;
-    $this->logger->info('Branding hero sync for node @nid: input=@input values=@values resolved_fid=@fid', [
+    $request_fragment = $this->brandingHeroMelFieldFragmentFromRequest();
+    $synced_hero_fid = EventStudioMelPayloadService::normalizeHeroFromMelFragment($mel_values)['fid'];
+    $input_fid = is_array($input_fragment) ? $this->brandingHeroFidFromMelFieldFragment($input_fragment) : 0;
+    $request_fid = is_array($request_fragment) ? $this->brandingHeroFidFromMelFieldFragment($request_fragment) : 0;
+    $this->logger->info('Branding hero save diagnostic for node @nid: existing_target=@existing input_fid=@input_fid request_fid=@request_fid values_fid=@values_fid resolved_fid=@resolved input=@input values=@values request=@request', [
       '@nid' => (string) $node->id(),
+      '@existing' => (string) $previous_hero_fid,
+      '@input_fid' => (string) $input_fid,
+      '@request_fid' => (string) $request_fid,
+      '@values_fid' => (string) (is_array($values_fragment) ? $this->brandingHeroFidFromMelFieldFragment($values_fragment) : 0),
+      '@resolved' => (string) $synced_hero_fid,
       '@input' => $this->brandingHeroSyncSnapshot($input_fragment),
       '@values' => $this->brandingHeroSyncSnapshot($values_fragment),
-      '@fid' => (string) $synced_hero_fid,
+      '@request' => $this->brandingHeroSyncSnapshot($request_fragment),
     ]);
+
+    $mel_structure = $this->normalizeBrandingMelFormStructure(
+      is_array($mel_structure) ? $mel_structure : [],
+    );
 
     $items = $node->get('field_event_image');
     try {
@@ -1045,6 +1057,11 @@ final class EventStudioSaveService {
         '@nid' => (string) $node->id(),
         '@message' => $e->getMessage(),
       ]);
+    }
+
+    $mel_values = $form_state->getValue('mel') ?? [];
+    if (!is_array($mel_values)) {
+      $mel_values = [];
     }
 
     $synced_hero_fid_after_extract = EventStudioMelPayloadService::normalizeHeroFromMelFragment($mel_values)['fid'];
@@ -1067,17 +1084,27 @@ final class EventStudioSaveService {
     if ($fid < 1) {
       $fid = $hero['fid'];
     }
+    if ($fid < 1) {
+      $fid = $this->resolveBrandingHeroFidFromFormState($form_state);
+    }
     if ($alt === '' && $hero['alt'] !== '') {
       $alt = $hero['alt'];
+    }
+    if ($alt === '' && is_array($user_input['mel'] ?? NULL)) {
+      $alt = trim((string) ($user_input['mel']['field_event_image_alt'] ?? ''));
     }
 
     $warnings = [];
     $saved_hero_file = NULL;
+    $hero_file_status_before = NULL;
 
     if ($fid < 1) {
       $input_fid = is_array($input_fragment)
         ? $this->brandingHeroFidFromMelFieldFragment($input_fragment)
         : 0;
+      if ($input_fid < 1) {
+        $input_fid = $request_fid;
+      }
       if ($input_fid > 0) {
         return [
           'node' => NULL,
@@ -1104,6 +1131,7 @@ final class EventStudioSaveService {
         ]);
         return ['node' => NULL, 'errors' => [$this->brandingHeroUnsavedUploadErrorMessage()], 'warnings' => []];
       }
+      $hero_file_status_before = (int) $file->isPermanent();
       if (!$this->isHeroFileRenderable($file)) {
         $this->logger->warning('Branding save: hero file @fid is not renderable for node @nid.', [
           '@fid' => (string) $fid,
@@ -1163,6 +1191,18 @@ final class EventStudioSaveService {
     if ($style_errors !== []) {
       return ['node' => NULL, 'errors' => $style_errors, 'warnings' => []];
     }
+
+    $final_target_id = $node->hasField('field_event_image') && !$node->get('field_event_image')->isEmpty()
+      ? (int) ($node->get('field_event_image')->target_id ?? 0)
+      : 0;
+    $hero_file_status_after = $saved_hero_file instanceof FileInterface ? (int) $saved_hero_file->isPermanent() : NULL;
+    $this->logger->info('Branding hero save assignment for node @nid: resolved_fid=@resolved final_target=@final file_status_before=@before file_status_after=@after', [
+      '@nid' => (string) $node->id(),
+      '@resolved' => (string) $fid,
+      '@final' => (string) $final_target_id,
+      '@before' => $hero_file_status_before === NULL ? 'n/a' : (string) $hero_file_status_before,
+      '@after' => $hero_file_status_after === NULL ? 'n/a' : (string) $hero_file_status_after,
+    ]);
 
     EventNodeRevisionSave::prepare($node, $draft ? 'Event Studio branding draft.' : 'Event Studio branding save.');
     try {
@@ -1370,6 +1410,108 @@ final class EventStudioSaveService {
       $values['mel'] = $mel_values;
       $form_state->setValues($values);
     }
+
+    $this->ensureBrandingHeroFidInFormStateValues($form_state);
+  }
+
+  /**
+   * Ensures mel[field_event_image] form values include the best available fid.
+   */
+  private function ensureBrandingHeroFidInFormStateValues(FormStateInterface $form_state): void {
+    $best_fragment = $this->resolveBestBrandingHeroMelFieldFragment($form_state);
+    if ($best_fragment === NULL) {
+      return;
+    }
+
+    $best_fid = $this->brandingHeroFidFromMelFieldFragment($best_fragment);
+    if ($best_fid < 1) {
+      return;
+    }
+
+    $values = $form_state->getValues();
+    if (!is_array($values)) {
+      return;
+    }
+
+    $mel_values = $values['mel'] ?? NULL;
+    if (!is_array($mel_values)) {
+      $mel_values = [];
+    }
+
+    $current = $mel_values['field_event_image'] ?? NULL;
+    $current_fid = is_array($current) ? $this->brandingHeroFidFromMelFieldFragment($current) : 0;
+    if ($current_fid === $best_fid) {
+      return;
+    }
+
+    if (is_array($current)) {
+      if ($current_fid > 0 && $best_fid !== $current_fid) {
+        $current = $this->stripBrandingHeroCropFromMelFragment($current);
+      }
+      $mel_values['field_event_image'] = $this->mergeBrandingHeroMelFieldFragment($current, $best_fragment);
+    }
+    else {
+      $mel_values['field_event_image'] = $best_fragment;
+    }
+
+    $user_mel = $form_state->getUserInput()['mel'] ?? NULL;
+    if (is_array($user_mel)) {
+      $this->applyBrandingHeroAltToMelValues($user_mel, $mel_values);
+    }
+
+    $values['mel'] = $mel_values;
+    $form_state->setValues($values);
+  }
+
+  /**
+   * @return array<string, mixed>|null
+   */
+  private function resolveBestBrandingHeroMelFieldFragment(FormStateInterface $form_state): ?array {
+    $best_fragment = NULL;
+    $best_fid = 0;
+    foreach ($this->brandingHeroMelFieldFragmentCandidates($form_state) as $fragment) {
+      $fid = $this->brandingHeroFidFromMelFieldFragment($fragment);
+      if ($fid > $best_fid) {
+        $best_fid = $fid;
+        $best_fragment = $fragment;
+      }
+    }
+    return $best_fragment;
+  }
+
+  /**
+   * @return list<array<string, mixed>>
+   */
+  private function brandingHeroMelFieldFragmentCandidates(FormStateInterface $form_state): array {
+    $fragments = [];
+    $user_input = $form_state->getUserInput();
+    $user_mel = is_array($user_input) ? ($user_input['mel'] ?? NULL) : NULL;
+    if (is_array($user_mel['field_event_image'] ?? NULL)) {
+      $fragments[] = $user_mel['field_event_image'];
+    }
+
+    $request_fragment = $this->brandingHeroMelFieldFragmentFromRequest();
+    if (is_array($request_fragment)) {
+      $fragments[] = $request_fragment;
+    }
+
+    $values_mel = $form_state->getValue('mel');
+    if (is_array($values_mel['field_event_image'] ?? NULL)) {
+      $fragments[] = $values_mel['field_event_image'];
+    }
+
+    return $fragments;
+  }
+
+  /**
+   * Resolves the strongest hero fid available from submitted branding sources.
+   */
+  private function resolveBrandingHeroFidFromFormState(FormStateInterface $form_state): int {
+    $best_fragment = $this->resolveBestBrandingHeroMelFieldFragment($form_state);
+    if ($best_fragment === NULL) {
+      return 0;
+    }
+    return $this->brandingHeroFidFromMelFieldFragment($best_fragment);
   }
 
   /**
@@ -1420,6 +1562,9 @@ final class EventStudioSaveService {
    * @param array<string, mixed> $field_fragment
    */
   private function brandingHeroMelFragmentHasAuthoritativeInput(array $field_fragment): bool {
+    if ($this->brandingHeroFidFromMelFieldFragment($field_fragment) > 0) {
+      return TRUE;
+    }
     $delta = EventStudioMelPayloadService::imageWidgetDeltaFromRaw($field_fragment);
     return array_key_exists('fids', $delta)
       || array_key_exists('focal_point', $delta)

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -172,6 +172,9 @@ final class EventStudioSaveService {
 
     $choice = (string) ($payload['venue_choice'] ?? 'one_off');
     $location_values = NULL;
+    $venue_for_display = NULL;
+    $create_venue_name = NULL;
+    $address_row_for_display = NULL;
 
     $skip_venue_location = $draft && (
       ($choice === 'saved' && (int) ($payload['venue_id'] ?? 0) < 1)
@@ -186,17 +189,18 @@ final class EventStudioSaveService {
       if ($vid < 1) {
         return $this->abortSectionScopedSave(['Select a saved venue.'], $payload);
       }
-      $venue = $this->entityTypeManager->getStorage('myeventlane_venue')->load($vid);
-      if (!$venue instanceof Venue) {
+      $venue_for_display = $this->entityTypeManager->getStorage('myeventlane_venue')->load($vid);
+      if (!$venue_for_display instanceof Venue) {
         return $this->abortSectionScopedSave(['Venue not found.'], $payload);
       }
       $node->set('field_venue', ['target_id' => $vid]);
-      $primary = $this->venueManager->getPrimaryLocation($venue);
+      $primary = $this->venueManager->getPrimaryLocation($venue_for_display);
       $location_values = $primary ? [$this->addressFromVenueLocation($primary)] : [];
+      $address_row_for_display = $location_values[0] ?? NULL;
     }
     elseif ($choice === 'create') {
-      $name = trim((string) ($payload['new_venue_name'] ?? ''));
-      if ($name === '') {
+      $create_venue_name = trim((string) ($payload['new_venue_name'] ?? ''));
+      if ($create_venue_name === '') {
         return $this->abortSectionScopedSave(['Venue name is required.'], $payload);
       }
       $row = $this->normalizeAddressRow($payload['field_location'] ?? []);
@@ -204,10 +208,10 @@ final class EventStudioSaveService {
         return $this->abortSectionScopedSave(['Enter an address for the new venue.'], $payload);
       }
       try {
-        $venue = $this->venueManager->createVenueWithLocation(
-          ['name' => $name, 'visibility' => Venue::VISIBILITY_SHARED, 'description' => ''],
+        $venue_for_display = $this->venueManager->createVenueWithLocation(
+          ['name' => $create_venue_name, 'visibility' => Venue::VISIBILITY_SHARED, 'description' => ''],
           [
-            'title' => $name,
+            'title' => $create_venue_name,
             'address_text' => $this->formatAddressText($row),
             'lat' => $payload['field_location_latitude'] ?? NULL,
             'lng' => $payload['field_location_longitude'] ?? NULL,
@@ -219,8 +223,9 @@ final class EventStudioSaveService {
         $this->logger->error('Studio venue create failed: @m', ['@m' => $e->getMessage()]);
         return $this->abortSectionScopedSave(['Could not create venue.'], $payload);
       }
-      $node->set('field_venue', ['target_id' => $venue->id()]);
+      $node->set('field_venue', ['target_id' => $venue_for_display->id()]);
       $location_values = [$row];
+      $address_row_for_display = $row;
     }
     else {
       if ($node->hasField('field_venue')) {
@@ -231,11 +236,14 @@ final class EventStudioSaveService {
         return $this->abortSectionScopedSave(['Location is required.'], $payload);
       }
       $location_values = $row !== NULL ? [$row] : [];
+      $address_row_for_display = $row;
     }
 
     if ($node->hasField('field_location') && $location_values !== NULL) {
       $node->set('field_location', $location_values);
     }
+
+    $this->applyVenueDisplayName($node, $choice, $address_row_for_display, $venue_for_display, $create_venue_name);
 
     $this->applyOptionalCoordinates($node, $payload);
 
@@ -572,6 +580,54 @@ final class EventStudioSaveService {
       $address_row['administrative_area'] ?? '',
       $address_row['postal_code'] ?? '',
     ], static fn ($p) => $p !== ''));
+  }
+
+  /**
+   * Writes field_venue_name for hero/card location summaries.
+   *
+   * One-off events have no venue entity; reuse the saved address row so public
+   * heroes and cards can show a location line without a separate venue profile.
+   */
+  private function applyVenueDisplayName(
+    NodeInterface $node,
+    string $choice,
+    ?array $address_row,
+    ?Venue $venue = NULL,
+    ?string $create_name = NULL,
+  ): void {
+    if (!$node->hasField('field_venue_name')) {
+      return;
+    }
+
+    $display_name = '';
+    if ($choice === 'saved' && $venue instanceof Venue) {
+      $display_name = trim((string) $venue->label());
+    }
+    elseif ($choice === 'create' && $create_name !== NULL) {
+      $display_name = trim($create_name);
+    }
+    elseif ($choice === 'one_off' && is_array($address_row)) {
+      $display_name = $this->deriveVenueDisplayNameFromAddressRow($address_row);
+    }
+
+    if ($display_name === '') {
+      return;
+    }
+
+    $node->set('field_venue_name', $display_name);
+  }
+
+  /**
+   * @param array<string, string> $address_row
+   */
+  private function deriveVenueDisplayNameFromAddressRow(array $address_row): string {
+    $locality = trim((string) ($address_row['locality'] ?? ''));
+    $administrative_area = trim((string) ($address_row['administrative_area'] ?? ''));
+    if ($locality !== '') {
+      return $administrative_area !== '' ? $locality . ', ' . $administrative_area : $locality;
+    }
+
+    return trim((string) ($address_row['address_line1'] ?? ''));
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -165,7 +165,7 @@ final class EventStudioSaveService {
 
     $ticket_errors = $this->applyTicketPayload($node, $payload, $event_type, $draft);
     if ($ticket_errors !== []) {
-      return ['node' => NULL, 'errors' => $ticket_errors];
+      return $this->abortSectionScopedSave($ticket_errors, $payload);
     }
 
     $this->applyDonationPayload($node, $payload);
@@ -184,11 +184,11 @@ final class EventStudioSaveService {
     elseif ($choice === 'saved') {
       $vid = (int) ($payload['venue_id'] ?? 0);
       if ($vid < 1) {
-        return ['node' => NULL, 'errors' => ['Select a saved venue.']];
+        return $this->abortSectionScopedSave(['Select a saved venue.'], $payload);
       }
       $venue = $this->entityTypeManager->getStorage('myeventlane_venue')->load($vid);
       if (!$venue instanceof Venue) {
-        return ['node' => NULL, 'errors' => ['Venue not found.']];
+        return $this->abortSectionScopedSave(['Venue not found.'], $payload);
       }
       $node->set('field_venue', ['target_id' => $vid]);
       $primary = $this->venueManager->getPrimaryLocation($venue);
@@ -197,11 +197,11 @@ final class EventStudioSaveService {
     elseif ($choice === 'create') {
       $name = trim((string) ($payload['new_venue_name'] ?? ''));
       if ($name === '') {
-        return ['node' => NULL, 'errors' => ['Venue name is required.']];
+        return $this->abortSectionScopedSave(['Venue name is required.'], $payload);
       }
       $row = $this->normalizeAddressRow($payload['field_location'] ?? []);
       if ($row === NULL) {
-        return ['node' => NULL, 'errors' => ['Enter an address for the new venue.']];
+        return $this->abortSectionScopedSave(['Enter an address for the new venue.'], $payload);
       }
       try {
         $venue = $this->venueManager->createVenueWithLocation(
@@ -217,7 +217,7 @@ final class EventStudioSaveService {
       }
       catch (\Throwable $e) {
         $this->logger->error('Studio venue create failed: @m', ['@m' => $e->getMessage()]);
-        return ['node' => NULL, 'errors' => ['Could not create venue.']];
+        return $this->abortSectionScopedSave(['Could not create venue.'], $payload);
       }
       $node->set('field_venue', ['target_id' => $venue->id()]);
       $location_values = [$row];
@@ -228,7 +228,7 @@ final class EventStudioSaveService {
       }
       $row = $this->normalizeAddressRow($payload['field_location'] ?? []);
       if (!$draft && $row === NULL) {
-        return ['node' => NULL, 'errors' => ['Location is required.']];
+        return $this->abortSectionScopedSave(['Location is required.'], $payload);
       }
       $location_values = $row !== NULL ? [$row] : [];
     }
@@ -239,15 +239,17 @@ final class EventStudioSaveService {
 
     $this->applyOptionalCoordinates($node, $payload);
 
-    $image_errors = $this->applyHeroImagePayload($node, $payload, $draft);
-    if ($image_errors !== []) {
-      return ['node' => NULL, 'errors' => $image_errors];
+    if ($this->shouldApplyHeroImagePayload($payload)) {
+      $image_errors = $this->applyHeroImagePayload($node, $payload, $draft);
+      if ($image_errors !== []) {
+        return $this->abortSectionScopedSave($image_errors, $payload);
+      }
     }
 
     if (array_key_exists('event_highlights_items_state', $payload)) {
       $highlight_errors = $this->eventHighlightHelper->validateHighlightItemsStateJson((string) ($payload['event_highlights_items_state'] ?? ''));
       if ($highlight_errors !== []) {
-        return ['node' => NULL, 'errors' => $highlight_errors];
+        return $this->abortSectionScopedSave($highlight_errors, $payload);
       }
     }
 
@@ -256,28 +258,28 @@ final class EventStudioSaveService {
     }
     catch (\Throwable $e) {
       $this->logger->error('Studio event highlights sync failed: @m', ['@m' => $e->getMessage()]);
-      return ['node' => NULL, 'errors' => ['Could not save event highlights.']];
+      return $this->abortSectionScopedSave(['Could not save event highlights.'], $payload);
     }
 
     $attendee_errors = $this->syncAttendeeQuestions($node, $payload, $account);
     if ($attendee_errors !== []) {
-      return ['node' => NULL, 'errors' => $attendee_errors];
+      return $this->abortSectionScopedSave($attendee_errors, $payload);
     }
 
     $visibility_errors = $this->applyVisibilityPayload($node, $payload);
     if ($visibility_errors !== []) {
-      return ['node' => NULL, 'errors' => $visibility_errors];
+      return $this->abortSectionScopedSave($visibility_errors, $payload);
     }
 
     $capability_errors = $this->applyOperationalCapabilitiesPayload($node, $payload);
     if ($capability_errors !== []) {
-      return ['node' => NULL, 'errors' => $capability_errors];
+      return $this->abortSectionScopedSave($capability_errors, $payload);
     }
 
     if (!$draft && $willPublish) {
       $eligibility = $this->publishEligibilityEvaluator->evaluate($node, $account);
       if (!$eligibility['allowed']) {
-        return ['node' => NULL, 'errors' => $eligibility['messages']];
+        return $this->abortSectionScopedSave($eligibility['messages'], $payload);
       }
     }
 
@@ -287,7 +289,7 @@ final class EventStudioSaveService {
     }
     catch (\Throwable $e) {
       $this->logger->error('Studio event save failed: @m', ['@m' => $e->getMessage()]);
-      return ['node' => NULL, 'errors' => ['Save failed.']];
+      return $this->abortSectionScopedSave(['Save failed.'], $payload);
     }
 
     return ['node' => $node, 'errors' => []];
@@ -1073,7 +1075,22 @@ final class EventStudioSaveService {
     $saved_hero_file = NULL;
 
     if ($fid < 1) {
-      $node->set('field_event_image', []);
+      $input_fid = is_array($input_fragment)
+        ? $this->brandingHeroFidFromMelFieldFragment($input_fragment)
+        : 0;
+      if ($input_fid > 0) {
+        return [
+          'node' => NULL,
+          'errors' => [$this->brandingHeroUnsavedUploadErrorMessage()],
+          'warnings' => [],
+        ];
+      }
+      if ($previous_hero_fid > 0 && !$this->brandingHeroExplicitRemovalRequested($input_fragment)) {
+        $this->applyBrandingHeroAltToExistingNode($node, $mel_values);
+      }
+      else {
+        $node->set('field_event_image', []);
+      }
     }
     else {
       if ($alt === '' && !$draft) {
@@ -1085,7 +1102,7 @@ final class EventStudioSaveService {
           '@fid' => (string) $fid,
           '@nid' => (string) $node->id(),
         ]);
-        return ['node' => NULL, 'errors' => ['The uploaded image could not be loaded. Try uploading again.'], 'warnings' => []];
+        return ['node' => NULL, 'errors' => [$this->brandingHeroUnsavedUploadErrorMessage()], 'warnings' => []];
       }
       if (!$this->isHeroFileRenderable($file)) {
         $this->logger->warning('Branding save: hero file @fid is not renderable for node @nid.', [
@@ -1973,6 +1990,96 @@ final class EventStudioSaveService {
     return (string) $this->stringTranslation->translate(
       'The cover image file is missing or unreadable. Upload a new image or remove the cover image.'
     );
+  }
+
+  /**
+   * User-facing error when a submitted hero upload could not be resolved for save.
+   */
+  private function brandingHeroUnsavedUploadErrorMessage(): string {
+    return (string) $this->stringTranslation->translate(
+      'The event image could not be saved. Please reselect the image.'
+    );
+  }
+
+  /**
+   * Hero image is owned by the branding workspace section only.
+   *
+   * @param array<string, mixed> $payload
+   */
+  private function shouldApplyHeroImagePayload(array $payload): bool {
+    $section = trim((string) ($payload['studio_section'] ?? ''));
+    return $section === '';
+  }
+
+  /**
+   * @param list<string> $errors
+   * @param array<string, mixed> $payload
+   *
+   * @return array{node: null, errors: list<string>}
+   */
+  private function abortSectionScopedSave(array $errors, array $payload): array {
+    return ['node' => NULL, 'errors' => $this->enrichSectionScopedSaveErrors($errors, $payload)];
+  }
+
+  /**
+   * Adds workspace section context when a scoped save aborts after content fields apply.
+   *
+   * @param list<string> $errors
+   * @param array<string, mixed> $payload
+   *
+   * @return list<string>
+   */
+  private function enrichSectionScopedSaveErrors(array $errors, array $payload): array {
+    if ($errors === []) {
+      return [];
+    }
+    $section = trim((string) ($payload['studio_section'] ?? ''));
+    if ($section !== 'content') {
+      return $errors;
+    }
+    return [
+      (string) $this->stringTranslation->translate(
+        'Accessibility and content could not be saved because another field failed validation.'
+      ),
+      ...$errors,
+    ];
+  }
+
+  /**
+   * Detects an intentional hero removal from branding widget submission.
+   *
+   * @param array<string, mixed>|null $input_fragment
+   */
+  private function brandingHeroExplicitRemovalRequested(?array $input_fragment): bool {
+    if (!is_array($input_fragment)) {
+      return FALSE;
+    }
+    $delta = EventStudioMelPayloadService::imageWidgetDeltaFromRaw($input_fragment);
+    if (!array_key_exists('fids', $delta)) {
+      return FALSE;
+    }
+    return EventStudioMelPayloadService::firstPositiveIntFromFidsValue($delta['fids'] ?? NULL) < 1;
+  }
+
+  /**
+   * Updates alt text on an existing hero when branding save did not replace the file.
+   *
+   * @param array<string, mixed> $mel_values
+   */
+  private function applyBrandingHeroAltToExistingNode(NodeInterface $node, array $mel_values): void {
+    if ($node->get('field_event_image')->isEmpty()) {
+      return;
+    }
+    $hero = EventStudioMelPayloadService::normalizeHeroFromMelFragment($mel_values);
+    if ($hero['alt'] === '') {
+      return;
+    }
+    $row = $node->get('field_event_image')->first()?->getValue() ?? [];
+    if (!is_array($row) || (int) ($row['target_id'] ?? 0) < 1) {
+      return;
+    }
+    $row['alt'] = $hero['alt'];
+    $node->set('field_event_image', [$row]);
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -243,7 +243,9 @@ final class EventStudioSaveService {
       $node->set('field_location', $location_values);
     }
 
-    $this->applyVenueDisplayName($node, $choice, $address_row_for_display, $venue_for_display, $create_venue_name);
+    if (!$skip_venue_location) {
+      $this->applyVenueDisplayName($node, $choice, $address_row_for_display, $venue_for_display, $create_venue_name);
+    }
 
     $this->applyOptionalCoordinates($node, $payload);
 
@@ -587,6 +589,7 @@ final class EventStudioSaveService {
    *
    * One-off events have no venue entity; reuse the saved address row so public
    * heroes and cards can show a location line without a separate venue profile.
+   * Clears the field when location processing yields no display label.
    */
   private function applyVenueDisplayName(
     NodeInterface $node,
@@ -611,6 +614,7 @@ final class EventStudioSaveService {
     }
 
     if ($display_name === '') {
+      $node->set('field_venue_name', NULL);
       return;
     }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -113,15 +113,15 @@ final class EventStudioSaveService {
     }
 
     // Keep Content Moderation aligned with the requested published flag.
-    // Draft revisions are not default revisions in the editorial workflow, so
-    // unpublishing a live event must use the unpublished default state.
+    // Unpublishing a live event returns organisers to draft so update access and
+    // Event Studio remain available (archived blocks vendor edit transitions).
     if (!$draft && $node->hasField('moderation_state') && !$node->get('moderation_state')->isEmpty()) {
       $moderationState = (string) $node->get('moderation_state')->value;
       if ($willPublish && $moderationState !== 'published') {
         $node->set('moderation_state', 'published');
       }
       if (!$willPublish && $moderationState === 'published') {
-        $node->set('moderation_state', 'archived');
+        $node->set('moderation_state', 'draft');
       }
     }
 
@@ -498,7 +498,7 @@ final class EventStudioSaveService {
         $node->set('moderation_state', 'published');
       }
       if (!$published && $moderationState === 'published') {
-        $node->set('moderation_state', 'archived');
+        $node->set('moderation_state', 'draft');
       }
     }
     EventNodeRevisionSave::prepare($node, $revision_log);

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWorkspacePresentation.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWorkspacePresentation.php
@@ -7,6 +7,7 @@ namespace Drupal\myeventlane_event_studio\Service;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_event\EventCard\EventCardViewModel;
 use Drupal\myeventlane_event\Service\FeaturedEventReadinessRenderBuilder;
 use Drupal\myeventlane_event_studio\DTO\EventReadinessResult;
 use Drupal\node\NodeInterface;
@@ -23,6 +24,7 @@ final class EventStudioWorkspacePresentation {
   public function __construct(
     private readonly DateFormatterInterface $dateFormatter,
     private readonly FeaturedEventReadinessRenderBuilder $homepageReadinessRender,
+    private readonly EventCardViewModel $eventCardViewModel,
     TranslationInterface $stringTranslation,
   ) {
     $this->stringTranslation = $stringTranslation;
@@ -218,6 +220,142 @@ final class EventStudioWorkspacePresentation {
     return (string) $this->t('Last updated @time', [
       '@time' => $this->dateFormatter->format($node->getChangedTime(), 'short'),
     ]);
+  }
+
+  /**
+   * Builds venue/address summary for the Event Studio topbar.
+   *
+   * Reuses the public event card location label and field_location address rows
+   * written by Event Studio save — no duplicate geocoding or formatting.
+   *
+   * @return array{
+   *   configured: bool,
+   *   mode: 'saved'|'one_off',
+   *   primary_line: ?string,
+   *   secondary_line: ?string,
+   *   warning: string,
+   * }
+   */
+  public function buildTopbarLocation(NodeInterface $node): array {
+    $warning = (string) $this->t('Venue not yet configured');
+    if ($node->bundle() !== 'event') {
+      return [
+        'configured' => FALSE,
+        'mode' => 'one_off',
+        'primary_line' => NULL,
+        'secondary_line' => NULL,
+        'warning' => $warning,
+      ];
+    }
+
+    if (!$this->isLocationConfigured($node)) {
+      return [
+        'configured' => FALSE,
+        'mode' => 'one_off',
+        'primary_line' => NULL,
+        'secondary_line' => NULL,
+        'warning' => $warning,
+      ];
+    }
+
+    $has_saved_venue = $node->hasField('field_venue') && !$node->get('field_venue')->isEmpty();
+    $mode = $has_saved_venue ? 'saved' : 'one_off';
+    $venue_name = $this->resolveVenueName($node, $has_saved_venue);
+    $address_summary = $this->resolveAddressSummary($node);
+
+    if ($mode === 'one_off') {
+      return [
+        'configured' => TRUE,
+        'mode' => 'one_off',
+        'primary_line' => (string) $this->t('One-off venue'),
+        'secondary_line' => $this->combineOneOffLocationLines($venue_name, $address_summary),
+        'warning' => $warning,
+      ];
+    }
+
+    return [
+      'configured' => TRUE,
+      'mode' => 'saved',
+      'primary_line' => $venue_name,
+      'secondary_line' => $address_summary,
+      'warning' => $warning,
+    ];
+  }
+
+  private function isLocationConfigured(NodeInterface $node): bool {
+    if ($node->hasField('field_venue') && !$node->get('field_venue')->isEmpty()) {
+      return TRUE;
+    }
+    if (!$node->hasField('field_location') || $node->get('field_location')->isEmpty()) {
+      return FALSE;
+    }
+    $item = $node->get('field_location')->first();
+    if ($item === NULL) {
+      return FALSE;
+    }
+    foreach (['address_line1', 'locality', 'administrative_area'] as $key) {
+      if (trim((string) $item->get($key)->getValue()) !== '') {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  private function resolveVenueName(NodeInterface $node, bool $has_saved_venue): ?string {
+    if ($has_saved_venue) {
+      $venue = $node->get('field_venue')->entity;
+      if ($venue !== NULL) {
+        $name = trim((string) $venue->label());
+        if ($name !== '') {
+          return $name;
+        }
+      }
+    }
+    if ($node->hasField('field_venue_name') && !$node->get('field_venue_name')->isEmpty()) {
+      $name = trim((string) $node->get('field_venue_name')->value);
+      if ($name !== '') {
+        return $name;
+      }
+    }
+    return $this->eventCardViewModel->getLocationLabel($node);
+  }
+
+  private function resolveAddressSummary(NodeInterface $node): ?string {
+    if (!$node->hasField('field_location') || $node->get('field_location')->isEmpty()) {
+      return NULL;
+    }
+    $item = $node->get('field_location')->first();
+    if ($item === NULL) {
+      return NULL;
+    }
+    $locality = trim((string) $item->get('locality')->getValue());
+    $administrative_area = trim((string) $item->get('administrative_area')->getValue());
+    if ($locality !== '') {
+      return $administrative_area !== '' ? $locality . ' ' . $administrative_area : $locality;
+    }
+    $line1 = trim((string) $item->get('address_line1')->getValue());
+    return $line1 !== '' ? $line1 : NULL;
+  }
+
+  private function combineOneOffLocationLines(?string $venue_name, ?string $address_summary): ?string {
+    $parts = array_values(array_filter([$venue_name, $address_summary], static fn (?string $part): bool => $part !== NULL && $part !== ''));
+    if ($parts === []) {
+      return NULL;
+    }
+    if (count($parts) === 1) {
+      return $parts[0];
+    }
+    $first = $this->normalizeLocationToken($parts[0]);
+    $second = $this->normalizeLocationToken($parts[1]);
+    if ($first === $second || str_contains($second, $first) || str_contains($first, $second)) {
+      return $parts[1];
+    }
+    return implode(', ', $parts);
+  }
+
+  private function normalizeLocationToken(string $value): string {
+    $normalized = strtolower(str_replace(',', ' ', $value));
+    return trim((string) preg_replace('/\s+/', ' ', $normalized));
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWorkspacePresentation.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWorkspacePresentation.php
@@ -282,6 +282,63 @@ final class EventStudioWorkspacePresentation {
     ];
   }
 
+  /**
+   * Read-only saved location summary for Event Studio information forms.
+   *
+   * Uses the same payload as {@see buildTopbarLocation()}.
+   *
+   * @return array<string, mixed>
+   */
+  public function buildSavedLocationSummaryRenderArray(NodeInterface $node): array {
+    $location = $this->buildTopbarLocation($node);
+    $build = [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => ['mel-es-location-summary'],
+        'data-mel-location-summary' => '1',
+        'role' => 'status',
+        'aria-live' => 'polite',
+      ],
+    ];
+
+    if (!$location['configured']) {
+      $build['warning'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $location['warning'],
+        '#attributes' => ['class' => ['mel-es-location-summary__line', 'mel-es-location-summary__line--warning']],
+      ];
+      return $build;
+    }
+
+    $build['heading'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'h4',
+      '#value' => $this->t('Saved location'),
+      '#attributes' => ['class' => ['mel-es-location-summary__title']],
+    ];
+
+    if (!empty($location['primary_line'])) {
+      $build['primary'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => '📍 ' . $location['primary_line'],
+        '#attributes' => ['class' => ['mel-es-location-summary__line', 'mel-es-location-summary__line--primary']],
+      ];
+    }
+
+    if (!empty($location['secondary_line'])) {
+      $build['secondary'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $location['secondary_line'],
+        '#attributes' => ['class' => ['mel-es-location-summary__line', 'mel-es-location-summary__line--secondary']],
+      ];
+    }
+
+    return $build;
+  }
+
   private function isLocationConfigured(NodeInterface $node): bool {
     if ($node->hasField('field_venue') && !$node->get('field_venue')->isEmpty()) {
       return TRUE;

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-topbar.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-topbar.html.twig
@@ -8,6 +8,27 @@
   <div class="mel-event-studio-topbar__primary">
     <p class="mel-event-studio-topbar__eyebrow">{{ 'Event Studio'|t }}</p>
     <h1 class="mel-event-studio-topbar__title">{{ topbar.title }}</h1>
+    {% set location = topbar.location|default({}) %}
+    <div class="mel-event-studio-topbar__location" data-mel-topbar-location role="status" aria-live="polite">
+      {% if location.configured|default(false) %}
+        {% if location.primary_line|default('') %}
+          <p class="mel-event-studio-topbar__location-line mel-event-studio-topbar__location-line--primary">
+            <span class="mel-event-studio-topbar__location-icon" aria-hidden="true">📍</span>
+            <span class="mel-event-studio-topbar__location-text" data-mel-topbar-location-primary>{{ location.primary_line }}</span>
+          </p>
+        {% endif %}
+        {% if location.secondary_line|default('') %}
+          <p class="mel-event-studio-topbar__location-line mel-event-studio-topbar__location-line--secondary">
+            <span class="mel-event-studio-topbar__location-text" data-mel-topbar-location-secondary>{{ location.secondary_line }}</span>
+          </p>
+        {% endif %}
+      {% else %}
+        <p class="mel-event-studio-topbar__location-line mel-event-studio-topbar__location-line--warning">
+          <span class="mel-event-studio-topbar__location-icon" aria-hidden="true">⚠</span>
+          <span class="mel-event-studio-topbar__location-text" data-mel-topbar-location-warning>{{ location.warning|default('Venue not yet configured'|t) }}</span>
+        </p>
+      {% endif %}
+    </div>
     <div class="mel-event-studio-topbar__meta" aria-label="{{ 'Event status'|t }}">
       <span class="mel-event-studio-topbar__badge" data-mel-publish-status>{{ topbar.status }}</span>
       {% if topbar.state %}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioMelPayloadEntityExtractionTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioMelPayloadEntityExtractionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\myeventlane_event_studio\Service\EventHighlightHelper;
+use Drupal\myeventlane_event_studio\Service\EventStudioMelPayloadService;
+use Drupal\myeventlane_event_studio\Service\QuestionFieldTypeRegistry;
+use Drupal\Tests\UnitTestCase;
+use ReflectionMethod;
+
+/**
+ * @group myeventlane_event_studio
+ */
+final class EventStudioMelPayloadEntityExtractionTest extends UnitTestCase {
+
+  /**
+   * @covers ::extractMultipleEntityIds
+   */
+  public function testExtractMultipleEntityIdsAcceptsEntityInterfaceObjects(): void {
+    $first = $this->createMock(EntityInterface::class);
+    $first->method('id')->willReturn('12');
+    $second = $this->createMock(EntityInterface::class);
+    $second->method('id')->willReturn('34');
+
+    $service = new EventStudioMelPayloadService(
+      $this->createMock(EventHighlightHelper::class),
+      $this->createMock(QuestionFieldTypeRegistry::class),
+    );
+
+    $method = new ReflectionMethod(EventStudioMelPayloadService::class, 'extractMultipleEntityIds');
+    $method->setAccessible(TRUE);
+
+    /** @var list<int> $ids */
+    $ids = $method->invoke($service, [$first, $second]);
+
+    $this->assertSame([12, 34], $ids);
+  }
+
+  /**
+   * @covers ::extractMultipleEntityIds
+   */
+  public function testExtractMultipleEntityIdsPreservesTargetIdArrays(): void {
+    $service = new EventStudioMelPayloadService(
+      $this->createMock(EventHighlightHelper::class),
+      $this->createMock(QuestionFieldTypeRegistry::class),
+    );
+
+    $method = new ReflectionMethod(EventStudioMelPayloadService::class, 'extractMultipleEntityIds');
+    $method->setAccessible(TRUE);
+
+    /** @var list<int> $ids */
+    $ids = $method->invoke($service, [
+      ['target_id' => 5],
+      ['target_id' => 6],
+    ]);
+
+    $this->assertSame([5, 6], $ids);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioSaveServiceHeroPersistenceTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioSaveServiceHeroPersistenceTest.php
@@ -7,6 +7,8 @@ namespace Drupal\Tests\myeventlane_event_studio\Unit;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\Form\FormState;
+use Drupal\myeventlane_event_studio\Service\EventStudioMelPayloadService;
 use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
 use Drupal\Tests\UnitTestCase;
 use Psr\Log\LoggerInterface;
@@ -18,19 +20,6 @@ use ReflectionProperty;
  * @group myeventlane_event_studio
  */
 final class EventStudioSaveServiceHeroPersistenceTest extends UnitTestCase {
-
-  /**
-   * @covers ::shouldApplyHeroImagePayload
-   */
-  public function testShouldApplyHeroImagePayloadSkipsWorkspaceSections(): void {
-    $service = $this->buildPartialSaveService();
-    $method = new ReflectionMethod(EventStudioSaveService::class, 'shouldApplyHeroImagePayload');
-    $method->setAccessible(TRUE);
-
-    $this->assertFalse($method->invoke($service, ['studio_section' => 'content']));
-    $this->assertFalse($method->invoke($service, ['studio_section' => 'information']));
-    $this->assertTrue($method->invoke($service, ['studio_section' => '']));
-  }
 
   /**
    * @covers ::brandingHeroExplicitRemovalRequested
@@ -47,6 +36,55 @@ final class EventStudioSaveServiceHeroPersistenceTest extends UnitTestCase {
     $this->assertTrue($method->invoke($service, [
       0 => ['fids' => ''],
     ]));
+  }
+
+  public function testFirstPositiveIntFromFidsValueAcceptsNumericScalar(): void {
+    $this->assertSame(606, EventStudioMelPayloadService::firstPositiveIntFromFidsValue(606));
+  }
+
+  public function testSyncBrandingHeroSubmittedValuesCopiesRequestFid(): void {
+    $service = $this->buildPartialSaveService();
+    $requestStack = new \Symfony\Component\HttpFoundation\RequestStack();
+    $request = \Symfony\Component\HttpFoundation\Request::create('/', 'POST', [
+      'mel' => [
+        'field_event_image' => [
+          0 => [
+            'fids' => 606,
+            'display' => 1,
+          ],
+        ],
+        'field_event_image_alt' => 'Cover alt',
+      ],
+    ]);
+    $requestStack->push($request);
+    $this->setPrivateProperty($service, 'requestStack', $requestStack);
+
+    $form_state = new FormState();
+    $form_state->setValues([
+      'mel' => [
+        'field_event_image' => [
+          0 => [
+            'image_crop' => [
+              'crop_wrapper' => [
+                'event_hero' => [
+                  'crop_container' => [
+                    'values' => ['crop_applied' => 1],
+                  ],
+                ],
+              ],
+            ],
+          ],
+        ],
+      ],
+    ]);
+
+    $method = new ReflectionMethod(EventStudioSaveService::class, 'syncBrandingHeroSubmittedValues');
+    $method->setAccessible(TRUE);
+    $method->invoke($service, $form_state);
+
+    $mel = $form_state->getValue('mel');
+    $hero = EventStudioMelPayloadService::normalizeHeroFromMelFragment(is_array($mel) ? $mel : []);
+    $this->assertSame(606, $hero['fid']);
   }
 
   private function buildPartialSaveService(): EventStudioSaveService {

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioSaveServiceHeroPersistenceTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioSaveServiceHeroPersistenceTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
+use Drupal\Tests\UnitTestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+
+/**
+ * @group myeventlane_event_studio
+ */
+final class EventStudioSaveServiceHeroPersistenceTest extends UnitTestCase {
+
+  /**
+   * @covers ::shouldApplyHeroImagePayload
+   */
+  public function testShouldApplyHeroImagePayloadSkipsWorkspaceSections(): void {
+    $service = $this->buildPartialSaveService();
+    $method = new ReflectionMethod(EventStudioSaveService::class, 'shouldApplyHeroImagePayload');
+    $method->setAccessible(TRUE);
+
+    $this->assertFalse($method->invoke($service, ['studio_section' => 'content']));
+    $this->assertFalse($method->invoke($service, ['studio_section' => 'information']));
+    $this->assertTrue($method->invoke($service, ['studio_section' => '']));
+  }
+
+  /**
+   * @covers ::brandingHeroExplicitRemovalRequested
+   */
+  public function testBrandingHeroExplicitRemovalRequestedRequiresEmptyFids(): void {
+    $service = $this->buildPartialSaveService();
+    $method = new ReflectionMethod(EventStudioSaveService::class, 'brandingHeroExplicitRemovalRequested');
+    $method->setAccessible(TRUE);
+
+    $this->assertFalse($method->invoke($service, NULL));
+    $this->assertFalse($method->invoke($service, [
+      0 => ['focal_point' => '50,50'],
+    ]));
+    $this->assertTrue($method->invoke($service, [
+      0 => ['fids' => ''],
+    ]));
+  }
+
+  private function buildPartialSaveService(): EventStudioSaveService {
+    $translation = $this->createMock(TranslationInterface::class);
+    $translation->method('translate')->willReturnCallback(
+      static fn (string $string, array $args = [], array $options = []): string => $string,
+    );
+
+    $service = (new ReflectionClass(EventStudioSaveService::class))->newInstanceWithoutConstructor();
+    $this->setPrivateProperty($service, 'entityTypeManager', $this->createMock(EntityTypeManagerInterface::class));
+    $this->setPrivateProperty($service, 'fileSystem', $this->createMock(FileSystemInterface::class));
+    $this->setPrivateProperty($service, 'stringTranslation', $translation);
+    $this->setPrivateProperty($service, 'logger', $this->createMock(LoggerInterface::class));
+
+    return $service;
+  }
+
+  private function setPrivateProperty(object $object, string $property, mixed $value): void {
+    $ref = new ReflectionProperty($object, $property);
+    $ref->setAccessible(TRUE);
+    $ref->setValue($object, $value);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioSaveServiceHeroPersistenceTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioSaveServiceHeroPersistenceTest.php
@@ -87,6 +87,36 @@ final class EventStudioSaveServiceHeroPersistenceTest extends UnitTestCase {
     $this->assertSame(606, $hero['fid']);
   }
 
+  /**
+   * @dataProvider deriveVenueDisplayNameFromAddressRowProvider
+   */
+  public function testDeriveVenueDisplayNameFromAddressRow(array $row, string $expected): void {
+    $service = $this->buildPartialSaveService();
+    $method = new ReflectionMethod(EventStudioSaveService::class, 'deriveVenueDisplayNameFromAddressRow');
+    $method->setAccessible(TRUE);
+    $this->assertSame($expected, $method->invoke($service, $row));
+  }
+
+  /**
+   * @return array<string, array{0: array<string, string>, 1: string}>
+   */
+  public static function deriveVenueDisplayNameFromAddressRowProvider(): array {
+    return [
+      'locality and state' => [
+        ['locality' => 'Sydney', 'administrative_area' => 'NSW', 'address_line1' => '1 George St'],
+        'Sydney, NSW',
+      ],
+      'locality only' => [
+        ['locality' => 'Melbourne', 'address_line1' => '100 Collins St'],
+        'Melbourne',
+      ],
+      'line1 fallback' => [
+        ['address_line1' => '100 Collins St'],
+        '100 Collins St',
+      ],
+    ];
+  }
+
   private function buildPartialSaveService(): EventStudioSaveService {
     $translation = $this->createMock(TranslationInterface::class);
     $translation->method('translate')->willReturnCallback(

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceLibraryAttachmentTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceLibraryAttachmentTest.php
@@ -99,6 +99,18 @@ final class EventStudioWorkspaceLibraryAttachmentTest extends TestCase {
     $this->assertFileExists($this->moduleRoot . '/js/mel-event-studio-ai-assist.js');
   }
 
+  public function testInformationWorkspaceLocationLibraryIsDefined(): void {
+    $libraries = file_get_contents($this->moduleRoot . '/myeventlane_event_studio.libraries.yml');
+    $information = file_get_contents($this->moduleRoot . '/src/Form/EventInformationForm.php');
+    $this->assertIsString($libraries);
+    $this->assertIsString($information);
+    $this->assertStringContainsString('mel_event_studio_workspace_location:', $libraries);
+    $this->assertStringContainsString('js/mel-event-studio-workspace-location.js', $libraries);
+    $this->assertStringContainsString('myeventlane_location/address_autocomplete', $libraries);
+    $this->assertStringContainsString('myeventlane_event_studio/mel_event_studio_workspace_location', $information);
+    $this->assertFileExists($this->moduleRoot . '/js/mel-event-studio-workspace-location.js');
+  }
+
   public function testBrandingAndTicketPreviewLibrariesUnchanged(): void {
     $branding = file_get_contents($this->moduleRoot . '/src/Form/EventBrandingForm.php');
     $preview = file_get_contents($this->moduleRoot . '/src/Service/EventTicketPreviewBuilder.php');

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspacePresentationContractTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspacePresentationContractTest.php
@@ -30,7 +30,9 @@ final class EventStudioWorkspacePresentationContractTest extends UnitTestCase {
     );
     $homepageReadinessRender = (new ReflectionClass(\Drupal\myeventlane_event\Service\FeaturedEventReadinessRenderBuilder::class))
       ->newInstanceWithoutConstructor();
-    $this->presentation = new EventStudioWorkspacePresentation($dateFormatter, $homepageReadinessRender, $translator);
+    $eventCardViewModel = (new ReflectionClass(\Drupal\myeventlane_event\EventCard\EventCardViewModel::class))
+      ->newInstanceWithoutConstructor();
+    $this->presentation = new EventStudioWorkspacePresentation($dateFormatter, $homepageReadinessRender, $eventCardViewModel, $translator);
   }
 
   public function testStripAndAjaxPayloadShareReadinessSummaryFields(): void {
@@ -113,6 +115,16 @@ final class EventStudioWorkspacePresentationContractTest extends UnitTestCase {
     $this->assertCount(3, $health['items']);
     $this->assertSame('Needs attention before homepage promotion', $health['items'][1]['value']);
     $this->assertSame('Not active', $health['items'][2]['value']);
+  }
+
+  public function testTopbarLocationContractUsesEventCardViewModel(): void {
+    $topbar = file_get_contents(dirname(__DIR__, 3) . '/templates/mel-event-studio-topbar.html.twig');
+    $presentation = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioWorkspacePresentation.php');
+    $this->assertIsString($topbar);
+    $this->assertIsString($presentation);
+    $this->assertStringContainsString('data-mel-topbar-location', $topbar);
+    $this->assertStringContainsString('buildTopbarLocation', $presentation);
+    $this->assertStringContainsString('eventCardViewModel', $presentation);
   }
 
   public function testPublishControllerUsesFacadeBundleForAjaxPayload(): void {

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceStateMatrixTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceStateMatrixTest.php
@@ -30,7 +30,9 @@ final class EventStudioWorkspaceStateMatrixTest extends UnitTestCase {
     );
     $homepageReadinessRender = (new ReflectionClass(\Drupal\myeventlane_event\Service\FeaturedEventReadinessRenderBuilder::class))
       ->newInstanceWithoutConstructor();
-    $this->presentation = new EventStudioWorkspacePresentation($dateFormatter, $homepageReadinessRender, $translator);
+    $eventCardViewModel = (new ReflectionClass(\Drupal\myeventlane_event\EventCard\EventCardViewModel::class))
+      ->newInstanceWithoutConstructor();
+    $this->presentation = new EventStudioWorkspacePresentation($dateFormatter, $homepageReadinessRender, $eventCardViewModel, $translator);
   }
 
   public function testDraftReadyShowsPublishStrip(): void {

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -4646,6 +4646,62 @@ function _myeventlane_theme_apply_event_page_style_theme_variables(array &$varia
 }
 
 /**
+ * Sets mel_venue, mel_address, mel_suburb, mel_lat, mel_lng for event templates.
+ */
+function _myeventlane_theme_apply_event_location_variables(array &$variables, NodeInterface $node): void {
+  $variables['mel_venue'] = _myeventlane_theme_event_primary_location_label($node);
+
+  $address_parts = [];
+  $variables['mel_suburb'] = NULL;
+  if ($node->hasField('field_location') && !$node->get('field_location')->isEmpty()) {
+    $loc = $node->get('field_location')->first();
+    if ($loc && method_exists($loc, 'getValue')) {
+      $raw = $loc->getValue();
+      if (is_array($raw)) {
+        $order = ['address_line1', 'address_line2', 'locality', 'administrative_area', 'postal_code', 'country_code'];
+        foreach ($order as $key) {
+          if (!empty($raw[$key]) && trim((string) $raw[$key]) !== '') {
+            $address_parts[] = trim((string) $raw[$key]);
+            if ($key === 'locality') {
+              $variables['mel_suburb'] = trim((string) $raw[$key]);
+            }
+          }
+        }
+        if (empty($address_parts)) {
+          $address_keys = [
+            'address_line1', 'address_line2', 'locality', 'dependent_locality',
+            'administrative_area', 'postal_code', 'sorting_code', 'organization',
+          ];
+          foreach ($address_keys as $key) {
+            if (!empty($raw[$key]) && trim((string) $raw[$key]) !== '') {
+              $address_parts[] = trim((string) $raw[$key]);
+              if ($key === 'locality') {
+                $variables['mel_suburb'] = trim((string) $raw[$key]);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  $variables['mel_address'] = !empty($address_parts) ? implode(', ', $address_parts) : NULL;
+
+  /** @var \Drupal\myeventlane_event\Service\EventGeoResolver $geo_resolver */
+  $geo_resolver = \Drupal::service('myeventlane_event.geo_resolver');
+  $geo = $geo_resolver->resolve($node);
+
+  $variables['mel_lat'] = $geo['lat'] ?? NULL;
+  $variables['mel_lng'] = $geo['lng'] ?? NULL;
+  $variables['mel_geo_source'] = $geo['source'] ?? 'none';
+
+  $variables['#attached']['drupalSettings']['myeventlaneLocationEvent'] = [
+    'latitude' => $variables['mel_lat'],
+    'longitude' => $variables['mel_lng'],
+    'title' => $node->label(),
+  ];
+}
+
+/**
  * Preprocess event nodes to resolve hero image safely.
  */
 function myeventlane_theme_preprocess_node__event(array &$variables): void {
@@ -4711,45 +4767,7 @@ function myeventlane_theme_preprocess_node__event(array &$variables): void {
   $variables['image_src'] = $image_url;
   $variables['mel_has_hero_image'] = (bool) $image_url;
 
-  // Location: primary label = venue entity, then field_venue_name, then field_location summary.
-  $variables['mel_venue'] = _myeventlane_theme_event_primary_location_label($node);
-
-  // Address: use getValue() array so locality/address_line1 are reliable.
-  $address_parts = [];
-  $variables['mel_suburb'] = NULL;
-  if ($node->hasField('field_location') && !$node->get('field_location')->isEmpty()) {
-    $loc = $node->get('field_location')->first();
-    if ($loc && method_exists($loc, 'getValue')) {
-      $raw = $loc->getValue();
-      if (is_array($raw)) {
-        $order = ['address_line1', 'address_line2', 'locality', 'administrative_area', 'postal_code', 'country_code'];
-        foreach ($order as $key) {
-          if (!empty($raw[$key]) && trim((string) $raw[$key]) !== '') {
-            $address_parts[] = trim((string) $raw[$key]);
-            if ($key === 'locality') {
-              $variables['mel_suburb'] = trim((string) $raw[$key]);
-            }
-          }
-        }
-        // Fallback: if no ordered parts, use any non-empty address key so we never drop data.
-        if (empty($address_parts)) {
-          $address_keys = [
-            'address_line1', 'address_line2', 'locality', 'dependent_locality',
-            'administrative_area', 'postal_code', 'sorting_code', 'organization',
-          ];
-          foreach ($address_keys as $key) {
-            if (!empty($raw[$key]) && trim((string) $raw[$key]) !== '') {
-              $address_parts[] = trim((string) $raw[$key]);
-              if ($key === 'locality') {
-                $variables['mel_suburb'] = trim((string) $raw[$key]);
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-  $variables['mel_address'] = !empty($address_parts) ? implode(', ', $address_parts) : NULL;
+  _myeventlane_theme_apply_event_location_variables($variables, $node);
 
   // Category label/slug for hero badge and Event Info card (first category term).
   $variables['mel_category_label'] = NULL;
@@ -4814,23 +4832,6 @@ function myeventlane_theme_preprocess_node__event(array &$variables): void {
       $variables['mel_age_policy_note'] = $note !== '' ? $note : NULL;
     }
   }
-
-  // Canonical geo resolution (single point): mel_lat, mel_lng, mel_geo_source.
-  /** @var \Drupal\myeventlane_event\Service\EventGeoResolver $geo_resolver */
-  $geo_resolver = \Drupal::service('myeventlane_event.geo_resolver');
-  $geo = $geo_resolver->resolve($node);
-
-  $variables['mel_lat'] = $geo['lat'] ?? NULL;
-  $variables['mel_lng'] = $geo['lng'] ?? NULL;
-  $variables['mel_geo_source'] = $geo['source'] ?? 'none';
-
-  // Ensure map JS has canonical coords available via drupalSettings.
-  // Provider settings are attached by myeventlane_location; we only ensure event coords are correct.
-  $variables['#attached']['drupalSettings']['myeventlaneLocationEvent'] = [
-    'latitude' => $variables['mel_lat'],
-    'longitude' => $variables['mel_lng'],
-    'title' => $node->label(),
-  ];
 
   // Public organiser trust data for Event Full (field_event_vendor → myeventlane_vendor).
   $variables['mel_organiser'] = NULL;
@@ -5008,6 +5009,7 @@ function myeventlane_theme_preprocess_node__event__full(array &$variables): void
   $node = $variables['node'] ?? NULL;
   if ($node instanceof NodeInterface) {
     _myeventlane_theme_apply_event_page_style_theme_variables($variables, $node);
+    _myeventlane_theme_apply_event_location_variables($variables, $node);
   }
   _myeventlane_theme_attach_event_sidebar_carousel($variables);
 }

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -129,7 +129,7 @@
           <h1 class="mel-event-hero__title" id="mel-event-title">{{ label }}</h1>
           {% set _hero_has_schedule = node.hasField('field_event_start') and not node.field_event_start.isEmpty %}
           {% set _hero_venue_entity = (node.hasField('field_venue') and not node.field_venue.isEmpty and node.field_venue.entity) ? node.field_venue.entity.label : '' %}
-          {% set _hero_venue_line = (node.hasField('field_venue_name') and not node.field_venue_name.isEmpty) ? node.field_venue_name.value|trim : _hero_venue_entity|trim %}
+          {% set _hero_venue_line = (node.hasField('field_venue_name') and not node.field_venue_name.isEmpty) ? node.field_venue_name.value|trim : (_hero_venue_entity|trim ?: mel_venue|default('')|trim) %}
           {% set _hero_has_location = _hero_venue_line is not empty %}
           {% if _hero_has_schedule or _hero_has_location %}
             <ul class="mel-event-hero__meta" role="list">
@@ -350,7 +350,7 @@
             {% set has_field_location = node.hasField('field_location') and not node.field_location.isEmpty %}
             {% set has_venue_name = node.hasField('field_venue_name') and not node.field_venue_name.isEmpty %}
             {% set venue_entity_label = (node.hasField('field_venue') and not node.field_venue.isEmpty and node.field_venue.entity) ? node.field_venue.entity.label : '' %}
-            {% set info_venue_line = has_venue_name ? node.field_venue_name.value|trim : venue_entity_label|trim %}
+            {% set info_venue_line = has_venue_name ? node.field_venue_name.value|trim : (venue_entity_label|trim ?: mel_venue|default('')|trim) %}
             {% set location_has_markup = content.field_location is defined and content.field_location|render|striptags|trim %}
             {% if info_venue_line is not empty or info_address is not empty or has_field_location %}
               {% set map_query = '' %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches event save, content moderation on unpublish, and branding hero file handling—important for vendor workflows but scoped mainly to Event Studio and display fields.
> 
> **Overview**
> **Event Studio location UX** surfaces venue/address in the **topbar** (with AJAX refresh after publish) and a **saved location summary** on the information workspace. Presentation reuses **`EventCardViewModel::getLocationLabel()`** and extends card location logic to fall back to **`address_line1`** when locality is missing.
> 
> **Save pipeline changes** populate **`field_venue_name`** from saved venue, new venue, or one-off address so heroes/cards show a line without a venue entity. **Unpublishing** now sets moderation to **`draft`** instead of **`archived`** so vendors can keep editing. Section-scoped saves carry **`mel_studio_section`**: full wizard save skips hero image unless the section is unset (branding-only), and content-section failures get a clearer wrapper message.
> 
> **Branding cover image** persistence is hardened—numeric fids, request/input/value merging, alt-only updates without clearing the file, explicit removal detection, and form validation when an upload cannot be resolved—with extra logging and unit tests.
> 
> **Information workspace** attaches a dedicated **location search → hidden field** JS library (parity with the legacy wizard). **Public event full** templates and theme preprocess share **`_myeventlane_theme_apply_event_location_variables()`** so hero and sidebar venue lines can use **`mel_venue`** when **`field_venue_name`** is empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b044fcc1f58413c436a3ac3f4f5f4903a649561. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->