### PR TITLE
feat(dashboard): enhance Pro subscription status display logic

### DIFF
--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
@@ -610,6 +610,8 @@ final class VendorDashboardController extends VendorConsoleBaseController {
             'status_label' => $status['status_label'],
             'state' => $status['state'],
             'has_active_subscription' => $status['has_active_subscription'],
+            'is_manual_pro' => $status['is_manual_pro'],
+            'is_in_grace' => $status['is_in_grace'],
             'can_cancel' => $status['can_cancel'],
             'renews_label' => $status['renews_label'] ?? NULL,
             'manage_url' => Url::fromRoute('myeventlane_pro.manage')->toString(),

--- a/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/dashboard/dashboard.html.twig
@@ -142,9 +142,23 @@
       </div>
 
       <ul class="mel-pro-panel__checklist" role="list">
-        <li class="mel-pro-panel__check mel-pro-panel__check--on">
-          <span class="mel-pro-panel__check-mark" aria-hidden="true">✓</span>{{ 'Pro subscription active'|t }}
-        </li>
+        {% if pro_status.has_active_subscription|default(false) %}
+          <li class="mel-pro-panel__check mel-pro-panel__check--on">
+            <span class="mel-pro-panel__check-mark" aria-hidden="true">✓</span>{{ 'Pro subscription active'|t }}
+          </li>
+        {% elseif pro_status.is_manual_pro|default(false) %}
+          <li class="mel-pro-panel__check mel-pro-panel__check--on">
+            <span class="mel-pro-panel__check-mark" aria-hidden="true">✓</span>{{ 'Manual Pro access'|t }}
+          </li>
+        {% elseif pro_status.is_in_grace|default(false) %}
+          <li class="mel-pro-panel__check mel-pro-panel__check--on">
+            <span class="mel-pro-panel__check-mark" aria-hidden="true">✓</span>{{ 'Pro access in grace period'|t }}
+          </li>
+        {% else %}
+          <li class="mel-pro-panel__check mel-pro-panel__check--on">
+            <span class="mel-pro-panel__check-mark" aria-hidden="true">✓</span>{{ 'Pro access active'|t }}
+          </li>
+        {% endif %}
         <li class="mel-pro-panel__check mel-pro-panel__check--on">
           <span class="mel-pro-panel__check-mark" aria-hidden="true">✓</span>{{ 'Premium features enabled'|t }}
         </li>


### PR DESCRIPTION
- Updated dashboard template to conditionally display Pro subscription status based on various conditions (active, manual access, grace period).
- Modified VendorDashboardController to include additional status flags for improved subscription management.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only copy and two additional template variables; no changes to Pro entitlement or billing behavior.
> 
> **Overview**
> Pro vendors no longer always see **“Pro subscription active”** in the dashboard confirmation checklist. The first checklist line now reflects **how** Pro access was granted: paid subscription, admin **manual Pro**, **grace period** after billing issues, or a generic **Pro access active** fallback.
> 
> `VendorDashboardController` forwards **`is_manual_pro`** and **`is_in_grace`** from `ProSubscriptionStatusService::getStatusForUser()` into the existing `pro_status` Twig variable so the template can branch without recomputing entitlement logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8a981dec1b69ee2299548f3524cb4cf86bf1277. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->