### PR TITLE
Fix Drupal 11 authenticated role handling in continuity kernel test

### DIFF
--- a/web/modules/custom/myeventlane_surface/tests/src/Kernel/MelExperienceContinuityKernelTest.php
+++ b/web/modules/custom/myeventlane_surface/tests/src/Kernel/MelExperienceContinuityKernelTest.php
@@ -55,7 +55,6 @@ final class MelExperienceContinuityKernelTest extends MelSurfaceGovernanceKernel
       'mail' => $this->randomMachineName() . '@example.com',
       'status' => 1,
     ]);
-    $user->addRole('authenticated');
     $user->save();
     $this->setCurrentUser($user);
     $this->pushRouteRequest('/checkout/order', 'commerce_checkout.order_information', new Route('/checkout/order'));


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line test-only change with no production or runtime behavior impact.
> 
> **Overview**
> Fixes **Drupal 11** kernel test breakage in `MelExperienceContinuityKernelTest::testCommerceCheckoutPrimaryWorkflowBandDeferred` by removing the explicit `$user->addRole('authenticated')` call before save.
> 
> The test still creates an active user and uses `setCurrentUser($user)` to exercise commerce checkout workflow attachments; only the disallowed manual **authenticated** role assignment is removed, matching the pattern already documented elsewhere in the same file for lightweight kernel setups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7eb97327884a3d98c118067f00ecd24c8e9b615. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->