### PR TITLE
feat(checkout): enhance cacheability and performance settings

### DIFF
--- a/config/sync/system.performance.yml
+++ b/config/sync/system.performance.yml
@@ -4,7 +4,7 @@ cache:
   page:
     max_age: 900
 css:
-  preprocess: false
+  preprocess: true
   gzip: true
 fast_404:
   enabled: true
@@ -12,5 +12,5 @@ fast_404:
   exclude_paths: '/\/(?:styles|imagecache)\//'
   html: '<!DOCTYPE html><html><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL "@path" was not found on this server.</p></body></html>'
 js:
-  preprocess: false
+  preprocess: true
   gzip: true

--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/MelCheckoutSummaryPresenter.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/MelCheckoutSummaryPresenter.php
@@ -40,8 +40,13 @@ final class MelCheckoutSummaryPresenter {
     }
 
     $built = $this->groupedSummaryBuilder->build($order);
+    // Include legal settings so refund_url / trust link updates invalidate summaries.
     $cache = [
-      'tags' => Cache::mergeTags($order->getCacheTags(), (array) ($built['cache_tags'] ?? [])),
+      'tags' => Cache::mergeTags(
+        $order->getCacheTags(),
+        (array) ($built['cache_tags'] ?? []),
+        ['config:myeventlane_legal.settings'],
+      ),
       'contexts' => $order->getCacheContexts(),
     ];
 

--- a/web/modules/custom/myeventlane_checkout_flow/tests/src/Unit/MelCheckoutSummaryPresenterTest.php
+++ b/web/modules/custom/myeventlane_checkout_flow/tests/src/Unit/MelCheckoutSummaryPresenterTest.php
@@ -147,6 +147,7 @@ final class MelCheckoutSummaryPresenterTest extends UnitTestCase {
     $this->assertSame('/help/policies/refund-policy', $render['#trust']['refund_url']);
     $this->assertSame('View the Refund Policy', $render['#trust']['refund_link_label']);
     $this->assertSame('Booking summary', $render['#labels']['title']);
+    $this->assertContains('config:myeventlane_legal.settings', $render['#cache']['tags']);
 
     $legacy = [
       'Jump to payment',


### PR DESCRIPTION
- Include legal settings in cache tags for checkout summary to ensure updates invalidate summaries.
- Enable CSS and JS preprocessing in performance configuration for improved loading times.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to performance asset settings and checkout render cache tags; no auth or payment logic is modified, though enabling preprocess can affect how assets are debugged after deploy.
> 
> **Overview**
> Turns on **CSS and JS preprocessing** in synced `system.performance` config so aggregated assets can be served in production.
> 
> Checkout **grouped order summaries** now merge the `config:myeventlane_legal.settings` cache tag into their render cache, so changes to refund policy URL and related trust copy invalidate cached summaries instead of showing stale links. A unit test asserts that tag is present on the checkout trust block output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8578e491117c497cbef002316deab568ea03c8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->