### PR TITLE
fix: improve error messaging for release metadata handling in MelCore…

### DIFF
--- a/web/modules/custom/myeventlane_core/src/Commands/MelCoreCommands.php
+++ b/web/modules/custom/myeventlane_core/src/Commands/MelCoreCommands.php
@@ -107,6 +107,8 @@ final class MelCoreCommands extends DrushCommands {
 
     if (!is_readable($metadataPath)) {
       $this->io()->warning(sprintf('Release metadata not found or unreadable: %s', ReleaseMetadataSchema::FILE));
+      $this->io()->writeln('Run the release validator successfully to generate metadata.');
+      return 1;
     }
     else {
       $contents = file_get_contents($metadataPath);


### PR DESCRIPTION
…Commands

- Added a message prompting users to run the release validator if the release metadata is unreadable.
- Ensured the function returns an error code when metadata is not found or unreadable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Drush-only UX and exit-code fix; no runtime or security impact.
> 
> **Overview**
> When `drush mel:build-info` cannot read `build/release-metadata.json`, it now **stops immediately** with exit code **1** instead of continuing with empty metadata.
> 
> It also prints a short hint to **run the release validator** so the metadata file gets generated, alongside the existing warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 085d713c83d0f89e7a47211f42d03dade99bb8ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->