### PR TITLE
fix(dashboard): align my tickets cache tags with account dashboard

### DIFF
--- a/web/modules/custom/myeventlane_dashboard/src/Controller/CustomerDashboardController.php
+++ b/web/modules/custom/myeventlane_dashboard/src/Controller/CustomerDashboardController.php
@@ -62,7 +62,15 @@ final class CustomerDashboardController extends ControllerBase {
     $includeRsvpSubmissions = $userId > 0;
     $participation = $this->customerHubDataBuilder->buildParticipationLists($userId, (string) $userEmail, $now, $includeRsvpSubmissions);
 
-    $cacheTags = ['node_list', 'user:' . $userId];
+    // Same participation sources as /my-account — keep list tags aligned so
+    // staging Dynamic Page Cache invalidates when bookings change.
+    $cacheTags = [
+      'node_list',
+      'user:' . $userId,
+      'commerce_order_list',
+      'event_attendee_list',
+      'rsvp_submission_list',
+    ];
     foreach (array_merge($participation['unified_upcoming'], $participation['unified_past']) as $event) {
       $cacheTags[] = 'node:' . $event['id'];
     }


### PR DESCRIPTION
## Summary

- Problem: `/my-tickets` (CustomerDashboardController) still only carried `node_list` and `user:{uid}` cache tags after account-dashboard bookings phase 3 (#681). Participation lists also read Commerce orders, event attendees, and RSVP submissions, so Dynamic Page Cache on staging could keep serving a stale My Tickets page for up to `max-age` (300s) after bookings changed.
- Root cause: Phase 3 aligned `/my-account` list tags; the companion My Tickets controller cache tags were left behind on the mixed local branch and never shipped with #681.
- Implementation: Add `commerce_order_list`, `event_attendee_list`, and `rsvp_submission_list` to the My Tickets render `#cache.tags`, matching the participation sources used by `CustomerHubDataBuilder::buildParticipationLists()`.
- Cacheability: No new imports or API changes. Existing `#cache.contexts` (`user`) and `max-age` (300) are unchanged. Node-specific tags continue to be appended per listed event. Invalidation now tracks the same entity list tags as the account hub, so order/attendee/RSVP mutations clear the page instead of waiting out max-age alone.
- Single-file PR from `origin/main`; no deploy/workflow changes.

## Test plan

- [ ] Confirm PR diff is only `CustomerDashboardController.php`
- [ ] `php -l` / `ddev php -l` on the controller (syntax clean in this worktree)
- [ ] Spot-check that `/my-account` already uses the same list tags (merged in #681)
- [ ] On staging after deploy: book/RSVP, then confirm `/my-tickets` updates without waiting ~300s (or clears after expected entity saves)
- [ ] Confirm no regression on anonymous/empty email early return (unchanged)

## Rollback

Revert this PR or restore the previous `$cacheTags = ['node_list', 'user:' . $userId];` assignment in `CustomerDashboardController::myEvents()`. Behaviour returns to pre-fix caching (stale-until-max-age risk returns; no data-model impact).


Made with [Cursor](https://cursor.com)