### PR TITLE
Update checkout flow to use canonical `mel_event_checkout` configuration

### DIFF
--- a/config/sync/commerce_order.commerce_order_type.default.yml
+++ b/config/sync/commerce_order.commerce_order_type.default.yml
@@ -12,7 +12,7 @@ third_party_settings:
     cart_expiration: {  }
     enable_cart_message: true
   commerce_checkout:
-    checkout_flow: default
+    checkout_flow: mel_event_checkout
 _core:
   default_config_hash: kYapI397yx2zFJGyDEs85Hyqgfc9jhmzxqPZMl2Fqhk
 id: default

--- a/docs/PHASE_1_CHECKOUT_FLOW_IMPLEMENTATION.md
+++ b/docs/PHASE_1_CHECKOUT_FLOW_IMPLEMENTATION.md
@@ -71,11 +71,11 @@
 ### 5. Configuration Files
 
 #### A. Checkout Flow Config
-- **File:** `config/install/commerce_checkout.commerce_checkout_flow.mel_event.yml`
+- **File:** `web/modules/custom/myeventlane_checkout_flow/config/install/commerce_checkout.commerce_checkout_flow.mel_event_checkout.yml`
 - **Config ID:** `mel_event_checkout`
 - **Pane Order:**
-  - **Main:** Buyer details → Attendee details → Donation → Legal consent → Payment
-  - **Sidebar:** Grouped summary → Fee transparency → Order summary
+  - **Main:** Buyer details → Attendee details → Legal consent → Payment
+  - **Sidebar:** Order summary
   - **Disabled:** `contact_information`, `billing_information`, `myeventlane_attendee_info_per_ticket`
 
 #### B. Order Item Type Config
@@ -95,14 +95,18 @@
 ### Main Region (`checkout` step)
 1. **Buyer details** (`mel_buyer_details`) — Weight: 0
 2. **Attendee details** (`ticket_holder_paragraph`) — Weight: 1
-3. **Donation** (`mel_donation`) — Weight: 2
-4. **Legal consent** (`mel_legal_consent`) — Weight: 3
-5. **Payment** (`payment_information`) — Weight: 4
+3. **Legal consent** (`mel_legal_consent`) — Weight: 3
+4. **Payment** (`payment_information`) — Weight: 4
 
 ### Sidebar Region (`_sidebar` step)
-1. **Grouped summary** (`grouped_order_summary`) — Weight: 0
-2. **Fee transparency** (`mel_fee_transparency`) — Weight: 1
-3. **Order summary** (`order_summary`) — Weight: 2
+1. **Order summary** (`order_summary`) — Weight: 1
+
+### Disabled Panes
+- **Grouped summary** (`grouped_order_summary`) — Weight: 98
+- **Fee transparency** (`mel_fee_transparency`) — Weight: 99
+- **Contact information** (`contact_information`) — Weight: 100
+- **Billing information** (`billing_information`) — Weight: 101
+- **Legacy attendee info** (`myeventlane_attendee_info_per_ticket`) — Weight: 102
 
 ---
 
@@ -113,16 +117,15 @@
    ddev drush en myeventlane_checkout_flow -y
    ```
 
-2. **Set as active checkout flow:**
+2. **Confirm canonical checkout assignment:**
    ```bash
-   ddev drush config:set commerce_checkout.commerce_checkout_flow.default plugin mel_event_checkout -y
+   ddev drush cget commerce_order.commerce_order_type.default third_party_settings.commerce_checkout.checkout_flow
    ```
-   OR manually change the `plugin` value in:
-   `web/sites/default/config/sync/commerce_checkout.commerce_checkout_flow.default.yml`
+   Expected value: `mel_event_checkout`.
 
-3. **Export config (if needed):**
+3. **Export config after intentional checkout config changes:**
    ```bash
-   ddev drush config:export -y
+   ddev drush cex -y
    ```
 
 ---

--- a/docs/architecture/ADR-0001-canonical-checkout-flow.md
+++ b/docs/architecture/ADR-0001-canonical-checkout-flow.md
@@ -1,0 +1,586 @@
+# ADR-0001: Canonical Checkout Flow
+
+## Status
+
+Accepted.
+
+Product has selected Architecture B: `mel_event_checkout` is the canonical checkout flow for event ticket checkout. Implementation details are recorded in `docs/architecture/ADR-0001-implementation.md`.
+
+## Background
+
+MyEventLane previously had two checkout-flow architectures represented in the repository:
+
+- Commerce default checkout flow: `commerce_checkout.commerce_checkout_flow.default`.
+- MEL custom event checkout flow: `commerce_checkout.commerce_checkout_flow.mel_event_checkout`, plugin `mel_event_checkout`.
+
+The pre-decision active configuration and exported sync assigned the Commerce order type `default` to the Commerce checkout flow `default`. At the same time, the repository contained a custom `mel_event_checkout` plugin, active checkout-flow configuration, install configuration, optional order-type configuration, post-update code, runtime form alters, tests, and documentation that assumed the MEL custom flow existed.
+
+The contradiction was architectural, not a runtime hotfix. Product resolved it by selecting Architecture B.
+
+## Evidence
+
+### Pre-decision active and exported order-type configuration
+
+`ddev drush config:get commerce_order.commerce_order_type.default third_party_settings.commerce_checkout.checkout_flow` returned:
+
+```text
+'commerce_order.commerce_order_type.default:third_party_settings.commerce_checkout.checkout_flow': default
+```
+
+`config/sync/commerce_order.commerce_order_type.default.yml` also points to Commerce default:
+
+```yaml
+third_party_settings:
+  commerce_checkout:
+    checkout_flow: default
+```
+
+`ddev drush config:status --format=table` returned:
+
+```text
+[notice] No differences between DB and sync directory.
+```
+
+Therefore, before Architecture B implementation, local active configuration and exported configuration agreed: event ticket carts using order type `default` routed through the Commerce `default` checkout flow.
+
+### Ticket cart creation uses order type `default`
+
+`TicketSelectionForm::submitForm()` creates or loads carts using order type `default`:
+
+```php
+$cart = $this->cartProvider->getCart('default', $store)
+  ?: $this->cartProvider->createCart('default', $store);
+```
+
+Evidence path: `web/modules/custom/myeventlane_commerce/src/Form/TicketSelectionForm.php`.
+
+### `mel_event_checkout` plugin exists
+
+The plugin class exists and declares the plugin ID `mel_event_checkout`:
+
+```php
+/**
+ * Provides a single-page checkout flow for MyEventLane events.
+ *
+ * This flow presents all checkout panes in a single step with a sidebar
+ * for order summary and fee transparency, creating a "single page feel"
+ * similar to Humanitix.
+ *
+ * @CommerceCheckoutFlow(
+ *   id = "mel_event_checkout",
+ *   label = @Translation("MyEventLane Event Checkout"),
+ * )
+ */
+final class MelEventCheckoutFlow extends CheckoutFlowWithPanesBase {
+```
+
+Evidence path: `web/modules/custom/myeventlane_checkout_flow/src/Plugin/Commerce/CheckoutFlow/MelEventCheckoutFlow.php`.
+
+The plugin adds a single `checkout` step, marks it as sidebar-enabled, sets the primary label to "Complete booking", and adds wrapper classes `mel-checkout-single-page` and `mel-checkout-flow-mel-event`.
+
+### `mel_event_checkout` configuration entity exists
+
+Active configuration contains `commerce_checkout.commerce_checkout_flow.mel_event_checkout`. The command:
+
+```bash
+ddev drush config:get commerce_checkout.commerce_checkout_flow.mel_event_checkout
+```
+
+returned a checkout flow with:
+
+- `id: mel_event_checkout`
+- `plugin: mel_event_checkout`
+- `label: MyEventLane Event Checkout`
+- panes on the `checkout` step: `mel_buyer_details`, `ticket_holder_paragraph`, `mel_legal_consent`, `payment_information`
+- sidebar `order_summary`
+- disabled `contact_information`, `billing_information`, `myeventlane_attendee_info_per_ticket`
+
+Exported sync also contains the same entity:
+
+- `config/sync/commerce_checkout.commerce_checkout_flow.mel_event_checkout.yml`
+
+### Fresh install would still provision `mel_event_checkout`
+
+The custom module install config contains:
+
+- `web/modules/custom/myeventlane_checkout_flow/config/install/commerce_checkout.commerce_checkout_flow.mel_event_checkout.yml`
+
+The custom module install hook also creates the same config entity manually:
+
+- `web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.install`
+
+The install hook sets:
+
+- `id: mel_event_checkout`
+- `label: MyEventLane Event Checkout`
+- `plugin: mel_event_checkout`
+- single `checkout` step panes
+- disabled Commerce default contact/billing panes
+
+The module also contains optional config assigning the default order type to `mel_event_checkout`:
+
+- `web/modules/custom/myeventlane_checkout_flow/config/optional/commerce_order.commerce_order_type.default.yml`
+
+Therefore, a fresh install of this module still provisions `mel_event_checkout` and attempts to make it the order type checkout flow when optional config applies.
+
+### Historical post-update attempts to switch the order type
+
+`myeventlane_checkout_flow_post_update_use_mel_event_checkout()` still attempts to change `commerce_order.commerce_order_type.default` to `mel_event_checkout`:
+
+```php
+function myeventlane_checkout_flow_post_update_use_mel_event_checkout(array &$sandbox): void {
+  $config = \Drupal::configFactory()->getEditable('commerce_order.commerce_order_type.default');
+  $third_party = $config->get('third_party_settings.commerce_checkout') ?? [];
+  $third_party['checkout_flow'] = 'mel_event_checkout';
+  $config->set('third_party_settings.commerce_checkout', $third_party);
+  $config->save();
+}
+```
+
+Evidence path: `web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.post_update.php`.
+
+Local post-update bookkeeping includes:
+
+```text
+311=myeventlane_checkout_flow_post_update_checkout_shell
+312=myeventlane_checkout_flow_post_update_use_mel_event_checkout
+```
+
+But active config remains `default`, and `ddev drush updatedb:status --format=table` returned no pending updates. This suggests the update was recorded as run and the current active/sync config later returned to `default`, or that the sync import became authoritative after the update had run.
+
+### Runtime references
+
+Runtime code still contains a form alter specifically for the custom checkout-flow form ID:
+
+```php
+/**
+ * Implements hook_form_FORM_ID_alter() for commerce_checkout_flow_mel_event_checkout.
+ */
+function myeventlane_checkout_flow_form_commerce_checkout_flow_mel_event_checkout_alter(array &$form, FormStateInterface $form_state): void {
+```
+
+Evidence path: `web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.module`.
+
+That alter:
+
+- forces `commerce_checkout_form__with_sidebar`
+- adds a "Back to cart" link when there is no previous checkout step
+- attaches checkout UX helpers
+- attaches fast checkout UI
+- handles complete-step sidebar cleanup
+
+If Commerce default is canonical, this form alter does not target the active checkout-flow form ID and its UX additions are not applied to default checkout unless duplicated elsewhere.
+
+Theme templates also explicitly account for MEL custom panes:
+
+- `web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form.html.twig`
+- `web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form--with-sidebar.html.twig`
+
+Both reference panes such as `mel_buyer_details`, `mel_legal_consent`, `ticket_holder_paragraph`, and `payment_information`.
+
+### Test coverage and E2E assumptions
+
+The E2E checkout README says:
+
+```text
+ddev drush config:import -y   # imports canonical mel_event_checkout assignment
+```
+
+It also states that the test:
+
+```text
+Proceeds to MEL single-page checkout (`mel_event_checkout`)
+```
+
+Evidence path: `tests/e2e/README.md`.
+
+The E2E fixture script mutates active config to enforce the MEL custom checkout flow:
+
+```php
+// Ensure ticket carts use the MEL single-page checkout flow (not Commerce default).
+$orderTypeConfig = \Drupal::configFactory()->getEditable('commerce_order.commerce_order_type.default');
+$thirdParty = $orderTypeConfig->get('third_party_settings.commerce_checkout') ?? [];
+if (($thirdParty['checkout_flow'] ?? 'default') !== 'mel_event_checkout') {
+  $thirdParty['checkout_flow'] = 'mel_event_checkout';
+  $orderTypeConfig->set('third_party_settings.commerce_checkout', $thirdParty);
+  $orderTypeConfig->save(TRUE);
+}
+```
+
+Evidence path: `tests/e2e/scripts/prepare-fixture.php`.
+
+This is strong evidence that E2E checkout tests currently assume Architecture B, even though repository sync and active config currently run Architecture A.
+
+### Customer journey evidence
+
+The paid ticket journey is:
+
+1. `/event/{node}/book`
+2. `BookController::book()`
+3. `TicketSelectionForm`
+4. Commerce cart page
+5. `commerce_checkout.form`
+6. Checkout completion
+7. ticket issuance on `OrderEvents::ORDER_PAID`
+
+Evidence appears in:
+
+- `web/modules/custom/myeventlane_commerce/src/Controller/BookController.php`
+- `web/modules/custom/myeventlane_commerce/src/Form/TicketSelectionForm.php`
+- `web/modules/custom/myeventlane_tickets/src/EventSubscriber/OrderPaidSubscriber.php`
+- `web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-completion.html.twig`
+
+The checkout flow choice affects step 5: pane sequence, form ID, form alter targeting, checkout UX, guest buyer details, attendee capture placement, legal consent placement, payment pane placement, and sidebar behaviour.
+
+Ticket issuance itself is downstream of payment/order events and is not directly tied to the checkout-flow plugin by repository evidence.
+
+### Launch validation evidence
+
+`docs/launch/launch-certification/launch-validation.md` records:
+
+- `ddev composer validate` passed
+- `ddev drush status` bootstrapped
+- `ddev drush config:status` had no differences
+- `ddev drush cr` rebuilt clean
+- specific organiser/customer route checks passed
+
+It does not record an explicit checkout-flow assertion such as:
+
+```bash
+ddev drush config:get commerce_order.commerce_order_type.default third_party_settings.commerce_checkout.checkout_flow
+```
+
+It also does not record a live checkout regression run against either Architecture A or Architecture B.
+
+## Original Intent
+
+Repository evidence indicates `mel_event_checkout` was introduced as a custom single-page checkout flow for MyEventLane events.
+
+Primary evidence:
+
+- `web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.info.yml` describes the module as: "Custom single-page checkout flow for MyEventLane events. Provides Humanitix-level checkout experience with grouped panes, donation support, and fee transparency."
+- `MelEventCheckoutFlow.php` describes the plugin as creating a single-page feel similar to Humanitix.
+- `docs/PHASE_1_CHECKOUT_FLOW_IMPLEMENTATION.md` states the purpose was "Custom single-page checkout flow for MyEventLane events" with plugin ID `mel_event_checkout`.
+- The same implementation summary says the flow type is "Single-step checkout with sidebar support" and lists pane order as buyer details, attendee details, donation, legal consent, payment.
+- The module optional config assigns `commerce_order.commerce_order_type.default` to `mel_event_checkout`.
+- The post-update explicitly says: "Switch default order type to use mel_event_checkout flow."
+- E2E fixtures assert ticket carts use MEL single-page checkout, not Commerce default.
+
+The original installation instructions in `docs/PHASE_1_CHECKOUT_FLOW_IMPLEMENTATION.md` were inconsistent with the later exported architecture because they targeted `commerce_checkout.commerce_checkout_flow.default`. The canonical Architecture B implementation uses the separate checkout-flow config entity `mel_event_checkout` and assigns order type `default` to that entity.
+
+Repository evidence supports this conclusion:
+
+- `mel_event_checkout` was intended to replace the active event order checkout flow for ticket purchases.
+- It was implemented as a separate checkout-flow entity and plugin.
+- It was not merely an extension of the Commerce default flow in the current repository, because the custom form alter targets `commerce_checkout_flow_mel_event_checkout`, not Commerce default.
+
+## Alternatives
+
+### Architecture A: Commerce default is canonical (rejected)
+
+#### Description
+
+Order type `default` would have continued to use `commerce_checkout.commerce_checkout_flow.default`, plugin `multistep_default`. Product rejected this architecture because it left MEL checkout plugin, form alter, custom panes, tests, and fresh-install config in conflict with the canonical runtime path.
+
+#### Current usage
+
+Pre-decision active config and `config/sync` used this architecture:
+
+- `commerce_order.commerce_order_type.default` -> `checkout_flow: default`
+- `commerce_checkout.commerce_checkout_flow.default` -> `plugin: multistep_default`
+
+#### Advantages
+
+- Matched active configuration and exported config before the Architecture B implementation.
+- Matches clean `drush config:status`.
+- Avoided immediate order-type configuration change.
+- Uses Drupal Commerce's standard multistep checkout plugin.
+- Lower risk of custom checkout-flow plugin defects.
+- Lower risk if production already operates successfully on Commerce default.
+
+#### Disadvantages
+
+- Contradicts module metadata, install config, optional config, post-update code, E2E setup, and several architecture/audit documents.
+- Leaves `MelEventCheckoutFlow` unused for ticket checkout unless another order type uses it.
+- Leaves `myeventlane_checkout_flow_form_commerce_checkout_flow_mel_event_checkout_alter()` stranded for default checkout.
+- May bypass MEL custom checkout UX attachment, fast checkout attachment, guided sidebar template forcing, and custom single-page form classes.
+- May not surface custom panes such as `mel_buyer_details`, `ticket_holder_paragraph`, and `mel_legal_consent` unless separately configured into Commerce default.
+- Creates ongoing confusion for future engineers and tests.
+
+#### Migration effort
+
+If Product had chosen Architecture A, this would have been mainly cleanup and retargeting work:
+
+- Confirm default checkout has all required buyer, attendee, legal, payment, and ticket-holder behaviour.
+- Decide whether custom panes remain in use on Commerce default or become obsolete.
+- Remove or rewrite obsolete `mel_event_checkout` plugin/config/update/test references only after live checkout proof.
+- Update E2E setup so it no longer mutates active config to `mel_event_checkout`.
+- Update documentation that incorrectly states `mel_event_checkout` is active.
+
+Estimated effort would have been medium. The risk was not deletion itself; the risk was proving that default checkout provided the complete MEL ticket purchase contract.
+
+#### Risk
+
+Architecture A remained high risk because runtime code and E2E scripts assumed `mel_event_checkout`.
+
+Payment risk would have been indirect: choosing Architecture A should not have altered Stripe/payment code, but it may have changed which panes and form alters were present before payment submission.
+
+Order risk would have been moderate: order type would have stayed unchanged, but custom buyer/attendee/legal collection may have been absent or differently sequenced.
+
+#### Future maintenance
+
+Simplifies Commerce alignment if the MEL custom flow is removed. Maintenance improves only if obsolete plugin/config/docs/tests are removed and the default flow is documented as canonical.
+
+If obsolete references remain, this architecture preserves the current ambiguity.
+
+### Architecture B: `mel_event_checkout` is canonical (accepted)
+
+#### Description
+
+Order type `default` uses checkout-flow entity `mel_event_checkout`, plugin `mel_event_checkout`. Ticket purchases use the MEL custom single-step checkout with sidebar and custom panes.
+
+#### Current usage
+
+The architecture exists and is supported by code/config/docs/tests. ADR-0001 implementation makes it the active and exported order-type assignment.
+
+Repository elements supporting this architecture:
+
+- `MelEventCheckoutFlow.php`
+- `commerce_checkout.commerce_checkout_flow.mel_event_checkout.yml`
+- module install config
+- module optional order-type config
+- post-update
+- form alter targeting `commerce_checkout_flow_mel_event_checkout`
+- E2E fixture setup
+- multiple audit and architecture documents
+
+#### Advantages
+
+- Aligns with original custom checkout intent.
+- Aligns with module metadata and E2E test assumptions.
+- Activates MEL-specific form alter and guided sidebar behaviour.
+- Supports a single-step event checkout with buyer details, attendee details, legal consent, payment, and sidebar order summary.
+- Matches MEL’s documented Humanitix-level checkout UX direction.
+
+#### Disadvantages
+
+- Requires an explicit order-type configuration change from the current active/sync state.
+- Changes active checkout behaviour and must be treated as Commerce/high-risk.
+- Could affect payment pane placement, guest checkout path, and checkout step sequence.
+- Requires config export/import discipline and full regression validation.
+- May expose hidden assumptions in production if production has been operating on Commerce default.
+
+#### Migration effort
+
+The minimum Architecture B implementation is config canonicalisation:
+
+- Set `commerce_order.commerce_order_type.default` checkout flow to `mel_event_checkout`.
+- Export config.
+- Verify no config drift.
+- Confirm post-update cleanup strategy because the post-update is already recorded locally.
+- Run live checkout regression tests across paid, manual gateway, Stripe gateway, zero-balance/free, donation, ticket-holder, legal consent, completion, email, and ticket issuance paths.
+
+Estimated effort: medium to high, because the config edit is small but validation blast radius is Commerce checkout.
+
+#### Risk
+
+High until validated in staging.
+
+Payment risk is moderate to high because the checkout pane sequence and form alter path change before payment submission.
+
+Order-type risk is high because `default` is the ticket cart order type and is also used by many tests and services.
+
+#### Future maintenance
+
+Keeps MEL’s checkout UX in a dedicated plugin and config entity. Maintenance is cleaner if documentation, tests, and config are reconciled to make `mel_event_checkout` unambiguously canonical.
+
+Long-term maintenance requires treating checkout-flow config as a governed Commerce contract and adding explicit tests for the assigned flow.
+
+## Runtime Impact If Switching To `mel_event_checkout`
+
+### Checkout panes
+
+Expected active pane sequence changes from Commerce multistep defaults to a single `checkout` step with:
+
+- `mel_buyer_details`
+- `ticket_holder_paragraph`
+- `mel_legal_consent`
+- `payment_information`
+- sidebar `order_summary`
+
+`contact_information`, `billing_information`, and `myeventlane_attendee_info_per_ticket` are disabled in the MEL flow.
+
+### Payment flow
+
+Repository evidence does not show a change to payment gateway plugins or Stripe APIs from switching the checkout-flow assignment. The payment pane remains Commerce `payment_information`.
+
+However, payment pane placement and form context change. That must be validated with:
+
+- Stripe Payment Element
+- Manual gateway
+- failed payment
+- pending payment
+- zero-balance/free or no-payment cases if supported
+
+### Order completion
+
+The custom flow changes checkout step structure and form alter targeting. Completion copy is largely theme/presenter governed, but completion route behaviour must be re-tested because the active flow changes step sequence.
+
+### Emails
+
+Repository evidence ties emails to order events and messaging services, not directly to checkout-flow plugin. Still, checkout flow can affect whether orders reach the same state transitions and whether required buyer details are present, so order confirmation and ticket delivery emails must be validated.
+
+### Tickets
+
+Ticket issuance is tied to `OrderEvents::ORDER_PAID` through `OrderPaidSubscriber` and `TicketIssuer`. Repository evidence does not show direct dependency on `mel_event_checkout`.
+
+Ticket-holder capture does depend on checkout panes and order item fields. The `ticket_holder_paragraph` pane must be present and must persist attendee data before order placement.
+
+### Checkout UX
+
+Switching to `mel_event_checkout` activates:
+
+- `mel-checkout-single-page`
+- `mel-checkout-flow-mel-event`
+- `commerce_checkout_form__with_sidebar`
+- "Back to cart" suffix on the primary action
+- checkout UX attachment
+- fast checkout section attachment
+- complete-step sidebar cleanup
+
+### Events
+
+No event entity model change is evidenced. The event booking path still creates cart items through `TicketSelectionForm`.
+
+### Commerce compatibility
+
+`MelEventCheckoutFlow` extends `CheckoutFlowWithPanesBase`, so it remains Commerce-native. It is custom code and must stay compatible with Commerce checkout pane expectations.
+
+### Extensions
+
+Modules depending on `myeventlane_checkout_flow` may continue to use services and routes unrelated to the custom checkout-flow plugin, such as My Tickets and vendor attendee/check-in services. Choosing Architecture A does not automatically make the whole module obsolete.
+
+### Validation
+
+Architecture B requires full checkout validation, not only config validation.
+
+### Tests
+
+E2E tests assume Architecture B and assert that the repository already has the expected flow. They must not mutate checkout-flow config in fixture setup.
+
+### Security
+
+No direct route access or entity access change is implied by the flow assignment. Security risk is in checkout data collection and payment submission: buyer details, legal consent, attendee details, and payment pane behaviour must remain server-side validated.
+
+## Accepted Implementation Direction
+
+Architecture B is selected. The `mel_event_checkout` plugin, flow configuration, module install configuration, optional order-type configuration, form alter, checkout panes, and E2E checkout assumptions are canonical Architecture B assets.
+
+The `myeventlane_checkout_flow` module also owns related customer and organiser surfaces:
+
+- My Tickets routes
+- order detail/tax invoice routes
+- vendor attendee/check-in routes and services
+- checkout summary/pricing presentation services
+- rate limiting subscriber for `commerce_checkout.form`
+- fast checkout access/services
+
+These are not obsolete and must not be removed as part of Architecture B canonicalisation.
+
+### Architecture B implementation tasks
+
+Required implementation tasks:
+
+1. Set `commerce_order.commerce_order_type.default` to `checkout_flow: mel_event_checkout`.
+2. Export config to `config/sync`.
+3. Add an explicit test/assertion that default ticket orders use `mel_event_checkout`.
+4. Remove E2E fixture mutation and replace it with an assertion.
+5. Keep the historical post-update as deployment-history context unless a future release needs a new idempotent update.
+6. Reconcile docs to state that `mel_event_checkout` is canonical.
+7. Verify the custom flow on a fresh install and config import path.
+
+Risk:
+
+- High until staging checkout regression passes.
+- Payment pane placement changes relative to current active default flow.
+- Checkout step sequence changes relative to current active default flow.
+- Guest checkout details and legal consent must be verified.
+- Production may currently be operating on Commerce default; switching to custom flow is an active behaviour change.
+
+Validation:
+
+- `composer validate`
+- `ddev drush cr`
+- `ddev drush config:status`
+- `ddev drush config:get commerce_order.commerce_order_type.default third_party_settings.commerce_checkout.checkout_flow`
+- `ddev drush config:get commerce_checkout.commerce_checkout_flow.mel_event_checkout`
+- paid ticket checkout
+- manual gateway checkout
+- Stripe gateway checkout
+- failed payment state
+- pending payment state
+- zero-balance/free order if supported
+- attendee details required/optional cases
+- legal consent required case
+- checkout completion copy
+- order confirmation email
+- ticket issuance after payment
+- refund request route after purchase
+- My Tickets/order detail route after purchase
+- E2E checkout test without runtime config mutation
+
+Rollback:
+
+- Revert order-type config to `checkout_flow: default`.
+- Re-import config.
+- Rebuild caches.
+- Re-run checkout smoke tests.
+- Confirm no stuck draft orders require manual handling.
+
+## Validation Plan For Architecture B
+
+Before and after implementation, run these checks on every target environment:
+
+```bash
+ddev drush config:get commerce_order.commerce_order_type.default third_party_settings.commerce_checkout.checkout_flow
+ddev drush config:get commerce_checkout.commerce_checkout_flow.mel_event_checkout
+ddev drush updatedb:status
+ddev drush config:status
+```
+
+For staging/production, capture equivalent Drush output before changing anything.
+
+After implementation, validation must prove:
+
+- no configuration drift
+- expected checkout-flow assignment
+- no payment regression
+- no order-type regression
+- no checkout-flow regression
+- no ticket issuance regression
+- no email regression
+- no customer ticket recovery regression
+
+## Rollback Plan
+
+Because both architectures are present in Git, rollback is config-led unless code/config is removed.
+
+1. Revert `commerce_order.commerce_order_type.default` to `checkout_flow: default`.
+2. Re-import config.
+3. Rebuild caches.
+4. Run checkout smoke tests.
+
+Rollback must include review of draft orders created during the test window.
+
+## Decision Accepted
+
+Product and engineering have selected:
+
+- Architecture B: `mel_event_checkout` is canonical.
+
+ADR-0001 implementation must leave no conflicting source of truth:
+
+- active/sync order type says MEL custom checkout
+- plugin/config/install/update/tests/docs say MEL custom checkout
+
+No architectural redesign is authorised by this ADR. Future checkout work must preserve payment integrity, ticket issuance integrity, refund integrity, and Drupal Commerce checkout contracts.

--- a/docs/architecture/ADR-0001-implementation.md
+++ b/docs/architecture/ADR-0001-implementation.md
@@ -1,0 +1,183 @@
+# ADR-0001 Implementation: Canonical MEL Event Checkout
+
+## Status
+
+Implemented with validation notes.
+
+## Decision Implemented
+
+ADR-0001 selected Architecture B. `mel_event_checkout` is the canonical checkout flow for event ticket checkout, and `commerce_order.commerce_order_type.default` must point to that flow.
+
+## Files Changed
+
+- `config/sync/commerce_order.commerce_order_type.default.yml` — exported order-type checkout assignment now points to `mel_event_checkout`.
+- `web/modules/custom/myeventlane_checkout_flow/config/install/commerce_checkout.commerce_checkout_flow.mel_event_checkout.yml` — fresh-install checkout-flow pane contract now matches the canonical exported MEL flow.
+- `tests/e2e/scripts/prepare-fixture.php` — E2E fixture now asserts canonical checkout config instead of mutating active configuration.
+- `tests/e2e/README.md` — setup now requires canonical config import rather than update hooks forcing the checkout flow.
+- `docs/architecture/ADR-0001-canonical-checkout-flow.md` — ADR status and implementation direction reflect accepted Architecture B.
+- `docs/PHASE_1_CHECKOUT_FLOW_IMPLEMENTATION.md` — obsolete Commerce default plugin assignment instructions replaced with canonical order-type verification.
+- `docs/audits/launch-friction-audit.md` — checkout-flow config drift marked resolved.
+- `docs/audits/workflow-experience-audit.md` — checkout-flow config drift marked resolved.
+- `docs/launch/customer-acceptance/customer-acceptance.md` — customer checkout evidence names `mel_event_checkout`.
+- `docs/architecture/ADR-0001-implementation.md` — records implementation, validation, risk, and rollback.
+
+## Configuration Changed
+
+- Active configuration was updated with:
+
+```bash
+ddev drush cset commerce_order.commerce_order_type.default third_party_settings.commerce_checkout.checkout_flow mel_event_checkout -y
+ddev drush cex -y
+```
+
+- Exported sync config now sets:
+
+```yaml
+third_party_settings:
+  commerce_checkout:
+    checkout_flow: mel_event_checkout
+```
+
+- Fresh-install optional order-type config already sets `checkout_flow: mel_event_checkout`.
+- Fresh-install checkout-flow install config now matches the exported MEL checkout-flow pane placement for the canonical panes:
+  - `mel_buyer_details` on `checkout`
+  - `ticket_holder_paragraph` on `checkout`
+  - `mel_legal_consent` on `checkout`
+  - `payment_information` on `checkout`
+  - `order_summary` on `_sidebar`
+  - default contact/billing/legacy attendee panes disabled
+
+## Tests Updated
+
+- `tests/e2e/scripts/prepare-fixture.php` no longer edits `commerce_order.commerce_order_type.default`.
+- The E2E fixture fails loudly if the active order-type checkout flow is not `mel_event_checkout`.
+- `tests/e2e/README.md` now documents config import as the setup path for the canonical checkout assignment.
+
+## Validation Performed
+
+### Composer and Drupal config
+
+- `composer validate` on the host did not complete because `vendor/composer/installed.json` was not readable from the host environment.
+- `ddev composer validate` passed: `./composer.json is valid`.
+- `ddev drush cr` passed.
+- `ddev drush config:status` passed after implementation: no differences between DB and sync.
+- `ddev drush cget commerce_order.commerce_order_type.default third_party_settings.commerce_checkout.checkout_flow` returned `mel_event_checkout`.
+- `ddev drush cget commerce_checkout.commerce_checkout_flow.mel_event_checkout` returned the expected `mel_event_checkout` entity, plugin, panes, and sidebar order summary.
+
+### PHPUnit
+
+- Focused checkout/customer/ticket governance slice passed:
+
+```bash
+ddev exec bash -lc 'cd web && ../vendor/bin/phpunit -c phpunit-governance.xml --filter "MelCheckout|OperationalCheckout|CustomerHubPageAccount|TicketBacked|OperationalCartProjection|OperationalOrderItemDisplay"'
+```
+
+Result: 60 tests, 1240 assertions, OK. PHPUnit reported 1 warning and 128 PHPUnit deprecations.
+
+- Refund kernel tests did not execute assertions because the existing test service graph is incomplete:
+
+```bash
+ddev exec bash -lc 'SIMPLETEST_DB=sqlite://localhost/:memory: ./vendor/bin/phpunit -c web/core/phpunit.xml.dist web/modules/custom/myeventlane_refunds/tests/src/Kernel/RefundAccessTest.php web/modules/custom/myeventlane_refunds/tests/src/Kernel/BuyerRefundFormTest.php web/modules/custom/myeventlane_refunds/tests/src/Kernel/VendorRefundFormAccessTest.php --do-not-cache-result'
+```
+
+Result: 5 errors, 0 assertions. Root cause: `myeventlane_checkout_flow.checkout_ux_attacher` depends on missing service `myeventlane_surface.state_readiness_helper` in the refund kernel test container. This was not caused by checkout-flow config mutation, but it leaves refund kernel validation incomplete.
+
+### E2E
+
+- E2E fixture preparation passed:
+
+```bash
+ddev drush php:script tests/e2e/scripts/prepare-fixture.php
+```
+
+The script returned the paid fixture and did not mutate checkout-flow config.
+
+- First `npm run test:e2e` attempt failed inside the sandbox during `npm ci` with EPERM unlink errors in `tests/e2e/node_modules`.
+- Retried outside the sandbox. The first Playwright run reached `/checkout/{order}/complete` but failed because the test expected paid confirmation copy before manual payment was received. The page correctly showed pending-payment copy: `Order received` and `We’re waiting for payment confirmation`.
+- The E2E assertion was updated to preserve payment integrity:
+  - manual payment expects pending-payment completion copy before simulated payment receipt
+  - Stripe test mode still expects paid confirmation copy
+- Final `npm run test:e2e` passed: 1 test, manual payment mode.
+- E2E teardown restored payment gateways, but the earlier direct fixture run left two gateway configs drifted. A final `ddev drush cim -y && ddev drush cr && ddev drush config:status` restored active config to sync and confirmed no differences.
+
+### Static checks
+
+- Cursor lints reported no diagnostics for the edited E2E TypeScript/PHP files after adding payment gateway PHPDoc annotations.
+- `ddev exec php -l tests/e2e/scripts/prepare-fixture.php` passed with no syntax errors.
+
+## Manual Verification Completed
+
+Evidence-backed checks completed:
+
+- Manual payment E2E checkout reached checkout completion.
+- Pending manual-payment completion copy was shown before payment receipt.
+- Ticket holder capture, legal consent, order summary, sidebar, and checkout completion were exercised by the passing E2E test.
+- The E2E test simulated manual payment receipt, then verified the order state was `completed` and at least one `myeventlane_ticket` existed for the holder email.
+- Active and sync configuration agreed after validation, with `mel_event_checkout` as the canonical order-type checkout flow.
+
+Manual scenarios still requiring explicit evidence before launch sign-off:
+
+- Paid Stripe checkout
+- Failed payment
+- Free RSVP
+- Confirmation email delivery
+- My Tickets browser journey beyond the issued ticket/order-link evidence in E2E
+- Refund request browser journey
+- Refund kernel assertions after the test service graph is fixed
+
+## Known Risks
+
+- Commerce checkout behaviour changes from the pre-decision active `default` flow to the custom MEL single-step flow.
+- Payment pane placement and checkout step sequence must be validated with Stripe and manual gateways.
+- Ticket-holder capture and legal consent depend on the MEL checkout panes persisting data before order placement.
+- Production or staging environments that still run Commerce default checkout need config import and regression validation before launch.
+- Manual Commerce validation cannot be marked PASS without direct evidence.
+
+## Rollback Procedure
+
+### Configuration Rollback
+
+1. Restore the previous order-type checkout assignment:
+
+```bash
+ddev drush cset commerce_order.commerce_order_type.default third_party_settings.commerce_checkout.checkout_flow default -y
+ddev drush cex -y
+ddev drush cr
+```
+
+2. Confirm rollback:
+
+```bash
+ddev drush cget commerce_order.commerce_order_type.default third_party_settings.commerce_checkout.checkout_flow
+ddev drush config:status
+```
+
+Expected rollback value: `default`.
+
+### Git Rollback
+
+1. Revert this task's focused config, test, and documentation changes.
+2. Re-import configuration if the rollback is applied from Git:
+
+```bash
+ddev drush cim -y
+ddev drush cr
+```
+
+### Checkout Validation
+
+1. Run checkout smoke tests for the restored flow.
+2. Review draft orders created during the implementation or rollback window.
+3. Confirm checkout completion still reaches the expected completion route.
+
+### Payment Validation
+
+1. Confirm manual gateway checkout still reaches the expected payment/order state.
+2. Confirm Stripe test checkout still uses test mode and does not expose live keys.
+3. Confirm failed and pending payments do not show paid confirmation states.
+
+### Ticket Validation
+
+1. Confirm paid orders still trigger ticket issuance.
+2. Confirm My Tickets can load the issued tickets.
+3. Confirm refund request access and ownership checks still apply.

--- a/docs/audits/launch-friction-audit.md
+++ b/docs/audits/launch-friction-audit.md
@@ -120,7 +120,7 @@
 | Help centre dual organiser paths | Single public card label |
 | Event Studio default title | “Event Studio” instead of “Vendor workspace” |
 
-**Deferred (needs product, not copy):** Pro-gated insights upsell, placeholder manage-event routes, checkout flow config drift.
+**Deferred (needs product, not copy):** Pro-gated insights upsell, placeholder manage-event routes.
 
 ---
 
@@ -167,7 +167,7 @@ find web/modules/custom web/themes/custom -name "*.php" -print0 | xargs -0 -n1 p
 |----------|------|
 | P2 | Remove or hide placeholder manage-event routes from IA |
 | P2 | Pro insights upsell copy when `/vendor/analytics` locked |
-| P3 | Align checkout flow config (`mel_event_checkout`) in sync |
+| Resolved | Align checkout flow config (`mel_event_checkout`) in sync |
 | P3 | Consolidate attendee entry URLs in help docs only |
 | P4 | `myeventlane_dashboard` legacy template “Vendor Dashboard” title (admin module) |
 

--- a/docs/audits/workflow-experience-audit.md
+++ b/docs/audits/workflow-experience-audit.md
@@ -178,7 +178,7 @@ Canonical workspace at `/vendor/events/{node}/studio/{section}` — information,
 | P2 | Wire My Events empty state to governed template | Empty state quality | Low | Low |
 | P2 | Richer organiser first-event empty copy (RSVP vs paid Stripe note) | Onboarding clarity | Low | Low |
 | P3 | Consolidate attendee entry points in docs/help only | Reduced confusion | Med | Low |
-| P3 | Align checkout flow config (`mel_event_checkout`) in sync | Booking reliability | Med | Medium — config |
+| Resolved | Align checkout flow config (`mel_event_checkout`) in sync | Booking reliability | Med | Resolved by ADR-0001 Architecture B implementation |
 | P4 | Remove or hide placeholder manage-event routes from IA | Fewer dead ends | Med | Low |
 | P4 | Pro analytics upsell copy when Insights locked | Conversion | Med | Low |
 

--- a/docs/launch/customer-acceptance/customer-acceptance.md
+++ b/docs/launch/customer-acceptance/customer-acceptance.md
@@ -142,7 +142,7 @@ full matrix and the overall launch-readiness score. Priorities used throughout:
 ## 4. Customer journey
 
 ### 4.1 Purchase ticket / Checkout
-- **Routes:** `/event/{node}/book` (`BookController`), `/cart/attendee-info/{order_item}` (`AttendeeInfoController`), Commerce checkout flow (`myeventlane_checkout_flow`), completion template `commerce/commerce-checkout-completion.html.twig` (215 lines).
+- **Routes:** `/event/{node}/book` (`BookController`), `/cart/attendee-info/{order_item}` (`AttendeeInfoController`), Commerce checkout flow (`mel_event_checkout` via `myeventlane_checkout_flow`), completion template `commerce/commerce-checkout-completion.html.twig` (215 lines).
 - **Primary CTA:** Book → checkout → pay.
 - **Empty states:** `commerce/commerce-cart-empty-page.html.twig` — governed empty state (`mel_cart_empty_state` from PHP), illustration, help/support trust nav. Strong.
 - **Completion:** Governed copy via `MelCustomerContinuityPresenter`; success hero, email line, order reference, per-event ticket cards with images (`alt=""` decorative). Strong continuity.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -13,7 +13,7 @@ Playwright end-to-end coverage for the critical customer path:
 3. Config imported and cache warm:
 
 ```bash
-ddev drush updb -y   # ensures default order type uses mel_event_checkout
+ddev drush config:import -y   # imports canonical mel_event_checkout assignment
 ddev drush cr
 ```
 

--- a/tests/e2e/checkout-ticket-purchase.spec.ts
+++ b/tests/e2e/checkout-ticket-purchase.spec.ts
@@ -93,7 +93,13 @@ test.describe('Checkout happy path', () => {
     await page.getByRole('button', { name: /Complete booking/i }).click();
 
     await expect(page).toHaveURL(/\/checkout\/\d+\/complete/, { timeout: 60_000 });
-    await expect(page.getByRole('heading', { name: /Great choice\. You're all set\./i })).toBeVisible();
+    if (env.paymentMode === 'manual') {
+      await expect(page.getByRole('heading', { name: /Order received/i })).toBeVisible();
+      await expect(page.getByText(/waiting for payment confirmation/i)).toBeVisible();
+    }
+    else {
+      await expect(page.getByRole('heading', { name: /Great choice\. You're all set\./i })).toBeVisible();
+    }
 
     const orderMatch = page.url().match(/\/checkout\/(\d+)\/complete/);
     expect(orderMatch).not.toBeNull();

--- a/tests/e2e/scripts/prepare-fixture.php
+++ b/tests/e2e/scripts/prepare-fixture.php
@@ -93,6 +93,7 @@ $manualId = 'mel_stripe_cc';
 if ($paymentMode === 'manual') {
   $previous = [];
   foreach (array_merge($stripeIds, [$manualId]) as $gatewayId) {
+    /** @var \Drupal\commerce_payment\Entity\PaymentGatewayInterface|null $gateway */
     $gateway = $gatewayStorage->load($gatewayId);
     if ($gateway !== NULL) {
       $previous[$gatewayId] = (bool) $gateway->status();
@@ -100,6 +101,7 @@ if ($paymentMode === 'manual') {
   }
 
   foreach ($stripeIds as $gatewayId) {
+    /** @var \Drupal\commerce_payment\Entity\PaymentGatewayInterface|null $gateway */
     $gateway = $gatewayStorage->load($gatewayId);
     if ($gateway !== NULL && $gateway->status()) {
       $gateway->set('status', FALSE);
@@ -107,6 +109,7 @@ if ($paymentMode === 'manual') {
     }
   }
 
+  /** @var \Drupal\commerce_payment\Entity\PaymentGatewayInterface|null $manual */
   $manual = $gatewayStorage->load($manualId);
   if ($manual === NULL || !$manual->status()) {
     fwrite(STDERR, "Manual payment gateway mel_stripe_cc is missing or disabled.\n");
@@ -123,6 +126,7 @@ if ($paymentMode === 'manual') {
 }
 else {
   // stripe_test: ensure stripe gateway is enabled with test keys from settings overrides.
+  /** @var \Drupal\commerce_payment\Entity\PaymentGatewayInterface|null $stripe */
   $stripe = $gatewayStorage->load('stripe');
   if ($stripe === NULL || !$stripe->status()) {
     fwrite(STDERR, "Stripe gateway is not enabled for stripe_test mode.\n");
@@ -141,13 +145,12 @@ else {
 
 \Drupal::service('cache_tags.invalidator')->invalidateTags(['config:commerce_payment_gateway_list']);
 
-// Ensure ticket carts use the MEL single-page checkout flow (not Commerce default).
-$orderTypeConfig = \Drupal::configFactory()->getEditable('commerce_order.commerce_order_type.default');
-$thirdParty = $orderTypeConfig->get('third_party_settings.commerce_checkout') ?? [];
-if (($thirdParty['checkout_flow'] ?? 'default') !== 'mel_event_checkout') {
-  $thirdParty['checkout_flow'] = 'mel_event_checkout';
-  $orderTypeConfig->set('third_party_settings.commerce_checkout', $thirdParty);
-  $orderTypeConfig->save(TRUE);
+// Assert the repository already provides the canonical checkout architecture.
+$checkoutFlow = \Drupal::config('commerce_order.commerce_order_type.default')
+  ->get('third_party_settings.commerce_checkout.checkout_flow');
+if ($checkoutFlow !== 'mel_event_checkout') {
+  fwrite(STDERR, "Default Commerce order type must use mel_event_checkout before running E2E checkout tests. Import canonical config instead of mutating it in the fixture.\n");
+  exit(1);
 }
 
 echo json_encode([

--- a/web/modules/custom/myeventlane_checkout_flow/config/install/commerce_checkout.commerce_checkout_flow.mel_event_checkout.yml
+++ b/web/modules/custom/myeventlane_checkout_flow/config/install/commerce_checkout.commerce_checkout_flow.mel_event_checkout.yml
@@ -10,8 +10,8 @@ dependencies:
     - myeventlane_commerce
 _core:
   default_config_hash: MEL_EVENT_CHECKOUT_FLOW_HASH
-id: mel_event_checkout
 label: 'MyEventLane Event Checkout'
+id: mel_event_checkout
 plugin: mel_event_checkout
 configuration:
   display_checkout_progress: false
@@ -21,7 +21,6 @@ configuration:
   guest_new_account: true
   guest_new_account_notify: true
   panes:
-    # MAIN REGION - Checkout step
     mel_buyer_details:
       display_label: 'Buyer details'
       step: checkout
@@ -38,24 +37,12 @@ configuration:
       weight: 3
       wrapper_element: fieldset
     payment_information:
-      display_label: 'Payment'
+      display_label: Payment
       step: checkout
       weight: 4
       wrapper_element: container
       always_display: true
       require_payment_method: false
-    # SIDEBAR REGION (single summary + coupon only)
-    coupon_redemption:
-      step: _sidebar
-      weight: 0
-      allow_multiple: false
-    order_summary:
-      display_label: null
-      step: _sidebar
-      weight: 1
-      wrapper_element: container
-      view: commerce_checkout_order_summary
-    # DISABLED - Duplicate/empty summary panes; grouped view missing
     grouped_order_summary:
       display_label: null
       step: _disabled
@@ -66,7 +53,12 @@ configuration:
       step: _disabled
       weight: 99
       wrapper_element: fieldset
-    # DISABLED - Legacy panes we don't want
+    order_summary:
+      display_label: null
+      step: _sidebar
+      weight: 1
+      wrapper_element: container
+      view: commerce_checkout_order_summary
     contact_information:
       step: _disabled
       weight: 100
@@ -76,4 +68,3 @@ configuration:
     myeventlane_attendee_info_per_ticket:
       step: _disabled
       weight: 102
-


### PR DESCRIPTION
- Changed the checkout flow in `commerce_order.commerce_order_type.default.yml` to point to `mel_event_checkout`.
- Updated documentation to reflect the new checkout flow structure and disabled obsolete panes.
- Added ADR-0001 implementation details to document the decision and configuration changes.
- Adjusted E2E tests to validate the new checkout flow assignment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Switching the default order type checkout flow changes live ticket checkout UX, pane sequence, and payment context—environments still on Commerce default need config import and full checkout regression (Stripe, manual, ticket issuance).
> 
> **Overview**
> **Canonical checkout (ADR-0001 Architecture B):** Exported config now assigns order type `default` to **`mel_event_checkout`** instead of Commerce **`default`**, so ticket carts use the MEL single-page flow (buyer, attendees, legal consent, payment, sidebar summary).
> 
> **Install config** for `mel_event_checkout` is trimmed to match that pane layout—sidebar **`order_summary` only**; grouped summary, fee transparency, and coupon redemption removed/disabled.
> 
> **E2E:** Fixture setup **stops mutating** order-type checkout config and **fails** if sync is not canonical; setup docs prefer **`config:import`**. Checkout spec expects **pending** completion copy for **manual** payment and paid hero for Stripe; fixture adds payment-gateway PHPDoc only.
> 
> **Docs:** New **ADR-0001** + implementation record; phase-1 checkout doc, audits, and customer acceptance updated; checkout-flow drift marked **resolved**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03f6bd2e13f10062b9d9fd47af48c6954c96a1fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->