### PR TITLE
Feature/mel checkout ux polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,14 @@ tmp/
 memory/
 docs/internal/
 *.bak
+
+# macOS
+.DS_Store
+
+# Storage runtime
+shared/private_files/storage-audit/
+shared/private_files/storage-migration/
+shared/private_files/backups/
+
+# Ignore everything under shared except intentional placeholders
+shared/**/.DS_Store

--- a/config/sync/commerce_payment.commerce_payment_gateway.stripe_pe_recurring.yml
+++ b/config/sync/commerce_payment.commerce_payment_gateway.stripe_pe_recurring.yml
@@ -26,6 +26,11 @@ configuration:
     custom_label: ''
     show_payment_method_logos: 'no'
     include_logos: {  }
+  express_checkout:
+    enable_on_cart: false
+    allowed_payment_method_types: {  }
+    collect_phone_number: false
+    collect_billing_address: true
 conditions:
   -
     plugin: current_currency

--- a/config/sync/commerce_payment.commerce_payment_gateway.stripe_pe_recurring.yml
+++ b/config/sync/commerce_payment.commerce_payment_gateway.stripe_pe_recurring.yml
@@ -16,6 +16,11 @@ configuration:
   collect_billing_information: true
   publishable_key: ''
   secret_key: ''
+  express_checkout:
+    enable_on_cart: false
+    allowed_payment_method_types: {  }
+    collect_phone_number: false
+    collect_billing_address: true
   webhook_signing_secret: ''
   payment_method_usage: off_session
   capture_method: automatic
@@ -26,11 +31,6 @@ configuration:
     custom_label: ''
     show_payment_method_logos: 'no'
     include_logos: {  }
-  express_checkout:
-    enable_on_cart: false
-    allowed_payment_method_types: {  }
-    collect_phone_number: false
-    collect_billing_address: true
 conditions:
   -
     plugin: current_currency

--- a/config/sync/myeventlane_legal.settings.yml
+++ b/config/sync/myeventlane_legal.settings.yml
@@ -7,6 +7,6 @@ privacy_url: /privacy
 refund_policy_url: /help/policies/refund-policy
 cookie_policy_url: /cookie-policy
 collection_notice_rsvp: 'We collect your name and email to process your RSVP, send confirmation, and manage your booking. Our Privacy Policy explains how we use and protect your information.'
-collection_notice_checkout: 'We collect your contact details to process your order, send tickets and receipts, and manage your booking. Our Privacy Policy explains how we use and protect your information.'
+collection_notice_checkout: 'We collect your contact details to process your booking, send tickets and receipts, and manage your booking. Our Privacy Policy explains how we use and protect your information.'
 updated_at: null
 store_vendor_ip_ua: false

--- a/config/sync/myeventlane_messaging.template.order_confirmation.yml
+++ b/config/sync/myeventlane_messaging.template.order_confirmation.yml
@@ -1,10 +1,10 @@
 enabled: true
-subject: 'Your order is confirmed – {{ event_name|default("your event") }}'
+subject: 'Your booking is confirmed – {{ event_name|default("your event") }}'
 body_html: |
   <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; max-width: 600px; margin: 0 auto; background-color: #fef5ec; padding: 20px;">
     <div style="background-color: #ffffff; border-radius: 8px; padding: 30px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
       <div style="text-align: center; margin-bottom: 30px;">
-        <h1 style="color: #2c3e50; margin: 0; font-size: 28px;">Thank you for your order!</h1>
+        <h1 style="color: #2c3e50; margin: 0; font-size: 28px;">Thank you for your booking!</h1>
       </div>
 
       <p style="color: #34495e; font-size: 16px; line-height: 1.6; margin-bottom: 20px;">
@@ -12,7 +12,7 @@ body_html: |
       </p>
 
       <p style="color: #34495e; font-size: 16px; line-height: 1.6; margin-bottom: 20px;">
-        Your order <strong>#{{ order_number }}</strong> is confirmed. Calendar file(s) are attached—use <strong>Add to calendar</strong> below or open the attachment.
+        Your booking <strong>#{{ order_number }}</strong> is confirmed. Calendar file(s) are attached—use <strong>Add to calendar</strong> below or open the attachment.
       </p>
 
       {% if events|length > 0 %}
@@ -168,7 +168,7 @@ body_html: |
           Your tickets are attached when available.
         </p>
         <p style="color: #34495e; font-size: 14px; line-height: 1.5; margin: 0 0 18px 0; text-align: center;">
-          You can always access your tickets from your order page.
+          You can always access your tickets from your booking page.
         </p>
         <div style="text-align: center;">
           {% set download_href = tickets_url|default(order_url) %}
@@ -179,7 +179,7 @@ body_html: |
           {% endif %}
         </div>
         {% if order_url and download_href and download_href != order_url %}
-          <p style="text-align: center; margin: 14px 0 0;"><a href="{{ order_url }}" style="color: #34495e; font-size: 14px;">View order details</a></p>
+          <p style="text-align: center; margin: 14px 0 0;"><a href="{{ order_url }}" style="color: #34495e; font-size: 14px;">View booking details</a></p>
         {% endif %}
       </div>
 

--- a/config/sync/myeventlane_messaging.template.order_receipt.yml
+++ b/config/sync/myeventlane_messaging.template.order_receipt.yml
@@ -4,7 +4,7 @@ body_html: |
   <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; max-width: 600px; margin: 0 auto; background-color: #fef5ec; padding: 20px;">
     <div style="background-color: #ffffff; border-radius: 8px; padding: 30px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
       <div style="text-align: center; margin-bottom: 30px;">
-        <h1 style="color: #2c3e50; margin: 0; font-size: 28px;">Thank you for your order</h1>
+        <h1 style="color: #2c3e50; margin: 0; font-size: 28px;">Thank you for your booking</h1>
       </div>
 
       <p style="color: #34495e; font-size: 16px; line-height: 1.6; margin-bottom: 20px;">
@@ -12,7 +12,7 @@ body_html: |
       </p>
 
       <p style="color: #34495e; font-size: 16px; line-height: 1.6; margin-bottom: 20px;">
-        Your order <strong>#{{ order_number }}</strong> has been confirmed. We've attached your calendar file(s) to this email.
+        Your booking <strong>#{{ order_number }}</strong> has been confirmed. We've attached your calendar file(s) to this email.
       </p>
 
       {% if events|length > 0 %}

--- a/config/sync/myeventlane_wallet.settings.yml
+++ b/config/sync/myeventlane_wallet.settings.yml
@@ -1,7 +1,7 @@
-apple_enabled: false
-apple_team_id: ''
-apple_pass_type_id: ''
-apple_organisation_name: ''
+apple_enabled: true
+apple_team_id: WT8K739P63
+apple_pass_type_id: pass.com.tickets.myeventlane
+apple_organisation_name: 'My Eventlane'
 google_enabled: true
 google_issuer_id: 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
 show_wallet_buttons: true

--- a/config/sync/system.performance.yml
+++ b/config/sync/system.performance.yml
@@ -4,7 +4,7 @@ cache:
   page:
     max_age: 900
 css:
-  preprocess: true
+  preprocess: false
   gzip: true
 fast_404:
   enabled: true
@@ -12,5 +12,5 @@ fast_404:
   exclude_paths: '/\/(?:styles|imagecache)\//'
   html: '<!DOCTYPE html><html><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL "@path" was not found on this server.</p></body></html>'
 js:
-  preprocess: true
+  preprocess: false
   gzip: true

--- a/web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.services.yml
+++ b/web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.services.yml
@@ -24,6 +24,7 @@ services:
       - '@myeventlane_checkout_flow.checkout_grouped_summary_builder'
       - '@myeventlane_surface.state_readiness_helper'
       - '@myeventlane_surface.governed_operational_templates'
+      - '@myeventlane_legal.settings'
 
   myeventlane_checkout_flow.order_pricing_breakdown:
     class: Drupal\myeventlane_checkout_flow\Service\OrderPricingBreakdownBuilder

--- a/web/modules/custom/myeventlane_checkout_flow/src/Plugin/Commerce/CheckoutPane/DonationPane.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Plugin/Commerce/CheckoutPane/DonationPane.php
@@ -26,6 +26,15 @@ final class DonationPane extends CheckoutPaneBase {
   /**
    * {@inheritdoc}
    */
+  public function isVisible(): bool {
+    // Keep the plugin registered for legacy flow config, but never expose an
+    // empty donation control (or its Twig heading wrapper) on checkout.
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function buildPaneForm(array $pane_form, FormStateInterface $form_state, array &$complete_form): array {
     $pane_form['#access'] = FALSE;
     return $pane_form;

--- a/web/modules/custom/myeventlane_checkout_flow/src/Plugin/Commerce/CheckoutPane/LegalConsentPane.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Plugin/Commerce/CheckoutPane/LegalConsentPane.php
@@ -6,7 +6,11 @@ namespace Drupal\myeventlane_checkout_flow\Plugin\Commerce\CheckoutPane;
 
 use Drupal\commerce_checkout\Plugin\Commerce\CheckoutPane\CheckoutPaneBase;
 use Drupal\commerce_checkout\Plugin\Commerce\CheckoutFlow\CheckoutFlowInterface;
+use Drupal\Component\Render\MarkupInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Link;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Url;
 use Drupal\myeventlane_legal\Service\LegalSettingsService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -51,13 +55,6 @@ final class LegalConsentPane extends CheckoutPaneBase {
       $consent_timestamp = (int) $order->get('field_legal_consent_timestamp')->value;
     }
 
-    $termsUrl = $this->legalSettings->getCustomerTermsUrl();
-    $privacyUrl = $this->legalSettings->getPrivacyUrl();
-    $refundUrl = $this->legalSettings->getRefundPolicyUrl();
-    $termsLink = $termsUrl ? '<a href="' . htmlspecialchars($termsUrl) . '" target="_blank" rel="noopener">' . $this->t('Terms of Service') . '</a>' : $this->t('Terms of Service');
-    $privacyLink = $privacyUrl ? '<a href="' . htmlspecialchars($privacyUrl) . '" target="_blank" rel="noopener">' . $this->t('Privacy Policy') . '</a>' : $this->t('Privacy Policy');
-    $refundLink = $refundUrl ? '<a href="' . htmlspecialchars($refundUrl) . '" target="_blank" rel="noopener">' . $this->t('Refund Policy') . '</a>' : $this->t('Refund Policy');
-
     $collection_notice = $this->legalSettings->getCollectionNoticeCheckout();
 
     if ($collection_notice !== '') {
@@ -68,15 +65,28 @@ final class LegalConsentPane extends CheckoutPaneBase {
       ];
     }
 
+    // Link::toString() returns MarkupInterface so @ placeholders in t() do not
+    // escape the anchors (plain HTML strings were being escaped previously).
     $pane_form['consent_text'] = [
       '#type' => 'container',
       '#attributes' => ['class' => ['mel-consent-text']],
-      'markup' => [
-        '#markup' => '<p>' . $this->t('By proceeding, you agree to our @terms, @privacy, and @refund.', [
-          '@terms' => $termsLink,
-          '@privacy' => $privacyLink,
-          '@refund' => $refundLink,
-        ]) . '</p>',
+      'message' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('By proceeding, you agree to our @terms, @privacy, and @refund.', [
+          '@terms' => $this->buildPolicyLinkMarkup(
+            $this->legalSettings->getCustomerTermsUrl(),
+            $this->t('Terms of Service'),
+          ),
+          '@privacy' => $this->buildPolicyLinkMarkup(
+            $this->legalSettings->getPrivacyUrl(),
+            $this->t('Privacy Policy'),
+          ),
+          '@refund' => $this->buildPolicyLinkMarkup(
+            $this->legalSettings->getRefundPolicyUrl(),
+            $this->t('Refund Policy'),
+          ),
+        ]),
       ],
     ];
 
@@ -99,6 +109,32 @@ final class LegalConsentPane extends CheckoutPaneBase {
     ];
 
     return $pane_form;
+  }
+
+  /**
+   * Builds a policy link safe for @ placeholders (MarkupInterface, XSS-safe).
+   */
+  private function buildPolicyLinkMarkup(string $url, TranslatableMarkup $title): MarkupInterface|TranslatableMarkup {
+    $url = trim($url);
+    if ($url === '') {
+      return $title;
+    }
+
+    try {
+      $url_object = str_starts_with($url, '/')
+        ? Url::fromUserInput($url)
+        : Url::fromUri($url);
+    }
+    catch (\InvalidArgumentException) {
+      return $title;
+    }
+
+    $url_object->setOption('attributes', [
+      'target' => '_blank',
+      'rel' => 'noopener',
+    ]);
+
+    return Link::fromTextAndUrl($title, $url_object)->toString();
   }
 
   /**

--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/MelCheckoutSummaryPresenter.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/MelCheckoutSummaryPresenter.php
@@ -8,6 +8,7 @@ use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\Core\Cache\Cache;
 use Drupal\myeventlane_core\GovernedOperationalTemplates;
 use Drupal\myeventlane_core\MelReadinessHelper;
+use Drupal\myeventlane_legal\Service\LegalSettingsService;
 
 /**
  * Canonical checkout order summary presentation (grouped structure, labels, trust).
@@ -20,6 +21,7 @@ final class MelCheckoutSummaryPresenter {
     private readonly CheckoutGroupedSummaryBuilderInterface $groupedSummaryBuilder,
     private readonly MelReadinessHelper $readinessHelper,
     private readonly GovernedOperationalTemplates $operationalTemplates,
+    private readonly LegalSettingsService $legalSettings,
   ) {}
 
   /**
@@ -27,7 +29,7 @@ final class MelCheckoutSummaryPresenter {
    *
    * @param array<string, mixed> $options
    *   - surface: 'checkout' (default), 'cart', or 'complete'. Controls layout-only flags
-   *     (e.g. jump-to-payment link) — pricing still comes from Commerce via builders only.
+   *     — pricing still comes from Commerce via builders only.
    *
    * @return array<string, mixed>
    */
@@ -55,10 +57,14 @@ final class MelCheckoutSummaryPresenter {
     }
 
     $labels = $this->readinessHelper->customerCheckoutOrderSummarySurfaceLabels();
+    $refund_url = trim($this->legalSettings->getRefundPolicyUrl());
     $trust = [
+      'heading' => $labels['trust_heading'],
       'line_secure' => $labels['trust_footer_secure'],
       'line_instant' => $labels['trust_footer_instant'],
       'line_refund' => $labels['trust_footer_refund_hint'],
+      'refund_url' => $refund_url,
+      'refund_link_label' => $labels['trust_refund_link_label'],
     ];
 
     return [
@@ -77,7 +83,8 @@ final class MelCheckoutSummaryPresenter {
       '#has_pricing_block' => $has_pricing_block,
       '#has_grouped_line_items' => $has_grouped_line_items,
       '#surface' => $surface,
-      '#show_jump_to_payment' => $surface === 'checkout',
+      // Jump-to-payment was removed from the customer checkout summary contract.
+      '#show_jump_to_payment' => FALSE,
     ];
   }
 

--- a/web/modules/custom/myeventlane_checkout_flow/tests/src/Unit/DonationPaneVisibilityTest.php
+++ b/web/modules/custom/myeventlane_checkout_flow/tests/src/Unit/DonationPaneVisibilityTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_checkout_flow\Unit;
+
+use Drupal\myeventlane_checkout_flow\Plugin\Commerce\CheckoutPane\DonationPane;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_checkout_flow\Plugin\Commerce\CheckoutPane\DonationPane
+ *
+ * @group myeventlane_checkout_flow
+ */
+final class DonationPaneVisibilityTest extends UnitTestCase {
+
+  /**
+   * @covers ::isVisible
+   */
+  public function testLegacyDonationPaneIsNotVisibleWithoutControl(): void {
+    $pane = (new \ReflectionClass(DonationPane::class))->newInstanceWithoutConstructor();
+    $this->assertFalse($pane->isVisible());
+  }
+
+  /**
+   * When a real donation control is present, Twig must keep the heading wrapper.
+   *
+   * The pane plugin stays invisible (legacy stub). Live donation UI, if reintroduced,
+   * must ship a non-empty renderable control so the Twig striptags guard keeps the
+   * OPTIONAL / Optional donation heading.
+   */
+  public function testDonationHeadingContractDocumentsPresentControlRequirement(): void {
+    $this->assertTrue(method_exists(DonationPane::class, 'isVisible'));
+    $this->assertTrue(method_exists(DonationPane::class, 'buildPaneForm'));
+  }
+
+}

--- a/web/modules/custom/myeventlane_checkout_flow/tests/src/Unit/MelCheckoutSummaryPresenterTest.php
+++ b/web/modules/custom/myeventlane_checkout_flow/tests/src/Unit/MelCheckoutSummaryPresenterTest.php
@@ -4,11 +4,16 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\myeventlane_checkout_flow\Unit;
 
+use Drupal\Component\Datetime\TimeInterface;
 use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\myeventlane_checkout_flow\Service\CheckoutGroupedSummaryBuilderInterface;
 use Drupal\myeventlane_checkout_flow\Service\MelCheckoutSummaryPresenter;
 use Drupal\myeventlane_core\GovernedOperationalTemplates;
 use Drupal\myeventlane_core\MelReadinessHelper;
+use Drupal\myeventlane_legal\Service\LegalSettingsService;
 use Drupal\Tests\UnitTestCase;
 
 /**
@@ -17,6 +22,18 @@ use Drupal\Tests\UnitTestCase;
  * @group myeventlane_checkout_flow
  */
 final class MelCheckoutSummaryPresenterTest extends UnitTestCase {
+
+  private function legalSettings(string $refund_url = '/help/policies/refund-policy'): LegalSettingsService {
+    $config = $this->createMock(ImmutableConfig::class);
+    $config->method('get')->willReturnCallback(static function (string $key) use ($refund_url) {
+      return $key === 'refund_policy_url' ? $refund_url : NULL;
+    });
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('get')->with('myeventlane_legal.settings')->willReturn($config);
+    $logger_factory = $this->createMock(LoggerChannelFactoryInterface::class);
+    $time = $this->createMock(TimeInterface::class);
+    return new LegalSettingsService($factory, $logger_factory, $time);
+  }
 
   /**
    * @covers ::buildGroupedSummaryRenderArray
@@ -44,7 +61,7 @@ final class MelCheckoutSummaryPresenterTest extends UnitTestCase {
     $readiness = new MelReadinessHelper($this->getStringTranslationStub());
     $templates = new GovernedOperationalTemplates($readiness);
 
-    $presenter = new MelCheckoutSummaryPresenter($grouped, $readiness, $templates);
+    $presenter = new MelCheckoutSummaryPresenter($grouped, $readiness, $templates, $this->legalSettings());
     $render = $presenter->buildGroupedSummaryRenderArray($order, ['surface' => 'cart']);
 
     $this->assertSame('mel_checkout_order_summary_grouped', $render['#theme']);
@@ -78,13 +95,69 @@ final class MelCheckoutSummaryPresenterTest extends UnitTestCase {
     $readiness = new MelReadinessHelper($this->getStringTranslationStub());
     $templates = new GovernedOperationalTemplates($readiness);
 
-    $presenter = new MelCheckoutSummaryPresenter($grouped, $readiness, $templates);
+    $presenter = new MelCheckoutSummaryPresenter($grouped, $readiness, $templates, $this->legalSettings());
     $render = $presenter->buildGroupedSummaryRenderArray($order, ['surface' => 'complete']);
 
     $this->assertSame('complete', $render['#surface']);
     $this->assertFalse($render['#show_jump_to_payment']);
     $this->assertFalse($render['#has_grouped_line_items']);
     $this->assertTrue($render['#has_pricing_block']);
+  }
+
+  /**
+   * @covers ::buildGroupedSummaryRenderArray
+   */
+  public function testCheckoutTrustBlockUsesApprovedCopyAndOmitsLegacyStrings(): void {
+    $order = $this->createMock(OrderInterface::class);
+    $order->method('getCacheTags')->willReturn(['commerce_order:4']);
+    $order->method('getCacheContexts')->willReturn(['user']);
+
+    $built = [
+      'grouped_items' => [[
+        'title' => 'Show',
+        'items' => [[
+          'quantity' => 1,
+          'ticket_type' => 'General',
+          'total_price' => '$25.00',
+        ]],
+      ]],
+      'order_total' => '$25.00',
+      'subtotal_formatted' => '$25.00',
+      'optional_donation_formatted' => '',
+      'tax_rows' => [],
+      'fee_rows' => [],
+      'platform_fee_absorbed' => FALSE,
+      'show_includes_gst_note' => FALSE,
+      'cache_tags' => [],
+    ];
+
+    $grouped = $this->createMock(CheckoutGroupedSummaryBuilderInterface::class);
+    $grouped->method('build')->willReturn($built);
+
+    $readiness = new MelReadinessHelper($this->getStringTranslationStub());
+    $templates = new GovernedOperationalTemplates($readiness);
+    $presenter = new MelCheckoutSummaryPresenter($grouped, $readiness, $templates, $this->legalSettings('/help/policies/refund-policy'));
+    $render = $presenter->buildGroupedSummaryRenderArray($order, ['surface' => 'checkout']);
+
+    $this->assertFalse($render['#show_jump_to_payment']);
+    $this->assertSame('Book with confidence', $render['#trust']['heading']);
+    $this->assertSame('Secure payment processed by Stripe', $render['#trust']['line_secure']);
+    $this->assertStringContainsString('booking confirmation', $render['#trust']['line_instant']);
+    $this->assertStringContainsString('organiser', $render['#trust']['line_refund']);
+    $this->assertSame('/help/policies/refund-policy', $render['#trust']['refund_url']);
+    $this->assertSame('View the Refund Policy', $render['#trust']['refund_link_label']);
+    $this->assertSame('Booking summary', $render['#labels']['title']);
+
+    $legacy = [
+      'Jump to payment',
+      'Secure payments via Stripe',
+      'Confirmation emailed instantly',
+      'Refund policy and organiser rules are in the Help Centre.',
+    ];
+    foreach ($legacy as $needle) {
+      $this->assertStringNotContainsString($needle, implode("\n", $render['#trust']));
+      $this->assertStringNotContainsString($needle, implode("\n", $render['#labels']));
+    }
   }
 
   /**
@@ -120,7 +193,7 @@ final class MelCheckoutSummaryPresenterTest extends UnitTestCase {
     $readiness = new MelReadinessHelper($this->getStringTranslationStub());
     $templates = new GovernedOperationalTemplates($readiness);
 
-    $presenter = new MelCheckoutSummaryPresenter($grouped, $readiness, $templates);
+    $presenter = new MelCheckoutSummaryPresenter($grouped, $readiness, $templates, $this->legalSettings());
     $render = $presenter->buildGroupedSummaryRenderArray($order, ['surface' => 'complete']);
 
     $this->assertTrue($render['#has_grouped_line_items']);
@@ -153,7 +226,7 @@ final class MelCheckoutSummaryPresenterTest extends UnitTestCase {
     $readiness = new MelReadinessHelper($this->getStringTranslationStub());
     $templates = new GovernedOperationalTemplates($readiness);
 
-    $presenter = new MelCheckoutSummaryPresenter($grouped, $readiness, $templates);
+    $presenter = new MelCheckoutSummaryPresenter($grouped, $readiness, $templates, $this->legalSettings());
     $render = $presenter->buildGroupedSummaryRenderArray($order);
 
     $this->assertSame('container', $render['#type']);

--- a/web/modules/custom/myeventlane_core/src/Form/GeneralSettingsForm.php
+++ b/web/modules/custom/myeventlane_core/src/Form/GeneralSettingsForm.php
@@ -39,6 +39,7 @@ final class GeneralSettingsForm extends ConfigFormBase {
       '#type' => 'details',
       '#title' => $this->t('Platform settings'),
       '#open' => TRUE,
+      '#tree' => TRUE,
     ];
 
     $form['platform']['site_name'] = [
@@ -60,6 +61,7 @@ final class GeneralSettingsForm extends ConfigFormBase {
       '#type' => 'details',
       '#title' => $this->t('Default settings'),
       '#open' => TRUE,
+      '#tree' => TRUE,
     ];
 
     $form['defaults']['default_timezone'] = [
@@ -83,6 +85,7 @@ final class GeneralSettingsForm extends ConfigFormBase {
       '#type' => 'details',
       '#title' => $this->t('Payments & fees'),
       '#open' => TRUE,
+      '#tree' => TRUE,
     ];
 
     $ticket_fee = PlatformFeeDefaults::normalizePercent($config->get('platform_fee_percent'));

--- a/web/modules/custom/myeventlane_core/src/MelReadinessHelper.php
+++ b/web/modules/custom/myeventlane_core/src/MelReadinessHelper.php
@@ -349,11 +349,11 @@ final class MelReadinessHelper {
   }
 
   public function customerCheckoutCtaSecurePaymentNote(): string {
-    return (string) $this->t('Your payment will be processed securely.');
+    return (string) $this->t('Your payment will be processed securely');
   }
 
   public function customerCheckoutOrderSummaryAriaLabel(): string {
-    return (string) $this->t('Order summary');
+    return (string) $this->t('Booking summary');
   }
 
   /**
@@ -394,7 +394,8 @@ final class MelReadinessHelper {
   public function customerCheckoutCompletionHero(): array {
     return [
       'heading' => (string) $this->customerCheckoutCompletionHeadline(),
-      'lead' => (string) $this->t('Confirmation and tickets have been sent.'),
+      // Do not claim tickets were attached or delivered — issuance may still be queued.
+      'lead' => (string) $this->t('Check your email for your booking confirmation.'),
     ];
   }
 
@@ -472,23 +473,25 @@ final class MelReadinessHelper {
    * @return array<string, string>
    */
   public function customerCheckoutOrderSummarySurfaceLabels(): array {
+    $booking_summary = $this->customerCheckoutBookingSummaryHeading();
     return [
-      'summary_region' => $this->customerCheckoutOrderSummaryAriaLabel(),
+      'summary_region' => $booking_summary,
       'pricing_breakdown_region' => (string) $this->t('Pricing breakdown'),
       'contribution_label' => (string) $this->t('Contribution'),
       'total_label' => (string) $this->t('Total'),
       'platform_fee_label' => (string) $this->t('Platform fee'),
       'platform_fee_absorbed_value' => (string) $this->t('Organiser absorbs'),
       'gst_note' => (string) $this->t('All prices include GST'),
-      'jump_payment' => (string) $this->t('Jump to payment'),
       'tickets_table_caption' => (string) $this->t('Tickets and quantities'),
-      'core_heading_visually_hidden' => (string) $this->t('Order summary'),
-      'sidebar_visible_title' => (string) $this->t('Your order'),
-      'title' => (string) $this->t('Your order'),
+      'core_heading_visually_hidden' => $booking_summary,
+      'sidebar_visible_title' => $booking_summary,
+      'title' => $booking_summary,
       'subtotal_label' => (string) $this->t('Subtotal'),
-      'trust_footer_secure' => (string) $this->t('Secure payments via Stripe'),
-      'trust_footer_instant' => (string) $this->t('Confirmation emailed instantly'),
-      'trust_footer_refund_hint' => (string) $this->t('Refund policy and organiser rules are in the Help Centre.'),
+      'trust_heading' => (string) $this->t('Book with confidence'),
+      'trust_footer_secure' => (string) $this->t('Secure payment processed by Stripe'),
+      'trust_footer_instant' => (string) $this->t('We’ll email your booking confirmation after your booking is confirmed'),
+      'trust_footer_refund_hint' => (string) $this->t('Refunds are subject to the organiser’s refund policy'),
+      'trust_refund_link_label' => (string) $this->t('View the Refund Policy'),
       'event_fallback_title' => (string) $this->t('Event'),
       'additional_items_title' => (string) $this->t('Additional items'),
       'help_region_short' => (string) $this->t('Help'),
@@ -510,8 +513,11 @@ final class MelReadinessHelper {
     return [
       'title' => $labels['title'],
       'subtotal_label' => $labels['subtotal_label'],
+      'trust_heading' => $labels['trust_heading'],
       'trust_footer_secure' => $labels['trust_footer_secure'],
       'trust_footer_instant' => $labels['trust_footer_instant'],
+      'trust_footer_refund_hint' => $labels['trust_footer_refund_hint'],
+      'trust_refund_link_label' => $labels['trust_refund_link_label'],
     ];
   }
 
@@ -540,7 +546,7 @@ final class MelReadinessHelper {
   }
 
   public function customerCheckoutOrderNumberLine(string $order_number): string {
-    return (string) $this->t('Order #@number', ['@number' => $order_number]);
+    return (string) $this->t('Booking #@number', ['@number' => $order_number]);
   }
 
   /**
@@ -560,7 +566,7 @@ final class MelReadinessHelper {
       'google_calendar' => (string) $this->t('Google Calendar'),
       'outlook_calendar' => (string) $this->t('Outlook'),
       'guest_ticket_email_body' => (string) $this->t('Check your inbox for ticket PDFs, calendar files, and this order number — you can open them anytime without signing in.'),
-      'guest_order_number_intro' => (string) $this->t('Order number:'),
+      'guest_order_number_intro' => (string) $this->t('Booking number:'),
       'what_next_title' => (string) $this->t('What happens next'),
       'what_next_body' => (string) $this->t('Keep this confirmation handy. Sign in later to find tickets under My tickets, or use the links in your email. The organiser may send practical details closer to the date.'),
       'organiser_trust_title' => (string) $this->t('About your organiser'),

--- a/web/modules/custom/myeventlane_surface/tests/src/Unit/MelReadinessHelperCustomerTest.php
+++ b/web/modules/custom/myeventlane_surface/tests/src/Unit/MelReadinessHelperCustomerTest.php
@@ -60,20 +60,34 @@ final class MelReadinessHelperCustomerTest extends UnitTestCase {
    * @covers ::customerCheckoutOrderSummarySurfaceLabels
    * @covers ::customerCheckoutCartRemovedUnavailableSlots
    * @covers ::customerCartShellLabels
+   * @covers ::customerCheckoutOrderNumberLine
+   * @covers ::customerCheckoutCompletionHero
    */
   public function testCheckoutSummaryAndCartShellLabelsIncludeTrustFooter(): void {
     $h = $this->helper();
     $labels = $h->customerCheckoutOrderSummarySurfaceLabels();
+    $this->assertSame('Booking summary', $labels['title']);
+    $this->assertSame('Book with confidence', $labels['trust_heading']);
     $this->assertArrayHasKey('trust_footer_refund_hint', $labels);
-    $this->assertNotSame('', $labels['trust_footer_secure']);
-    $this->assertNotSame('', $labels['trust_footer_instant']);
-    $this->assertNotSame('', $labels['trust_footer_refund_hint']);
+    $this->assertSame('Secure payment processed by Stripe', $labels['trust_footer_secure']);
+    $this->assertStringContainsString('booking confirmation', $labels['trust_footer_instant']);
+    $this->assertStringContainsString('organiser’s refund policy', $labels['trust_footer_refund_hint']);
+    $this->assertSame('View the Refund Policy', $labels['trust_refund_link_label']);
+    $this->assertArrayNotHasKey('jump_payment', $labels);
+    $this->assertStringNotContainsString('Jump to payment', implode("\n", $labels));
+    $this->assertStringNotContainsString('Confirmation emailed instantly', implode("\n", $labels));
+    $this->assertStringNotContainsString('Refund policy and organiser rules are in the Help Centre.', implode("\n", $labels));
+    $this->assertStringNotContainsString('Secure payments via Stripe', implode("\n", $labels));
     $removed = $h->customerCheckoutCartRemovedUnavailableSlots();
     $this->assertNotSame('', $removed['heading']);
     $this->assertNotSame('', $removed['what_happened']);
     $cart = $h->customerCartShellLabels();
     $this->assertSame($labels['trust_footer_secure'], $cart['reassurance_secure']);
     $this->assertArrayHasKey('reassurance_refund_hint', $cart);
+    $this->assertSame('Booking #2026-07-3', $h->customerCheckoutOrderNumberLine('2026-07-3'));
+    $hero = $h->customerCheckoutCompletionHero();
+    $this->assertSame('Booking confirmed', $hero['heading']);
+    $this->assertStringNotContainsString('tickets have been sent', $hero['lead']);
   }
 
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_checkout.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_checkout.scss
@@ -1247,100 +1247,92 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
 
 .mel-summary-grouped .mel-summary-event,
 .mel-summary-event {
-  margin-bottom: spacing.mel-space(4);
-  padding-bottom: spacing.mel-space(3);
-  border-bottom: 1px solid rgba(colors.$mel-color-border, 0.6);
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  column-gap: spacing.mel-space(3);
+  row-gap: spacing.mel-space(3);
+  align-items: start;
+  margin: 0 0 spacing.mel-space(4);
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
 
   &:last-of-type {
-    border-bottom: none;
-    padding-bottom: 0;
+    margin-bottom: spacing.mel-space(2);
+  }
+
+  &:not(:has(.mel-summary-event__media)) {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   h3,
   .mel-summary-event__title {
-    font-size: typography.mel-font-size(sm);
+    font-size: typography.mel-font-size(md);
     font-weight: typography.$mel-font-bold;
     color: colors.$mel-color-text;
     margin: 0 0 spacing.mel-space(1) 0;
-  }
-}
-
-.mel-summary-grouped .mel-summary-event--card {
-  border-bottom: none;
-  padding-bottom: 0;
-}
-
-.mel-summary-event--card {
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  gap: spacing.mel-space(3);
-  padding: spacing.mel-space(4);
-  margin-bottom: spacing.mel-space(4);
-  border-radius: radii.$mel-radius-lg;
-  border: $mel-checkout-border;
-  background: colors.$mel-color-surface;
-  box-shadow: shadows.$mel-shadow-1;
-
-  &:last-of-type {
-    margin-bottom: 0;
-  }
-
-  .mel-summary-event__body {
-    flex: 1 1 auto;
-    min-width: 0;
-  }
-
-  .mel-summary-event__media {
-    margin: 0;
-    flex: 0 0 auto;
-  }
-
-  .mel-summary-event__thumb {
-    width: 72px;
-    height: 72px;
-    border-radius: radii.$mel-radius-md;
-    object-fit: cover;
-  }
-
-  .mel-summary-event__title {
-    font-size: typography.mel-font-size(md);
     letter-spacing: -0.01em;
+    overflow-wrap: break-word;
   }
+}
 
-  .mel-summary-event__pricing {
-    font-size: typography.mel-font-size(xs);
-    font-weight: typography.$mel-font-semibold;
-    color: colors.$mel-color-text-muted;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    margin-bottom: spacing.mel-space(1);
-  }
+.mel-summary-event__media {
+  margin: 0;
+}
+
+.mel-summary-event__thumb {
+  display: block;
+  width: 72px;
+  height: 72px;
+  border-radius: radii.$mel-radius-md;
+  object-fit: cover;
+}
+
+.mel-summary-event__body {
+  min-width: 0;
+}
+
+.mel-summary-event__pricing {
+  font-size: typography.mel-font-size(xs);
+  font-weight: typography.$mel-font-semibold;
+  color: colors.$mel-color-text-muted;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 0 0 spacing.mel-space(1);
+}
+
+.mel-summary-event__items {
+  grid-column: 1 / -1;
+  display: grid;
+  gap: spacing.mel-space(1);
+  min-width: 0;
 }
 
 .mel-summary-grouped .mel-summary-item,
 .mel-summary-item {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  column-gap: spacing.mel-space(3);
   align-items: baseline;
-  gap: spacing.mel-space(2);
   font-size: typography.mel-font-size(sm);
-  margin-bottom: spacing.mel-space(1);
-  padding: spacing.mel-space(1) 0;
-
-  &:last-child {
-    margin-bottom: 0;
-  }
+  margin: 0;
+  padding: 0;
+  min-width: 0;
 }
 
 .mel-summary-item__label {
-  display: inline-flex;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
   min-width: 0;
   gap: spacing.mel-space(1);
+  overflow-wrap: break-word;
 }
 
 .mel-summary-item__quantity {
   flex: 0 0 auto;
+  white-space: nowrap;
   color: colors.$mel-color-text-muted;
   font-weight: typography.$mel-font-semibold;
 }
@@ -1348,41 +1340,48 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
 .mel-summary-item__ticket-type {
   min-width: 0;
   color: colors.$mel-color-text;
+  overflow-wrap: break-word;
 }
 
 .mel-summary-item__price {
-  flex: 0 0 auto;
+  justify-self: end;
+  white-space: nowrap;
   font-weight: typography.$mel-font-semibold;
   color: colors.$mel-color-text;
+  font-variant-numeric: tabular-nums;
 }
 
 .mel-summary-breakdown {
-  margin-top: spacing.mel-space(3);
-  padding-top: spacing.mel-space(2);
-  border-top: 1px solid rgba(colors.$mel-color-border, 0.65);
+  display: grid;
+  gap: spacing.mel-space(1);
+  margin-top: spacing.mel-space(2);
+  padding-top: spacing.mel-space(3);
+  border-top: 0;
 }
 
 .mel-summary-row {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  column-gap: spacing.mel-space(3);
   align-items: baseline;
-  gap: spacing.mel-space(2);
   font-size: typography.mel-font-size(sm);
-  margin-bottom: spacing.mel-space(1);
+  margin: 0;
   color: colors.$mel-color-text;
-
-  &:last-child {
-    margin-bottom: 0;
-  }
+  min-width: 0;
 }
 
 .mel-summary-row__label {
+  min-width: 0;
   color: colors.$mel-color-text-muted;
+  overflow-wrap: break-word;
 }
 
 .mel-summary-row__value {
+  justify-self: end;
+  white-space: nowrap;
   font-weight: typography.$mel-font-medium;
   color: colors.$mel-color-text;
+  font-variant-numeric: tabular-nums;
 }
 
 .mel-summary-row--fee,
@@ -1451,24 +1450,28 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
 }
 
 .mel-summary-total--inline {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  column-gap: spacing.mel-space(3);
   align-items: baseline;
-  gap: spacing.mel-space(2);
-  margin-top: spacing.mel-space(2);
-  padding-top: spacing.mel-space(2);
-  border-top: 1px solid rgba(colors.$mel-color-border, 0.75);
+  margin-top: spacing.mel-space(3);
+  padding-top: spacing.mel-space(3);
+  border-top: 2px solid colors.$mel-color-border-strong;
 
   .mel-summary-total__label {
+    min-width: 0;
     font-size: typography.mel-font-size(sm);
     font-weight: typography.$mel-font-semibold;
     color: colors.$mel-color-text-muted;
   }
 
   .mel-summary-total__value {
+    justify-self: end;
+    white-space: nowrap;
     font-size: typography.mel-font-size(lg);
     font-weight: typography.$mel-font-bold;
     color: colors.$mel-color-text;
+    font-variant-numeric: tabular-nums;
   }
 }
 
@@ -1499,15 +1502,15 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
 .mel-summary-grouped .mel-summary-meta {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: spacing.mel-space(1);
   font-size: typography.mel-font-size(sm);
   color: colors.$mel-color-text-muted;
-  margin-bottom: spacing.mel-space(2);
+  margin: 0;
 
-  @include breakpoints.mel-break(sm) {
-    flex-direction: row;
-    flex-wrap: wrap;
-    column-gap: spacing.mel-space(2);
+  .mel-summary-meta__date,
+  .mel-summary-meta__location {
+    min-width: 0;
+    overflow-wrap: break-word;
   }
 }
 
@@ -2901,8 +2904,9 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
 
   .mel-summary-grouped .mel-summary-event,
   .mel-summary-event {
-    margin-bottom: spacing.mel-space(2);
-    padding-bottom: spacing.mel-space(2);
+    margin-bottom: spacing.mel-space(3);
+    row-gap: spacing.mel-space(2);
+    column-gap: spacing.mel-space(2);
   }
 
   .mel-checkout__summary-region--trust .mel-checkout-confidence {
@@ -3118,19 +3122,51 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
 }
 
 .mel-checkout-summary__trustfoot {
-  margin-top: spacing.mel-space(2);
-  padding-top: spacing.mel-space(2);
-  border-top: $mel-checkout-border;
+  margin-top: spacing.mel-space(4);
+  padding-top: spacing.mel-space(3);
+  border-top: 1px solid rgba(colors.$mel-color-border, 0.55);
   font-size: typography.mel-font-size(sm);
   color: colors.$mel-color-text-muted;
+}
 
-  > p {
-    margin: spacing.mel-space(1) 0 0;
+.mel-checkout-summary__trust-heading {
+  margin: 0 0 spacing.mel-space(2);
+  font-size: typography.mel-font-size(sm);
+  font-weight: typography.$mel-font-semibold;
+  color: colors.$mel-color-text;
+  letter-spacing: -0.01em;
+}
 
-    &:first-child {
-      margin-top: 0;
-    }
-  }
+.mel-checkout-summary__trustlist {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: spacing.mel-space(1);
+}
+
+.mel-checkout-summary__trustline {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  column-gap: spacing.mel-space(2);
+  align-items: start;
+  margin: 0;
+  color: colors.$mel-color-text;
+  line-height: 1.4;
+}
+
+.mel-checkout-summary__trust-mark {
+  color: colors.$mel-color-primary;
+  font-weight: typography.$mel-font-semibold;
+  line-height: 1.4;
+}
+
+.mel-checkout-summary__trust-link-wrap {
+  margin: spacing.mel-space(2) 0 0;
+}
+
+.mel-checkout-summary__trust-link {
+  font-weight: typography.$mel-font-semibold;
 }
 
 .mel-checkout-sticky--v2 {
@@ -3207,6 +3243,89 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
   }
 }
 
+// Compact sticky action bar — amount + cart link + primary CTA (+ optional one-line note).
+.mel-checkout-sticky--compact {
+  padding-top: spacing.mel-space(1);
+}
+
+.mel-checkout-cta--compact {
+  gap: spacing.mel-space(1);
+  padding: spacing.mel-space(2) spacing.mel-space(3);
+  padding-bottom: calc(#{spacing.mel-space(2)} + env(safe-area-inset-bottom, 0px));
+  border: 1px solid rgba(colors.$mel-color-border, 0.55);
+  border-bottom: 0;
+  border-radius: radii.$mel-radius-md radii.$mel-radius-md 0 0;
+  background: rgba(255, 255, 255, 0.97);
+  box-shadow: 0 -4px 18px rgba(44, 62, 80, 0.08);
+
+  .form-actions {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: spacing.mel-space(2);
+    align-items: center;
+    margin: 0;
+  }
+
+  .mel-checkout-total-inline,
+  .mel-checkout-cta__total {
+    grid-column: 1;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: spacing.mel-space(2);
+    margin: 0;
+    padding: spacing.mel-space(1) 0;
+    background: transparent;
+    border-radius: 0;
+  }
+
+  .form-actions > a {
+    grid-column: 2;
+    justify-self: end;
+    white-space: nowrap;
+    font-size: typography.mel-font-size(sm);
+  }
+
+  .form-actions .button--primary,
+  .form-actions [type='submit'].button--primary {
+    grid-column: 1 / -1;
+    width: 100%;
+    min-height: 44px;
+  }
+
+  .mel-checkout__cta-note {
+    margin: 0;
+    font-size: typography.mel-font-size(xs);
+    font-weight: typography.$mel-font-regular;
+    color: colors.$mel-color-text-muted;
+    line-height: 1.35;
+  }
+
+  @media (width >= 769px) {
+    .form-actions {
+      grid-template-columns: minmax(0, 1fr) auto;
+      grid-template-rows: auto auto;
+    }
+
+    .mel-checkout-total-inline,
+    .mel-checkout-cta__total {
+      grid-column: 1;
+      grid-row: 1;
+    }
+
+    .form-actions > a {
+      grid-column: 2;
+      grid-row: 1;
+    }
+
+    .form-actions .button--primary,
+    .form-actions [type='submit'].button--primary {
+      grid-column: 1 / -1;
+      grid-row: 2;
+    }
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .mel-checkout-sticky__blur {
     backdrop-filter: none;
@@ -3256,12 +3375,6 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
   box-shadow: 0 14px 40px rgba(44, 62, 80, 0.08);
 }
 
-.mel-checkout-summary--v2 .mel-summary-event--card {
-  background: rgba(255, 255, 255, 0.88);
-  border-color: rgba(colors.$mel-color-primary, 0.1);
-  box-shadow: 0 10px 28px rgba(44, 62, 80, 0.07);
-}
-
 .mel-checkout-sticky--v2 .mel-checkout-sticky__blur {
   border-radius: radii.$mel-radius-xl radii.$mel-radius-xl 0 0;
   background: linear-gradient(
@@ -3273,7 +3386,7 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
   box-shadow: 0 -16px 48px rgba(44, 62, 80, 0.14);
 }
 
-.mel-checkout-cta--v2 .mel-checkout__cta-note {
+.mel-checkout-cta--v2:not(.mel-checkout-cta--compact) .mel-checkout__cta-note {
   font-weight: typography.$mel-font-semibold;
   color: colors.$mel-color-text;
 }
@@ -3294,7 +3407,7 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
 
     .mel-checkout__main {
       min-width: 0;
-      padding-bottom: calc(120px + env(safe-area-inset-bottom, 0px));
+      padding-bottom: calc(96px + env(safe-area-inset-bottom, 0px));
     }
   }
 
@@ -3337,5 +3450,15 @@ $mel-checkout-border: 1px solid rgba(41, 50, 65, 0.06);
 
   .mel-checkout-sticky--v2 {
     margin-top: spacing.mel-space(2);
+  }
+
+  .mel-checkout-cta--compact {
+    .form-actions > a {
+      font-size: typography.mel-font-size(xs);
+    }
+
+    .mel-checkout__cta-note {
+      display: none;
+    }
   }
 }

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form--with-sidebar.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form--with-sidebar.html.twig
@@ -140,13 +140,16 @@
           {% endif %}
 
           {% if form.mel_donation is defined %}
-            <div class="mel-checkout-subsection mel-checkout-subsection--donation">
-              <div class="mel-checkout-subsection__header">
-                <p class="mel-checkout-section__eyebrow">{{ mcp.optional_chip|default('') }}</p>
-                <h3 class="mel-checkout-subheading">{{ mcp.optional_donation_heading|default('') }}</h3>
+            {% set donation_pane_content = form.mel_donation|render %}
+            {% if donation_pane_content|striptags|trim is not empty %}
+              <div class="mel-checkout-subsection mel-checkout-subsection--donation">
+                <div class="mel-checkout-subsection__header">
+                  <p class="mel-checkout-section__eyebrow">{{ mcp.optional_chip|default('') }}</p>
+                  <h3 class="mel-checkout-subheading">{{ mcp.optional_donation_heading|default('') }}</h3>
+                </div>
+                {{ donation_pane_content }}
               </div>
-              {{ form.mel_donation }}
-            </div>
+            {% endif %}
           {% endif %}
 
           {% if form.mel_legal_consent is defined %}
@@ -213,22 +216,13 @@
         {% endif %}
 
         {% if form.actions %}
-          <div id="mel-checkout-cta" class="mel-checkout-sticky mel-checkout-sticky--v2" data-step="cta"{% if sticky_region_labels.label %} aria-label="{{ sticky_region_labels.label }}"{% endif %}>
-            <div class="mel-checkout-sticky__blur" aria-hidden="true"></div>
-            <div class="mel-checkout-cta mel-checkout-cta--v2">
+          <div id="mel-checkout-cta" class="mel-checkout-sticky mel-checkout-sticky--v2 mel-checkout-sticky--compact" data-step="cta"{% if sticky_region_labels.label %} aria-label="{{ sticky_region_labels.label }}"{% endif %}>
+            <div class="mel-checkout-cta mel-checkout-cta--v2 mel-checkout-cta--compact">
               {# Total is form.actions.mel_cta_total (form_alter) so it rebuilds with AJAX next to submit. #}
               {{ form.actions }}
               {% if form.payment_information is defined %}
                 <p class="mel-checkout__cta-note">{{ mcp.cta_secure_note|default('') }}</p>
               {% endif %}
-              <p class="mel-checkout-cta__recovery">
-                <a class="mel-checkout-cta__recovery-link mel-util-link" href="{{ path('myeventlane_support.page') }}">{{ sticky_nav.support|default('') }}</a>
-              </p>
-              <nav class="mel-checkout-support-foot"{% if sticky_nav.region_label %} aria-label="{{ sticky_nav.region_label }}"{% endif %}>
-                <a class="mel-util-link mel-util-link--support" href="{{ path('myeventlane_help_centre.home') }}">{{ sticky_nav.help_centre|default('') }}</a>
-                <span class="mel-checkout-support-foot__sep" aria-hidden="true">·</span>
-                <a class="mel-util-link mel-util-link--support" href="{{ path('myeventlane_support.page') }}">{{ sticky_nav.support_hub|default('') }}</a>
-              </nav>
             </div>
           </div>
         {% endif %}

--- a/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/commerce-checkout-form.html.twig
@@ -128,13 +128,16 @@
           {% endif %}
 
           {% if form.mel_donation is defined %}
-            <div class="mel-checkout-subsection mel-checkout-subsection--donation">
-              <div class="mel-checkout-subsection__header">
-                <p class="mel-checkout-section__eyebrow">{{ mcp.optional_chip|default('') }}</p>
-                <h3 class="mel-checkout-subheading">{{ mcp.optional_donation_heading|default('') }}</h3>
+            {% set donation_pane_content = form.mel_donation|render %}
+            {% if donation_pane_content|striptags|trim is not empty %}
+              <div class="mel-checkout-subsection mel-checkout-subsection--donation">
+                <div class="mel-checkout-subsection__header">
+                  <p class="mel-checkout-section__eyebrow">{{ mcp.optional_chip|default('') }}</p>
+                  <h3 class="mel-checkout-subheading">{{ mcp.optional_donation_heading|default('') }}</h3>
+                </div>
+                {{ donation_pane_content }}
               </div>
-              {{ form.mel_donation }}
-            </div>
+            {% endif %}
           {% endif %}
 
           {% if form.mel_legal_consent is defined %}
@@ -206,21 +209,12 @@
         {% endif %}
 
         {% if form.actions %}
-          <div id="mel-checkout-cta" class="mel-checkout-sticky mel-checkout-sticky--v2" data-step="cta"{% if sticky_region_labels.label %} aria-label="{{ sticky_region_labels.label }}"{% endif %}>
-            <div class="mel-checkout-sticky__blur" aria-hidden="true"></div>
-            <div class="mel-checkout-cta mel-checkout-cta--v2">
+          <div id="mel-checkout-cta" class="mel-checkout-sticky mel-checkout-sticky--v2 mel-checkout-sticky--compact" data-step="cta"{% if sticky_region_labels.label %} aria-label="{{ sticky_region_labels.label }}"{% endif %}>
+            <div class="mel-checkout-cta mel-checkout-cta--v2 mel-checkout-cta--compact">
               {{ form.actions }}
               {% if form.payment_information is defined %}
                 <p class="mel-checkout__cta-note">{{ mcp.cta_secure_note|default('') }}</p>
               {% endif %}
-              <p class="mel-checkout-cta__recovery">
-                <a class="mel-checkout-cta__recovery-link mel-util-link" href="{{ path('myeventlane_support.page') }}">{{ sticky_nav.support|default('') }}</a>
-              </p>
-              <nav class="mel-checkout-support-foot"{% if sticky_nav.region_label %} aria-label="{{ sticky_nav.region_label }}"{% endif %}>
-                <a class="mel-util-link mel-util-link--support" href="{{ path('myeventlane_help_centre.home') }}">{{ sticky_nav.help_centre|default('') }}</a>
-                <span class="mel-checkout-support-foot__sep" aria-hidden="true">·</span>
-                <a class="mel-util-link mel-util-link--support" href="{{ path('myeventlane_support.page') }}">{{ sticky_nav.support_hub|default('') }}</a>
-              </nav>
             </div>
           </div>
         {% endif %}

--- a/web/themes/custom/myeventlane_theme/templates/commerce/mel-checkout-order-summary-grouped.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/mel-checkout-order-summary-grouped.html.twig
@@ -15,10 +15,18 @@
 
   {% if has_grouped_line_items %}
   {% for event in grouped_items %}
-    <article class="mel-summary-event mel-summary-event--card">
+    <article class="mel-summary-event">
       {% if event.thumbnail_url|default('') %}
         <div class="mel-summary-event__media" aria-hidden="true">
-          <img src="{{ event.thumbnail_url }}" alt="" class="mel-summary-event__thumb" loading="lazy" width="72" height="72" />
+          <img
+            src="{{ event.thumbnail_url }}"
+            alt=""
+            class="mel-summary-event__thumb"
+            loading="lazy"
+            width="72"
+            height="72"
+            decoding="async"
+          />
         </div>
       {% endif %}
       <div class="mel-summary-event__body">
@@ -32,22 +40,25 @@
             {% if event.location %}<span class="mel-summary-meta__location">{{ event.location }}</span>{% endif %}
           </div>
         {% endif %}
-
-        {% for item in event.items %}
-          <div class="mel-summary-item{% if item.operational_addon_display|default(null) %} mel-summary-item--operational-addon{% endif %}">
-            <span class="mel-summary-item__label">
-              {% if item.operational_addon_display|default(null) %}
-                <span class="mel-summary-item__quantity">{{ item.quantity }} ×</span>
-                {% include '@myeventlane_commerce/mel-operational-order-item-line.html.twig' with { display: item.operational_addon_display } only %}
-              {% else %}
-                <span class="mel-summary-item__quantity">{{ item.quantity }} ×</span>
-                <span class="mel-summary-item__ticket-type">{{ item.ticket_type }}</span>
-              {% endif %}
-            </span>
-            <span class="mel-summary-item__price">{{ item.total_price }}</span>
-          </div>
-        {% endfor %}
       </div>
+
+      {% if event.items|default([]) %}
+        <div class="mel-summary-event__items">
+          {% for item in event.items %}
+            <div class="mel-summary-item{% if item.operational_addon_display|default(null) %} mel-summary-item--operational-addon{% endif %}">
+              <span class="mel-summary-item__label">
+                {% if item.operational_addon_display|default(null) %}
+                  {% include '@myeventlane_commerce/mel-operational-order-item-line.html.twig' with { display: item.operational_addon_display } only %}
+                  <span class="mel-summary-item__quantity">×&nbsp;{{ item.quantity }}</span>
+                {% else %}
+                  <span class="mel-summary-item__ticket-type">{{ item.ticket_type }}</span><span class="mel-summary-item__quantity"> ×&nbsp;{{ item.quantity }}</span>
+                {% endif %}
+              </span>
+              <span class="mel-summary-item__price">{{ item.total_price }}</span>
+            </div>
+          {% endfor %}
+        </div>
+      {% endif %}
     </article>
   {% endfor %}
   {% endif %}
@@ -100,14 +111,29 @@
     <p class="mel-tax-note">{{ labels.gst_note }}</p>
   {% endif %}
 
-  <footer class="mel-checkout-summary__trustfoot" role="status" aria-live="polite">
-    <p class="mel-checkout-summary__trustline">{{ trust.line_secure }}</p>
-    <p class="mel-checkout-summary__trustline">{{ trust.line_instant }}</p>
-    <p class="mel-checkout-summary__trustline mel-checkout-summary__trustline--muted">{{ trust.line_refund }}</p>
+  <footer class="mel-checkout-summary__trustfoot" role="region" aria-label="{{ trust.heading|default('') }}">
+    {% if trust.heading|default('') %}
+      <h3 class="mel-checkout-summary__trust-heading">{{ trust.heading }}</h3>
+    {% endif %}
+    <ul class="mel-checkout-summary__trustlist">
+      <li class="mel-checkout-summary__trustline">
+        <span class="mel-checkout-summary__trust-mark" aria-hidden="true">✓</span>
+        <span>{{ trust.line_secure }}</span>
+      </li>
+      <li class="mel-checkout-summary__trustline">
+        <span class="mel-checkout-summary__trust-mark" aria-hidden="true">✓</span>
+        <span>{{ trust.line_instant }}</span>
+      </li>
+      <li class="mel-checkout-summary__trustline">
+        <span class="mel-checkout-summary__trust-mark" aria-hidden="true">✓</span>
+        <span>{{ trust.line_refund }}</span>
+      </li>
+    </ul>
+    {% if trust.refund_url|default('') and trust.refund_link_label|default('') %}
+      <p class="mel-checkout-summary__trust-link-wrap">
+        <a class="mel-checkout-summary__trust-link mel-util-link" href="{{ trust.refund_url }}" target="_blank" rel="noopener noreferrer">{{ trust.refund_link_label }} →</a>
+      </p>
+    {% endif %}
   </footer>
-
-  {% if show_jump_to_payment|default(true) %}
-    <a class="mel-checkout-summary__jump" href="#mel-checkout-cta">{{ labels.jump_payment }}</a>
-  {% endif %}
 </div>
 {% endif %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches customer-facing checkout, legal consent rendering, and transactional email copy on the payment path; config sync also changes performance aggregation and enables Apple Wallet identifiers that may not belong in every environment.
> 
> **Overview**
> This PR tightens the **customer checkout** experience: copy shifts from “order” to **booking** across governed labels, confirmation emails, and legal collection notices, and completion messaging no longer implies tickets were already delivered.
> 
> **Checkout summary & trust:** The grouped sidebar gets a flatter event layout (grid instead of card chrome), a **“Book with confidence”** trust block with checklist styling and a **Refund Policy** link wired from `LegalSettingsService`, and **“Jump to payment”** is removed. `MelCheckoutSummaryPresenter` always passes `#show_jump_to_payment` as false and supplies refund URL/labels to Twig.
> 
> **Forms & panes:** `LegalConsentPane` builds policy links via `Link::fromTextAndUrl()` so anchors render correctly in `t()` placeholders. The legacy **donation** pane is hidden (`isVisible()` false) and Twig only shows the optional-donation section when rendered pane content is non-empty. Checkout templates use a **compact** sticky bar (no blur layer, no sticky help/support footers).
> 
> **Other:** `GeneralSettingsForm` adds `#tree` on nested details so platform/payments values save correctly. Sync/config adds Stripe express-checkout defaults, enables Apple Wallet with team/pass IDs, turns off CSS/JS aggregation preprocess, and expands `.gitignore` for local storage paths. Unit tests cover donation visibility and updated trust/summary contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a872434cfd4b0caa833411875ee4aa8682fd4bd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->