### PR TITLE
fix(tests): enable filter for commerce_order Kernel governance suite

### DIFF
--- a/web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalMerchandiseKernelTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalMerchandiseKernelTest.php
@@ -47,6 +47,7 @@ class OperationalMerchandiseKernelTest extends KernelTestBase {
     'system',
     'user',
     'field',
+    'filter',
     'text',
     'node',
     'path',

--- a/web/modules/custom/myeventlane_tickets/tests/src/Kernel/FulfillmentLifecycleConvergenceKernelTest.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Kernel/FulfillmentLifecycleConvergenceKernelTest.php
@@ -46,6 +46,7 @@ final class FulfillmentLifecycleConvergenceKernelTest extends KernelTestBase {
     'system',
     'user',
     'field',
+    'filter',
     'text',
     'link',
     'path',


### PR DESCRIPTION
## Summary
- Enable Drupal `filter` in governance Kernel tests that install `commerce_order` config.
- Fixes CI failure on Drupal 11.4: missing `Drupal\filter\FilterFormatRepositoryInterface` during `commerce_order` config install (67 Kernel errors).

## Test plan
- [ ] `composer run-script governance:test` passes in CI
- [ ] Confirm no remaining `FilterFormatRepositoryInterface` Kernel boot errors


Made with [Cursor](https://cursor.com)