### PR TITLE
fix(tickets): harden QR secret handling and decouple My Tickets overview

### DIFF
--- a/docs/STAGING_DEPLOY_GIT.md
+++ b/docs/STAGING_DEPLOY_GIT.md
@@ -50,6 +50,8 @@ If **Build** succeeds and **Deploy to staging** is red, the problem is in the de
 
 **Secrets to verify** (Repository **Settings → Secrets and variables**): `SSH_PRIVATE_KEY`, `SSH_HOST`, `SSH_USER` must match a key that is authorised on the staging host.
 
+**Host application secrets** (staging server env / shared `settings.php`, **not** GitHub Actions secrets and **not** `config/sync`): `MEL_QR_SECRET` must be set so ticket QR HMAC signing works. Verify with `drush mel:qr-secret-status` (expect Status: PASS).
+
 ## 4. Optional: other deploy triggers (not in the repo today)
 
 To deploy only on tags, on a `staging` branch, or from a **workflow_dispatch** button, you need a separate or amended workflow. That is a process change and a YAML change, not a Git client-only switch.

--- a/docs/architecture/environment-configuration.md
+++ b/docs/architecture/environment-configuration.md
@@ -80,3 +80,32 @@ Same chain **except**:
 - Missing optional local files do not fatal (`file_exists` / `is_readable` guards).
 - Missing required shared session fragment fails deploy verification in `scripts/deploy/remote-deploy.sh`.
 - Secrets must not live in tracked PHP/YAML; use `MEL_STRIPE_*`, `STRIPE_*`, `MEL_POSTMARK_*`, `MEL_QR_SECRET`, `MEL_AUTH_*`, `MEL_OPENAI_API_KEY`.
+
+## Ticket QR signing secret
+
+Required for signed ticket QR payloads (`mel:v1:` / `mel:v1:json:`).
+
+| Environment | Requirement |
+|-------------|-------------|
+| DDEV local | Optional: set `MEL_QR_SECRET` in `.ddev/config.local.yaml`. If unset, `settings.mel_shared_session.php` applies a **local-only** default when `IS_DDEV_PROJECT=true`. |
+| Staging | **Required:** `MEL_QR_SECRET` on PHP-FPM and CLI (deploy Drush). |
+| Production | **Required:** `MEL_QR_SECRET` on PHP-FPM and CLI. |
+
+Resolution order (see `TicketQrPayload`):
+
+1. `$settings['myeventlane_qr_secret']` (usually from `MEL_QR_SECRET` via `settings.mel_shared_session.php`)
+2. Legacy `$settings['myeventlane_ticket_qr_secret']`
+3. Environment `MEL_QR_SECRET`
+
+**Never** store the signing secret in `config/sync` or `myeventlane_tickets.settings`.
+
+Validation:
+
+```bash
+ddev drush mel:qr-secret-status
+ddev drush mel:healthcheck
+ddev drush mel:health
+```
+
+Expect Status: **PASS** and a source label such as `settings:myeventlane_qr_secret` (never the raw secret).
+

--- a/docs/deploy/staging-ops-runbook.md
+++ b/docs/deploy/staging-ops-runbook.md
@@ -138,6 +138,7 @@ Expect: `Drupal bootstrap : Successful`, database connected.
 - [ ] `show-release.sh --path ~/staging/current --verify` exits 0
 - [ ] HTTP homepage returns 200 with Drupal headers
 - [ ] `drush status` bootstrap successful
+- [ ] `drush mel:qr-secret-status` reports **PASS** (host `MEL_QR_SECRET` or `$settings['myeventlane_qr_secret']`; never in `config/sync`)
 - [ ] Production HOLD path untouched
 - [ ] No ad-hoc server overlay of `remote-deploy.sh` on the activation path
 

--- a/docs/launch/launch-readiness.md
+++ b/docs/launch/launch-readiness.md
@@ -1141,7 +1141,7 @@ Custom Views plugins implement `VendorStoreAccess` which uses static service cal
 | C9 | Site slogan typo corrected (`evnts` → `events`) | ❌ | Critical | Yes |
 | C10 | Google Maps API key restricted to production domains | 🔲 | High | No |
 | C11 | Postmark sender domain and signatures verified | 🔲 | Critical | Yes |
-| C12 | QR signing secret (`MEL_QR_SECRET`) set in production settings | 🔲 | Critical | Yes |
+| C12 | QR signing secret (`MEL_QR_SECRET`) set in production settings; verify with `drush mel:qr-secret-status` (PASS) | 🔲 | Critical | Yes |
 
 ### 14.4 Payments
 

--- a/docs/release-hardening.md
+++ b/docs/release-hardening.md
@@ -26,6 +26,8 @@ ddev drush cr
 
 ```bash
 ddev drush mel:health
+ddev drush mel:qr-secret-status
+ddev drush mel:healthcheck
 ```
 
 - **Queue dry run (read-only)**
@@ -53,11 +55,12 @@ ddev drush config:status
 
 ### Expected output (mel:health)
 
-- A table with **OK/WARN/FAIL** rows for:
+- A table with **OK/WARN/FAIL/PASS** rows for:
   - **Config drift**
   - **Queue worker instantiation**
   - **Queue backlog counts**
   - **Messaging template Twig compilation**
+  - **QR signing secret** (`MEL_QR_SECRET` / settings; FAIL blocks release)
 
 Exit codes:
 - **0**: no failures (may include warnings).
@@ -73,3 +76,5 @@ Exit codes:
   - Queue backend is not readable for that queue (schema/runtime issue).
 - **Messaging templates = FAIL**
   - An enabled messaging template has invalid Twig syntax and will not render correctly.
+- **QR signing secret = FAIL**
+  - Host missing `MEL_QR_SECRET` (or settings equivalent). Customer My Tickets QR and scanners cannot sign payloads. Fix host env before promoting the release.

--- a/docs/ticket-view-model.md
+++ b/docs/ticket-view-model.md
@@ -95,13 +95,20 @@ This slice does not remove legacy order-item PDF routes, attendee fallbacks, wal
 
 ## QR inclusion flag
 
-`UniversalTicketViewModelBuilder::build($ticket, bool $include_qr = TRUE)` controls whether QR payload/data URI generation runs.
+`UniversalTicketViewModelBuilder::build($ticket, bool $include_qr = TRUE, bool $allow_qr_unavailable = FALSE)` controls QR generation and missing-secret behaviour.
 
-| Caller | `$include_qr` |
-|--------|----------------|
-| My Tickets overview (`/my-tickets`) | `FALSE` |
-| My Tickets order detail | `TRUE` |
-| PDF / wallet / scanner / canonical PDF view model | `TRUE` (default) |
+| Caller | `$include_qr` | `$allow_qr_unavailable` |
+|--------|----------------|-------------------------|
+| My Tickets overview (`/my-tickets`) | `FALSE` | n/a (QR skipped) |
+| My Tickets order detail | `TRUE` | `TRUE` (via `MyTicketsOrderViewModelBuilder`) |
+| PDF / Apple Wallet / default `build()` | `TRUE` (default) | `FALSE` (default; fail-loud) |
 
-When signing is required and `MEL_QR_SECRET` (or settings equivalent) is missing, customer order detail sets `qr.unavailable = TRUE` and omits the image instead of throwing. Direct `TicketQrPayload::buildForTicket()` callers (e.g. scanners, legacy PDF) still fail loud.
+When signing is required (`qr_payload_mode` ≠ `code_only`) and `MEL_QR_SECRET` (or settings equivalent) is missing:
+
+- `$allow_qr_unavailable = TRUE` → `qr.unavailable = TRUE` (customer order detail trust panel)
+- otherwise → `RuntimeException` (PDF / wallet / canonical default paths)
+
+`code_only` mode does not require a signing secret; `drush mel:qr-secret-status`, `mel:health`, and `mel:healthcheck` treat a missing secret as PASS in that mode.
+
+Direct `TicketQrPayload::buildForTicket()` callers (e.g. scanners) still fail loud when signing is required and the secret is missing.
 

--- a/docs/ticket-view-model.md
+++ b/docs/ticket-view-model.md
@@ -92,3 +92,16 @@ Do not rely on Twig hiding or frontend filtering. Any new surface consuming this
 ## Backwards Compatibility
 
 This slice does not remove legacy order-item PDF routes, attendee fallbacks, wallet routes, scanner routes, or `mel:v1:` QR support. It introduces the shared model those surfaces will converge on in later Phase 2B slices.
+
+## QR inclusion flag
+
+`UniversalTicketViewModelBuilder::build($ticket, bool $include_qr = TRUE)` controls whether QR payload/data URI generation runs.
+
+| Caller | `$include_qr` |
+|--------|----------------|
+| My Tickets overview (`/my-tickets`) | `FALSE` |
+| My Tickets order detail | `TRUE` |
+| PDF / wallet / scanner / canonical PDF view model | `TRUE` (default) |
+
+When signing is required and `MEL_QR_SECRET` (or settings equivalent) is missing, customer order detail sets `qr.unavailable = TRUE` and omits the image instead of throwing. Direct `TicketQrPayload::buildForTicket()` callers (e.g. scanners, legacy PDF) still fail loud.
+

--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/MyTicketsOrderViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/MyTicketsOrderViewModelBuilder.php
@@ -209,7 +209,9 @@ final class MyTicketsOrderViewModelBuilder {
         continue;
       }
       $orderId = (int) $ticket->get('order_id')->target_id;
-      $models[$orderId][] = $this->ticketViewModelBuilder->build($ticket, $includeQr);
+      // Customer UI may degrade QR when the host secret is missing; PDF/wallet
+      // callers use UniversalTicketViewModelBuilder::build() defaults (fail-loud).
+      $models[$orderId][] = $this->ticketViewModelBuilder->build($ticket, $includeQr, TRUE);
     }
 
     return $models;

--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/MyTicketsOrderViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/MyTicketsOrderViewModelBuilder.php
@@ -55,8 +55,8 @@ final class MyTicketsOrderViewModelBuilder {
    * @return list<array<string, mixed>>
    *   My Tickets order view models.
    */
-  public function buildMultiple(array $orders, bool $includeDetails = FALSE): array {
-    $ticketModelsByOrder = $this->loadTicketModelsByOrder($orders);
+  public function buildMultiple(array $orders, bool $includeDetails = FALSE, bool $includeQr = FALSE): array {
+    $ticketModelsByOrder = $this->loadTicketModelsByOrder($orders, $includeQr);
     $models = [];
 
     foreach ($orders as $order) {
@@ -79,8 +79,8 @@ final class MyTicketsOrderViewModelBuilder {
    * @return array<string, mixed>
    *   My Tickets order view model.
    */
-  public function build(OrderInterface $order, bool $includeDetails = FALSE, ?array $ticketModels = NULL): array {
-    $ticketModels ??= $this->loadTicketModelsByOrder([$order])[(int) $order->id()] ?? [];
+  public function build(OrderInterface $order, bool $includeDetails = FALSE, ?array $ticketModels = NULL, bool $includeQr = TRUE): array {
+    $ticketModels ??= $this->loadTicketModelsByOrder([$order], $includeQr)[(int) $order->id()] ?? [];
 
     $events = [];
     $legacyTicketItems = [];
@@ -176,7 +176,7 @@ final class MyTicketsOrderViewModelBuilder {
    * @return array<int, list<array<string, mixed>>>
    *   Canonical ticket models keyed by order ID.
    */
-  private function loadTicketModelsByOrder(array $orders): array {
+  private function loadTicketModelsByOrder(array $orders, bool $includeQr = TRUE): array {
     $orderIds = [];
     foreach ($orders as $order) {
       if ($order instanceof OrderInterface && $order->id() !== NULL) {
@@ -209,7 +209,7 @@ final class MyTicketsOrderViewModelBuilder {
         continue;
       }
       $orderId = (int) $ticket->get('order_id')->target_id;
-      $models[$orderId][] = $this->ticketViewModelBuilder->build($ticket);
+      $models[$orderId][] = $this->ticketViewModelBuilder->build($ticket, $includeQr);
     }
 
     return $models;

--- a/web/modules/custom/myeventlane_checkout_flow/templates/myeventlane-order-detail.html.twig
+++ b/web/modules/custom/myeventlane_checkout_flow/templates/myeventlane-order-detail.html.twig
@@ -41,6 +41,11 @@
             <img src="{{ ticket.qr.data_uri }}" alt="{{ 'Scan at entry'|t }}" width="200" height="200">
             <p class="mel-ticket-pass__qr-hint">{{ 'Show this code at entry'|t }}</p>
           </div>
+        {% elseif ticket.qr.unavailable|default(false) %}
+          <div class="mel-ticket-pass__qr-unavailable" role="status">
+            <p class="mel-ticket-pass__qr-unavailable-title">{{ 'QR code temporarily unavailable'|t }}</p>
+            <p class="mel-ticket-pass__qr-unavailable-body">{{ 'Your booking remains valid. Please contact support if this issue persists.'|t }}</p>
+          </div>
         {% endif %}
 
         <div class="mel-ticket-pass__details">

--- a/web/modules/custom/myeventlane_checkout_flow/tests/src/Kernel/MyTicketsOrderViewModelBuilderTest.php
+++ b/web/modules/custom/myeventlane_checkout_flow/tests/src/Kernel/MyTicketsOrderViewModelBuilderTest.php
@@ -84,6 +84,7 @@ final class MyTicketsOrderViewModelBuilderTest extends KernelTestBase {
     $container->register('myeventlane_commerce.order_item_classifier', \stdClass::class);
     $container->register('myeventlane_core.entity_id_normalizer', \stdClass::class);
     $container->register('myeventlane_boost.manager', \stdClass::class);
+    $container->register('myeventlane_commerce.ticket_backed_order_item_classifier', \stdClass::class);
   }
 
   /**
@@ -147,6 +148,8 @@ final class MyTicketsOrderViewModelBuilderTest extends KernelTestBase {
       'field_event_vendor' => $this->customer->id(),
     ]);
     $this->event->save();
+
+    $this->setSetting('myeventlane_qr_secret', 'kernel-test-qr-secret');
   }
 
   /**
@@ -270,6 +273,34 @@ final class MyTicketsOrderViewModelBuilderTest extends KernelTestBase {
     $this->assertCount(1, $model['ticket_items']);
     $this->assertSame('Legacy Admission', $model['ticket_items'][0]['title']);
     $this->assertSame(2, $model['ticket_items'][0]['quantity']);
+  }
+
+
+  /**
+   * Overview models skip QR generation (includeQr defaults FALSE).
+   */
+  public function testOverviewSkipsQrGeneration(): void {
+    $order = $this->createOrder();
+    $this->createTicket($order, ['ticket_code' => 'MEL-OVERVIEW-NO-QR']);
+    $model = $this->builder()->buildMultiple([$order])[0];
+    $this->assertCount(1, $model['ticket_models']);
+    $qr = $model['ticket_models'][0]['qr'];
+    $this->assertFalse($qr['included']);
+    $this->assertSame('', $qr['payload']);
+    $this->assertFalse($qr['unavailable']);
+  }
+
+  /**
+   * Detail models include QR when the signing secret is present.
+   */
+  public function testDetailIncludesQrWhenSecretConfigured(): void {
+    $order = $this->createOrder();
+    $this->createTicket($order, ['ticket_code' => 'MEL-DETAIL-QR']);
+    $model = $this->builder()->build($order, TRUE);
+    $qr = $model['ticket_models'][0]['qr'];
+    $this->assertTrue($qr['included']);
+    $this->assertStringStartsWith('mel:v1:', $qr['payload']);
+    $this->assertFalse($qr['unavailable']);
   }
 
   /**

--- a/web/modules/custom/myeventlane_checkout_flow/tests/src/Kernel/MyTicketsOrderViewModelBuilderTest.php
+++ b/web/modules/custom/myeventlane_checkout_flow/tests/src/Kernel/MyTicketsOrderViewModelBuilderTest.php
@@ -304,6 +304,21 @@ final class MyTicketsOrderViewModelBuilderTest extends KernelTestBase {
   }
 
   /**
+   * Detail models degrade QR when the signing secret is missing.
+   */
+  public function testDetailDegradesQrWhenSecretMissing(): void {
+    $this->setSetting('myeventlane_qr_secret', '');
+    putenv('MEL_QR_SECRET');
+    $order = $this->createOrder();
+    $this->createTicket($order, ['ticket_code' => 'MEL-DETAIL-NO-SECRET']);
+    $model = $this->builder()->build($order, TRUE);
+    $qr = $model['ticket_models'][0]['qr'];
+    $this->assertTrue($qr['included']);
+    $this->assertTrue($qr['unavailable']);
+    $this->assertSame('', $qr['payload']);
+  }
+
+  /**
    * Returns the My Tickets order view model builder.
    */
   private function builder(): object {

--- a/web/modules/custom/myeventlane_core/src/Commands/MelCoreCommands.php
+++ b/web/modules/custom/myeventlane_core/src/Commands/MelCoreCommands.php
@@ -84,7 +84,10 @@ final class MelCoreCommands extends DrushCommands {
     }
 
 
-    // Mirrors TicketQrPayload::resolveSecretSource() without depending on tickets.
+    // Mirrors TicketQrPayload secret resolution without depending on tickets.
+    // code_only mode does not use HMAC signing — missing secret is healthy.
+    $qrMode = (string) ($this->configFactory->get('myeventlane_tickets.settings')->get('qr_payload_mode') ?? 'signed');
+    $qrRequiresSigning = $qrMode !== 'code_only';
     $qrSource = NULL;
     $qrSecret = Settings::get('myeventlane_qr_secret');
     if (!empty($qrSecret)) {
@@ -96,7 +99,13 @@ final class MelCoreCommands extends DrushCommands {
     elseif ((getenv('MEL_QR_SECRET') ?: '') !== '') {
       $qrSource = 'env:MEL_QR_SECRET';
     }
-    if ($qrSource === NULL) {
+    if (!$qrRequiresSigning) {
+      $this->io()->writeln(sprintf(
+        'QR signing secret: PASS (not required; qr_payload_mode=code_only%s)',
+        $qrSource !== NULL ? '; optional source ' . $qrSource : '',
+      ));
+    }
+    elseif ($qrSource === NULL) {
       $this->io()->error("QR signing secret: FAIL — MEL_QR_SECRET missing (set host env or \$settings['myeventlane_qr_secret']).");
       $failures++;
     }

--- a/web/modules/custom/myeventlane_core/src/Commands/MelCoreCommands.php
+++ b/web/modules/custom/myeventlane_core/src/Commands/MelCoreCommands.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_core\Commands;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Site\Settings;
 use Drupal\myeventlane_core\PlatformFeeDefaults;
 use Drupal\myeventlane_core\ReleaseMetadataSchema;
 use Drush\Commands\DrushCommands;
@@ -80,6 +81,27 @@ final class MelCoreCommands extends DrushCommands {
     }
     else {
       $this->io()->note('APP_ENV not set to production|staging — skipping strict domain trio assertion.');
+    }
+
+
+    // Mirrors TicketQrPayload::resolveSecretSource() without depending on tickets.
+    $qrSource = NULL;
+    $qrSecret = Settings::get('myeventlane_qr_secret');
+    if (!empty($qrSecret)) {
+      $qrSource = 'settings:myeventlane_qr_secret';
+    }
+    elseif (!empty(Settings::get('myeventlane_ticket_qr_secret'))) {
+      $qrSource = 'settings:myeventlane_ticket_qr_secret';
+    }
+    elseif ((getenv('MEL_QR_SECRET') ?: '') !== '') {
+      $qrSource = 'env:MEL_QR_SECRET';
+    }
+    if ($qrSource === NULL) {
+      $this->io()->error("QR signing secret: FAIL — MEL_QR_SECRET missing (set host env or \$settings['myeventlane_qr_secret']).");
+      $failures++;
+    }
+    else {
+      $this->io()->writeln(sprintf('QR signing secret: PASS (source: %s)', $qrSource));
     }
 
     if ($failures > 0) {

--- a/web/modules/custom/myeventlane_messaging/drush.services.yml
+++ b/web/modules/custom/myeventlane_messaging/drush.services.yml
@@ -14,5 +14,6 @@ services:
       - '@queue'
       - '@twig'
       - '@module_handler'
+      - '@?myeventlane_tickets.ticket_qr_payload'
     tags:
       - { name: drush.command }

--- a/web/modules/custom/myeventlane_messaging/src/Commands/HealthCommands.php
+++ b/web/modules/custom/myeventlane_messaging/src/Commands/HealthCommands.php
@@ -8,6 +8,7 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\StorageComparer;
 use Drupal\Core\Config\StorageInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\myeventlane_tickets\Ticket\TicketQrPayload;
 use Drupal\Core\Queue\QueueFactory;
 use Drupal\Core\Queue\QueueWorkerManagerInterface;
 use Drush\Commands\DrushCommands;
@@ -29,6 +30,7 @@ final class HealthCommands extends DrushCommands {
     private readonly QueueFactory $queueFactory,
     private readonly Environment $twig,
     private readonly ModuleHandlerInterface $moduleHandler,
+    private readonly ?TicketQrPayload $ticketQrPayload = NULL,
   ) {
     parent::__construct();
   }
@@ -51,6 +53,7 @@ final class HealthCommands extends DrushCommands {
     $this->checkQueueWorkers($results);
     $this->checkQueueBacklog($results);
     $this->checkMessagingTemplates($results);
+    $this->checkQrSigningSecret($results);
 
     $failures = 0;
     $warnings = 0;
@@ -80,6 +83,24 @@ final class HealthCommands extends DrushCommands {
 
     $this->io()->success('Health checks passed.');
     return 0;
+  }
+
+  /**
+   * Checks QR signing secret configuration (no secret value is logged).
+   */
+  private function checkQrSigningSecret(array &$results): void {
+    if (!$this->moduleHandler->moduleExists('myeventlane_tickets') || $this->ticketQrPayload === NULL) {
+      $this->addResult($results, 'WARN', 'QR signing secret', 'myeventlane_tickets not available; skipped.');
+      return;
+    }
+
+    $source = $this->ticketQrPayload->resolveSecretSource();
+    if ($source === NULL) {
+      $this->addResult($results, 'FAIL', 'QR signing secret', "MEL_QR_SECRET missing. Set host env or \$settings['myeventlane_qr_secret']. Never store in config/sync.");
+      return;
+    }
+
+    $this->addResult($results, 'PASS', 'QR signing secret', 'Configured via ' . $source);
   }
 
   /**

--- a/web/modules/custom/myeventlane_messaging/src/Commands/HealthCommands.php
+++ b/web/modules/custom/myeventlane_messaging/src/Commands/HealthCommands.php
@@ -94,6 +94,19 @@ final class HealthCommands extends DrushCommands {
       return;
     }
 
+    if (!$this->ticketQrPayload->requiresSigningSecret()) {
+      $source = $this->ticketQrPayload->resolveSecretSource();
+      $this->addResult(
+        $results,
+        'PASS',
+        'QR signing secret',
+        $source === NULL
+          ? 'Not required (qr_payload_mode=code_only).'
+          : 'Not required (qr_payload_mode=code_only); optional source ' . $source,
+      );
+      return;
+    }
+
     $source = $this->ticketQrPayload->resolveSecretSource();
     if ($source === NULL) {
       $this->addResult($results, 'FAIL', 'QR signing secret', "MEL_QR_SECRET missing. Set host env or \$settings['myeventlane_qr_secret']. Never store in config/sync.");

--- a/web/modules/custom/myeventlane_tickets/drush.services.yml
+++ b/web/modules/custom/myeventlane_tickets/drush.services.yml
@@ -1,0 +1,7 @@
+services:
+  myeventlane_tickets.commands:
+    class: Drupal\myeventlane_tickets\Commands\TicketsCommands
+    arguments:
+      - '@myeventlane_tickets.ticket_qr_payload'
+    tags:
+      - { name: drush.command }

--- a/web/modules/custom/myeventlane_tickets/myeventlane_tickets.services.yml
+++ b/web/modules/custom/myeventlane_tickets/myeventlane_tickets.services.yml
@@ -196,6 +196,7 @@ services:
       - '@myeventlane_tickets.device_operation_identity_manager'
       - '@myeventlane_tickets.operational_continuity_policy_manager'
       - '@myeventlane_tickets.occupancy_policy_manager'
+      - '@logger.channel.myeventlane_tickets'
       - '@?myeventlane_wallet.presentation_gate'
 
   myeventlane_tickets.ticket_mailer:

--- a/web/modules/custom/myeventlane_tickets/src/Commands/TicketsCommands.php
+++ b/web/modules/custom/myeventlane_tickets/src/Commands/TicketsCommands.php
@@ -24,22 +24,37 @@ final class TicketsCommands extends DrushCommands {
    * @command mel:qr-secret-status
    * @aliases mel-qr-secret-status
    * @usage ddev drush mel:qr-secret-status
-   *   Verify MEL_QR_SECRET / settings QR signing secret is present.
+   *   Verify MEL_QR_SECRET / settings QR signing secret is present when required.
    *
    * @return int
-   *   0 when configured, 1 when missing.
+   *   0 when configuration is healthy for the active qr_payload_mode, 1 otherwise.
    */
   public function qrSecretStatus(): int {
     $source = $this->ticketQrPayload->resolveSecretSource();
+    $requiresSigning = $this->ticketQrPayload->requiresSigningSecret();
+    $healthy = $this->ticketQrPayload->isSigningConfigurationHealthy();
     $this->io()->title('QR signing secret');
 
-    if ($source === NULL) {
+    if (!$requiresSigning) {
+      $this->io()->table(
+        ['Field', 'Value'],
+        [
+          ['Status', 'PASS'],
+          ['Source', $source ?? 'not required (qr_payload_mode=code_only)'],
+          ['Requires signing', 'no (code_only)'],
+        ],
+      );
+      $this->io()->success('QR signing secret is not required for qr_payload_mode=code_only.');
+      return 0;
+    }
+
+    if (!$healthy) {
       $this->io()->table(
         ['Field', 'Value'],
         [
           ['Status', 'FAIL'],
           ['Source', 'MEL_QR_SECRET missing'],
-          ['Requires signing', $this->ticketQrPayload->requiresSigningSecret() ? 'yes' : 'no (code_only)'],
+          ['Requires signing', 'yes'],
         ],
       );
       $this->io()->error('Set MEL_QR_SECRET on the host or $settings[\'myeventlane_qr_secret\'] in settings.php. Never store the secret in config/sync.');
@@ -51,7 +66,7 @@ final class TicketsCommands extends DrushCommands {
       [
         ['Status', 'PASS'],
         ['Source', $source],
-        ['Requires signing', $this->ticketQrPayload->requiresSigningSecret() ? 'yes' : 'no (code_only)'],
+        ['Requires signing', 'yes'],
       ],
     );
     $this->io()->success('QR signing secret is configured.');

--- a/web/modules/custom/myeventlane_tickets/src/Commands/TicketsCommands.php
+++ b/web/modules/custom/myeventlane_tickets/src/Commands/TicketsCommands.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_tickets\Commands;
+
+use Drupal\myeventlane_tickets\Ticket\TicketQrPayload;
+use Drush\Commands\DrushCommands;
+
+/**
+ * Ticket operational Drush commands.
+ */
+final class TicketsCommands extends DrushCommands {
+
+  public function __construct(
+    private readonly TicketQrPayload $ticketQrPayload,
+  ) {
+    parent::__construct();
+  }
+
+  /**
+   * Reports QR signing secret configuration status (never prints the secret).
+   *
+   * @command mel:qr-secret-status
+   * @aliases mel-qr-secret-status
+   * @usage ddev drush mel:qr-secret-status
+   *   Verify MEL_QR_SECRET / settings QR signing secret is present.
+   *
+   * @return int
+   *   0 when configured, 1 when missing.
+   */
+  public function qrSecretStatus(): int {
+    $source = $this->ticketQrPayload->resolveSecretSource();
+    $this->io()->title('QR signing secret');
+
+    if ($source === NULL) {
+      $this->io()->table(
+        ['Field', 'Value'],
+        [
+          ['Status', 'FAIL'],
+          ['Source', 'MEL_QR_SECRET missing'],
+          ['Requires signing', $this->ticketQrPayload->requiresSigningSecret() ? 'yes' : 'no (code_only)'],
+        ],
+      );
+      $this->io()->error('Set MEL_QR_SECRET on the host or $settings[\'myeventlane_qr_secret\'] in settings.php. Never store the secret in config/sync.');
+      return 1;
+    }
+
+    $this->io()->table(
+      ['Field', 'Value'],
+      [
+        ['Status', 'PASS'],
+        ['Source', $source],
+        ['Requires signing', $this->ticketQrPayload->requiresSigningSecret() ? 'yes' : 'no (code_only)'],
+      ],
+    );
+    $this->io()->success('QR signing secret is configured.');
+    return 0;
+  }
+
+}

--- a/web/modules/custom/myeventlane_tickets/src/Form/TicketSettingsForm.php
+++ b/web/modules/custom/myeventlane_tickets/src/Form/TicketSettingsForm.php
@@ -4,14 +4,36 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_tickets\Form;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Site\Settings;
+use Drupal\myeventlane_tickets\Ticket\TicketQrPayload;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Configuration form for ticket PDF generation and download settings.
  */
 final class TicketSettingsForm extends ConfigFormBase {
+
+  public function __construct(
+    ConfigFactoryInterface $config_factory,
+    TypedConfigManagerInterface $typedConfigManager,
+    private readonly TicketQrPayload $ticketQrPayload,
+  ) {
+    parent::__construct($config_factory, $typedConfigManager);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('config.typed'),
+      $container->get('myeventlane_tickets.ticket_qr_payload'),
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -129,16 +151,17 @@ final class TicketSettingsForm extends ConfigFormBase {
     $form['security'] = [
       '#type' => 'details',
       '#title' => $this->t('QR signing'),
-      '#open' => FALSE,
+      '#open' => TRUE,
     ];
 
+    $source = $this->ticketQrPayload->resolveSecretSource();
     $form['security']['qr_secret_status'] = [
       '#type' => 'item',
       '#title' => $this->t('QR signing secret'),
-      '#markup' => $this->isQrSecretConfigured()
-        ? $this->t('Configured by environment: yes')
-        : $this->t('Configured by environment: no'),
-      '#description' => $this->t('Set $settings[\'myeventlane_qr_secret\'] in settings.php or the MEL_QR_SECRET environment variable. Secrets are never stored in exported configuration.'),
+      '#markup' => $source === NULL
+        ? $this->t('Status: <strong>FAIL</strong> — MEL_QR_SECRET missing')
+        : $this->t('Status: <strong>PASS</strong> — Source: @source', ['@source' => $source]),
+      '#description' => $this->t("Set \$settings['myeventlane_qr_secret'] in settings.php or the MEL_QR_SECRET environment variable. Secrets are never stored in exported configuration. Verify with: drush mel:qr-secret-status"),
     ];
 
     return parent::buildForm($form, $form_state);
@@ -161,23 +184,6 @@ final class TicketSettingsForm extends ConfigFormBase {
       ->save();
 
     parent::submitForm($form, $form_state);
-  }
-
-  /**
-   * Whether the QR signing secret is available from settings or environment.
-   */
-  private function isQrSecretConfigured(): bool {
-    $secret = Settings::get('myeventlane_qr_secret');
-    if (!empty($secret)) {
-      return TRUE;
-    }
-
-    $legacy = Settings::get('myeventlane_ticket_qr_secret');
-    if (!empty($legacy)) {
-      return TRUE;
-    }
-
-    return !empty(getenv('MEL_QR_SECRET'));
   }
 
 }

--- a/web/modules/custom/myeventlane_tickets/src/Form/TicketSettingsForm.php
+++ b/web/modules/custom/myeventlane_tickets/src/Form/TicketSettingsForm.php
@@ -155,13 +155,22 @@ final class TicketSettingsForm extends ConfigFormBase {
     ];
 
     $source = $this->ticketQrPayload->resolveSecretSource();
+    if (!$this->ticketQrPayload->requiresSigningSecret()) {
+      $markup = $source === NULL
+        ? $this->t('Status: <strong>PASS</strong> — Not required (QR payload mode is ticket code only)')
+        : $this->t('Status: <strong>PASS</strong> — Not required (code only); optional source: @source', ['@source' => $source]);
+    }
+    elseif ($source === NULL) {
+      $markup = $this->t('Status: <strong>FAIL</strong> — MEL_QR_SECRET missing');
+    }
+    else {
+      $markup = $this->t('Status: <strong>PASS</strong> — Source: @source', ['@source' => $source]);
+    }
     $form['security']['qr_secret_status'] = [
       '#type' => 'item',
       '#title' => $this->t('QR signing secret'),
-      '#markup' => $source === NULL
-        ? $this->t('Status: <strong>FAIL</strong> — MEL_QR_SECRET missing')
-        : $this->t('Status: <strong>PASS</strong> — Source: @source', ['@source' => $source]),
-      '#description' => $this->t("Set \$settings['myeventlane_qr_secret'] in settings.php or the MEL_QR_SECRET environment variable. Secrets are never stored in exported configuration. Verify with: drush mel:qr-secret-status"),
+      '#markup' => $markup,
+      '#description' => $this->t("Set \$settings['myeventlane_qr_secret'] in settings.php or the MEL_QR_SECRET environment variable when using signed QR mode. Secrets are never stored in exported configuration. Verify with: drush mel:qr-secret-status"),
     ];
 
     return parent::buildForm($form, $form_state);

--- a/web/modules/custom/myeventlane_tickets/src/Service/UniversalTicketViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/UniversalTicketViewModelBuilder.php
@@ -13,6 +13,7 @@ use Drupal\myeventlane_tickets\Ticket\QrCodeGenerator;
 use Drupal\myeventlane_tickets\Ticket\TicketQrPayload;
 use Drupal\myeventlane_wallet\Service\WalletPresentationGate;
 use Drupal\node\NodeInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Builds normalized operational view models for issued ticket entitlements.
@@ -32,22 +33,27 @@ final class UniversalTicketViewModelBuilder {
     private readonly DeviceOperationIdentityManager $deviceOperationIdentityManager,
     private readonly OperationalContinuityPolicyManager $operationalContinuityPolicyManager,
     private readonly OccupancyPolicyManager $occupancyPolicyManager,
+    private readonly LoggerInterface $logger,
     private readonly ?WalletPresentationGate $walletPresentationGate = NULL,
   ) {}
 
   /**
    * Builds one canonical operational model for an issued ticket.
    *
+   * @param bool $include_qr
+   *   When FALSE, skips QR payload/data URI generation (list surfaces).
+   *   Defaults to TRUE for PDF, wallet, scanner and order detail.
+   *
    * @return array<string, mixed>
    *   Normalized ticket view model for customer, PDF, wallet and scanner use.
    */
-  public function build(Ticket $ticket): array {
+  public function build(Ticket $ticket, bool $include_qr = TRUE): array {
     $ticket_code = $this->readString($ticket, 'ticket_code');
     $entitlement_type = $this->capabilityManager->getEntitlementType($ticket);
     $capabilities = $this->entitlementCapabilityRegistry->getCapabilityMap($entitlement_type);
     $status = $this->readString($ticket, 'status', Ticket::STATUS_ISSUED_UNASSIGNED);
     $fulfilment_status = $ticket->getFulfilmentStatus();
-    $qr_payload = $this->ticketQrPayload->buildForTicket($ticket);
+    $qr = $this->buildQrSection($ticket, $include_qr);
     $redemption_limit = $ticket->getRedemptionLimit();
     $redemption_count = $ticket->getRedemptionCount();
     $remaining_redemptions = $this->capabilityManager->getRemainingRedemptions($ticket);
@@ -78,10 +84,7 @@ final class UniversalTicketViewModelBuilder {
         'email' => $this->readString($ticket, 'holder_email'),
         'purchaser_uid' => $this->readTargetId($ticket, 'purchaser_uid'),
       ],
-      'qr' => [
-        'payload' => $qr_payload,
-        'data_uri' => $this->qrCodeGenerator->buildDataUri($qr_payload),
-      ],
+      'qr' => $qr,
       'redemption' => [
         'limit' => $redemption_limit,
         'count' => $redemption_count,
@@ -153,14 +156,55 @@ final class UniversalTicketViewModelBuilder {
    * @return list<array<string, mixed>>
    *   View models in input order.
    */
-  public function buildMultiple(iterable $tickets): array {
+  public function buildMultiple(iterable $tickets, bool $include_qr = TRUE): array {
     $models = [];
     foreach ($tickets as $ticket) {
       if ($ticket instanceof Ticket) {
-        $models[] = $this->build($ticket);
+        $models[] = $this->build($ticket, $include_qr);
       }
     }
     return $models;
+  }
+
+  /**
+   * Builds the QR section for a ticket view model.
+   *
+   * When $include_qr is FALSE, QR generation is skipped (My Tickets overview).
+   * When signing is required but the secret is missing, the booking model still
+   * loads with qr.unavailable = TRUE — no exception is thrown.
+   *
+   * @return array{payload: string, data_uri: string, unavailable: bool, included: bool}
+   *   QR presentation data.
+   */
+  private function buildQrSection(Ticket $ticket, bool $include_qr): array {
+    if (!$include_qr) {
+      return [
+        'payload' => '',
+        'data_uri' => '',
+        'unavailable' => FALSE,
+        'included' => FALSE,
+      ];
+    }
+
+    if ($this->ticketQrPayload->requiresSigningSecret() && !$this->ticketQrPayload->isSecretConfigured()) {
+      $this->logger->error('MEL QR signing secret is not configured; omitting QR from ticket view model for ticket @ticket.', [
+        '@ticket' => (string) $ticket->id(),
+      ]);
+      return [
+        'payload' => '',
+        'data_uri' => '',
+        'unavailable' => TRUE,
+        'included' => TRUE,
+      ];
+    }
+
+    $payload = $this->ticketQrPayload->buildForTicket($ticket);
+    return [
+      'payload' => $payload,
+      'data_uri' => $this->qrCodeGenerator->buildDataUri($payload),
+      'unavailable' => FALSE,
+      'included' => TRUE,
+    ];
   }
 
   /**

--- a/web/modules/custom/myeventlane_tickets/src/Service/UniversalTicketViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_tickets/src/Service/UniversalTicketViewModelBuilder.php
@@ -43,17 +43,21 @@ final class UniversalTicketViewModelBuilder {
    * @param bool $include_qr
    *   When FALSE, skips QR payload/data URI generation (list surfaces).
    *   Defaults to TRUE for PDF, wallet, scanner and order detail.
+   * @param bool $allow_qr_unavailable
+   *   When TRUE (My Tickets order detail only), missing signing secret yields
+   *   qr.unavailable instead of throwing. Defaults to FALSE so PDF / Apple
+   *   Wallet / default callers remain fail-loud for signed payloads.
    *
    * @return array<string, mixed>
    *   Normalized ticket view model for customer, PDF, wallet and scanner use.
    */
-  public function build(Ticket $ticket, bool $include_qr = TRUE): array {
+  public function build(Ticket $ticket, bool $include_qr = TRUE, bool $allow_qr_unavailable = FALSE): array {
     $ticket_code = $this->readString($ticket, 'ticket_code');
     $entitlement_type = $this->capabilityManager->getEntitlementType($ticket);
     $capabilities = $this->entitlementCapabilityRegistry->getCapabilityMap($entitlement_type);
     $status = $this->readString($ticket, 'status', Ticket::STATUS_ISSUED_UNASSIGNED);
     $fulfilment_status = $ticket->getFulfilmentStatus();
-    $qr = $this->buildQrSection($ticket, $include_qr);
+    $qr = $this->buildQrSection($ticket, $include_qr, $allow_qr_unavailable);
     $redemption_limit = $ticket->getRedemptionLimit();
     $redemption_count = $ticket->getRedemptionCount();
     $remaining_redemptions = $this->capabilityManager->getRemainingRedemptions($ticket);
@@ -156,11 +160,11 @@ final class UniversalTicketViewModelBuilder {
    * @return list<array<string, mixed>>
    *   View models in input order.
    */
-  public function buildMultiple(iterable $tickets, bool $include_qr = TRUE): array {
+  public function buildMultiple(iterable $tickets, bool $include_qr = TRUE, bool $allow_qr_unavailable = FALSE): array {
     $models = [];
     foreach ($tickets as $ticket) {
       if ($ticket instanceof Ticket) {
-        $models[] = $this->build($ticket, $include_qr);
+        $models[] = $this->build($ticket, $include_qr, $allow_qr_unavailable);
       }
     }
     return $models;
@@ -170,13 +174,14 @@ final class UniversalTicketViewModelBuilder {
    * Builds the QR section for a ticket view model.
    *
    * When $include_qr is FALSE, QR generation is skipped (My Tickets overview).
-   * When signing is required but the secret is missing, the booking model still
-   * loads with qr.unavailable = TRUE — no exception is thrown.
+   * When signing is required but the secret is missing:
+   * - $allow_qr_unavailable TRUE → qr.unavailable (customer order detail only)
+   * - otherwise → RuntimeException (PDF / wallet / default fail-loud paths)
    *
    * @return array{payload: string, data_uri: string, unavailable: bool, included: bool}
    *   QR presentation data.
    */
-  private function buildQrSection(Ticket $ticket, bool $include_qr): array {
+  private function buildQrSection(Ticket $ticket, bool $include_qr, bool $allow_qr_unavailable): array {
     if (!$include_qr) {
       return [
         'payload' => '',
@@ -187,15 +192,21 @@ final class UniversalTicketViewModelBuilder {
     }
 
     if ($this->ticketQrPayload->requiresSigningSecret() && !$this->ticketQrPayload->isSecretConfigured()) {
-      $this->logger->error('MEL QR signing secret is not configured; omitting QR from ticket view model for ticket @ticket.', [
-        '@ticket' => (string) $ticket->id(),
-      ]);
-      return [
-        'payload' => '',
-        'data_uri' => '',
-        'unavailable' => TRUE,
-        'included' => TRUE,
-      ];
+      if ($allow_qr_unavailable) {
+        $this->logger->error('MEL QR signing secret is not configured; omitting QR from ticket view model for ticket @ticket.', [
+          '@ticket' => (string) $ticket->id(),
+        ]);
+        return [
+          'payload' => '',
+          'data_uri' => '',
+          'unavailable' => TRUE,
+          'included' => TRUE,
+        ];
+      }
+
+      // Fail-loud for PDF, Apple Wallet, and any default include_qr caller.
+      $this->logger->error('MEL QR signing secret is not configured.');
+      throw new \RuntimeException('MEL QR signing secret is not configured.');
     }
 
     $payload = $this->ticketQrPayload->buildForTicket($ticket);

--- a/web/modules/custom/myeventlane_tickets/src/Ticket/TicketQrPayload.php
+++ b/web/modules/custom/myeventlane_tickets/src/Ticket/TicketQrPayload.php
@@ -269,6 +269,15 @@ final class TicketQrPayload {
   }
 
   /**
+   * Whether host QR signing configuration is healthy for the active mode.
+   *
+   * code_only does not use HMAC signing, so a missing secret is healthy.
+   */
+  public function isSigningConfigurationHealthy(): bool {
+    return !$this->requiresSigningSecret() || $this->isSecretConfigured();
+  }
+
+  /**
    * Gets QR signing secret from settings.php first, then environment.
    */
   private function getSecret(): string {

--- a/web/modules/custom/myeventlane_tickets/src/Ticket/TicketQrPayload.php
+++ b/web/modules/custom/myeventlane_tickets/src/Ticket/TicketQrPayload.php
@@ -226,20 +226,63 @@ final class TicketQrPayload {
   }
 
   /**
+   * Whether a QR signing secret is available from settings or environment.
+   */
+  public function isSecretConfigured(): bool {
+    return $this->resolveSecretSource() !== NULL;
+  }
+
+  /**
+   * Resolves which non-empty source would supply the QR signing secret.
+   *
+   * Order matches getSecret(): settings key, legacy settings key, then MEL_QR_SECRET.
+   * Does not reveal the secret value.
+   *
+   * @return string|null
+   *   Machine-safe source label, or NULL when missing.
+   */
+  public function resolveSecretSource(): ?string {
+    $secret = Settings::get('myeventlane_qr_secret');
+    if (!empty($secret)) {
+      return 'settings:myeventlane_qr_secret';
+    }
+
+    $legacy = Settings::get('myeventlane_ticket_qr_secret');
+    if (!empty($legacy)) {
+      return 'settings:myeventlane_ticket_qr_secret';
+    }
+
+    $env = getenv('MEL_QR_SECRET') ?: '';
+    if ($env !== '') {
+      return 'env:MEL_QR_SECRET';
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Whether the active qr_payload_mode requires a signing secret.
+   */
+  public function requiresSigningSecret(): bool {
+    $mode = (string) ($this->configFactory->get('myeventlane_tickets.settings')->get('qr_payload_mode') ?? 'signed');
+    return $mode !== 'code_only';
+  }
+
+  /**
    * Gets QR signing secret from settings.php first, then environment.
    */
   private function getSecret(): string {
+    if (!$this->isSecretConfigured()) {
+      $this->logger->error('MEL QR signing secret is not configured.');
+      throw new \RuntimeException('MEL QR signing secret is not configured.');
+    }
+
     $secret = Settings::get('myeventlane_qr_secret');
     if (empty($secret)) {
       $secret = Settings::get('myeventlane_ticket_qr_secret');
     }
     if (empty($secret)) {
       $secret = getenv('MEL_QR_SECRET') ?: '';
-    }
-
-    if (empty($secret)) {
-      $this->logger->error('MEL QR signing secret is not configured.');
-      throw new \RuntimeException('MEL QR signing secret is not configured.');
     }
 
     return (string) $secret;

--- a/web/modules/custom/myeventlane_tickets/tests/src/Kernel/UniversalTicketViewModelBuilderTest.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Kernel/UniversalTicketViewModelBuilderTest.php
@@ -348,19 +348,31 @@ final class UniversalTicketViewModelBuilderTest extends KernelTestBase {
   }
 
   /**
-   * Detail builds degrade when the signing secret is missing.
+   * Customer detail may degrade when allow_qr_unavailable is TRUE.
    */
-  public function testBuildWithQrDegradesWhenSecretMissing(): void {
+  public function testBuildWithQrDegradesWhenSecretMissingAndAllowed(): void {
     $this->setSetting('myeventlane_qr_secret', '');
     putenv('MEL_QR_SECRET');
     $ticket = $this->createTicket(['ticket_code' => 'MEL-QR-MISS']);
-    $model = $this->builder()->build($ticket, TRUE);
+    $model = $this->builder()->build($ticket, TRUE, TRUE);
     $this->assertSame('', $model['qr']['payload']);
     $this->assertSame('', $model['qr']['data_uri']);
     $this->assertTrue($model['qr']['unavailable']);
     $this->assertTrue($model['qr']['included']);
     $this->assertSame('MEL-QR-MISS', $model['ticket']['code']);
     $this->assertNotEmpty($model['event']);
+  }
+
+  /**
+   * PDF/wallet default build() fails loud when the signing secret is missing.
+   */
+  public function testBuildWithQrThrowsWhenSecretMissingByDefault(): void {
+    $this->setSetting('myeventlane_qr_secret', '');
+    putenv('MEL_QR_SECRET');
+    $ticket = $this->createTicket(['ticket_code' => 'MEL-QR-FAIL']);
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('MEL QR signing secret is not configured.');
+    $this->builder()->build($ticket, TRUE);
   }
 
   /**

--- a/web/modules/custom/myeventlane_tickets/tests/src/Kernel/UniversalTicketViewModelBuilderTest.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Kernel/UniversalTicketViewModelBuilderTest.php
@@ -76,6 +76,7 @@ final class UniversalTicketViewModelBuilderTest extends KernelTestBase {
     $container->register('myeventlane_analytics.order_item_classifier', \stdClass::class);
     $container->register('myeventlane_core.entity_id_normalizer', \stdClass::class);
     $container->register('myeventlane_boost.manager', \stdClass::class);
+    $container->register('myeventlane_commerce.ticket_backed_order_item_classifier', \stdClass::class);
   }
 
   /**
@@ -112,6 +113,9 @@ final class UniversalTicketViewModelBuilderTest extends KernelTestBase {
       'field_event_vendor' => $this->customer->id(),
     ]);
     $this->event->save();
+
+    // Signed QR payloads require a non-exportable signing secret.
+    $this->setSetting('myeventlane_qr_secret', 'kernel-test-qr-secret');
   }
 
   /**
@@ -325,6 +329,52 @@ final class UniversalTicketViewModelBuilderTest extends KernelTestBase {
     $this->assertFalse($expired_model['scanner']['can_scan']);
     $this->assertSame('fulfilment_expired', $expired_model['scanner']['status']);
     $this->assertStringContainsString('fulfilment', strtolower($expired_model['scanner']['message']));
+  }
+
+
+  /**
+   * Overview-style builds can omit QR without requiring a signing secret.
+   */
+  public function testBuildWithoutQrSkipsSigning(): void {
+    $this->setSetting('myeventlane_qr_secret', '');
+    putenv('MEL_QR_SECRET');
+    $ticket = $this->createTicket(['ticket_code' => 'MEL-NO-QR']);
+    $model = $this->builder()->build($ticket, FALSE);
+    $this->assertSame('', $model['qr']['payload']);
+    $this->assertSame('', $model['qr']['data_uri']);
+    $this->assertFalse($model['qr']['unavailable']);
+    $this->assertFalse($model['qr']['included']);
+    $this->assertSame('MEL-NO-QR', $model['ticket']['code']);
+  }
+
+  /**
+   * Detail builds degrade when the signing secret is missing.
+   */
+  public function testBuildWithQrDegradesWhenSecretMissing(): void {
+    $this->setSetting('myeventlane_qr_secret', '');
+    putenv('MEL_QR_SECRET');
+    $ticket = $this->createTicket(['ticket_code' => 'MEL-QR-MISS']);
+    $model = $this->builder()->build($ticket, TRUE);
+    $this->assertSame('', $model['qr']['payload']);
+    $this->assertSame('', $model['qr']['data_uri']);
+    $this->assertTrue($model['qr']['unavailable']);
+    $this->assertTrue($model['qr']['included']);
+    $this->assertSame('MEL-QR-MISS', $model['ticket']['code']);
+    $this->assertNotEmpty($model['event']);
+  }
+
+  /**
+   * Detail builds include a signed QR when the secret is configured.
+   */
+  public function testBuildWithQrSucceedsWhenSecretConfigured(): void {
+    $this->setSetting('myeventlane_qr_secret', 'kernel-test-qr-secret');
+    $ticket = $this->createTicket(['ticket_code' => 'MEL-QR-OK']);
+    $model = $this->builder()->build($ticket, TRUE);
+    $this->assertNotSame('', $model['qr']['payload']);
+    $this->assertStringStartsWith('mel:v1:', $model['qr']['payload']);
+    $this->assertNotSame('', $model['qr']['data_uri']);
+    $this->assertFalse($model['qr']['unavailable']);
+    $this->assertTrue($model['qr']['included']);
   }
 
   /**

--- a/web/modules/custom/myeventlane_tickets/tests/src/Unit/TicketQrPayloadSecretTest.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Unit/TicketQrPayloadSecretTest.php
@@ -62,11 +62,34 @@ final class TicketQrPayloadSecretTest extends UnitTestCase {
 
   /**
    * @covers ::requiresSigningSecret
+   * @covers ::isSigningConfigurationHealthy
    */
   public function testCodeOnlyModeDoesNotRequireSecret(): void {
     new Settings([]);
+    putenv('MEL_QR_SECRET');
     $payload = $this->payload('code_only');
     $this->assertFalse($payload->requiresSigningSecret());
+    $this->assertTrue($payload->isSigningConfigurationHealthy());
+  }
+
+  /**
+   * @covers ::isSigningConfigurationHealthy
+   */
+  public function testSignedModeUnhealthyWithoutSecret(): void {
+    new Settings([]);
+    putenv('MEL_QR_SECRET');
+    $payload = $this->payload('signed');
+    $this->assertTrue($payload->requiresSigningSecret());
+    $this->assertFalse($payload->isSigningConfigurationHealthy());
+  }
+
+  /**
+   * @covers ::isSigningConfigurationHealthy
+   */
+  public function testSignedModeHealthyWithSecret(): void {
+    new Settings(['myeventlane_qr_secret' => 'present']);
+    $payload = $this->payload('signed');
+    $this->assertTrue($payload->isSigningConfigurationHealthy());
   }
 
   private function payload(string $mode): TicketQrPayload {

--- a/web/modules/custom/myeventlane_tickets/tests/src/Unit/TicketQrPayloadSecretTest.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Unit/TicketQrPayloadSecretTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_tickets\Unit;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Site\Settings;
+use Drupal\myeventlane_tickets\Ticket\TicketQrPayload;
+use Drupal\Tests\UnitTestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for QR signing secret resolution.
+ *
+ * @coversDefaultClass \Drupal\myeventlane_tickets\Ticket\TicketQrPayload
+ * @group myeventlane_tickets
+ */
+final class TicketQrPayloadSecretTest extends UnitTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    // Reset Settings between tests.
+    new Settings([]);
+  }
+
+  /**
+   * @covers ::resolveSecretSource
+   * @covers ::isSecretConfigured
+   */
+  public function testResolveSecretSourceFromSettings(): void {
+    new Settings(['myeventlane_qr_secret' => 'from-settings']);
+    $payload = $this->payload('signed');
+    $this->assertTrue($payload->isSecretConfigured());
+    $this->assertSame('settings:myeventlane_qr_secret', $payload->resolveSecretSource());
+  }
+
+  /**
+   * @covers ::resolveSecretSource
+   */
+  public function testResolveSecretSourceFromEnv(): void {
+    new Settings([]);
+    putenv('MEL_QR_SECRET=from-env');
+    $payload = $this->payload('signed');
+    $this->assertTrue($payload->isSecretConfigured());
+    $this->assertSame('env:MEL_QR_SECRET', $payload->resolveSecretSource());
+    putenv('MEL_QR_SECRET');
+  }
+
+  /**
+   * @covers ::resolveSecretSource
+   * @covers ::isSecretConfigured
+   */
+  public function testMissingSecretReportsNullSource(): void {
+    new Settings([]);
+    putenv('MEL_QR_SECRET');
+    $payload = $this->payload('signed');
+    $this->assertFalse($payload->isSecretConfigured());
+    $this->assertNull($payload->resolveSecretSource());
+  }
+
+  /**
+   * @covers ::requiresSigningSecret
+   */
+  public function testCodeOnlyModeDoesNotRequireSecret(): void {
+    new Settings([]);
+    $payload = $this->payload('code_only');
+    $this->assertFalse($payload->requiresSigningSecret());
+  }
+
+  private function payload(string $mode): TicketQrPayload {
+    $config = $this->createMock(ImmutableConfig::class);
+    $config->method('get')->willReturnCallback(static function (string $key) use ($mode) {
+      return $key === 'qr_payload_mode' ? $mode : NULL;
+    });
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('get')->with('myeventlane_tickets.settings')->willReturn($config);
+    $logger = $this->createMock(LoggerInterface::class);
+    return new TicketQrPayload($factory, $logger);
+  }
+
+}

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_user.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_user.scss
@@ -763,6 +763,29 @@
   text-align: center;
 }
 
+
+.mel-ticket-pass__qr-unavailable {
+  margin: spacing.mel-space(4);
+  padding: spacing.mel-space(4);
+  border-radius: radii.$mel-radius-sm;
+  background: colors.$mel-color-bg;
+  text-align: center;
+}
+
+.mel-ticket-pass__qr-unavailable-title {
+  margin: 0 0 spacing.mel-space(2);
+  font-size: typography.mel-font-size(base);
+  font-weight: 600;
+  color: colors.$mel-color-text;
+}
+
+.mel-ticket-pass__qr-unavailable-body {
+  margin: 0;
+  font-size: typography.mel-font-size(sm);
+  color: colors.$mel-color-text-muted;
+}
+
+
 .mel-ticket-pass__details {
   padding: spacing.mel-space(4);
 }


### PR DESCRIPTION
## Summary
- Harden QR signing secret status APIs while keeping fail-loud signing when a QR is required.
- Decouple `/my-tickets` overview from QR generation (`include_qr=FALSE`) so a missing host secret no longer crashes the list page.
- On order detail, degrade gracefully with a trust panel when the secret is missing.
- Add `drush mel:qr-secret-status`, health reporting, admin settings status, docs, and regression tests.

## Test plan
- [ ] `/my-tickets` loads with issued tickets when `MEL_QR_SECRET` is unset
- [ ] `/my-tickets/order/{order}` shows trust panel (no exception) when secret unset; shows QR when set
- [ ] PDF / Apple Wallet / scanner paths still require a configured secret for signing
- [ ] `drush mel:qr-secret-status` reports PASS/FAIL without printing the secret
- [ ] No `config/sync` secret material; no staging host mutations in this PR

## Notes
- Deploy-script pre-activation gating is intentionally **out of scope** (see follow-up `chore/deploy-preflight-qr-secret`).

Made with [Cursor](https://cursor.com)