### PR TITLE
fix(git): separate ordinary push validation from staging release checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,6 +200,11 @@ memory/
 docs/internal/
 *.bak
 
+# Local path pointers and ACE/agent workspace backups (do not commit).
+# Narrow patterns only — not a broad .tmp-* ignore (fixtures/release artefacts).
+.mel-*-backup-path.txt
+.tmp-ace-*-backup-*/
+
 # macOS
 .DS_Store
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-bash scripts/validate-release.sh staging
+# Ordinary push gate. Does not treat the branch as a staging deploy candidate.
+# Deployment readiness remains: bash scripts/validate-release.sh staging|production
+bash scripts/validate-push.sh

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,6 +13,7 @@ Operational scripts for local development, audits, deployment, and governance. R
 | Script | Purpose | Safe environment | Destructive | Required confirmation |
 |--------|---------|------------------|-------------|----------------------|
 | `preflight-health-check.sh` | DB, cache, config sync, and filesystem smoke checks | Local DDEV | No | None |
+| `validate-push.sh` | Ordinary branch push gate: clean tree, review-branch allowlist (includes chore/docs/test), lightweight safety checks | Local | No | None |
 | `validate-release.sh` | Canonical pre-deployment release validation: Git, Drush bootstrap, config status, database updates, MEL tests, and theme builds | Local DDEV / staging / production checkout | No | None |
 | `rebuild-scss.sh` | Clears theme caches, reinstalls npm deps, rebuilds theme assets | Local DDEV | No (removes theme `node_modules`/`dist`) | None |
 | `myeventlane-audit-collector.sh` | Collects git/composer/drush audit snapshot into `_myeventlane_audit/` | Local | No | None |
@@ -41,6 +42,18 @@ Operational scripts for local development, audits, deployment, and governance. R
 | `verify-access-fix.sh` | Post-fix vendor access verification | Local DDEV | No | None |
 
 ---
+
+## Push vs release validation
+
+Ordinary `git push` and deployment readiness are separate gates.
+
+| Gate | Script | When | Branch policy |
+|------|--------|------|---------------|
+| Push (review) | `scripts/validate-push.sh` | Husky pre-push on every push | Accepts `main`, `release/*`, `feature/*`, `fix/*`, `hotfix/*`, `cursor/*`, plus maintenance `chore/*`, `docs/*`, `test/*` |
+| Staging release | `scripts/validate-release.sh staging` | Explicit pre-deploy / packaging | `main`, `release/*`, `feature/*`, `fix/*`, `hotfix/*`, `cursor/*` only |
+| Production release | `scripts/validate-release.sh production` | Explicit production validation | `main` or annotated tag (`--force` for exceptions) |
+
+Push validation never claims the branch is ready for staging or production.
 
 ## Release validation workflow
 
@@ -101,13 +114,22 @@ It intentionally does not run npm builds, governance tests, PHPUnit, or Drush ca
 
 ### Pre-push
 
-The pre-push hook runs the staging release validator:
+The pre-push hook runs the ordinary push validator (not the staging release validator):
+
+```bash
+bash scripts/validate-push.sh
+```
+
+This checks working-tree cleanliness, the review-branch allowlist (including `chore/*`, `docs/*`, and `test/*`), and the same lightweight safety scripts as pre-commit. It does **not** run Drush, config drift review, governance suites, theme builds, or release-metadata writes, and it does **not** treat the branch as a staging deployment candidate.
+
+Deployment readiness remains an explicit release command:
 
 ```bash
 bash scripts/validate-release.sh staging
+bash scripts/validate-release.sh production
 ```
 
-If validation fails, Git rejects the push and prints the validator output unchanged.
+If push validation fails, Git rejects the push and prints the validator output unchanged.
 
 ### Bypassing hooks
 

--- a/scripts/validate-push.sh
+++ b/scripts/validate-push.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# MEL ordinary branch push validation.
+#
+# Purpose:
+# - Gate local `git push` with cleanliness and lightweight safety checks.
+# - Allow legitimate review/maintenance branches to be pushed for PR review.
+#
+# This script is NOT a staging or production release validator.
+# It does not claim the checkout is ready to deploy.
+# Strict deployment allowlists remain in scripts/validate-release.sh.
+#
+# Usage:
+#   bash scripts/validate-push.sh
+#   bash scripts/validate-push.sh --check-branch chore/example
+#   bash scripts/validate-push.sh --help
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT" || exit 1
+
+CHECK_BRANCH_ONLY=0
+BRANCH_OVERRIDE=""
+declare -a REASONS=()
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/validate-push.sh
+  scripts/validate-push.sh --check-branch <name>
+
+Push validation (ordinary review pushes):
+  - Requires a clean working tree
+  - Accepts: main, release/*, feature/*, fix/*, hotfix/*, cursor/*,
+              chore/*, docs/*, test/*
+  - Runs lightweight safety checks (composer validate + config/webroot/card checks)
+  - Does not run Drush, config drift review, governance suites, or theme builds
+  - Does not write release metadata
+  - Does not treat the branch as a staging deployment candidate
+
+Deployment validation remains:
+  bash scripts/validate-release.sh staging
+  bash scripts/validate-release.sh production
+
+--check-branch <name>
+  Non-destructive allowlist check only (no cleanliness or quality gates).
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --check-branch)
+      if [ -z "${2:-}" ]; then
+        echo "ERROR: --check-branch requires a branch name." >&2
+        usage >&2
+        exit 2
+      fi
+      CHECK_BRANCH_ONLY=1
+      BRANCH_OVERRIDE="$2"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+add_reason() {
+  REASONS+=("$1")
+}
+
+print_rule() {
+  echo "----------------------------------------"
+}
+
+# Review / maintenance branches may be pushed for PR review.
+# Staging/production deploy allowlists are intentionally stricter and live in
+# scripts/validate-release.sh — do not merge those policies here.
+#
+# Prefix rationale:
+#   main, release/*, feature/*, fix/*, hotfix/*, cursor/*
+#     Existing MEL collaboration / agent prefixes already accepted for review.
+#   chore/*
+#     Documented in CLAUDE.md / AGENTS.md; used for tooling and maintenance
+#     (e.g. local PHPUnit helper, CI hygiene). Not a deploy candidate by itself.
+#   docs/*
+#     Documentation / help-content branches already used on origin.
+#   test/*
+#     Isolated test-harness or fixture review branches; not deployment targets.
+is_push_branch() {
+  case "$1" in
+    main|release/*|feature/*|fix/*|hotfix/*|cursor/*|chore/*|docs/*|test/*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+mask_sensitive() {
+  sed -E \
+    -e 's/sk_(live|test)_[A-Za-z0-9_]+/[MASKED_STRIPE_SECRET]/g' \
+    -e 's/rk_(live|test)_[A-Za-z0-9_]+/[MASKED_STRIPE_RESTRICTED_KEY]/g' \
+    -e 's/pk_(live|test)_[A-Za-z0-9_]+/[MASKED_STRIPE_PUBLISHABLE_KEY]/g' \
+    -e 's/whsec_[A-Za-z0-9_]+/[MASKED_STRIPE_WEBHOOK_SECRET]/g' \
+    -e 's/((secret|SECRET|api[_-]?key|API[_-]?KEY|token|TOKEN)[^:=]*[=:][[:space:]]*)[^[:space:]]+/\1[MASKED]/g'
+}
+
+run_and_report() {
+  local label="$1"
+  shift
+
+  echo ""
+  echo "== ${label} =="
+
+  local tmp rc
+  tmp="$(mktemp)"
+  "$@" >"$tmp" 2>&1
+  rc=$?
+  mask_sensitive <"$tmp"
+  rm -f "$tmp"
+
+  if [ "$rc" -ne 0 ]; then
+    add_reason "${label} failed."
+    return "$rc"
+  fi
+
+  return 0
+}
+
+print_git_cleanliness() {
+  local modified untracked
+  modified="$(git status --porcelain 2>/dev/null | grep -Ev '^\?\?' || true)"
+  untracked="$(git status --porcelain 2>/dev/null | grep -E '^\?\?' || true)"
+
+  echo ""
+  echo "Modified files:"
+  if [ -n "$modified" ]; then
+    printf '%s\n' "$modified"
+  else
+    echo "(none)"
+  fi
+
+  echo ""
+  echo "Untracked files:"
+  if [ -n "$untracked" ]; then
+    printf '%s\n' "$untracked"
+  else
+    echo "(none)"
+  fi
+}
+
+print_failure_and_exit() {
+  echo ""
+  print_rule
+  echo "PUSH VALIDATION FAILED"
+  echo ""
+  echo "Reasons:"
+  for reason in "${REASONS[@]}"; do
+    echo "- ${reason}"
+  done
+  echo ""
+  echo "Note: This gate validates ordinary branch pushes for review."
+  echo "It does not certify staging or production deployment readiness."
+  echo "For deployment candidates run: bash scripts/validate-release.sh staging|production"
+  print_rule
+  exit 1
+}
+
+print_rule
+echo "MEL Push Validation"
+print_rule
+echo ""
+echo "Mode: ordinary branch push (not a staging/production deploy check)"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  add_reason "Git metadata is unavailable; push validation requires a repository checkout."
+  print_failure_and_exit
+fi
+
+if [ -n "$BRANCH_OVERRIDE" ]; then
+  CURRENT_BRANCH="$BRANCH_OVERRIDE"
+else
+  CURRENT_BRANCH="$(git branch --show-current 2>/dev/null || true)"
+  if [ -z "$CURRENT_BRANCH" ]; then
+    CURRENT_BRANCH="DETACHED"
+  fi
+fi
+
+echo "Current branch: ${CURRENT_BRANCH}"
+
+if [ "$CURRENT_BRANCH" = "DETACHED" ]; then
+  add_reason "Push validation rejects detached HEAD. Check out a named review branch."
+elif ! is_push_branch "$CURRENT_BRANCH"; then
+  add_reason "Push validation rejects branch '${CURRENT_BRANCH}'. Allowed: main, release/*, feature/*, fix/*, hotfix/*, cursor/*, chore/*, docs/*, test/*."
+fi
+
+if [ "$CHECK_BRANCH_ONLY" = "1" ]; then
+  if [ "${#REASONS[@]}" -gt 0 ]; then
+    print_failure_and_exit
+  fi
+  echo ""
+  print_rule
+  echo "PUSH BRANCH POLICY: PASS"
+  print_rule
+  exit 0
+fi
+
+if [ "${#REASONS[@]}" -gt 0 ]; then
+  print_failure_and_exit
+fi
+
+GIT_STATUS="$(git status --porcelain 2>/dev/null || true)"
+if [ -n "$GIT_STATUS" ]; then
+  print_git_cleanliness
+  add_reason "Working tree is not clean. Commit, stash, relocate, or ignore local artefacts before pushing."
+  print_failure_and_exit
+fi
+
+FAILURES=0
+run_and_report "Composer validate" composer validate || FAILURES=$((FAILURES + 1))
+run_and_report "Config safety check" bash scripts/check-config-safety.sh || FAILURES=$((FAILURES + 1))
+run_and_report "Webroot safety check" bash scripts/check-webroot-safety.sh || FAILURES=$((FAILURES + 1))
+run_and_report "Raw card data safety check" bash scripts/check-no-raw-card-data.sh || FAILURES=$((FAILURES + 1))
+
+if [ "$FAILURES" -ne 0 ] || [ "${#REASONS[@]}" -gt 0 ]; then
+  print_failure_and_exit
+fi
+
+echo ""
+print_rule
+echo "PUSH VALIDATION PASSED"
+echo ""
+echo "Ordinary review push checks succeeded."
+echo "Staging/production deployment still requires:"
+echo "  bash scripts/validate-release.sh staging|production"
+print_rule
+exit 0


### PR DESCRIPTION
## Summary
- Replace Husky pre-push staging release validation with a dedicated push gate (`scripts/validate-push.sh`).
- Allow ordinary review/maintenance branches (`chore/*`, `docs/*`, `test/*`) to be pushed without treating them as staging deploy candidates.
- Keep `scripts/validate-release.sh staging|production` allowlists and deploy behaviour unchanged.
- Add narrow `.gitignore` entries for local backup path pointers and ACE backup trees.

## Test plan
- [x] `bash -n scripts/validate-push.sh`
- [x] `composer validate`
- [x] Push allowlist: `chore/*`, `feature/*`, `fix/*`, `main` pass; `random/*` rejects
- [x] Staging allowlist still excludes `chore/*` / `docs/*` / `test/*`
- [x] Dirty working tree still fails push validation
- [x] Branch pushed successfully under the new pre-push hook

Made with [Cursor](https://cursor.com)