### PR TITLE
fix(deploy): record GitHub SHA in release REVISION

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -182,6 +182,7 @@ jobs:
             'MEL_VENDOR_DOMAIN="https://vendor.staging.myeventlane.com.au" \' \
             'MEL_ADMIN_DOMAIN="https://admin.staging.myeventlane.com.au" \' \
             'MEL_FORCE_DOMAIN_REDIRECTS=1 \' \
+            'MEL_REVISION="${{ github.sha }}" \' \
             'ARTIFACT_PATH="$temp_dir" \' \
             'bash scripts/deploy/remote-deploy.sh' \
             | ssh -i ~/.ssh/id_ed25519 "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" bash -s

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -141,6 +141,8 @@ jobs:
           set -euo pipefail
           archive_path="$RUNNER_TEMP/artifact.tar.gz"
 
+          printf '%s\n' "${GITHUB_SHA}" > REVISION
+
           tar \
             --exclude='.git' \
             --exclude='.ddev' \

--- a/docs/STAGING_DEPLOY_GIT.md
+++ b/docs/STAGING_DEPLOY_GIT.md
@@ -6,6 +6,7 @@ This document describes how Git and GitHub Actions work for staging in this repo
 
 - **Trigger:** Any **push to `main`** runs `.github/workflows/deploy-staging.yml`.
 - **Flow:** The **Build** job (reusable workflow in `.github/workflows/reusable-build.yml`) produces a deployable artifact, then the **Deploy** job downloads it, uses SSH/SCP to the staging host, and runs `scripts/deploy/remote-deploy.sh` on the server (see the workflow for exact steps and `SITE_URI` / `APP_PATH`).
+- **Release identity:** The build writes a top-level `REVISION` file from `GITHUB_SHA`; deploy passes `MEL_REVISION` from `github.sha` into `remote-deploy.sh` so staging releases are not `REVISION=unknown`.
 - **UI-only deploys:** The staging workflow is triggered by `push` to `main` only. There is no `workflow_dispatch` in that file, so you cannot start the same deploy from the Actions "Run workflow" button without a workflow change.
 
 ## 1. Work locally without affecting staging


### PR DESCRIPTION
## Summary
- Hardening from `631023e16` is already on `main` via #671 (including the `autoload.php` fix).
- This PR only closes the `REVISION=unknown` gap observed on staging.
- After merge, a normal push to `main` deploys via GitHub Actions as usual.
- No feature, config, or Stripe changes.

## Changes
- Write top-level `REVISION` from `GITHUB_SHA` in the build artifact packaging step.
- Pass `MEL_REVISION` from `github.sha` into `remote-deploy.sh` on staging deploy.
- Minimal note in `docs/STAGING_DEPLOY_GIT.md`.

## Test plan
- [ ] Confirm Actions expands `${{ github.sha }}` into the remote env line in the deploy script.
- [ ] After merge + staging deploy, inspect release `REVISION` (not `unknown`) and that it matches the deploy commit.

Made with [Cursor](https://cursor.com)