### PR TITLE
debug(ci): trace deploy script through staging workflow

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -55,6 +55,24 @@ jobs:
             exit 1
           }
 
+      - name: Diagnose extracted release artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          temp_dir="$(mktemp -d)"
+          trap 'rm -rf "$temp_dir"' EXIT
+          debug_marker="MEL REMOTE DEPLOY DEBUG BUILD"
+          deploy_script="$temp_dir/scripts/deploy/remote-deploy.sh"
+          deploy_dir="$temp_dir/scripts/deploy"
+
+          tar -xzf ./artifact/artifact.tar.gz -C "$temp_dir"
+
+          echo "===== EXTRACTED ARTIFACT ====="
+          grep "$debug_marker" "$deploy_script" || true
+          sha256sum "$deploy_script"
+          ls -la "$deploy_dir"
+          find "$temp_dir/scripts" -maxdepth 2 | sort
+
       - name: Write SSH key
         shell: bash
         run: |
@@ -123,6 +141,8 @@ jobs:
             '' \
             'temp_dir="$(mktemp -d)"' \
             'trap '\''rm -rf "$temp_dir"; rm -f /tmp/artifact.tar.gz'\'' EXIT' \
+            'deploy_script="$temp_dir/scripts/deploy/remote-deploy.sh"' \
+            'deploy_dir="$temp_dir/scripts/deploy"' \
             '' \
             'echo "TEMP DIR:"' \
             'echo "$temp_dir"' \
@@ -135,6 +155,12 @@ jobs:
             '' \
             'echo "Running deploy..."' \
             'cd "$temp_dir"' \
+            '' \
+            'echo "===== EXECUTING ====="' \
+            'pwd' \
+            'echo "$temp_dir"' \
+            'ls -la "$deploy_dir"' \
+            'head -5 "$deploy_script"' \
             '' \
             'APP_PATH="$HOME/staging" \' \
             'APP_ENV=staging \' \

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -37,6 +37,17 @@ jobs:
           echo "Building commit:"
           git rev-parse HEAD
 
+      - name: Diagnose checked-out deploy script
+        run: |
+          set -euo pipefail
+          debug_marker="MEL REMOTE DEPLOY DEBUG BUILD"
+          deploy_script="scripts/deploy/remote-deploy.sh"
+          echo "===== WORKSPACE ====="
+          git rev-parse HEAD
+          git status --short
+          grep "$debug_marker" "$deploy_script" || true
+          sha256sum "$deploy_script"
+
       - name: Set up PHP
         uses: shivammathur/setup-php@2.37.0
         with:
@@ -227,6 +238,17 @@ jobs:
             exit 1
           fi
           echo "OK: followed_organisers route present in packaged account routing.yml ($member)"
+
+      - name: Diagnose deploy script before artifact upload
+        run: |
+          set -euo pipefail
+          debug_marker="MEL REMOTE DEPLOY DEBUG BUILD"
+          deploy_script="scripts/deploy/remote-deploy.sh"
+          echo "===== ARTIFACT CONTENT CHECK ====="
+          ls -la scripts/deploy/
+          grep "$debug_marker" "$deploy_script" || true
+          sha256sum "$deploy_script"
+          find scripts -maxdepth 2 | sort
 
       - name: Upload release artifact
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow-only logging around existing deploy steps; no changes to artifact contents, secrets handling, or remote deploy commands beyond extra echo output.
> 
> **Overview**
> Adds **diagnostic CI steps** so staging deploy logs can be compared at each hop for `scripts/deploy/remote-deploy.sh`: checkout, pre-upload packaging, post-download extraction, and the remote SSH run.
> 
> In **reusable-build**, new steps after checkout and before artifact upload print commit/status, grep for the `MEL REMOTE DEPLOY DEBUG BUILD` marker, `sha256sum` the script, and list `scripts/deploy/`.
> 
> In **deploy-staging**, a step extracts the downloaded tarball locally and logs the same marker, checksum, and directory layout. The remote deploy `printf` block now sets `deploy_script` / `deploy_dir` and prints **EXECUTING** context (`pwd`, temp dir, `ls`, `head -5` of the script) before invoking `bash scripts/deploy/remote-deploy.sh`.
> 
> These steps do not change packaging rules or deploy behavior—only observability for tracing which script revision runs on the server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f92877f6723c6753e0da9d9d0e85a614bb90195. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->