### PR TITLE
chore: add release validation workflow

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,6 +13,7 @@ Operational scripts for local development, audits, deployment, and governance. R
 | Script | Purpose | Safe environment | Destructive | Required confirmation |
 |--------|---------|------------------|-------------|----------------------|
 | `preflight-health-check.sh` | DB, cache, config sync, and filesystem smoke checks | Local DDEV | No | None |
+| `validate-release.sh` | Canonical pre-deployment release validation: Git, Drush bootstrap, config status, database updates, MEL tests, and theme builds | Local DDEV / staging / production checkout | No | None |
 | `rebuild-scss.sh` | Clears theme caches, reinstalls npm deps, rebuilds theme assets | Local DDEV | No (removes theme `node_modules`/`dist`) | None |
 | `myeventlane-audit-collector.sh` | Collects git/composer/drush audit snapshot into `_myeventlane_audit/` | Local | No | None |
 | `backup-build-and-db.sh` | Exports DB + optional DDEV snapshot and code tarball to `backups/` | Local DDEV | No | None |

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -1,0 +1,427 @@
+#!/usr/bin/env bash
+# Canonical MEL pre-deployment validation.
+#
+# This script validates the current checkout only. It does not deploy, import
+# config, run database updates, or mutate Drupal state.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT" || exit 1
+
+SITE_URI="${SITE_URI:-}"
+MEL_DRUSH_PHP_MEMORY="${MEL_DRUSH_PHP_MEMORY:-1024M}"
+TARGET="staging"
+FORCE=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/validate-release.sh staging
+  scripts/validate-release.sh production
+  scripts/validate-release.sh production --force
+
+Targets:
+  staging     Accepts main, release/*, feature/*, fix/*, hotfix/*, cursor/*.
+  production  Requires main or an annotated tag. Non-main branches require --force.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    staging|production)
+      TARGET="$1"
+      ;;
+    --force)
+      FORCE=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+REASONS=()
+BRANCH_STATUS="PASS"
+DRUPAL_STATUS="NOT RUN"
+CONFIG_STATUS="NOT RUN"
+DATABASE_STATUS="NOT RUN"
+TESTS_STATUS="NOT RUN"
+BUILD_STATUS="NOT RUN"
+
+print_rule() {
+  echo "----------------------------------------"
+}
+
+add_reason() {
+  REASONS+=("$1")
+}
+
+mask_sensitive() {
+  sed -E \
+    -e 's/sk_(live|test)_[A-Za-z0-9_]+/[MASKED_STRIPE_SECRET]/g' \
+    -e 's/rk_(live|test)_[A-Za-z0-9_]+/[MASKED_STRIPE_RESTRICTED_KEY]/g' \
+    -e 's/pk_(live|test)_[A-Za-z0-9_]+/[MASKED_STRIPE_PUBLISHABLE_KEY]/g' \
+    -e 's/whsec_[A-Za-z0-9_]+/[MASKED_STRIPE_WEBHOOK_SECRET]/g' \
+    -e 's/((secret|SECRET|api[_-]?key|API[_-]?KEY|token|TOKEN)[^:=]*[=:][[:space:]]*)[^[:space:]]+/\1[MASKED]/g'
+}
+
+run_and_report() {
+  local label="$1"
+  shift
+
+  echo ""
+  echo "== ${label} =="
+
+  local tmp rc
+  tmp="$(mktemp)"
+  "$@" >"$tmp" 2>&1
+  rc=$?
+  mask_sensitive <"$tmp"
+  rm -f "$tmp"
+
+  if [ "$rc" -ne 0 ]; then
+    add_reason "${label} failed."
+    return "$rc"
+  fi
+
+  return 0
+}
+
+configure_drush() {
+  DRUSH_URI_ARGS=()
+  if [ -n "$SITE_URI" ]; then
+    DRUSH_URI_ARGS=(--uri="$SITE_URI")
+  fi
+
+  if command -v ddev >/dev/null 2>&1 && [ -d ".ddev" ]; then
+    DRUSH_CMD=(ddev drush)
+    return 0
+  fi
+
+  if [ -f "vendor/bin/drush.php" ]; then
+    DRUSH_CMD=(php -d "memory_limit=${MEL_DRUSH_PHP_MEMORY}" -d opcache.enable_cli=0 vendor/bin/drush.php)
+    return 0
+  fi
+
+  if [ -x "vendor/bin/drush" ]; then
+    DRUSH_CMD=(vendor/bin/drush)
+    return 0
+  fi
+
+  return 1
+}
+
+drush_capture() {
+  "${DRUSH_CMD[@]}" "$@" "${DRUSH_URI_ARGS[@]}"
+}
+
+is_staging_branch() {
+  case "$1" in
+    main|release/*|feature/*|fix/*|hotfix/*|cursor/*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+annotated_tag_at_head() {
+  local tag
+  tag="$(git describe --exact-match --tags HEAD 2>/dev/null || true)"
+  if [ -z "$tag" ]; then
+    return 1
+  fi
+
+  if [ "$(git cat-file -t "refs/tags/${tag}" 2>/dev/null || true)" = "tag" ]; then
+    printf '%s\n' "$tag"
+    return 0
+  fi
+
+  return 1
+}
+
+upstream_summary() {
+  local upstream counts behind ahead
+  upstream="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)"
+  if [ -z "$upstream" ]; then
+    echo "No upstream configured"
+    return 0
+  fi
+
+  counts="$(git rev-list --left-right --count "${upstream}...HEAD" 2>/dev/null || true)"
+  if [ -z "$counts" ]; then
+    echo "${upstream}: unable to compare"
+    return 0
+  fi
+
+  behind="${counts%%[[:space:]]*}"
+  ahead="${counts##*[[:space:]]}"
+  echo "${upstream}: ahead ${ahead}, behind ${behind}"
+}
+
+print_git_cleanliness() {
+  local modified untracked
+  modified="$(git status --porcelain 2>/dev/null | grep -Ev '^\?\?' || true)"
+  untracked="$(git status --porcelain 2>/dev/null | grep -E '^\?\?' || true)"
+
+  echo ""
+  echo "Modified files:"
+  if [ -n "$modified" ]; then
+    printf '%s\n' "$modified"
+  else
+    echo "(none)"
+  fi
+
+  echo ""
+  echo "Untracked files:"
+  if [ -n "$untracked" ]; then
+    printf '%s\n' "$untracked"
+  else
+    echo "(none)"
+  fi
+}
+
+evaluate_target_policy() {
+  local annotated_tag=""
+
+  case "$TARGET" in
+    staging)
+      if [ "$CURRENT_BRANCH" = "DETACHED" ]; then
+        BRANCH_STATUS="FAIL"
+        add_reason "Staging validation rejects detached HEAD."
+      elif ! is_staging_branch "$CURRENT_BRANCH"; then
+        BRANCH_STATUS="FAIL"
+        add_reason "Staging validation rejects branch '${CURRENT_BRANCH}'. Allowed: main, release/*, feature/*, fix/*, hotfix/*, cursor/*."
+      fi
+      ;;
+    production)
+      if [ "$CURRENT_BRANCH" = "main" ]; then
+        return 0
+      fi
+
+      annotated_tag="$(annotated_tag_at_head || true)"
+      if [ -n "$annotated_tag" ]; then
+        BRANCH_STATUS="PASS (annotated tag ${annotated_tag})"
+        return 0
+      fi
+
+      if [ "$FORCE" = "1" ] && [ "$CURRENT_BRANCH" != "DETACHED" ]; then
+        BRANCH_STATUS="PASS (forced)"
+        return 0
+      fi
+
+      BRANCH_STATUS="FAIL"
+      if [ "$CURRENT_BRANCH" = "DETACHED" ]; then
+        add_reason "Production validation requires main or an annotated tag; detached HEAD is not an annotated tag."
+      else
+        add_reason "Production validation requires main or an annotated tag. Branch '${CURRENT_BRANCH}' is rejected without --force."
+      fi
+      ;;
+  esac
+}
+
+print_not_ready_and_exit() {
+  echo ""
+  print_rule
+  echo "NOT READY FOR DEPLOY"
+  echo ""
+  echo "Reasons:"
+  for reason in "${REASONS[@]}"; do
+    echo "- ${reason}"
+  done
+  print_rule
+  exit 1
+}
+
+print_rule
+echo "MEL Release Validation"
+print_rule
+echo ""
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  add_reason "Git metadata is unavailable; release validation requires a repository checkout so branch, tag, commit, and cleanliness can be verified."
+  print_not_ready_and_exit
+fi
+
+CURRENT_BRANCH="$(git branch --show-current 2>/dev/null || true)"
+if [ -z "$CURRENT_BRANCH" ]; then
+  CURRENT_BRANCH="DETACHED"
+fi
+CURRENT_SHA="$(git rev-parse HEAD 2>/dev/null || true)"
+CURRENT_SHORT_SHA="$(git rev-parse --short HEAD 2>/dev/null || true)"
+CURRENT_MESSAGE="$(git log -1 --pretty=%s 2>/dev/null || true)"
+UPSTREAM_STATUS="$(upstream_summary)"
+
+echo "Target:          ${TARGET}"
+echo "Force:           ${FORCE}"
+echo "Current branch:  ${CURRENT_BRANCH}"
+echo "Current commit:  ${CURRENT_SHA}"
+echo "Commit message:  ${CURRENT_MESSAGE}"
+echo "Remote status:   ${UPSTREAM_STATUS}"
+
+evaluate_target_policy
+
+GIT_STATUS="$(git status --porcelain 2>/dev/null || true)"
+if [ -n "$GIT_STATUS" ]; then
+  print_git_cleanliness
+  add_reason "Working tree is not clean."
+  print_not_ready_and_exit
+fi
+
+if ! configure_drush; then
+  DRUPAL_STATUS="FAIL"
+  add_reason "Drush is unavailable; expected DDEV Drush locally or vendor/bin/drush.php on a release host."
+else
+  echo ""
+  echo "Drush command: ${DRUSH_CMD[*]}${SITE_URI:+ --uri=${SITE_URI}}"
+
+  echo ""
+  echo "== Drupal Bootstrap =="
+  DRUPAL_OUT="$(drush_capture status 2>&1)"
+  DRUPAL_RC=$?
+  printf '%s\n' "$DRUPAL_OUT" | mask_sensitive
+  if [ "$DRUPAL_RC" -eq 0 ] && printf '%s\n' "$DRUPAL_OUT" | grep -qE 'Drupal bootstrap[[:space:]]*:[[:space:]]*Successful'; then
+    DRUPAL_STATUS="PASS"
+  else
+    DRUPAL_STATUS="FAIL"
+    add_reason "Drupal did not bootstrap successfully."
+  fi
+
+  echo ""
+  echo "== Config Status =="
+  CONFIG_OUT="$(drush_capture config:status 2>&1)"
+  CONFIG_RC=$?
+  printf '%s\n' "$CONFIG_OUT" | mask_sensitive
+
+  if [ "$CONFIG_RC" -ne 0 ] && ! printf '%s\n' "$CONFIG_OUT" | grep -Eiq 'No differences|configuration differences|Only in|Different|Missing|New'; then
+    CONFIG_STATUS="FAIL"
+    add_reason "drush config:status failed."
+  elif printf '%s\n' "$CONFIG_OUT" | grep -Eiq 'No differences'; then
+    CONFIG_STATUS="PASS"
+  else
+    ENV_CONFIG="$(printf '%s\n' "$CONFIG_OUT" | grep -E 'myeventlane_core\.domain_settings' || true)"
+    STRIPE_CONFIG="$(printf '%s\n' "$CONFIG_OUT" | grep -Ei 'commerce_payment\.commerce_payment_gateway|commerce_stripe|stripe' || true)"
+    UNEXPECTED_CONFIG="$(printf '%s\n' "$CONFIG_OUT" \
+      | grep -Eiv 'myeventlane_core\.domain_settings|commerce_payment\.commerce_payment_gateway|commerce_stripe|stripe|configuration differences|^$|^[[:space:]-]+$|^[[:space:]]*Name[[:space:]]|^[[:space:]]*Collection[[:space:]]' \
+      || true)"
+
+    if [ -n "$ENV_CONFIG" ]; then
+      echo ""
+      echo "Expected environment differences:"
+      printf '%s\n' "$ENV_CONFIG" | mask_sensitive
+    fi
+
+    if [ -n "$STRIPE_CONFIG" ]; then
+      echo ""
+      echo "Stripe/payment gateway differences (review separately; not automatically treated as errors):"
+      printf '%s\n' "$STRIPE_CONFIG" | mask_sensitive
+    fi
+
+    if [ -n "$UNEXPECTED_CONFIG" ]; then
+      echo ""
+      echo "Unexpected configuration drift:"
+      printf '%s\n' "$UNEXPECTED_CONFIG" | mask_sensitive
+      CONFIG_STATUS="WARN"
+      add_reason "Unexpected configuration drift detected."
+    elif [ -n "$ENV_CONFIG" ] && [ -n "$STRIPE_CONFIG" ]; then
+      CONFIG_STATUS="PASS (Environment overrides and Stripe/payment differences detected)"
+    elif [ -n "$ENV_CONFIG" ]; then
+      CONFIG_STATUS="PASS (Environment overrides detected)"
+    elif [ -n "$STRIPE_CONFIG" ]; then
+      CONFIG_STATUS="PASS (Stripe/payment differences detected)"
+    else
+      CONFIG_STATUS="PASS"
+    fi
+  fi
+
+  echo ""
+  echo "== Database Update Status =="
+  UPDB_OUT="$(drush_capture updatedb:status 2>&1)"
+  UPDB_RC=$?
+  printf '%s\n' "$UPDB_OUT" | mask_sensitive
+  if [ "$UPDB_RC" -ne 0 ]; then
+    DATABASE_STATUS="FAIL"
+    add_reason "drush updatedb:status failed."
+  elif printf '%s\n' "$UPDB_OUT" | grep -Eiq 'No pending updates|No database updates required|No updates required'; then
+    DATABASE_STATUS="PASS"
+  else
+    DATABASE_STATUS="FAIL"
+    add_reason "Pending database updates detected."
+  fi
+fi
+
+TEST_FAILURES=0
+run_and_report "Composer validate" composer validate || TEST_FAILURES=$((TEST_FAILURES + 1))
+run_and_report "Config safety check" bash scripts/check-config-safety.sh || TEST_FAILURES=$((TEST_FAILURES + 1))
+run_and_report "Webroot safety check" bash scripts/check-webroot-safety.sh || TEST_FAILURES=$((TEST_FAILURES + 1))
+run_and_report "Raw card data safety check" bash scripts/check-no-raw-card-data.sh || TEST_FAILURES=$((TEST_FAILURES + 1))
+run_and_report "Governance audit" composer run-script governance:audit || TEST_FAILURES=$((TEST_FAILURES + 1))
+run_and_report "Governance tests" composer run-script governance:test || TEST_FAILURES=$((TEST_FAILURES + 1))
+
+if [ "$TEST_FAILURES" -eq 0 ]; then
+  TESTS_STATUS="PASS"
+else
+  TESTS_STATUS="FAIL"
+fi
+
+BUILD_FAILURES=0
+run_and_report "MEL lint" npm run mel:lint || BUILD_FAILURES=$((BUILD_FAILURES + 1))
+run_and_report "MEL build" npm run mel:build || BUILD_FAILURES=$((BUILD_FAILURES + 1))
+
+if [ "$BUILD_FAILURES" -eq 0 ]; then
+  BUILD_STATUS="PASS"
+else
+  BUILD_STATUS="FAIL"
+fi
+
+echo ""
+print_rule
+if [ "${#REASONS[@]}" -eq 0 ]; then
+  echo "READY FOR DEPLOY"
+else
+  echo "NOT READY FOR DEPLOY"
+fi
+echo ""
+echo "Branch:"
+echo "${CURRENT_BRANCH} (${BRANCH_STATUS})"
+echo ""
+echo "Commit:"
+echo "${CURRENT_SHORT_SHA}"
+echo ""
+echo "Drupal:"
+echo "${DRUPAL_STATUS}"
+echo ""
+echo "Config:"
+echo "${CONFIG_STATUS}"
+echo ""
+echo "Database:"
+echo "${DATABASE_STATUS}"
+echo ""
+echo "Tests:"
+echo "${TESTS_STATUS}"
+echo ""
+echo "Build:"
+echo "${BUILD_STATUS}"
+
+if [ "${#REASONS[@]}" -gt 0 ]; then
+  echo ""
+  echo "Reasons:"
+  for reason in "${REASONS[@]}"; do
+    echo "- ${reason}"
+  done
+fi
+print_rule
+
+if [ "${#REASONS[@]}" -gt 0 ]; then
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds a non-mutating validation script and README entry only; no runtime or deploy pipeline behavior changes in this diff.
> 
> **Overview**
> Adds **`scripts/validate-release.sh`** as the single pre-deployment check for a checkout: it is **read-only** (no deploy, config import, or DB updates) and exits with **READY FOR DEPLOY** or **NOT READY FOR DEPLOY** plus reasons.
> 
> **Staging vs production:** `staging` allows `main`, `release/*`, `feature/*`, `fix/*`, `hotfix/*`, and `cursor/*`; `production` requires **`main`**, an **annotated tag at HEAD**, or **`--force`** on a named branch. A **dirty working tree** fails immediately.
> 
> **Checks run:** Git metadata and upstream summary; Drush bootstrap (`status`), **config drift** (with allowances for domain settings and Stripe/payment diffs; unexpected drift is a **WARN**), and **pending updates** (`updatedb:status`); existing safety scripts and **governance** composer scripts; **`npm run mel:lint`** and **`mel:build`**. Command output is **masked** for Stripe keys and generic secrets. Drush is resolved via DDEV locally or `vendor/bin/drush.php` on release hosts.
> 
> **Docs:** `scripts/README.md` lists the script in the safe/diagnostic table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5957819a7c36c7facbe0b4b498494c7f2c9e71b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->