### PR TITLE
fix: complete launch readiness remediation

### DIFF
--- a/web/modules/custom/myeventlane_core/src/MelReadinessHelper.php
+++ b/web/modules/custom/myeventlane_core/src/MelReadinessHelper.php
@@ -535,6 +535,10 @@ final class MelReadinessHelper {
     return (string) $this->t('Confirmation sent to @email.', ['@email' => $email]);
   }
 
+  public function customerCheckoutPendingPaymentEmailLine(string $email): string {
+    return (string) $this->t('We’ll email @email once payment has been confirmed.', ['@email' => $email]);
+  }
+
   public function customerCheckoutOrderNumberLine(string $order_number): string {
     return (string) $this->t('Order #@number', ['@number' => $order_number]);
   }

--- a/web/modules/custom/myeventlane_pro/src/EventSubscriber/ProUpgradeRedirectSubscriber.php
+++ b/web/modules/custom/myeventlane_pro/src/EventSubscriber/ProUpgradeRedirectSubscriber.php
@@ -59,6 +59,12 @@ final class ProUpgradeRedirectSubscriber implements EventSubscriberInterface {
       return;
     }
 
+    // Admin/staff routes should keep Drupal's normal admin denial experience,
+    // not the vendor Pro upgrade funnel.
+    if ($this->isAdminRoute($route) || $this->currentUserHasAdminRoutePermission($route)) {
+      return;
+    }
+
     // Anonymous users follow the normal denial flow (e.g. redirect to login).
     if (!$this->currentUser->isAuthenticated()) {
       return;
@@ -85,6 +91,36 @@ final class ProUpgradeRedirectSubscriber implements EventSubscriberInterface {
 
     $event->setResponse(new RedirectResponse($url));
     $event->stopPropagation();
+  }
+
+  private function isAdminRoute(Route $route): bool {
+    if ((bool) $route->getOption('_admin_route')) {
+      return TRUE;
+    }
+
+    return str_starts_with($route->getPath(), '/admin/');
+  }
+
+  private function currentUserHasAdminRoutePermission(Route $route): bool {
+    $requirement = $route->getRequirement('_permission');
+    if (!is_string($requirement) || $requirement === '') {
+      return FALSE;
+    }
+
+    $permissions = preg_split('/[,+]/', $requirement) ?: [];
+    foreach ($permissions as $permission) {
+      $permission = trim($permission);
+      if ($this->isAdminPermission($permission) && $this->currentUser->hasPermission($permission)) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  private function isAdminPermission(string $permission): bool {
+    return str_starts_with($permission, 'administer ')
+      || str_starts_with($permission, 'access myeventlane admin ');
   }
 
 }

--- a/web/modules/custom/myeventlane_surface/src/MelCustomerContinuityPresenter.php
+++ b/web/modules/custom/myeventlane_surface/src/MelCustomerContinuityPresenter.php
@@ -244,11 +244,15 @@ final class MelCustomerContinuityPresenter {
       ];
     }
 
+    $email_line = $has_tickets && !$is_paid
+      ? $this->readinessHelper->customerCheckoutPendingPaymentEmailLine($email)
+      : $this->readinessHelper->customerCheckoutConfirmationEmailSentLine($email);
+
     return [
       'hero' => $hero,
       'labels' => $labels,
       'confirmation' => [
-        'email_line' => $this->readinessHelper->customerCheckoutConfirmationEmailSentLine($email),
+        'email_line' => $email_line,
         'order_line' => $this->readinessHelper->customerCheckoutOrderNumberLine($order_number),
       ],
       'guest' => [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Copy and access-denial UX tweaks only; no payment or authorization rule changes beyond excluding admin routes from the Pro funnel.
> 
> **Overview**
> **Checkout completion** for ticket orders that are not yet paid now shows a **pending-payment email line** (“We’ll email … once payment has been confirmed”) instead of implying confirmation was already sent. The string is centralized in `MelReadinessHelper` and wired in `MelCustomerContinuityPresenter` when there are tickets and `$is_paid` is false, alongside the existing pending-payment hero copy.
> 
> **Pro upgrade redirect** no longer hijacks access denials on **admin/staff routes**: routes marked `_admin_route`, paths under `/admin/`, or routes whose `_permission` includes an admin-style permission the user already has keep Drupal’s normal 403 experience instead of sending vendors to the Pro overview funnel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8538cb420b4a5f3fc7db03aa30beb42fc87f6327. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->