### PR TITLE
fix(tests): enable filter for commerce_order Kernel governance suite

### DIFF
--- a/web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalMerchandiseKernelTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Kernel/OperationalMerchandiseKernelTest.php
@@ -47,6 +47,7 @@ class OperationalMerchandiseKernelTest extends KernelTestBase {
     'system',
     'user',
     'field',
+    'filter',
     'text',
     'node',
     'path',

--- a/web/modules/custom/myeventlane_tickets/tests/src/Kernel/FulfillmentLifecycleConvergenceKernelTest.php
+++ b/web/modules/custom/myeventlane_tickets/tests/src/Kernel/FulfillmentLifecycleConvergenceKernelTest.php
@@ -46,6 +46,7 @@ final class FulfillmentLifecycleConvergenceKernelTest extends KernelTestBase {
     'system',
     'user',
     'field',
+    'filter',
     'text',
     'link',
     'path',


### PR DESCRIPTION
Drupal 11.4 FilterFormatRepositoryInterface is required when installing commerce_order config; enable filter so governance Kernel tests boot.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only module list updates with no production code or runtime behavior changes.
> 
> **Overview**
> Adds the **`filter`** module to the kernel test module lists in **`OperationalMerchandiseKernelTest`** and **`FulfillmentLifecycleConvergenceKernelTest`** so those suites can boot under Drupal 11.4.
> 
> Both tests install **`commerce_order`** configuration during `setUp()`; without **`filter`** enabled, config installation fails because **`FilterFormatRepositoryInterface`** is required. This change only adjusts test bootstrap dependencies—no application or Commerce behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca8b4f9b36e46c4bef7359f45990939362bd9ac3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->