### PR TITLE
refactor(EventCardViewModel): remove unused isSavedByCurrentUser method

### DIFF
--- a/web/modules/custom/myeventlane_event/src/EventCard/EventCardViewModel.php
+++ b/web/modules/custom/myeventlane_event/src/EventCard/EventCardViewModel.php
@@ -10,7 +10,6 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\flag\FlagInterface;
 use Drupal\flag\FlagServiceInterface;
 use Drupal\myeventlane_event\Service\BookingFlowResolver;
 use Drupal\myeventlane_event\Service\EventCtaResolver;
@@ -540,32 +539,6 @@ final class EventCardViewModel {
       $cacheability->addCacheTags([sprintf('event_metrics:%d', (int) $node->id())]);
     }
     return [$lowStock, $attendance];
-  }
-
-  private function isSavedByCurrentUser(NodeInterface $node): bool {
-    if (!$this->flagService) {
-      return FALSE;
-    }
-    if ($this->currentUser->isAnonymous()) {
-      $request = \Drupal::requestStack()->getCurrentRequest();
-      if ($request === NULL || !$request->hasSession() || !$request->getSession()->isStarted()) {
-        return FALSE;
-      }
-    }
-    $flag = $this->flagService->getFlagById('event_save');
-    if (!$flag instanceof FlagInterface) {
-      return FALSE;
-    }
-    if (!in_array('event', $flag->getBundles(), TRUE) && $flag->getBundles() !== []) {
-      return FALSE;
-    }
-    try {
-      return $flag->isFlagged($node, $this->currentUser);
-    }
-    catch (\LogicException) {
-      // Anonymous flag checks require an active session (see FlagService).
-      return FALSE;
-    }
   }
 
   /**


### PR DESCRIPTION
Eliminate the isSavedByCurrentUser method from EventCardViewModel as it is no longer needed, streamlining the codebase and improving maintainability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal only; no change to how cards expose save links or cache the card shell.
> 
> **Overview**
> Removes the private **`isSavedByCurrentUser`** helper and the unused **`FlagInterface`** import from `EventCardViewModel`.
> 
> Saved-state on cards was already handled elsewhere: **`build()`** keeps **`is_saved`** fixed at `FALSE` for a shareable card shell, and **`applyToNodeVariables()`** exposes save UI via **`buildSaveFlagLink()`** (flag lazy builder) without baking per-user flag checks into the view model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc28cfbfb2b2b197824818f55938dfd726f0c7ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->