### PR TITLE
feat(order): ensure readiness is maintained for same-event multi-pass…

### DIFF
--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/MyTicketsOrderViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/MyTicketsOrderViewModelBuilder.php
@@ -169,7 +169,6 @@ final class MyTicketsOrderViewModelBuilder {
     $bookingConfirmed = in_array($stateId, self::COMPLETED_ORDER_STATES, TRUE);
     $bookingNumber = (string) ($order->getOrderNumber() ?? $order->id());
     $enrichedTicketModels = [];
-    $readinessByEventId = [];
     $passIndex = 0;
     foreach ($ticketModels as $ticketModel) {
       if (!is_array($ticketModel)) {
@@ -186,10 +185,11 @@ final class MyTicketsOrderViewModelBuilder {
         ? $enriched['pass']['event']
         : NULL;
       $eventId = (int) ($passEvent['id'] ?? ($enriched['event']['id'] ?? 0));
-      // One readiness accordion per event, under the first digital pass for that event.
-      if ($eventId > 0 && !isset($readinessByEventId[$eventId])) {
+      // Every digital pass gets its own readiness accordion (same-event bookings
+      // included). Primary action anchors to this pass's QR, not a sibling pass.
+      if ($eventId > 0) {
         $passAnchor = $passIndex === 1 ? '#mel-pass-entry' : '#mel-pass-entry-' . $passIndex;
-        $readiness = $this->buildEventReadiness(
+        $enriched['readiness'] = $this->buildEventReadiness(
           $order,
           $passEvent !== NULL ? [$passEvent] : [],
           [$enriched],
@@ -198,8 +198,6 @@ final class MyTicketsOrderViewModelBuilder {
           $bookingConfirmed,
           $passAnchor,
         );
-        $readinessByEventId[$eventId] = $readiness;
-        $enriched['readiness'] = $readiness;
       }
       $enrichedTicketModels[] = $enriched;
     }

--- a/web/modules/custom/myeventlane_checkout_flow/tests/src/Kernel/MyTicketsOrderViewModelBuilderTest.php
+++ b/web/modules/custom/myeventlane_checkout_flow/tests/src/Kernel/MyTicketsOrderViewModelBuilderTest.php
@@ -411,11 +411,56 @@ final class MyTicketsOrderViewModelBuilderTest extends KernelTestBase {
   }
 
   /**
+   * Same-event multi-pass bookings keep readiness on every digital pass.
+   */
+  public function testSameEventPassesEachGetReadiness(): void {
+    $order = $this->createOrder();
+    $this->createTicket($order, [
+      'ticket_code' => 'MEL-SAME-A',
+      'status' => Ticket::STATUS_ASSIGNED,
+      'event_id' => $this->event->id(),
+      'order_item_id' => 1,
+    ]);
+    $this->createTicket($order, [
+      'ticket_code' => 'MEL-SAME-B',
+      'status' => Ticket::STATUS_ASSIGNED,
+      'event_id' => $this->event->id(),
+      'order_item_id' => 2,
+    ]);
+
+    $model = $this->builder()->build($order, TRUE);
+    $this->assertCount(2, $model['ticket_models']);
+    $first = $model['ticket_models'][0];
+    $second = $model['ticket_models'][1];
+
+    $this->assertArrayHasKey('readiness', $first);
+    $this->assertArrayHasKey('readiness', $second);
+    $this->assertSame('Gate A', $this->readinessVenueDetail($first['readiness']));
+    $this->assertSame('Gate A', $this->readinessVenueDetail($second['readiness']));
+    $this->assertSame('#mel-pass-entry', $first['readiness']['primary_action']['url']);
+    $this->assertSame('#mel-pass-entry-2', $second['readiness']['primary_action']['url']);
+    $this->assertSame('MEL-SAME-A', $this->readinessTicketCode($first['readiness']));
+    $this->assertSame('MEL-SAME-B', $this->readinessTicketCode($second['readiness']));
+  }
+
+  /**
    * @param array<string, mixed> $readiness
    */
   private function readinessVenueDetail(array $readiness): string {
     foreach ($readiness['detail_items'] ?? [] as $item) {
       if (($item['key'] ?? '') === 'venue') {
+        return (string) ($item['detail'] ?? '');
+      }
+    }
+    return '';
+  }
+
+  /**
+   * @param array<string, mixed> $readiness
+   */
+  private function readinessTicketCode(array $readiness): string {
+    foreach ($readiness['items'] ?? [] as $item) {
+      if (($item['key'] ?? '') === 'ticket_ready') {
         return (string) ($item['detail'] ?? '');
       }
     }


### PR DESCRIPTION
… bookings

- Updated MyTicketsOrderViewModelBuilder to assign readiness to each digital pass, allowing for accurate readiness display across multiple passes for the same event.
- Added a new test case to verify that readiness information is correctly associated with each digital pass in same-event bookings.
- Introduced helper methods to extract readiness details, enhancing code clarity and maintainability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Customer-facing presentation logic in the My Tickets view model only; behavior is narrowed to multi-pass same-event orders and is covered by new kernel tests.
> 
> **Overview**
> Fixes **My Tickets** when an order has **multiple digital passes for the same event**: the Event Readiness accordion now appears on **each** pass instead of only the first pass for that event.
> 
> `MyTicketsOrderViewModelBuilder` drops per-event deduplication (`readinessByEventId`) and builds readiness inside the per-pass loop, scoped to that pass’s ticket and with a **pass-specific** primary action anchor (`#mel-pass-entry` / `#mel-pass-entry-N`). Order-level `readiness` is unchanged (still the first pass with readiness).
> 
> Kernel coverage adds `testSameEventPassesEachGetReadiness` and a helper to assert ticket codes on the readiness checklist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78b908ec88af1231d1bd929b55c0f3fe4bcf6146. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->