### PR TITLE
chore(testing): add local Drupal PHPUnit helper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,8 @@
   "scripts": {
     "governance:test": "cd web && ../vendor/bin/phpunit -c phpunit-governance.xml",
     "governance:audit": "php scripts/governance/architecture-audit.php && php scripts/governance/surface-audit.php && php scripts/governance/template-parity-audit.php",
-    "governance:snapshot:update": "cd web && MEL_UPDATE_GOVERNANCE_SNAPSHOTS=1 ../vendor/bin/phpunit -c phpunit-governance.xml --filter testCheckoutAnonymousPublicSnapshot"
+    "governance:snapshot:update": "cd web && MEL_UPDATE_GOVERNANCE_SNAPSHOTS=1 ../vendor/bin/phpunit -c phpunit-governance.xml --filter testCheckoutAnonymousPublicSnapshot",
+    "test:drupal": "bash scripts/mel-phpunit"
   },
   "config": {
     "allow-plugins": {

--- a/docs/testing/local-phpunit.md
+++ b/docs/testing/local-phpunit.md
@@ -1,0 +1,136 @@
+# Local PHPUnit (canonical)
+
+Canonical guide for running Drupal PHPUnit suites on a MEL DDEV workspace.
+
+For the CI governance Kernel **slice** (`composer governance:test`), see [mel-governance-devtooling-and-ci.md](mel-governance-devtooling-and-ci.md). That path embeds `SIMPLETEST_DB` in `web/phpunit-governance.xml`. This document covers general Unit / Kernel / Functional / Browser runs via `web/core/phpunit.xml.dist`.
+
+## Why the helper exists
+
+`web/core/phpunit.xml.dist` leaves `SIMPLETEST_DB` and `SIMPLETEST_BASE_URL` empty. Unit tests do not need a database; Kernel and Functional tests abort before bootstrap without `SIMPLETEST_DB`. Drupal also expects a writable `web/sites/simpletest/browser_output` for HTML output from browser-oriented suites.
+
+MEL does **not** put `SIMPLETEST_DB` in tracked `.ddev/config.yaml`. Use the helper instead.
+
+## Entry points
+
+| Entry | What it does |
+| --- | --- |
+| `scripts/mel-phpunit` | Sets missing env defaults, creates `browser_output`, runs `vendor/bin/phpunit` |
+| `composer test:drupal` | Thin wrapper: `bash scripts/mel-phpunit` (all args after `--` are passed through) |
+
+Prefer running inside DDEV so PHP, extensions, and DB match the project.
+
+```bash
+ddev exec bash scripts/mel-phpunit <phpunit-args>
+# or
+ddev composer test:drupal -- <phpunit-args>
+```
+
+## Environment variables
+
+| Variable | Required for | Default when unset (helper) | Notes |
+| --- | --- | --- | --- |
+| `SIMPLETEST_DB` | Kernel, Functional, Browser | `sqlite://localhost/:memory:` | Matches CI governance style. **Never overwritten** if already set. |
+| `SIMPLETEST_BASE_URL` | Functional, Browser | `DDEV_PRIMARY_URL` when present, else `https://myeventlane.ddev.site` | **Never overwritten** if already set. |
+| `BROWSERTEST_OUTPUT_DIRECTORY` | HTML debug output | Absolute path to `web/sites/simpletest/browser_output` | Core’s XML default is CWD-relative (`sites/simpletest/browser_output`). The helper creates the web path and sets the absolute env when unset. **Never overwritten** if already set. |
+
+### Recommended overrides
+
+**Functional / Browser against DDEV MariaDB** (closer to a real stack):
+
+```bash
+export SIMPLETEST_DB='mysql://db:db@db/db'
+export SIMPLETEST_BASE_URL='https://myeventlane.ddev.site'
+ddev exec bash scripts/mel-phpunit -- web/modules/custom/myeventlane_legal/tests/src/Functional
+```
+
+**Preserve a custom DB URL** (helper will not replace it):
+
+```bash
+SIMPLETEST_DB='sqlite://localhost/tmp/mel-phpunit.sqlite' \
+  ddev exec bash scripts/mel-phpunit -- web/modules/custom/.../tests/src/Kernel
+```
+
+## Examples
+
+Paths below are from the repository root. Replace with any suite or file under `web/modules/custom/`.
+
+### Unit
+
+No database required, but the helper is still fine (sets env and default `-c`).
+
+```bash
+ddev exec bash scripts/mel-phpunit \
+  web/modules/custom/myeventlane_commerce/tests/src/Unit/OperationalAddonGuidanceBuilderTest.php
+```
+
+### Kernel
+
+```bash
+ddev exec bash scripts/mel-phpunit \
+  web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalCheckoutKernelTest.php
+```
+
+Composer equivalent:
+
+```bash
+ddev composer test:drupal -- \
+  web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalCheckoutKernelTest.php
+```
+
+### Functional
+
+Uses Mink against `SIMPLETEST_BASE_URL`. Prefer MariaDB for broader coverage:
+
+```bash
+ddev exec bash -lc '
+  export SIMPLETEST_DB=mysql://db:db@db/db
+  export SIMPLETEST_BASE_URL=https://myeventlane.ddev.site
+  bash scripts/mel-phpunit web/modules/custom/myeventlane_legal/tests/src/Functional/RsvpLegalConsentTest.php
+'
+```
+
+### Browser (FunctionalJavascript)
+
+Same env needs as Functional, plus a working ChromeDriver/Selenium stack in DDEV if configured for this project. HTML output lands under `web/sites/simpletest/browser_output`.
+
+```bash
+ddev exec bash -lc '
+  export SIMPLETEST_DB=mysql://db:db@db/db
+  export SIMPLETEST_BASE_URL=https://myeventlane.ddev.site
+  bash scripts/mel-phpunit web/modules/custom/<module>/tests/src/FunctionalJavascript
+'
+```
+
+### Explicit PHPUnit config
+
+The helper adds `-c web/core/phpunit.xml.dist` only when you did not pass `-c` / `--configuration`. Slice configs still work:
+
+```bash
+ddev exec bash scripts/mel-phpunit -c web/phpunit-governance.xml
+# same CI slice without the helper:
+ddev composer governance:test
+```
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| `There is no database connection… SIMPLETEST_DB` | Use `scripts/mel-phpunit` or `composer test:drupal`, or export `SIMPLETEST_DB` yourself. Do not run bare `vendor/bin/phpunit -c web/core/phpunit.xml.dist` for Kernel without the env. |
+| `sites/simpletest/browser_output is not writable` | Re-run the helper (it `mkdir -p`s the directory). Fix ownership/permissions if the web user differs. |
+| Unit OK, Kernel fails | You bypassed the helper and hit empty `SIMPLETEST_DB` in core `phpunit.xml.dist`. |
+| Functional cannot reach site | Set `SIMPLETEST_BASE_URL` to your DDEV primary URL (`ddev describe`). |
+| `vendor/bin/phpunit` missing | `ddev composer install` (`drupal/core-dev` supplies PHPUnit). |
+| Want MariaDB instead of sqlite | Export `SIMPLETEST_DB=mysql://db:db@db/db` before the helper; existing values are preserved. |
+
+## What this does not change
+
+- Production / staging runtime or deploy scripts
+- Tracked `.ddev/config.yaml`
+- Ticket QR / Commerce checkout behaviour
+- Active Drupal config / `config/sync`
+
+## Related
+
+- [mel-governance-devtooling-and-ci.md](mel-governance-devtooling-and-ci.md) — CI `governance:test` slice
+- [mel-governance-testing-system.md](mel-governance-testing-system.md) — surface governance test design
+- `web/core/tests/README.md` — upstream Drupal PHPUnit notes

--- a/docs/testing/mel-governance-devtooling-and-ci.md
+++ b/docs/testing/mel-governance-devtooling-and-ci.md
@@ -62,6 +62,8 @@ Future improvement: a dedicated kernel test asserting negotiator `#cache` contex
 
 ## 7. Developer workflows
 
+For general Unit / Kernel / Functional / Browser runs (including `SIMPLETEST_DB` defaults), use the canonical helper documented in [local-phpunit.md](local-phpunit.md) (`scripts/mel-phpunit` / `composer test:drupal`).
+
 **Run governance tests (same as CI):**
 
 ```bash

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,6 +12,7 @@ Operational scripts for local development, audits, deployment, and governance. R
 
 | Script | Purpose | Safe environment | Destructive | Required confirmation |
 |--------|---------|------------------|-------------|----------------------|
+| `mel-phpunit` | Local PHPUnit helper: sets missing `SIMPLETEST_*`, ensures `sites/simpletest/browser_output`, runs `vendor/bin/phpunit` | Local DDEV | No | None |
 | `preflight-health-check.sh` | DB, cache, config sync, and filesystem smoke checks | Local DDEV | No | None |
 | `validate-release.sh` | Canonical pre-deployment release validation: Git, Drush bootstrap, config status, database updates, MEL tests, and theme builds | Local DDEV / staging / production checkout | No | None |
 | `rebuild-scss.sh` | Clears theme caches, reinstalls npm deps, rebuilds theme assets | Local DDEV | No (removes theme `node_modules`/`dist`) | None |

--- a/scripts/mel-phpunit
+++ b/scripts/mel-phpunit
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# MyEventLane Local Drupal PHPUnit Helper
+#
+# Purpose:
+# - provide local defaults for Drupal's SIMPLETEST_* variables
+# - preserve developer overrides
+# - create browser output directories
+# - invoke PHPUnit using Drupal's configuration
+#
+# Runtime:
+# Local development only.
+#
+# This script must never affect production or staging.
+#
+# Usage (from repository root, preferably inside DDEV):
+#   ddev exec bash scripts/mel-phpunit \
+#     web/modules/custom/myeventlane_commerce/tests/src/Unit
+#   ddev composer test:drupal -- \
+#     web/modules/custom/myeventlane_commerce/tests/src/Kernel
+#
+# See docs/testing/local-phpunit.md
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+# Safe local defaults — never overwrite a variable that is already set
+# (including empty string: BROWSERTEST_OUTPUT_DIRECTORY='' disables HTML output).
+if [[ -z "${SIMPLETEST_DB+x}" ]]; then
+  export SIMPLETEST_DB='sqlite://localhost/:memory:'
+fi
+
+if [[ -z "${SIMPLETEST_BASE_URL+x}" ]]; then
+  if [[ -n "${DDEV_PRIMARY_URL:-}" ]]; then
+    export SIMPLETEST_BASE_URL="${DDEV_PRIMARY_URL}"
+  elif [[ "${IS_DDEV_PROJECT:-}" == "true" ]]; then
+    export SIMPLETEST_BASE_URL='https://myeventlane.ddev.site'
+  else
+    # Host-side runs still get a MEL-local default; override if your URL differs.
+    export SIMPLETEST_BASE_URL='https://myeventlane.ddev.site'
+  fi
+fi
+
+BROWSER_OUTPUT_DIR="${REPO_ROOT}/web/sites/simpletest/browser_output"
+mkdir -p "${BROWSER_OUTPUT_DIR}"
+
+# Core phpunit.xml.dist uses a CWD-relative sites/simpletest/browser_output.
+# Runs from the repo root need an absolute path (never overwrite an existing value).
+if [[ -z "${BROWSERTEST_OUTPUT_DIRECTORY+x}" ]]; then
+  export BROWSERTEST_OUTPUT_DIRECTORY="${BROWSER_OUTPUT_DIR}"
+fi
+
+PHPUNIT_BIN="${REPO_ROOT}/vendor/bin/phpunit"
+if [[ ! -x "${PHPUNIT_BIN}" ]]; then
+  echo "mel-phpunit: ${PHPUNIT_BIN} not found or not executable." >&2
+  echo "Run composer install (inside DDEV: ddev composer install) first." >&2
+  exit 1
+fi
+
+# Path-only invocations need Drupal's config; do not override if the caller
+# already passed -c / --configuration.
+has_config=0
+for arg in "$@"; do
+  case "${arg}" in
+    -c|--configuration|-c=*|--configuration=*)
+      has_config=1
+      break
+      ;;
+  esac
+done
+
+if [[ "${has_config}" -eq 0 ]]; then
+  set -- -c "${REPO_ROOT}/web/core/phpunit.xml.dist" "$@"
+fi
+
+echo "mel-phpunit: SIMPLETEST_DB=${SIMPLETEST_DB}"
+echo "mel-phpunit: SIMPLETEST_BASE_URL=${SIMPLETEST_BASE_URL}"
+echo "mel-phpunit: BROWSERTEST_OUTPUT_DIRECTORY=${BROWSERTEST_OUTPUT_DIRECTORY}"
+
+exec "${PHPUNIT_BIN}" "$@"


### PR DESCRIPTION
## Summary

Adds a canonical local Drupal PHPUnit workflow for MyEventLane development.

## Changes

- adds `scripts/mel-phpunit`
- adds `composer test:drupal`
- provides safe local defaults for `SIMPLETEST_DB`
- preserves existing developer environment variables
- automatically creates `web/sites/simpletest/browser_output`
- injects Drupal's PHPUnit configuration when none is supplied
- documents the canonical Unit, Kernel, Functional and Browser test workflow

## Why

Local Kernel and Functional tests required manual environment setup, while CI already provided the necessary configuration.

This PR standardises the local developer experience without changing runtime, deployment, staging or production behaviour.

## Validation

- ✅ Composer validation passed
- ✅ Helper executed successfully
- ✅ Composer shortcut works
- ✅ Unit tests pass
- ✅ Kernel tests bootstrap correctly with helper
- ✅ Functional tests progress beyond the previous `SIMPLETEST_DB` failure
- ✅ Existing environment variables are preserved
- ✅ Browser output directory is created automatically

## Scope

Developer tooling only.

This PR does **not** modify:

- Drupal runtime
- Ticketing
- QR signing
- Deployment
- DDEV configuration
- `config/sync`
- Production or staging behaviour

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local-only bash/composer/docs tooling; no application, deploy, or DDEV config changes.
> 
> **Overview**
> Introduces a **canonical local Drupal PHPUnit workflow** so Kernel/Functional/Browser suites no longer depend on hand-exported `SIMPLETEST_*` env vars or writable `browser_output` paths when using core’s empty `phpunit.xml.dist` defaults.
> 
> **`scripts/mel-phpunit`** sets `SIMPLETEST_DB` (in-memory sqlite), `SIMPLETEST_BASE_URL` (DDEV URL when available), and an absolute `BROWSERTEST_OUTPUT_DIRECTORY` only when those variables are unset; creates `web/sites/simpletest/browser_output`; injects `-c web/core/phpunit.xml.dist` unless the caller already passes a config; then runs `vendor/bin/phpunit`.
> 
> **`composer test:drupal`** wraps the script and forwards args after `--`. Existing **`governance:test`** / CI slice behavior is unchanged; docs add **`docs/testing/local-phpunit.md`**, link it from governance devtooling and **`scripts/README.md`**, and fix a trailing comma on the `governance:snapshot:update` composer script line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f0cc784783b51b56b1860a8f58d6da19a82f6bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->