### PR TITLE
chore(deploy): verify deploy-script fingerprint and add show-release

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -197,8 +197,8 @@ jobs:
             "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" \
             "ls -lt ~/staging/releases"
 
-      # Independent provenance check: live release REVISION vs this workflow commit
-      # and the repository composer.lock. Fail the job on any mismatch.
+      # Independent provenance check: live release REVISION vs this workflow commit,
+      # repository composer.lock, and repository remote-deploy.sh. Fail on mismatch.
       - name: Check out commit for provenance verification
         uses: actions/checkout@v5
         with:
@@ -206,7 +206,9 @@ jobs:
           fetch-depth: 1
           sparse-checkout: |
             composer.lock
+            scripts/deploy/remote-deploy.sh
             scripts/deploy/verify-revision-metadata.sh
+            scripts/deploy/show-release.sh
           sparse-checkout-cone-mode: false
 
       - name: Verify deployed REVISION provenance
@@ -216,9 +218,12 @@ jobs:
         run: |
           set -euo pipefail
           chmod +x scripts/deploy/verify-revision-metadata.sh
+          chmod +x scripts/deploy/show-release.sh
           expected_lock="$(sha256sum composer.lock | awk '{print $1}')"
+          expected_deploy_script="$(sha256sum scripts/deploy/remote-deploy.sh | awk '{print $1}')"
           echo "Expected artifact_sha=${EXPECTED_SHA}"
           echo "Expected composer_lock_sha256=${expected_lock}"
+          echo "Expected deploy_script_sha256=${expected_deploy_script}"
           echo "Build output composer_lock_sha256=${{ needs.build.outputs.composer_lock_sha256 }}"
 
           if [ "${{ needs.build.outputs.composer_lock_sha256 }}" != "$expected_lock" ]; then
@@ -240,4 +245,18 @@ jobs:
           scripts/deploy/verify-revision-metadata.sh \
             "$EXPECTED_SHA" \
             "$expected_lock" \
+            "$expected_deploy_script" \
             /tmp/mel-staging-REVISION
+
+          # Local consistency check using the deployed release copy of show-release.sh
+          # (only after REVISION fingerprints match this commit).
+          ssh -i ~/.ssh/id_ed25519 \
+            "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" \
+            'set -euo pipefail
+             release="$HOME/staging/current"
+             script="$release/scripts/deploy/show-release.sh"
+             if [ ! -x "$script" ]; then
+               echo "ERROR: missing executable $script in active release" >&2
+               exit 1
+             fi
+             "$script" --path "$release" --verify --quiet'

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -245,6 +245,15 @@ jobs:
             echo "❌ REVISION missing valid composer_lock_sha256"
             exit 1
           }
+          echo "$content" | grep -qE '^deploy_script_sha256=[0-9a-f]{64}$' || {
+            echo "❌ REVISION missing valid deploy_script_sha256"
+            exit 1
+          }
+          expected_deploy="$(sha256sum scripts/deploy/remote-deploy.sh | awk '{print $1}')"
+          echo "$content" | grep -qx "deploy_script_sha256=${expected_deploy}" || {
+            echo "❌ REVISION deploy_script_sha256 must match scripts/deploy/remote-deploy.sh"
+            exit 1
+          }
           echo "$content" | grep -qE '^workflow_run=[0-9]+$' || {
             echo "❌ REVISION missing workflow_run"
             exit 1

--- a/docs/STAGING_DEPLOY_GIT.md
+++ b/docs/STAGING_DEPLOY_GIT.md
@@ -6,7 +6,7 @@ This document describes how Git and GitHub Actions work for staging in this repo
 
 - **Trigger:** Any **push to `main`** runs `.github/workflows/deploy-staging.yml`.
 - **Flow:** The **Build** job (reusable workflow in `.github/workflows/reusable-build.yml`) produces a deployable artifact, then the **Deploy** job downloads it, uses SSH/SCP to the staging host, and runs `scripts/deploy/remote-deploy.sh` on the server (see the workflow for exact steps and `SITE_URI` / `APP_PATH`).
-- **Release identity:** Each release has a top-level `REVISION` file in KEY=VALUE provenance format (`artifact_sha`, workflow run ids, `composer_lock_sha256`, build/deploy timestamps, etc.). Build writes it into the artifact; remote deploy stamps deploy-time fields only. After deploy, Actions verifies `~/staging/current/REVISION` against `${{ github.sha }}` and the repository `composer.lock` and **fails the job** on mismatch. See [deploy/release-provenance.md](./deploy/release-provenance.md).
+- **Release identity:** Each release has a top-level `REVISION` file in KEY=VALUE provenance format (`artifact_sha`, workflow run ids, `composer_lock_sha256`, `deploy_script_sha256`, build/deploy timestamps, etc.). Build writes it into the artifact; remote deploy stamps deploy-time fields only. After deploy, Actions verifies `~/staging/current/REVISION` against `${{ github.sha }}`, the repository `composer.lock`, and `scripts/deploy/remote-deploy.sh`, then runs `show-release.sh --verify --quiet` on the active release, and **fails the job** on mismatch. See [deploy/release-provenance.md](./deploy/release-provenance.md).
 - **UI-only deploys:** The staging workflow is triggered by `push` to `main` only. There is no `workflow_dispatch` in that file, so you cannot start the same deploy from the Actions "Run workflow" button without a workflow change.
 
 ## 1. Work locally without affecting staging
@@ -46,7 +46,7 @@ If **Build** succeeds and **Deploy to staging** is red, the problem is in the de
 - **Validate SSH key / Test SSH connection** — key format, `secrets.SSH_PRIVATE_KEY`, host, user, firewall, or `known_hosts`.
 - **Upload artifact / Run remote deploy script** — `scp` or the remote `bash scripts/deploy/remote-deploy.sh` exiting non-zero (Drush, Composer, permissions, `APP_PATH`, etc.).
 - **Verify release** — the post-deploy `ssh ... ls` check if paths do not match what the server uses.
-- **Verify deployed REVISION provenance** — `artifact_sha` or `composer_lock_sha256` in `~/staging/current/REVISION` does not match this workflow commit / repository lockfile (see [deploy/release-provenance.md](./deploy/release-provenance.md)).
+- **Verify deployed REVISION provenance** — `artifact_sha`, `composer_lock_sha256`, or `deploy_script_sha256` in `~/staging/current/REVISION` does not match this workflow commit / repository lockfile / `remote-deploy.sh`, or `show-release.sh --verify` fails (see [deploy/release-provenance.md](./deploy/release-provenance.md)).
 
 **Secrets to verify** (Repository **Settings → Secrets and variables**): `SSH_PRIVATE_KEY`, `SSH_HOST`, `SSH_USER` must match a key that is authorised on the staging host.
 

--- a/docs/deploy/release-provenance.md
+++ b/docs/deploy/release-provenance.md
@@ -6,13 +6,20 @@ Every MEL staging release ships a top-level `REVISION` file so operators can ans
 - Which GitHub workflow / run deployed it?
 - When was it built and deployed?
 - Which `composer.lock` was in the artifact?
+- Which `scripts/deploy/remote-deploy.sh` was fingerprinted into the artifact?
 - Which release directory is live?
 
 GitHub remains the deployment source of truth. This metadata is observational: it does **not** change release activation, symlink switching, health checks, or rollback.
 
+**Scope:** staging only. Production HOLD (`/home/mel/sites/myeventlane_hold`) is out of scope and must not be modified by deploy or provenance tooling.
+
+**Policy:** never edit a live release tree by hand to “fix” provenance. Redeploy from GitHub, or use the existing rollback process.
+
 ## Format
 
 `REVISION` is plain text `KEY=VALUE` pairs, one per line (UTF-8, no BOM).
+
+Parsers must treat the file as **data only**. Never `source` / `eval` it.
 
 Example:
 
@@ -37,50 +44,131 @@ Empty values (for example `tag=` on a branch push) are intentional.
 
 ### Fields
 
-| Key | When written | Source |
-|-----|--------------|--------|
-| `artifact_sha` | Build | `GITHUB_SHA` / `${{ github.sha }}` |
-| `branch` | Build | `GITHUB_REF_NAME` when `GITHUB_REF_TYPE=branch` |
-| `tag` | Build | `GITHUB_REF_NAME` when `GITHUB_REF_TYPE=tag` |
-| `workflow` | Build | `GITHUB_WORKFLOW` (caller workflow name) |
-| `workflow_run` | Build | `GITHUB_RUN_ID` |
-| `run_attempt` | Build | `GITHUB_RUN_ATTEMPT` |
-| `actor` | Build | `GITHUB_ACTOR` |
-| `repository` | Build | `GITHUB_REPOSITORY` |
-| `build_time_utc` | Build | `date -u +%Y-%m-%dT%H:%M:%SZ` on the runner |
-| `composer_lock_sha256` | Build | `sha256sum composer.lock` |
-| `deploy_script_sha256` | Build | `sha256sum scripts/deploy/remote-deploy.sh` |
-| `release_identifier` | Build (updated on deploy if `MEL_RELEASE_IDENTIFIER` set) | `${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}` |
-| `deploy_time_utc` | Deploy | `MEL_DEPLOY_TIME_UTC` or server UTC clock |
-| `release_dir` | Deploy | Basename of the new release directory (`YYYYMMDDHHMMSS`) |
+| Key | Required for post-deploy verify | When written | Source |
+|-----|----------------------------------|--------------|--------|
+| `artifact_sha` | Yes (40 lowercase hex) | Build | `GITHUB_SHA` / `${{ github.sha }}` |
+| `branch` | No | Build | `GITHUB_REF_NAME` when `GITHUB_REF_TYPE=branch` |
+| `tag` | No | Build | `GITHUB_REF_NAME` when `GITHUB_REF_TYPE=tag` |
+| `workflow` | No | Build | `GITHUB_WORKFLOW` (caller workflow name) |
+| `workflow_run` | No (validated in artifact packaging) | Build | `GITHUB_RUN_ID` |
+| `run_attempt` | No | Build | `GITHUB_RUN_ATTEMPT` |
+| `actor` | No | Build | `GITHUB_ACTOR` |
+| `repository` | No | Build | `GITHUB_REPOSITORY` |
+| `build_time_utc` | No | Build | ISO 8601 UTC when artifact `REVISION` is written (`date -u +%Y-%m-%dT%H:%M:%SZ`) |
+| `composer_lock_sha256` | Yes (64 lowercase hex) | Build | `sha256sum composer.lock` |
+| `deploy_script_sha256` | Yes (64 lowercase hex) | Build | `sha256sum scripts/deploy/remote-deploy.sh` |
+| `release_identifier` | No | Build (may be updated on deploy if `MEL_RELEASE_IDENTIFIER` set) | `${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}` |
+| `deploy_time_utc` | No | Deploy | `MEL_DEPLOY_TIME_UTC` or server UTC clock |
+| `release_dir` | No | Deploy | Basename of the new release directory (`YYYYMMDDHHMMSS`) |
 
 Only values GitHub Actions or the deploy host can reliably provide are recorded. There is no invented semantic `deploy_script_version`; use `deploy_script_sha256` instead.
 
+### Timestamps
+
+| Field | Meaning |
+|-------|---------|
+| `build_time_utc` | When the release artifact metadata (`REVISION`) was created on the build runner. This is the artifact creation timestamp. |
+| `deploy_time_utc` | When remote deploy stamped the active release. |
+
+Do **not** add a second field with the same meaning as `build_time_utc` (for example `artifact_created_utc`).
+
 ## Where it is written
 
-1. **Build** (`.github/workflows/reusable-build.yml`) writes `REVISION` into the artifact before `tar`.
+1. **Build** (`.github/workflows/reusable-build.yml`) writes `REVISION` into the artifact before `tar`. The deploy-script fingerprint is taken from the **same checkout** that is packaged, so the release tree contains the exact `scripts/deploy/remote-deploy.sh` that was hashed.
 2. **Artifact copy** lands `REVISION` under `~/staging/releases/<timestamp>/REVISION`.
 3. **Remote deploy** (`scripts/deploy/remote-deploy.sh` → `mel_write_revision_metadata`) preserves KEY=VALUE provenance and stamps `deploy_time_utc` + `release_dir` only.
 4. **Live path:** `~/staging/current/REVISION` (symlink to the active release).
 
 `MEL_REVISION` (plain SHA from the deploy workflow) remains as a legacy fallback when an artifact has no KEY=VALUE `artifact_sha=` line. It no longer overwrites a complete provenance file.
 
-## Post-deploy verification
+## Operator inspection: `show-release.sh`
+
+On a deployed release:
+
+```bash
+cd /home/mel/staging/current
+./scripts/deploy/show-release.sh --path /home/mel/staging/current
+./scripts/deploy/show-release.sh --path /home/mel/staging/current --verify
+./scripts/deploy/show-release.sh --path /home/mel/staging/current --verify --quiet
+```
+
+From a repository checkout (no `REVISION` in cwd):
+
+```bash
+./scripts/deploy/show-release.sh
+```
+
+This reports repository Git metadata and clearly states that **deployed-release metadata is unavailable**. It does not pretend a checkout is a live release.
+
+### Behaviour
+
+- Never modifies files
+- Never requires database credentials
+- Never prints secrets (only REVISION fields and verification status)
+- Parses KEY=VALUE as data (never sources REVISION)
+- Rejects malformed lines and duplicate keys
+- Works without `jq`
+- Optional fields may be absent; required checksum fields are enforced under `--verify`
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success (display and/or `--verify` passed) |
+| 1 | Verification failed or fatal error |
+| 2 | Usage error |
+
+### Verification vocabulary
+
+| Status | Meaning |
+|--------|---------|
+| `verified` | Local file hash / format matches REVISION |
+| `mismatch` | Compared and failed |
+| `unavailable` | Field or file not present |
+| `unknown` / `not checked` | Not evaluated in this mode |
+| `not applicable` | Outside this tool’s scope (for example claiming GitHub commit existence) |
+
+`--verify` checks local consistency only:
+
+1. REVISION syntax
+2. `composer_lock_sha256` vs `RELEASE_PATH/composer.lock`
+3. `deploy_script_sha256` vs `RELEASE_PATH/scripts/deploy/remote-deploy.sh`
+4. `artifact_sha` is 40 lowercase hex (does **not** prove the commit exists on GitHub)
+
+## Post-deploy verification (GitHub Actions)
 
 After remote deploy succeeds, `.github/workflows/deploy-staging.yml`:
 
-1. Checks out `${{ github.sha }}` (sparse: `composer.lock` + verifier script).
+1. Checks out `${{ github.sha }}` (sparse: `composer.lock`, `remote-deploy.sh`, verifier, `show-release.sh`).
 2. SSHs to staging and reads `~/staging/current/REVISION`.
 3. Runs `scripts/deploy/verify-revision-metadata.sh` which asserts:
    - `artifact_sha` equals `${{ github.sha }}`
    - `composer_lock_sha256` equals `sha256sum` of the repository `composer.lock` at that commit
-4. Also asserts the build job output `composer_lock_sha256` matches the same lockfile hash.
+   - `deploy_script_sha256` equals `sha256sum` of the repository `scripts/deploy/remote-deploy.sh` at that commit
+   - critical keys are present, well-formed, and not duplicated
+4. Asserts the build job output `composer_lock_sha256` matches the same lockfile hash.
+5. Runs the **deployed** `~/staging/current/scripts/deploy/show-release.sh --path ~/staging/current --verify --quiet` after the REVISION fingerprints match this commit.
+
+Expected repository calculation (Linux / Actions / staging hosts):
+
+```bash
+sha256sum scripts/deploy/remote-deploy.sh
+sha256sum composer.lock
+```
+
+macOS local helpers may use `shasum -a 256` via `show-release.sh`; Actions and staging remain the deployment source of truth and use `sha256sum`.
 
 ### Failure behaviour
 
 Any mismatch or missing required field **fails the GitHub Actions job** (non-zero exit). Deploy does not silently succeed with bad provenance.
 
-Note: verification runs **after** the release has been activated. A red verification step means the live release is wrong or metadata is corrupt — investigate and redeploy or roll back using existing ops procedures. Verification itself does not perform rollback.
+Verification runs **after** the release has been activated. A red verification step means:
+
+- the live release may already be active
+- the Actions job fails
+- an operator must investigate and redeploy or invoke the **existing** rollback process
+
+Verification itself does **not** perform automatic rollback unless a future architecture change defines that behaviour.
 
 ## Troubleshooting
 
@@ -89,20 +177,36 @@ Note: verification runs **after** the release has been activated. A red verifica
 | `artifact_sha` mismatch | Wrong artifact / wrong checkout pin | Build `ref: ${{ github.sha }}`, artifact name `staging-release-<sha>`, live `REVISION` |
 | `composer_lock_sha256` missing | Old artifact format | Confirm build step writes KEY=VALUE `REVISION`; rebuild from `main` |
 | `composer_lock_sha256` mismatch | Lockfile drift between build tree and verify checkout | Same commit for build and verify; inspect `composer.lock` at `${{ github.sha }}` |
+| `deploy_script_sha256` missing / empty | Old artifact or truncated REVISION | Rebuild from a commit that fingerprints `remote-deploy.sh` |
+| `deploy_script_sha256` mismatch | Deploy script in release differs from repository commit | Compare `scripts/deploy/remote-deploy.sh` at `${{ github.sha }}` to the release copy; do not trust an ad-hoc server overlay |
+| Duplicate key error | Corrupt REVISION | Inspect `~/staging/current/REVISION`; redeploy; do not hand-edit |
+| Malformed SHA | Truncation / non-hex value | Inspect REVISION; rebuild |
 | `REVISION` missing on `current` | Deploy failed before metadata write, or `current` not switched | Remote deploy logs; `ls -l ~/staging/current` |
 | Legacy single-line SHA only | Pre-provenance release | Redeploy from a commit that includes KEY=VALUE generation |
+| `show-release.sh` missing on release | Release predates the operator script | Redeploy after merge; do not copy scripts onto the server manually |
 
 ### Manual inspection
 
 ```bash
 ssh <staging-user>@<host> 'cat ~/staging/current/REVISION'
-sha256sum composer.lock
+ssh <staging-user>@<host> \
+  '~/staging/current/scripts/deploy/show-release.sh --path ~/staging/current --verify'
 ```
 
 Local verifier (optional):
 
 ```bash
-scripts/deploy/verify-revision-metadata.sh <expected_sha> <expected_lock_sha256> /path/to/REVISION
+scripts/deploy/verify-revision-metadata.sh \
+  <expected_sha> \
+  <expected_lock_sha256> \
+  <expected_deploy_script_sha256> \
+  /path/to/REVISION
+```
+
+Focused local tests:
+
+```bash
+scripts/deploy/test-release-provenance.sh
 ```
 
 ## Related
@@ -112,3 +216,4 @@ scripts/deploy/verify-revision-metadata.sh <expected_sha> <expected_lock_sha256>
 - [`.github/workflows/reusable-build.yml`](../../.github/workflows/reusable-build.yml)
 - [`scripts/deploy/remote-deploy.sh`](../../scripts/deploy/remote-deploy.sh)
 - [`scripts/deploy/verify-revision-metadata.sh`](../../scripts/deploy/verify-revision-metadata.sh)
+- [`scripts/deploy/show-release.sh`](../../scripts/deploy/show-release.sh)

--- a/scripts/deploy/show-release.sh
+++ b/scripts/deploy/show-release.sh
@@ -1,0 +1,422 @@
+#!/usr/bin/env bash
+# Display and optionally verify MyEventLane release provenance.
+#
+# Usage:
+#   show-release.sh [--path PATH] [--verify] [--quiet] [--format text] [--help]
+#   show-release.sh [PATH]
+#
+# Default path is the current working directory when it contains REVISION,
+# otherwise deployed-release metadata is reported as unavailable (repository
+# Git metadata may still be shown). Never sources REVISION as shell.
+set -euo pipefail
+
+FORMAT="text"
+VERIFY=0
+QUIET=0
+RELEASE_PATH=""
+SHOW_HELP=0
+
+mel_usage() {
+  cat <<'EOF'
+Usage:
+  show-release.sh [--path PATH] [--verify] [--quiet] [--format text] [--help]
+  show-release.sh [PATH]
+
+Inspect MyEventLane release provenance (REVISION). Never modifies files.
+
+Options:
+  --path PATH     Release directory containing REVISION (default: cwd if present)
+  --verify        Verify local release consistency against REVISION checksums
+  --quiet         Suppress normal output; exit status only
+  --format text   Output format (text is the only supported format)
+  --help          Show this help
+
+Exit codes:
+  0  success (display and/or verification passed)
+  1  verification failed or fatal error
+  2  usage error
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --path)
+      if [ $# -lt 2 ]; then
+        echo "ERROR: --path requires an argument" >&2
+        exit 2
+      fi
+      RELEASE_PATH="$2"
+      shift 2
+      ;;
+    --verify)
+      VERIFY=1
+      shift
+      ;;
+    --quiet)
+      QUIET=1
+      shift
+      ;;
+    --format)
+      if [ $# -lt 2 ]; then
+        echo "ERROR: --format requires an argument" >&2
+        exit 2
+      fi
+      FORMAT="$2"
+      shift 2
+      ;;
+    --help|-h)
+      SHOW_HELP=1
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "ERROR: unknown option: $1" >&2
+      mel_usage >&2
+      exit 2
+      ;;
+    *)
+      if [ -n "$RELEASE_PATH" ]; then
+        echo "ERROR: multiple release paths specified" >&2
+        exit 2
+      fi
+      RELEASE_PATH="$1"
+      shift
+      ;;
+  esac
+done
+
+if [ "$SHOW_HELP" -eq 1 ]; then
+  mel_usage
+  exit 0
+fi
+
+if [ "$FORMAT" != "text" ]; then
+  echo "ERROR: unsupported --format '${FORMAT}' (only 'text' is supported)" >&2
+  exit 2
+fi
+
+mel_out() {
+  if [ "$QUIET" -eq 0 ]; then
+    printf '%s\n' "$*"
+  fi
+}
+
+mel_sha256_file() {
+  local file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file" | awk '{print $1}'
+  else
+    echo "ERROR: neither sha256sum nor shasum is available" >&2
+    return 1
+  fi
+}
+
+mel_is_hex() {
+  local value="$1"
+  local len="$2"
+  printf '%s' "$value" | grep -Eq "^[0-9a-f]{${len}}$"
+}
+
+# Resolve release path default.
+if [ -z "$RELEASE_PATH" ]; then
+  if [ -f "./REVISION" ]; then
+    RELEASE_PATH="$(pwd -P)"
+  else
+    RELEASE_PATH=""
+  fi
+fi
+
+REVISION_FILE=""
+HAS_DEPLOYED_REVISION=0
+if [ -n "$RELEASE_PATH" ]; then
+  if [ ! -d "$RELEASE_PATH" ]; then
+    echo "ERROR: release path is not a directory: ${RELEASE_PATH}" >&2
+    exit 1
+  fi
+  REVISION_FILE="${RELEASE_PATH%/}/REVISION"
+  if [ -f "$REVISION_FILE" ]; then
+    HAS_DEPLOYED_REVISION=1
+  fi
+fi
+
+# Repository Git context (never pretend a checkout is a deployed release).
+REPO_ROOT=""
+REPO_SHA="unavailable"
+REPO_BRANCH="unavailable"
+if REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  REPO_SHA="$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unavailable)"
+  REPO_BRANCH="$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null || echo unavailable)"
+fi
+
+CONTENT=""
+PARSE_STATUS="unavailable"
+ARTIFACT_SHA=""
+BRANCH=""
+TAG=""
+WORKFLOW=""
+WORKFLOW_RUN=""
+RUN_ATTEMPT=""
+ACTOR=""
+REPOSITORY=""
+BUILD_TIME_UTC=""
+COMPOSER_LOCK_SHA256=""
+DEPLOY_SCRIPT_SHA256=""
+RELEASE_IDENTIFIER=""
+DEPLOY_TIME_UTC=""
+RELEASE_DIR=""
+
+mel_key_count() {
+  local key="$1"
+  printf '%s\n' "$CONTENT" | grep -c "^${key}=" || true
+}
+
+mel_kv() {
+  local key="$1"
+  local count
+  count="$(mel_key_count "$key")"
+  if [ "$count" -gt 1 ]; then
+    echo "ERROR: duplicate key in REVISION: ${key}" >&2
+    exit 1
+  fi
+  if [ "$count" -eq 0 ]; then
+    printf '%s' ""
+    return 0
+  fi
+  printf '%s\n' "$CONTENT" | sed -n "s/^${key}=//p" | head -1
+}
+
+mel_parse_revision_file() {
+  local line key
+  local saw_kv=0
+  CONTENT="$(cat "$REVISION_FILE")"
+  if [ -z "$CONTENT" ]; then
+    echo "ERROR: REVISION is empty: ${REVISION_FILE}" >&2
+    exit 1
+  fi
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      ''|'#'*) continue ;;
+    esac
+    case "$line" in
+      *=*)
+        key="${line%%=*}"
+        if ! printf '%s' "$key" | grep -Eq '^[a-z][a-z0-9_]*$'; then
+          echo "ERROR: malformed REVISION key: ${key}" >&2
+          exit 1
+        fi
+        saw_kv=1
+        ;;
+      *)
+        if [ "$saw_kv" -eq 0 ] && mel_is_hex "$line" 40; then
+          continue
+        fi
+        echo "ERROR: malformed REVISION line (expected KEY=VALUE): ${line}" >&2
+        exit 1
+        ;;
+    esac
+  done <<EOF
+$CONTENT
+EOF
+
+  if [ "$(mel_key_count artifact_sha)" -gt 0 ]; then
+    ARTIFACT_SHA="$(mel_kv artifact_sha)"
+  else
+    ARTIFACT_SHA="$(printf '%s\n' "$CONTENT" | head -1 | tr -d '[:space:]')"
+  fi
+
+  BRANCH="$(mel_kv branch)"
+  TAG="$(mel_kv tag)"
+  WORKFLOW="$(mel_kv workflow)"
+  WORKFLOW_RUN="$(mel_kv workflow_run)"
+  RUN_ATTEMPT="$(mel_kv run_attempt)"
+  ACTOR="$(mel_kv actor)"
+  REPOSITORY="$(mel_kv repository)"
+  BUILD_TIME_UTC="$(mel_kv build_time_utc)"
+  COMPOSER_LOCK_SHA256="$(mel_kv composer_lock_sha256)"
+  DEPLOY_SCRIPT_SHA256="$(mel_kv deploy_script_sha256)"
+  RELEASE_IDENTIFIER="$(mel_kv release_identifier)"
+  DEPLOY_TIME_UTC="$(mel_kv deploy_time_utc)"
+  RELEASE_DIR="$(mel_kv release_dir)"
+  PARSE_STATUS="valid"
+}
+
+field_or_unavailable() {
+  local value="$1"
+  if [ -z "$value" ]; then
+    printf '%s' "unavailable"
+  else
+    printf '%s' "$value"
+  fi
+}
+
+branch_or_tag() {
+  if [ -n "$TAG" ]; then
+    printf '%s' "$TAG"
+  elif [ -n "$BRANCH" ]; then
+    printf '%s' "$BRANCH"
+  else
+    printf '%s' "unavailable"
+  fi
+}
+
+VERIFY_REVISION="unavailable"
+VERIFY_COMPOSER="unavailable"
+VERIFY_DEPLOY="unavailable"
+VERIFY_ARTIFACT_FORMAT="unavailable"
+VERIFY_GIT="not applicable"
+VERIFY_DRUPAL="not checked"
+
+mel_verify_local() {
+  local lock_path script_path got
+
+  if [ "$HAS_DEPLOYED_REVISION" -ne 1 ]; then
+    echo "ERROR: cannot --verify without a deployed REVISION file" >&2
+    exit 1
+  fi
+
+  VERIFY_REVISION="$PARSE_STATUS"
+  if [ "$PARSE_STATUS" != "valid" ]; then
+    echo "ERROR: REVISION format is not valid" >&2
+    exit 1
+  fi
+
+  if [ -z "$ARTIFACT_SHA" ]; then
+    VERIFY_ARTIFACT_FORMAT="mismatch"
+    echo "ERROR: artifact_sha missing" >&2
+    exit 1
+  fi
+  if mel_is_hex "$ARTIFACT_SHA" 40; then
+    VERIFY_ARTIFACT_FORMAT="verified"
+  else
+    VERIFY_ARTIFACT_FORMAT="mismatch"
+    echo "ERROR: artifact_sha is malformed (expected 40 lowercase hex chars)" >&2
+    echo "  got: ${ARTIFACT_SHA}" >&2
+    exit 1
+  fi
+
+  lock_path="${RELEASE_PATH%/}/composer.lock"
+  if [ -z "$COMPOSER_LOCK_SHA256" ]; then
+    VERIFY_COMPOSER="unavailable"
+    echo "ERROR: composer_lock_sha256 missing from REVISION" >&2
+    exit 1
+  fi
+  if ! mel_is_hex "$COMPOSER_LOCK_SHA256" 64; then
+    VERIFY_COMPOSER="mismatch"
+    echo "ERROR: composer_lock_sha256 is malformed" >&2
+    exit 1
+  fi
+  if [ ! -f "$lock_path" ]; then
+    VERIFY_COMPOSER="unavailable"
+    echo "ERROR: composer.lock not found at ${lock_path}" >&2
+    exit 1
+  fi
+  got="$(mel_sha256_file "$lock_path")"
+  if [ "$got" != "$COMPOSER_LOCK_SHA256" ]; then
+    VERIFY_COMPOSER="mismatch"
+    echo "ERROR: composer.lock SHA-256 mismatch" >&2
+    echo "  expected: $COMPOSER_LOCK_SHA256" >&2
+    echo "  got:      $got" >&2
+    exit 1
+  fi
+  VERIFY_COMPOSER="verified"
+
+  script_path="${RELEASE_PATH%/}/scripts/deploy/remote-deploy.sh"
+  if [ -z "$DEPLOY_SCRIPT_SHA256" ]; then
+    VERIFY_DEPLOY="unavailable"
+    echo "ERROR: deploy_script_sha256 missing from REVISION" >&2
+    exit 1
+  fi
+  if ! mel_is_hex "$DEPLOY_SCRIPT_SHA256" 64; then
+    VERIFY_DEPLOY="mismatch"
+    echo "ERROR: deploy_script_sha256 is malformed" >&2
+    exit 1
+  fi
+  if [ ! -f "$script_path" ]; then
+    VERIFY_DEPLOY="unavailable"
+    echo "ERROR: remote-deploy.sh not found at ${script_path}" >&2
+    exit 1
+  fi
+  got="$(mel_sha256_file "$script_path")"
+  if [ "$got" != "$DEPLOY_SCRIPT_SHA256" ]; then
+    VERIFY_DEPLOY="mismatch"
+    echo "ERROR: deploy script SHA-256 mismatch" >&2
+    echo "  expected: $DEPLOY_SCRIPT_SHA256" >&2
+    echo "  got:      $got" >&2
+    echo "  checked:  ${script_path}" >&2
+    exit 1
+  fi
+  VERIFY_DEPLOY="verified"
+}
+
+if [ "$HAS_DEPLOYED_REVISION" -eq 1 ]; then
+  mel_parse_revision_file
+else
+  PARSE_STATUS="unavailable"
+fi
+
+if [ "$VERIFY" -eq 1 ]; then
+  mel_verify_local
+fi
+
+# Display
+mel_out "MyEventLane Release"
+mel_out ""
+if [ -n "$RELEASE_PATH" ]; then
+  mel_out "Release path:              ${RELEASE_PATH}"
+else
+  mel_out "Release path:              unavailable"
+fi
+
+if [ "$HAS_DEPLOYED_REVISION" -eq 1 ]; then
+  mel_out "Release identifier:        $(field_or_unavailable "$RELEASE_IDENTIFIER")"
+  mel_out "Git artifact SHA:          $(field_or_unavailable "$ARTIFACT_SHA")"
+  mel_out "Branch or tag:             $(branch_or_tag)"
+  mel_out "Repository:                $(field_or_unavailable "$REPOSITORY")"
+  mel_out "Workflow:                  $(field_or_unavailable "$WORKFLOW")"
+  mel_out "Workflow run:              $(field_or_unavailable "$WORKFLOW_RUN")"
+  mel_out "Run attempt:               $(field_or_unavailable "$RUN_ATTEMPT")"
+  mel_out "Actor:                     $(field_or_unavailable "$ACTOR")"
+  mel_out "Build time UTC:            $(field_or_unavailable "$BUILD_TIME_UTC")"
+  mel_out "Deploy time UTC:           $(field_or_unavailable "$DEPLOY_TIME_UTC")"
+  mel_out "Composer lock SHA-256:     $(field_or_unavailable "$COMPOSER_LOCK_SHA256")"
+  mel_out "Deploy script SHA-256:     $(field_or_unavailable "$DEPLOY_SCRIPT_SHA256")"
+  mel_out "Release directory:         $(field_or_unavailable "$RELEASE_DIR")"
+else
+  mel_out "Deployed-release metadata: unavailable"
+  mel_out "(This checkout is not a deployed release with REVISION.)"
+  if [ -n "$REPO_ROOT" ]; then
+    mel_out "Repository root:           ${REPO_ROOT}"
+    mel_out "Repository HEAD:           ${REPO_SHA}"
+    mel_out "Repository branch:         ${REPO_BRANCH}"
+  fi
+fi
+
+mel_out ""
+mel_out "Verification"
+mel_out ""
+if [ "$VERIFY" -eq 1 ]; then
+  mel_out "REVISION format:           ${VERIFY_REVISION}"
+  mel_out "artifact_sha format:       ${VERIFY_ARTIFACT_FORMAT}"
+  mel_out "Composer lock:             ${VERIFY_COMPOSER}"
+  mel_out "Deploy script:             ${VERIFY_DEPLOY}"
+else
+  if [ "$HAS_DEPLOYED_REVISION" -eq 1 ]; then
+    mel_out "REVISION format:           ${PARSE_STATUS}"
+    mel_out "Composer lock:             not checked (pass --verify)"
+    mel_out "Deploy script:             not checked (pass --verify)"
+  else
+    mel_out "REVISION format:           unavailable"
+    mel_out "Composer lock:             unavailable"
+    mel_out "Deploy script:             unavailable"
+  fi
+fi
+mel_out "Git checkout:              ${VERIFY_GIT}"
+mel_out "Drupal bootstrap:          ${VERIFY_DRUPAL}"
+
+exit 0

--- a/scripts/deploy/test-release-provenance.sh
+++ b/scripts/deploy/test-release-provenance.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# Focused tests for release provenance scripts (no jq, no network).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VERIFY="$ROOT/deploy/verify-revision-metadata.sh"
+SHOW="$ROOT/deploy/show-release.sh"
+FAILS=0
+PASSES=0
+
+mel_sha256_file() {
+  local file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+  else
+    shasum -a 256 "$file" | awk '{print $1}'
+  fi
+}
+
+assert_ok() {
+  local name="$1"
+  shift
+  if "$@" >/tmp/mel-prov-test.out 2>/tmp/mel-prov-test.err; then
+    PASSES=$((PASSES + 1))
+    echo "PASS: $name"
+  else
+    FAILS=$((FAILS + 1))
+    echo "FAIL: $name (expected success)"
+    sed 's/^/  stdout: /' /tmp/mel-prov-test.out || true
+    sed 's/^/  stderr: /' /tmp/mel-prov-test.err || true
+  fi
+}
+
+assert_fail() {
+  local name="$1"
+  shift
+  if "$@" >/tmp/mel-prov-test.out 2>/tmp/mel-prov-test.err; then
+    FAILS=$((FAILS + 1))
+    echo "FAIL: $name (expected failure)"
+    sed 's/^/  stdout: /' /tmp/mel-prov-test.out || true
+  else
+    PASSES=$((PASSES + 1))
+    echo "PASS: $name"
+  fi
+}
+
+assert_stderr_not_contains() {
+  local name="$1"
+  local needle="$2"
+  if grep -Fq "$needle" /tmp/mel-prov-test.err /tmp/mel-prov-test.out 2>/dev/null; then
+    FAILS=$((FAILS + 1))
+    echo "FAIL: $name (output unexpectedly contained: $needle)"
+  else
+    PASSES=$((PASSES + 1))
+    echo "PASS: $name"
+  fi
+}
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/mel-prov-XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# Space in path must be handled safely.
+SPACE_DIR="$WORKDIR/release with spaces"
+mkdir -p "$SPACE_DIR/scripts/deploy"
+cp "$ROOT/deploy/remote-deploy.sh" "$SPACE_DIR/scripts/deploy/remote-deploy.sh"
+printf 'lock-content-for-test\n' > "$SPACE_DIR/composer.lock"
+
+LOCK_SHA="$(mel_sha256_file "$SPACE_DIR/composer.lock")"
+SCRIPT_SHA="$(mel_sha256_file "$SPACE_DIR/scripts/deploy/remote-deploy.sh")"
+ARTIFACT_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+write_revision() {
+  local dest="$1"
+  cat > "$dest" <<EOF
+artifact_sha=${ARTIFACT_SHA}
+branch=main
+tag=
+workflow=Deploy Staging
+workflow_run=1234567890
+run_attempt=1
+actor=test-actor
+repository=anna-pye/myeventlane-platform
+build_time_utc=2026-07-13T08:40:00Z
+composer_lock_sha256=${LOCK_SHA}
+deploy_script_sha256=${SCRIPT_SHA}
+release_identifier=1234567890.1
+deploy_time_utc=2026-07-13T08:45:12Z
+release_dir=20260713084512
+EOF
+}
+
+write_revision "$SPACE_DIR/REVISION"
+
+echo "=== verify-revision-metadata.sh ==="
+
+assert_ok "valid REVISION passes" \
+  "$VERIFY" "$ARTIFACT_SHA" "$LOCK_SHA" "$SCRIPT_SHA" "$SPACE_DIR/REVISION"
+
+assert_fail "missing REVISION fails" \
+  "$VERIFY" "$ARTIFACT_SHA" "$LOCK_SHA" "$SCRIPT_SHA" "$SPACE_DIR/missing-REVISION"
+
+MISSING_KEY="$WORKDIR/missing-key.REVISION"
+write_revision "$MISSING_KEY"
+# Drop deploy_script_sha256
+grep -v '^deploy_script_sha256=' "$MISSING_KEY" > "$MISSING_KEY.tmp"
+mv "$MISSING_KEY.tmp" "$MISSING_KEY"
+assert_fail "missing required deploy_script_sha256 fails" \
+  "$VERIFY" "$ARTIFACT_SHA" "$LOCK_SHA" "$SCRIPT_SHA" "$MISSING_KEY"
+
+DUP_KEY="$WORKDIR/dup.REVISION"
+write_revision "$DUP_KEY"
+printf 'deploy_script_sha256=%s\n' "$SCRIPT_SHA" >> "$DUP_KEY"
+assert_fail "duplicate critical key fails" \
+  "$VERIFY" "$ARTIFACT_SHA" "$LOCK_SHA" "$SCRIPT_SHA" "$DUP_KEY"
+
+BAD_SHA="$WORKDIR/bad-sha.REVISION"
+write_revision "$BAD_SHA"
+sed -i.bak 's/^deploy_script_sha256=.*/deploy_script_sha256=not-a-sha/' "$BAD_SHA"
+assert_fail "malformed deploy_script_sha256 fails" \
+  "$VERIFY" "$ARTIFACT_SHA" "$LOCK_SHA" "$SCRIPT_SHA" "$BAD_SHA"
+
+BAD_LOCK_META="$WORKDIR/bad-lock.REVISION"
+write_revision "$BAD_LOCK_META"
+sed -i.bak "s/^composer_lock_sha256=.*/composer_lock_sha256=$(printf 'b%.0s' {1..64})/" "$BAD_LOCK_META"
+assert_fail "composer_lock_sha256 mismatch fails" \
+  "$VERIFY" "$ARTIFACT_SHA" "$LOCK_SHA" "$SCRIPT_SHA" "$BAD_LOCK_META"
+
+BAD_DEPLOY_META="$WORKDIR/bad-deploy.REVISION"
+write_revision "$BAD_DEPLOY_META"
+sed -i.bak "s/^deploy_script_sha256=.*/deploy_script_sha256=$(printf 'c%.0s' {1..64})/" "$BAD_DEPLOY_META"
+assert_fail "deploy_script_sha256 mismatch fails" \
+  "$VERIFY" "$ARTIFACT_SHA" "$LOCK_SHA" "$SCRIPT_SHA" "$BAD_DEPLOY_META"
+
+OPTIONAL="$WORKDIR/optional.REVISION"
+cat > "$OPTIONAL" <<EOF
+artifact_sha=${ARTIFACT_SHA}
+composer_lock_sha256=${LOCK_SHA}
+deploy_script_sha256=${SCRIPT_SHA}
+EOF
+assert_ok "optional fields may be absent" \
+  "$VERIFY" "$ARTIFACT_SHA" "$LOCK_SHA" "$SCRIPT_SHA" "$OPTIONAL"
+
+# Values must never be evaluated as shell.
+EVIL="$WORKDIR/evil.REVISION"
+EVIL_MARKER="$WORKDIR/pwned-marker"
+rm -f "$EVIL_MARKER"
+cat > "$EVIL" <<EOF
+artifact_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+composer_lock_sha256=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+deploy_script_sha256=cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+actor=\$(touch '$EVIL_MARKER'; echo evil)
+EOF
+# Mismatch expected (hashes wrong) — but side effect must not run.
+assert_fail "evil actor value is not executed (mismatch path)" \
+  "$VERIFY" "$ARTIFACT_SHA" "$LOCK_SHA" "$SCRIPT_SHA" "$EVIL"
+if [ -e "$EVIL_MARKER" ]; then
+  FAILS=$((FAILS + 1))
+  echo "FAIL: evil actor value executed shell (marker file created)"
+else
+  PASSES=$((PASSES + 1))
+  echo "PASS: evil actor value produced no shell side effect"
+fi
+
+echo "=== show-release.sh ==="
+
+assert_ok "show-release displays metadata" \
+  "$SHOW" --path "$SPACE_DIR"
+
+assert_ok "show-release --verify succeeds for consistent release" \
+  "$SHOW" --path "$SPACE_DIR" --verify --quiet
+
+assert_fail "show-release --verify fails without REVISION" \
+  "$SHOW" --path "$WORKDIR" --verify --quiet
+
+# Composer lock mismatch under show-release --verify
+printf 'changed-lock\n' > "$SPACE_DIR/composer.lock"
+assert_fail "show-release composer lock mismatch fails" \
+  "$SHOW" --path "$SPACE_DIR" --verify --quiet
+
+# Restore lock and break deploy script
+printf 'lock-content-for-test\n' > "$SPACE_DIR/composer.lock"
+printf 'tampered-script\n' > "$SPACE_DIR/scripts/deploy/remote-deploy.sh"
+assert_fail "show-release deploy script mismatch fails" \
+  "$SHOW" --path "$SPACE_DIR" --verify --quiet
+
+# Shell injection via REVISION under show-release
+EVIL_RELEASE="$WORKDIR/evil release"
+EVIL_SHOW_MARKER="$WORKDIR/pwned-show-marker"
+rm -f "$EVIL_SHOW_MARKER"
+mkdir -p "$EVIL_RELEASE"
+cat > "$EVIL_RELEASE/REVISION" <<EOF
+artifact_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+composer_lock_sha256=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+deploy_script_sha256=cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+actor=\$(touch '$EVIL_SHOW_MARKER'; echo evil)
+EOF
+assert_ok "show-release parses evil actor as data" \
+  "$SHOW" --path "$EVIL_RELEASE"
+if [ -e "$EVIL_SHOW_MARKER" ]; then
+  FAILS=$((FAILS + 1))
+  echo "FAIL: show-release executed actor value (marker file created)"
+else
+  PASSES=$((PASSES + 1))
+  echo "PASS: show-release does not execute actor value"
+fi
+
+echo ""
+echo "Passed: $PASSES"
+echo "Failed: $FAILS"
+if [ "$FAILS" -ne 0 ]; then
+  exit 1
+fi
+echo "OK: release provenance tests passed"

--- a/scripts/deploy/verify-revision-metadata.sh
+++ b/scripts/deploy/verify-revision-metadata.sh
@@ -2,15 +2,23 @@
 # Verify a deployed release REVISION provenance file.
 #
 # Usage:
-#   verify-revision-metadata.sh <expected_artifact_sha> <expected_composer_lock_sha256> [REVISION_FILE]
+#   verify-revision-metadata.sh \
+#     <expected_artifact_sha> \
+#     <expected_composer_lock_sha256> \
+#     <expected_deploy_script_sha256> \
+#     [REVISION_FILE]
 #
 # REVISION_FILE defaults to stdin when omitted.
-# Exit 0 on match; exit 1 on any mismatch or missing required field.
+# Exit 0 on match; exit 1 on any mismatch, missing required field,
+# malformed value, or duplicate critical key.
+#
+# REVISION is parsed as data only — never sourced or evaluated.
 set -euo pipefail
 
 EXPECTED_SHA="${1:?expected artifact SHA required}"
 EXPECTED_LOCK="${2:?expected composer.lock SHA-256 required}"
-REVISION_FILE="${3:-/dev/stdin}"
+EXPECTED_DEPLOY_SCRIPT="${3:?expected deploy script SHA-256 required}"
+REVISION_FILE="${4:-/dev/stdin}"
 
 if [ ! -r "$REVISION_FILE" ] && [ "$REVISION_FILE" != "/dev/stdin" ]; then
   echo "ERROR: cannot read REVISION file: $REVISION_FILE" >&2
@@ -27,23 +35,84 @@ echo "===== REVISION UNDER TEST ====="
 printf '%s\n' "$content"
 echo "==============================="
 
-mel_kv() {
+# Count exact KEY= lines. Never eval/source REVISION.
+mel_key_count() {
   local key="$1"
+  printf '%s\n' "$content" | grep -c "^${key}=" || true
+}
+
+mel_kv_unique() {
+  local key="$1"
+  local count
+  count="$(mel_key_count "$key")"
+  if [ "$count" -gt 1 ]; then
+    echo "ERROR: duplicate key in REVISION: ${key}" >&2
+    exit 1
+  fi
+  if [ "$count" -eq 0 ]; then
+    printf '%s' ""
+    return 0
+  fi
+  # Data-only extract: strip KEY= prefix from the matching line.
   printf '%s\n' "$content" | sed -n "s/^${key}=//p" | head -1
 }
 
+mel_require_hex() {
+  local label="$1"
+  local value="$2"
+  local len="$3"
+  if [ -z "$value" ]; then
+    echo "ERROR: ${label} missing from REVISION" >&2
+    exit 1
+  fi
+  if ! printf '%s' "$value" | grep -Eq "^[0-9a-f]{${len}}$"; then
+    echo "ERROR: ${label} is malformed (expected ${len} lowercase hex chars)" >&2
+    echo "  got: ${value}" >&2
+    exit 1
+  fi
+}
+
+# Reject any line that is neither blank, comment, KEY=VALUE, nor legacy plain SHA.
+mel_validate_syntax() {
+  local line key
+  local saw_kv=0
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      ''|'#'*) continue ;;
+    esac
+    case "$line" in
+      *=*)
+        key="${line%%=*}"
+        if ! printf '%s' "$key" | grep -Eq '^[a-z][a-z0-9_]*$'; then
+          echo "ERROR: malformed REVISION key: ${key}" >&2
+          exit 1
+        fi
+        saw_kv=1
+        ;;
+      *)
+        if [ "$saw_kv" -eq 0 ] && printf '%s' "$line" | grep -Eq '^[0-9a-f]{40}$'; then
+          # Legacy plain-SHA REVISION (pre KEY=VALUE provenance).
+          continue
+        fi
+        echo "ERROR: malformed REVISION line (expected KEY=VALUE): ${line}" >&2
+        exit 1
+        ;;
+    esac
+  done <<EOF
+$content
+EOF
+}
+
+mel_validate_syntax
+
 got_sha=""
-if printf '%s\n' "$content" | grep -q '^artifact_sha='; then
-  got_sha="$(mel_kv artifact_sha)"
+if [ "$(mel_key_count artifact_sha)" -gt 0 ]; then
+  got_sha="$(mel_kv_unique artifact_sha)"
 else
   # Legacy plain-SHA REVISION (pre KEY=VALUE provenance).
   got_sha="$(printf '%s\n' "$content" | head -1 | tr -d '[:space:]')"
 fi
-
-if [ -z "$got_sha" ]; then
-  echo "ERROR: could not parse artifact_sha from REVISION" >&2
-  exit 1
-fi
+mel_require_hex "artifact_sha" "$got_sha" 40
 
 if [ "$got_sha" != "$EXPECTED_SHA" ]; then
   echo "ERROR: artifact_sha mismatch" >&2
@@ -53,11 +122,8 @@ if [ "$got_sha" != "$EXPECTED_SHA" ]; then
 fi
 echo "OK: artifact_sha matches ${EXPECTED_SHA}"
 
-got_lock="$(mel_kv composer_lock_sha256)"
-if [ -z "$got_lock" ]; then
-  echo "ERROR: composer_lock_sha256 missing from REVISION" >&2
-  exit 1
-fi
+got_lock="$(mel_kv_unique composer_lock_sha256)"
+mel_require_hex "composer_lock_sha256" "$got_lock" 64
 
 if [ "$got_lock" != "$EXPECTED_LOCK" ]; then
   echo "ERROR: composer_lock_sha256 mismatch" >&2
@@ -66,5 +132,17 @@ if [ "$got_lock" != "$EXPECTED_LOCK" ]; then
   exit 1
 fi
 echo "OK: composer_lock_sha256 matches repository lockfile"
+
+got_deploy="$(mel_kv_unique deploy_script_sha256)"
+mel_require_hex "deploy_script_sha256" "$got_deploy" 64
+
+if [ "$got_deploy" != "$EXPECTED_DEPLOY_SCRIPT" ]; then
+  echo "ERROR: deploy_script_sha256 mismatch" >&2
+  echo "  expected: $EXPECTED_DEPLOY_SCRIPT" >&2
+  echo "  got:      $got_deploy" >&2
+  echo "  expected source: repository scripts/deploy/remote-deploy.sh at the deployed commit" >&2
+  exit 1
+fi
+echo "OK: deploy_script_sha256 matches repository remote-deploy.sh"
 
 echo "OK: release provenance verified"


### PR DESCRIPTION
## Summary
- Extend post-deploy REVISION verification to require and match `deploy_script_sha256` against repository `scripts/deploy/remote-deploy.sh` at the deployed commit.
- Add operator-facing `scripts/deploy/show-release.sh` for safe REVISION inspection and local consistency checks (`--verify`), without sourcing metadata as shell.
- Keep `build_time_utc` as the sole artifact-creation timestamp; document staging-only provenance, post-verify failure behaviour, and production HOLD isolation.

## Test plan
- [ ] `bash -n scripts/deploy/{remote-deploy,verify-revision-metadata,show-release,test-release-provenance}.sh`
- [ ] `./scripts/deploy/test-release-provenance.sh`
- [ ] Review workflow YAML for sparse checkout + post-deploy verify steps
- [ ] After merge: confirm staging Actions build/deploy/provenance steps pass
- [ ] On staging (read-only): `~/staging/current/scripts/deploy/show-release.sh --path ~/staging/current --verify`
- [ ] Confirm production HOLD remains untouched


Made with [Cursor](https://cursor.com)