### PR TITLE
fix(studio): branding hero upload UX and persistence

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-branding.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-branding.css
@@ -249,6 +249,54 @@
   color: var(--mel-studio-text);
 }
 
+.mel-es-branding-upload-notice {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.85rem 1rem;
+  margin-block: 0.75rem 0;
+  border-radius: 10px;
+  border: 1px solid rgba(110, 126, 242, 0.35);
+  background: rgba(248, 250, 255, 0.98);
+  color: var(--mel-studio-text);
+}
+
+.mel-es-branding-upload-notice.is-error {
+  border-color: rgba(214, 69, 69, 0.55);
+  background: rgba(255, 241, 241, 0.98);
+}
+
+.mel-es-branding-upload-notice.is-success {
+  border-color: rgba(46, 125, 50, 0.45);
+  background: rgba(237, 247, 237, 0.98);
+}
+
+.mel-es-branding-upload-notice__title {
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 700;
+}
+
+.mel-es-branding-upload-notice__steps {
+  margin: 0;
+  padding-inline-start: 1.25rem;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--mel-studio-muted);
+}
+
+.mel-es-branding-upload-notice__step.is-active {
+  color: var(--mel-studio-text);
+  font-weight: 600;
+}
+
+.mel-es-branding-upload-notice__message {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  color: var(--mel-studio-text);
+}
+
 .mel-es-branding-crop-notice.is-error {
   border-color: rgba(214, 69, 69, 0.55);
   background: rgba(255, 241, 241, 0.98);

--- a/web/modules/custom/myeventlane_event_studio/js/mel-branding-hero-tools.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-branding-hero-tools.js
@@ -14,6 +14,219 @@
 
   const CROP_ATTENTION_CLASS = "mel-es-branding-crop-wrapper--attention";
 
+  const UPLOAD_STATE_EMPTY = "empty";
+  const UPLOAD_STATE_PENDING = "pending_upload";
+  const UPLOAD_STATE_UPLOADED = "uploaded";
+
+  /**
+   * @param {HTMLElement} root
+   * @returns {HTMLInputElement|null}
+   */
+  function findHeroFileInput(root) {
+    const input = root.querySelector(
+      'input[type="file"][name*="field_event_image"]',
+    );
+    return input instanceof HTMLInputElement ? input : null;
+  }
+
+  /**
+   * @param {HTMLElement} root
+   * @returns {HTMLElement|null}
+   */
+  function findUploadNotice(root) {
+    const notice = root.querySelector("#mel-es-branding-upload-notice");
+    return notice instanceof HTMLElement ? notice : null;
+  }
+
+  /**
+   * @param {HTMLFormElement|null} form
+   * @returns {boolean}
+   */
+  function hasAltText(form) {
+    if (!form) {
+      return false;
+    }
+    const alt = form.querySelector('[name="mel[field_event_image_alt]"]');
+    if (!(alt instanceof HTMLInputElement || alt instanceof HTMLTextAreaElement)) {
+      return false;
+    }
+    return String(alt.value || "").trim() !== "";
+  }
+
+  /**
+   * @param {HTMLFormElement|null} form
+   * @returns {HTMLInputElement|null}
+   */
+  function findAltField(form) {
+    if (!form) {
+      return null;
+    }
+    const alt = form.querySelector('[name="mel[field_event_image_alt]"]');
+    return alt instanceof HTMLInputElement ? alt : null;
+  }
+
+  /**
+   * @param {HTMLElement} root
+   * @returns {boolean}
+   */
+  function isPendingUpload(root) {
+    if (hasUploadedHeroFile(root)) {
+      return false;
+    }
+    const fileInput = findHeroFileInput(root);
+    return !!(fileInput && fileInput.files && fileInput.files.length > 0);
+  }
+
+  /**
+   * @param {HTMLElement} root
+   * @returns {string}
+   */
+  function resolveUploadState(root) {
+    if (hasUploadedHeroFile(root)) {
+      return UPLOAD_STATE_UPLOADED;
+    }
+    if (isPendingUpload(root)) {
+      return UPLOAD_STATE_PENDING;
+    }
+    return UPLOAD_STATE_EMPTY;
+  }
+
+  /**
+   * @param {HTMLElement} root
+   * @returns {boolean}
+   */
+  function hasHeroPreviewWithoutFid(root) {
+    if (hasUploadedHeroFile(root)) {
+      return false;
+    }
+    const preview = root.querySelector(
+      ".image-widget .preview img, .file--image img, .form-managed-file .file img",
+    );
+    return preview instanceof HTMLImageElement && String(preview.src || "").trim() !== "";
+  }
+
+  /**
+   * @param {HTMLElement} root
+   * @param {HTMLFormElement|null} form
+   */
+  function syncUploadNotice(root, form) {
+    const notice = findUploadNotice(root);
+    if (!notice) {
+      return;
+    }
+
+    const state = resolveUploadState(root);
+    const previousState = root.dataset.melHeroUploadState || "";
+    if (state === UPLOAD_STATE_UPLOADED && previousState !== UPLOAD_STATE_UPLOADED) {
+      root.dataset.melHeroUploadPendingSave = "1";
+    }
+    if (state === UPLOAD_STATE_EMPTY) {
+      delete root.dataset.melHeroUploadPendingSave;
+    }
+    root.dataset.melHeroUploadState = state;
+
+    const checklist = notice.querySelector(".mel-es-branding-upload-notice__steps");
+    const message = notice.querySelector(".mel-es-branding-upload-notice__message");
+    notice.classList.remove("is-error", "is-success");
+
+    let shouldShow = false;
+
+    if (state === UPLOAD_STATE_PENDING) {
+      shouldShow = true;
+      notice.classList.add("is-error");
+      if (checklist instanceof HTMLElement) {
+        checklist.hidden = true;
+      }
+      if (message instanceof HTMLElement) {
+        message.hidden = false;
+        message.textContent = Drupal.t(
+          "Click Upload before Save branding. Upload alone does not publish your cover.",
+        );
+      }
+      notice.querySelectorAll("[data-upload-step]").forEach((step) => {
+        step.classList.toggle(
+          "is-active",
+          step.getAttribute("data-upload-step") === "upload",
+        );
+      });
+    }
+    else if (hasHeroPreviewWithoutFid(root)) {
+      shouldShow = true;
+      notice.classList.add("is-error");
+      if (checklist instanceof HTMLElement) {
+        checklist.hidden = true;
+      }
+      if (message instanceof HTMLElement) {
+        message.hidden = false;
+        message.textContent = Drupal.t(
+          "Upload may not have finished — click Upload again, then Save branding.",
+        );
+      }
+    }
+    else if (state === UPLOAD_STATE_UPLOADED) {
+      const needsAlt = !hasAltText(form);
+      const pendingSave = root.dataset.melHeroUploadPendingSave === "1";
+      shouldShow = needsAlt || pendingSave;
+      if (shouldShow) {
+        notice.classList.add(needsAlt ? "is-error" : "is-success");
+        if (checklist instanceof HTMLElement) {
+          checklist.hidden = true;
+        }
+        if (message instanceof HTMLElement) {
+          message.hidden = false;
+          message.textContent = needsAlt
+            ? Drupal.t(
+                "Cover uploaded — add alt text, then click Save branding.",
+              )
+            : Drupal.t(
+                "Cover ready — click Save branding to publish it on your event page.",
+              );
+        }
+        notice.querySelectorAll("[data-upload-step]").forEach((step) => {
+          step.classList.toggle(
+            "is-active",
+            step.getAttribute("data-upload-step") === "save",
+          );
+        });
+      }
+    }
+    else if (state === UPLOAD_STATE_EMPTY) {
+      shouldShow = true;
+      if (checklist instanceof HTMLElement) {
+        checklist.hidden = false;
+      }
+      if (message instanceof HTMLElement) {
+        message.hidden = true;
+      }
+      notice.querySelectorAll("[data-upload-step]").forEach((step) => {
+        step.classList.toggle(
+          "is-active",
+          step.getAttribute("data-upload-step") === "choose",
+        );
+      });
+    }
+
+    notice.hidden = !shouldShow;
+  }
+
+  /**
+   * @param {HTMLElement} root
+   */
+  function bindHeroFileInput(root) {
+    const fileInput = findHeroFileInput(root);
+    if (!fileInput) {
+      return;
+    }
+    if (fileInput.dataset.melHeroFileInputBound === "1") {
+      return;
+    }
+    fileInput.dataset.melHeroFileInputBound = "1";
+    fileInput.addEventListener("change", () => {
+      const form = root.closest("form");
+      syncUploadNotice(root, form instanceof HTMLFormElement ? form : null);
+    });
+  }
+
   /**
    * @returns {string}
    */
@@ -292,6 +505,9 @@
   }
 
   /**
+   * Advisory crop guidance (notice UI). Not used to block save — studio_branding
+   * has crop_types_required empty; Drupal only hard-fails when the widget is .error.
+   *
    * @param {HTMLElement} root
    * @returns {boolean}
    */
@@ -299,29 +515,48 @@
     if (!hasUploadedHeroFile(root)) {
       return false;
     }
-    const wrapper = findCropWrapper(root);
-    if (wrapper && wrapper.classList.contains("error")) {
+    if (hasCropValidationError(root)) {
       return true;
     }
     return !isCropApplied(root);
   }
 
   /**
+   * Whether Save branding must be blocked for crop validation (server/widget error).
+   *
+   * @param {HTMLElement} root
+   * @returns {boolean}
+   */
+  function cropBlocksSave(root) {
+    return hasUploadedHeroFile(root) && hasCropValidationError(root);
+  }
+
+  /**
    * @param {HTMLElement} root
    */
   function syncCropRequiredNotice(root) {
-    const notice = root.querySelector(".mel-es-branding-crop-notice");
+    const notice = root.querySelector("#mel-es-branding-crop-notice");
     const wrapper = findCropWrapper(root);
     const needsAttention = cropNeedsAttention(root);
     const hasError = !!(wrapper && wrapper.classList.contains("error"));
 
-    if (notice) {
+    if (notice instanceof HTMLElement) {
       const shouldHide = !needsAttention;
       if (notice.hidden !== shouldHide) {
         notice.hidden = shouldHide;
       }
       if (notice.classList.contains("is-error") !== hasError) {
         notice.classList.toggle("is-error", hasError);
+      }
+      const text = notice.querySelector(".mel-es-branding-crop-notice__text");
+      if (text instanceof HTMLElement) {
+        text.textContent = hasError
+          ? Drupal.t(
+              "Cover crop is required — apply the 16:9 crop, then save branding.",
+            )
+          : Drupal.t(
+              "Apply the 16:9 crop under your cover image before saving branding.",
+            );
       }
     }
 
@@ -385,7 +620,7 @@
    */
   function scrollToBrandingFormIssue(root) {
     const cropIssue = root.querySelector(
-      ".image-data__crop-wrapper.error, .mel-es-branding-crop-wrapper--attention, .mel-es-branding-crop-notice:not([hidden])",
+      "#mel-es-branding-upload-notice:not([hidden]), #mel-es-branding-crop-notice:not([hidden]), .image-data__crop-wrapper.error, .mel-es-branding-crop-wrapper--attention",
     );
     if (cropIssue) {
       cropIssue.scrollIntoView({ behavior: "smooth", block: "center" });
@@ -451,6 +686,7 @@
    * @param {HTMLElement} root
    */
   function syncHeroToolStrip(root) {
+    const form = root.closest("form");
     const focal = findFocalField(root);
     const presets = root.querySelector(".mel-es-branding-hero-focal-presets");
     const framing = root.querySelector(".mel-es-branding-hero-framing");
@@ -484,6 +720,8 @@
     }
 
     syncCropRequiredNotice(root);
+    syncUploadNotice(root, form instanceof HTMLFormElement ? form : null);
+    bindHeroFileInput(root);
   }
 
   /**
@@ -602,13 +840,66 @@
                 if (!isSaveBrandingSubmit(event)) {
                   return;
                 }
-                if (cropNeedsAttention(root) || hasCropValidationError(root)) {
+                if (isPendingUpload(root)) {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  syncUploadNotice(
+                    root,
+                    form instanceof HTMLFormElement ? form : null,
+                  );
+                  scrollToBrandingFormIssue(root);
+                  return;
+                }
+                if (hasHeroPreviewWithoutFid(root)) {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  syncUploadNotice(
+                    root,
+                    form instanceof HTMLFormElement ? form : null,
+                  );
+                  scrollToBrandingFormIssue(root);
+                  return;
+                }
+                if (
+                  hasUploadedHeroFile(root)
+                  && !hasAltText(form instanceof HTMLFormElement ? form : null)
+                ) {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  syncUploadNotice(
+                    root,
+                    form instanceof HTMLFormElement ? form : null,
+                  );
+                  const alt = findAltField(
+                    form instanceof HTMLFormElement ? form : null,
+                  );
+                  if (alt) {
+                    alt.focus();
+                    alt.scrollIntoView({ behavior: "smooth", block: "center" });
+                  }
+                  return;
+                }
+                if (cropBlocksSave(root)) {
+                  event.preventDefault();
+                  event.stopPropagation();
                   syncCropRequiredNotice(root);
                   scrollToBrandingFormIssue(root);
                 }
               },
               true,
             );
+            const altField = findAltField(
+              form instanceof HTMLFormElement ? form : null,
+            );
+            if (altField && !altField.dataset.melHeroAltBound) {
+              altField.dataset.melHeroAltBound = "1";
+              altField.addEventListener("input", () => {
+                syncUploadNotice(
+                  root,
+                  form instanceof HTMLFormElement ? form : null,
+                );
+              });
+            }
           }
 
           const focal = findFocalField(root);

--- a/web/modules/custom/myeventlane_event_studio/js/mel-branding-hero-tools.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-branding-hero-tools.js
@@ -66,13 +66,14 @@
   }
 
   /**
+   * True when the native file input still holds a chosen file (Upload not clicked).
+   *
+   * Checked before existing fids so replacing a saved cover is also guarded.
+   *
    * @param {HTMLElement} root
    * @returns {boolean}
    */
   function isPendingUpload(root) {
-    if (hasUploadedHeroFile(root)) {
-      return false;
-    }
     const fileInput = findHeroFileInput(root);
     return !!(fileInput && fileInput.files && fileInput.files.length > 0);
   }
@@ -82,11 +83,11 @@
    * @returns {string}
    */
   function resolveUploadState(root) {
-    if (hasUploadedHeroFile(root)) {
-      return UPLOAD_STATE_UPLOADED;
-    }
     if (isPendingUpload(root)) {
       return UPLOAD_STATE_PENDING;
+    }
+    if (hasUploadedHeroFile(root)) {
+      return UPLOAD_STATE_UPLOADED;
     }
     return UPLOAD_STATE_EMPTY;
   }
@@ -126,7 +127,7 @@
     ) {
       root.dataset.melHeroUploadPendingSave = "1";
     }
-    if (state === UPLOAD_STATE_EMPTY) {
+    if (state === UPLOAD_STATE_EMPTY || state === UPLOAD_STATE_PENDING) {
       delete root.dataset.melHeroUploadPendingSave;
     }
     root.dataset.melHeroUploadState = state;

--- a/web/modules/custom/myeventlane_event_studio/js/mel-branding-hero-tools.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-branding-hero-tools.js
@@ -117,7 +117,13 @@
 
     const state = resolveUploadState(root);
     const previousState = root.dataset.melHeroUploadState || "";
-    if (state === UPLOAD_STATE_UPLOADED && previousState !== UPLOAD_STATE_UPLOADED) {
+    // Only flag pending save after an in-session transition (e.g. pending → uploaded).
+    // Initial attach with an already-saved cover has previousState "" and must not prompt again.
+    if (
+      state === UPLOAD_STATE_UPLOADED
+      && previousState !== ""
+      && previousState !== UPLOAD_STATE_UPLOADED
+    ) {
       root.dataset.melHeroUploadPendingSave = "1";
     }
     if (state === UPLOAD_STATE_EMPTY) {

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -107,7 +107,7 @@ mel_customer_operational_experience:
     - core/drupal
 
 mel_branding_hero_tools:
-  version: 1.3
+  version: 1.6
   js:
     js/mel-branding-hero-tools.js: {}
   dependencies:
@@ -117,7 +117,7 @@ mel_branding_hero_tools:
     - focal_point/drupal.focal_point
 
 mel_branding_workspace:
-  version: 1.4
+  version: 1.5
   css:
     theme:
       css/mel-event-studio-branding.css: {}

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -107,7 +107,7 @@ mel_customer_operational_experience:
     - core/drupal
 
 mel_branding_hero_tools:
-  version: 1.6
+  version: 1.7
   js:
     js/mel-branding-hero-tools.js: {}
   dependencies:

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -107,7 +107,7 @@ mel_customer_operational_experience:
     - core/drupal
 
 mel_branding_hero_tools:
-  version: 1.7
+  version: 1.8
   js:
     js/mel-branding-hero-tools.js: {}
   dependencies:

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
@@ -202,7 +202,41 @@ final class EventBrandingForm extends EventStudioBaseForm {
       );
     }
 
+    $this->validateBrandingHeroPendingUpload($form_state, $mel_for_hero);
     $this->validateBrandingHeroUploadResolution($form_state, $mel_for_hero);
+  }
+
+  /**
+   * Blocks save when a file was chosen but Upload was not clicked (managed_file pattern).
+   *
+   * @param array<string, mixed> $mel_for_hero
+   */
+  private function validateBrandingHeroPendingUpload(FormStateInterface $form_state, array $mel_for_hero): void {
+    $hero = EventStudioMelPayloadService::normalizeHeroFromMelFragment($mel_for_hero);
+    if ($hero['fid'] > 0) {
+      return;
+    }
+
+    $request = $this->requestStack->getCurrentRequest();
+    if ($request === NULL) {
+      return;
+    }
+
+    $files = $request->files->all();
+    $upload = $files['files']['mel_field_event_image_0'] ?? NULL;
+    if ($upload === NULL) {
+      return;
+    }
+
+    $original_name = trim((string) $upload->getClientOriginalName());
+    if ($original_name === '') {
+      return;
+    }
+
+    $form_state->setErrorByName(
+      'mel][field_event_image',
+      $this->t('Click Upload before Save branding. Upload alone does not publish your cover.')
+    );
   }
 
   /**
@@ -216,6 +250,12 @@ final class EventBrandingForm extends EventStudioBaseForm {
       return;
     }
     $input_fragment = $user_mel['field_event_image'] ?? NULL;
+    if (!is_array($input_fragment)) {
+      $wrapper = $user_mel['field_event_image_wrapper']['widget'] ?? NULL;
+      if (is_array($wrapper)) {
+        $input_fragment = $wrapper;
+      }
+    }
     if (!is_array($input_fragment)) {
       return;
     }
@@ -291,7 +331,7 @@ final class EventBrandingForm extends EventStudioBaseForm {
         . '<header class="mel-es-field-group__header">'
         . '<h3 class="mel-es-field-group__title" id="mel-es-branding-title">' . Html::escape((string) $this->t('Branding')) . '</h3>'
         . '<p class="mel-es-field-group__hint">' . Html::escape((string) $this->t('Shape how your event appears across MyEventLane and social sharing.')) . '</p>'
-        . '<p class="mel-es-field-group__reassurance">' . Html::escape((string) $this->t('Set the focus for your public event and book page heroes (16:9). Click the image or use shortcuts, then save branding. Alt text is required when a cover image is present.')) . '</p>'
+        . '<p class="mel-es-field-group__reassurance">' . Html::escape((string) $this->t('Choose a photo, click Upload, add alt text, then Save branding. Upload alone does not publish your cover. Set focal shortcuts after upload if you need to adjust the 16:9 hero.')) . '</p>'
         . '</header>'
         . '<div class="mel-es-field-group__body">'
         . '<div class="mel-identity-media mel-identity-media--compact">'
@@ -338,6 +378,71 @@ final class EventBrandingForm extends EventStudioBaseForm {
         $this->brandingHeroFocalAugmenter->attachAfterBuild($form['mel']['field_event_image'], $formNode, $focal_override);
       }
     }
+
+    $main['branding_hero_upload_notice'] = [
+      '#type' => 'container',
+      '#attributes' => [
+        'id' => 'mel-es-branding-upload-notice',
+        'class' => ['mel-es-branding-upload-notice'],
+        'hidden' => 'hidden',
+        'aria-live' => 'polite',
+      ],
+      '#weight' => 1,
+      'title' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#attributes' => ['class' => ['mel-es-branding-upload-notice__title']],
+        '#value' => Html::escape((string) $this->t('Cover image')),
+      ],
+      'checklist' => [
+        '#type' => 'html_tag',
+        '#tag' => 'ol',
+        '#attributes' => ['class' => ['mel-es-branding-upload-notice__steps']],
+        '#value' => Markup::create(
+          '<li class="mel-es-branding-upload-notice__step" data-upload-step="choose">'
+          . Html::escape((string) $this->t('Choose a landscape photo (at least 400×200 px).'))
+          . '</li>'
+          . '<li class="mel-es-branding-upload-notice__step" data-upload-step="upload">'
+          . Html::escape((string) $this->t('Click Upload and wait for the preview to appear.'))
+          . '</li>'
+          . '<li class="mel-es-branding-upload-notice__step" data-upload-step="save">'
+          . Html::escape((string) $this->t('Add alt text, then click Save branding.'))
+          . '</li>'
+        ),
+      ],
+      'message' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#attributes' => [
+          'class' => ['mel-es-branding-upload-notice__message'],
+          'hidden' => 'hidden',
+        ],
+        '#value' => '',
+      ],
+    ];
+
+    $main['branding_hero_crop_notice'] = [
+      '#type' => 'container',
+      '#attributes' => [
+        'id' => 'mel-es-branding-crop-notice',
+        'class' => ['mel-es-branding-crop-notice'],
+        'hidden' => 'hidden',
+        'aria-live' => 'polite',
+      ],
+      '#weight' => 2,
+      'title' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#attributes' => ['class' => ['mel-es-branding-crop-notice__title']],
+        '#value' => Html::escape((string) $this->t('Cover crop')),
+      ],
+      'text' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#attributes' => ['class' => ['mel-es-branding-crop-notice__text']],
+        '#value' => Html::escape((string) $this->t('Apply the 16:9 crop under your cover image before saving branding.')),
+      ],
+    ];
 
     $main['field_event_image_alt'] = [
       '#type' => 'textfield',

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
@@ -244,22 +244,15 @@ final class EventBrandingForm extends EventStudioBaseForm {
     if (!is_array($user_mel)) {
       return;
     }
-    $input_fragment = $user_mel['field_event_image'] ?? NULL;
-    if (!is_array($input_fragment)) {
-      $wrapper = $user_mel['field_event_image_wrapper']['widget'] ?? NULL;
-      if (is_array($wrapper)) {
-        $input_fragment = $wrapper;
-      }
-    }
-    if (!is_array($input_fragment)) {
+
+    $input_fragment = $this->brandingHeroInputFragmentWithFid($user_mel);
+    if ($input_fragment === NULL) {
       return;
     }
+
     $input_fid = EventStudioMelPayloadService::normalizeHeroFromMelFragment([
       'field_event_image' => $input_fragment,
     ])['fid'];
-    if ($input_fid < 1) {
-      return;
-    }
     $resolved_fid = EventStudioMelPayloadService::normalizeHeroFromMelFragment($mel_for_hero)['fid'];
     if ($resolved_fid > 0) {
       return;
@@ -268,6 +261,44 @@ final class EventBrandingForm extends EventStudioBaseForm {
       'mel][field_event_image',
       $this->t('The event image could not be saved. Please reselect the image.')
     );
+  }
+
+  /**
+   * Resolves the submitted hero image fragment that contains an uploaded fid.
+   *
+   * image_widget_crop can submit an empty direct field array while the uploaded
+   * file data lives under field_event_image_wrapper.widget.
+   *
+   * @param array<string, mixed> $user_mel
+   *
+   * @return array<string, mixed>|null
+   */
+  private function brandingHeroInputFragmentWithFid(array $user_mel): ?array {
+    $candidates = [];
+    if (isset($user_mel['field_event_image']) && is_array($user_mel['field_event_image'])) {
+      $candidates[] = $user_mel['field_event_image'];
+    }
+
+    $wrapper = $user_mel['field_event_image_wrapper'] ?? NULL;
+    if (is_array($wrapper)) {
+      if (isset($wrapper['widget']) && is_array($wrapper['widget'])) {
+        $candidates[] = $wrapper['widget'];
+      }
+      if (isset($wrapper[0]) && is_array($wrapper[0])) {
+        $candidates[] = $wrapper;
+      }
+    }
+
+    foreach ($candidates as $fragment) {
+      $fid = EventStudioMelPayloadService::normalizeHeroFromMelFragment([
+        'field_event_image' => $fragment,
+      ])['fid'];
+      if ($fid > 0) {
+        return $fragment;
+      }
+    }
+
+    return NULL;
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventBrandingForm.php
@@ -202,21 +202,16 @@ final class EventBrandingForm extends EventStudioBaseForm {
       );
     }
 
-    $this->validateBrandingHeroPendingUpload($form_state, $mel_for_hero);
+    $this->validateBrandingHeroPendingUpload($form_state);
     $this->validateBrandingHeroUploadResolution($form_state, $mel_for_hero);
   }
 
   /**
    * Blocks save when a file was chosen but Upload was not clicked (managed_file pattern).
    *
-   * @param array<string, mixed> $mel_for_hero
+   * Applies even when a previous cover fid is still in the form (replace-without-upload).
    */
-  private function validateBrandingHeroPendingUpload(FormStateInterface $form_state, array $mel_for_hero): void {
-    $hero = EventStudioMelPayloadService::normalizeHeroFromMelFragment($mel_for_hero);
-    if ($hero['fid'] > 0) {
-      return;
-    }
-
+  private function validateBrandingHeroPendingUpload(FormStateInterface $form_state): void {
     $request = $this->requestStack->getCurrentRequest();
     if ($request === NULL) {
       return;

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -1395,8 +1395,8 @@ final class EventStudioSaveService {
     if (!is_array($mel_input)) {
       $mel_input = [];
     }
-    $from_input = $mel_input['field_event_image'] ?? NULL;
-    if (!is_array($from_input) || !$this->brandingHeroMelFragmentHasAuthoritativeInput($from_input)) {
+    $from_input = $this->brandingHeroMelFieldFragmentFromMelArray($mel_input);
+    if ($from_input === NULL) {
       $from_request = $this->brandingHeroMelFieldFragmentFromRequest();
       if ($from_request === NULL) {
         return;
@@ -1546,8 +1546,11 @@ final class EventStudioSaveService {
     $fragments = [];
     $user_input = $form_state->getUserInput();
     $user_mel = is_array($user_input) ? ($user_input['mel'] ?? NULL) : NULL;
-    if (is_array($user_mel['field_event_image'] ?? NULL)) {
-      $fragments[] = $user_mel['field_event_image'];
+    if (is_array($user_mel)) {
+      $user_fragment = $this->brandingHeroMelFieldFragmentFromMelArray($user_mel);
+      if (is_array($user_fragment)) {
+        $fragments[] = $user_fragment;
+      }
     }
 
     $request_fragment = $this->brandingHeroMelFieldFragmentFromRequest();
@@ -1556,8 +1559,11 @@ final class EventStudioSaveService {
     }
 
     $values_mel = $form_state->getValue('mel');
-    if (is_array($values_mel['field_event_image'] ?? NULL)) {
-      $fragments[] = $values_mel['field_event_image'];
+    if (is_array($values_mel)) {
+      $values_fragment = $this->brandingHeroMelFieldFragmentFromMelArray($values_mel);
+      if (is_array($values_fragment)) {
+        $fragments[] = $values_fragment;
+      }
     }
 
     return $fragments;
@@ -1596,11 +1602,41 @@ final class EventStudioSaveService {
     if (!is_array($request_mel)) {
       return NULL;
     }
-    $fragment = $request_mel['field_event_image'] ?? NULL;
-    if (!is_array($fragment) || !$this->brandingHeroMelFragmentHasAuthoritativeInput($fragment)) {
-      return NULL;
+    return $this->brandingHeroMelFieldFragmentFromMelArray($request_mel);
+  }
+
+  /**
+   * Resolves a hero widget fragment from a mel array (direct or wrapper paths).
+   *
+   * image_widget_crop can leave values under field_event_image_wrapper.widget while
+   * POST field names still use mel[field_event_image][…].
+   *
+   * @param array<string, mixed> $mel
+   *
+   * @return array<string, mixed>|null
+   */
+  private function brandingHeroMelFieldFragmentFromMelArray(array $mel): ?array {
+    $candidates = [];
+    if (isset($mel['field_event_image']) && is_array($mel['field_event_image'])) {
+      $candidates[] = $mel['field_event_image'];
     }
-    return $fragment;
+    $wrapper = $mel['field_event_image_wrapper'] ?? NULL;
+    if (is_array($wrapper)) {
+      if (isset($wrapper['widget']) && is_array($wrapper['widget'])) {
+        $candidates[] = $wrapper['widget'];
+      }
+      if (isset($wrapper[0]) && is_array($wrapper[0])) {
+        $candidates[] = $wrapper;
+      }
+    }
+
+    foreach ($candidates as $fragment) {
+      if ($this->brandingHeroMelFragmentHasAuthoritativeInput($fragment)) {
+        return $fragment;
+      }
+    }
+
+    return NULL;
   }
 
   /**


### PR DESCRIPTION
...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes event cover persistence and validation paths for a user-facing save flow; mistakes could block valid saves or miss bad uploads, but scope is limited to Event Studio branding.
> 
> **Overview**
> Event Studio **branding** now walks organisers through cover upload as choose → **Upload** → alt text → **Save branding**, with live notices and stricter guards so Save alone cannot publish an unstaged file.
> 
> **Client-side**, `mel-branding-hero-tools.js` adds upload-state tracking, a `#mel-es-branding-upload-notice` checklist/messages (styled in CSS), and intercepts **Save branding** when a file is still pending upload, preview exists without a fid, alt text is missing, or the crop widget is in `.error`. Unapplied 16:9 crop stays **advisory** (notice only); save is blocked only on real crop validation errors. Crop guidance moves to a dedicated `#mel-es-branding-crop-notice` with dynamic copy.
> 
> **Server-side**, `EventBrandingForm` renders those notice containers, updates hero copy, rejects save when a file is in the request but not uploaded (`validateBrandingHeroPendingUpload`), and resolves hero fids from `image_widget_crop` wrapper paths for upload-resolution validation. `EventStudioSaveService` uses the same wrapper-aware fragment resolution when syncing submitted hero values into form state so persistence matches what the widget actually posted. Library versions are bumped for cache busting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50ced689a538ef4c53a30844e496e95486414431. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->