### PR TITLE
debug(deploy): test maintenance mode from new release

### DIFF
--- a/scripts/deploy/remote-deploy.sh
+++ b/scripts/deploy/remote-deploy.sh
@@ -608,12 +608,45 @@ echo "========================================"
 echo
 
 # ---- MAINTENANCE MODE ----
-# Prefer the live release for maintenance toggles (lighter, already warmed).
+# ------------------------------------------------------------------
+# TEMPORARY DIAGNOSTIC
+#
+# Purpose:
+# Determine whether maintenance mode fails because Drush is executed
+# from the previous release instead of the newly bootstrapped release.
+#
+# Remove immediately after investigation.
+# ------------------------------------------------------------------
 MEL_MM_ENABLED_ATTEMPTED=1
+echo "========================================"
+echo "TEMPORARY MAINTENANCE MODE DIAGNOSTIC"
+echo "========================================"
+echo "Attempt 1: Previous release"
+set +e
 if [ -n "${MEL_PREVIOUS_CURRENT:-}" ] && [ -f "${MEL_PREVIOUS_CURRENT}/vendor/bin/drush.php" ]; then
   ( cd "$MEL_PREVIOUS_CURRENT" && mel_drush_maintenance_mode 1 )
+  mel_mm_previous_rc=$?
 else
   mel_drush_maintenance_mode 1
+  mel_mm_previous_rc=$?
+fi
+set -e
+if [ "$mel_mm_previous_rc" -eq 0 ]; then
+  echo "SUCCESS: Previous release"
+else
+  echo "FAILED: Previous release"
+  echo "Attempt 2: New release"
+  set +e
+  ( cd "$RELEASE_PATH" && mel_drush_maintenance_mode 1 )
+  mel_mm_new_rc=$?
+  set -e
+  if [ "$mel_mm_new_rc" -eq 0 ]; then
+    echo "SUCCESS: New release"
+  else
+    echo "FAILED: New release"
+    echo "ERROR: Unable to enable maintenance mode from either release." >&2
+    exit "$mel_mm_previous_rc"
+  fi
 fi
 # No pre-switch cache rebuild: drush cr on the unreleased tree peaks memory during container
 # rebuild; staging CLI defaults are often 128M. Post-switch finalize runs drush cr with mel_drush.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the pre-switch maintenance path on production deploys; fallback to the new release could change which code runs if the previous attempt failed silently before, though intent is temporary debug only.
> 
> **Overview**
> Adds **temporary diagnostic logic** in `remote-deploy.sh` before the atomic `current/` symlink switch, to learn whether pre-switch maintenance mode fails when Drush runs from the **previous** live release vs the **new** bootstrapped release.
> 
> The old single-path enable (prefer previous release) is replaced with **Attempt 1** on `MEL_PREVIOUS_CURRENT`, then **Attempt 2** on `RELEASE_PATH` only if the first fails. Exit codes are captured with `set +e`, and deploy logs explicit `SUCCESS`/`FAILED` lines. If both attempts fail, the script **exits** with the previous release’s exit code instead of continuing to switch.
> 
> Comments mark this block for **removal after investigation**; deploy behavior is otherwise unchanged (still enables maintenance before switch when one attempt succeeds).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34559054fba5ac62b9aa906d4a3c98cd8f63fe36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->