### PR TITLE
fix(checkout): restore Commerce Stripe Payment Element compatibility

### DIFF
--- a/config/sync/commerce_checkout.commerce_checkout_flow.mel_event_checkout.yml
+++ b/config/sync/commerce_checkout.commerce_checkout_flow.mel_event_checkout.yml
@@ -5,6 +5,7 @@ dependencies:
   module:
     - commerce_payment
     - commerce_promotion
+    - commerce_stripe
     - myeventlane_checkout_flow
     - myeventlane_checkout_paragraph
     - myeventlane_commerce
@@ -43,6 +44,20 @@ configuration:
       wrapper_element: container
       always_display: true
       require_payment_method: false
+    stripe_review:
+      display_label: null
+      step: review
+      weight: 0
+      wrapper_element: container
+      button_id: edit-actions-next
+      auto_submit_review_form: false
+      setup_future_usage: ''
+    payment_process:
+      display_label: null
+      step: payment
+      weight: 8
+      wrapper_element: container
+      capture: true
     grouped_order_summary:
       display_label: null
       step: _disabled

--- a/docs/checkout/commerce-stripe-review-compat.md
+++ b/docs/checkout/commerce-stripe-review-compat.md
@@ -1,0 +1,75 @@
+# Commerce Stripe review-step compatibility (MEL)
+
+## Problem
+
+Paid checkout showed billing + gateway selection, but Stripe Payment Element
+card fields never appeared (`drupalSettings.commerceStripePaymentElement`
+undefined; no `commerce_stripe/payment_element` library).
+
+## Root causes (verified)
+
+1. **`stripe_connect` annotation omitted `offsite-payment`.** Drupal plugin
+   annotations do not inherit parent `forms`. `plugin_form.factory` threw:
+   `The "stripe_connect" plugin did not specify a "offsite-payment" form class`.
+2. **`mel_event_checkout` had no `review` step.** Commerce Stripe 2.2.1
+   attaches Payment Element only from `stripe_review`, whose
+   `default_step = "review"`. Without that step ID, the pane defaults to
+   `_disabled`. Return URLs also hardcode `step => 'review'`.
+
+## Evaluation: dedicated Review step vs single-page PE
+
+| Option | Feasible? | Why |
+|---|---|---|
+| Put `stripe_review` only on `checkout` | **No (unsafe)** | Return URL + `validateStepId()` require order `checkout_step` to equal the hardcoded `review` step. PE also expects billing/gateway already saved from a prior step. |
+| Alter `returnUrl` via `hook_js_settings_alter` only | **Incomplete** | `PaymentOffsiteForm` and Express Checkout still hardcode `review`. |
+| Add machine step `review`, customer label “Payment” | **Yes (chosen)** | Matches Commerce Stripe contract with minimum UX change. |
+
+## Checkout flow changes
+
+### 1. `MelEventCheckoutFlow::getSteps()` — add `review`
+
+**Why required:** Commerce Stripe hardcodes `step => 'review'` in:
+
+- `StripeReview` Payment Element `returnUrl`
+- `PaymentOffsiteForm` failure redirect
+- Express Checkout confirm path
+
+Customer-facing label is **Payment** (not “Review”) to preserve MEL wording.
+Progress UI remains off (`display_checkout_progress: false`).
+
+### 2. Enable `stripe_review` on step `review`
+
+**Why required:** Sole attach point for `commerce_stripe/payment_element` and
+`drupalSettings.commerceStripePaymentElement` in Commerce Stripe 2.2.1.
+
+### 3. Keep `payment_information` on `checkout`
+
+**Why:** Collects gateway + billing before Payment Element loads (stock
+Commerce Stripe order of operations). Preserves the existing details page.
+
+### 4. Keep `payment_process` on hidden `payment` step
+
+**Why:** Offsite completion path still required by Commerce; form class now
+present on `stripe_connect`.
+
+### 5. `StripeConnect` annotation — add `offsite-payment`
+
+**Why required:** Maps to installed
+`Drupal\commerce_stripe\PluginForm\OffsiteRedirect\PaymentOffsiteForm`.
+No behaviour change to Connect destination charges.
+
+## Resulting customer path
+
+1. **Checkout** — buyer/attendee details, legal consent, billing/gateway
+2. **Payment** (`review` machine ID) — Stripe Payment Element card fields
+3. **payment** (hidden) — Commerce offsite processing
+4. **complete** — confirmation
+
+Free/zero-balance orders skip Payment Element (`stripe_review::isVisible()`),
+so the review step stays invisible and checkout can advance past it.
+
+## Deploy notes
+
+- Import config or run
+  `myeventlane_checkout_flow_post_update_enable_stripe_review`
+- `drush cr` after deploy (plugin definition + checkout flow cache)

--- a/web/modules/custom/myeventlane_checkout_flow/config/install/commerce_checkout.commerce_checkout_flow.mel_event_checkout.yml
+++ b/web/modules/custom/myeventlane_checkout_flow/config/install/commerce_checkout.commerce_checkout_flow.mel_event_checkout.yml
@@ -5,6 +5,7 @@ dependencies:
   module:
     - commerce_payment
     - commerce_promotion
+    - commerce_stripe
     - myeventlane_checkout_flow
     - myeventlane_checkout_paragraph
     - myeventlane_commerce
@@ -43,6 +44,20 @@ configuration:
       wrapper_element: container
       always_display: true
       require_payment_method: false
+    stripe_review:
+      display_label: null
+      step: review
+      weight: 0
+      wrapper_element: container
+      button_id: edit-actions-next
+      auto_submit_review_form: false
+      setup_future_usage: ''
+    payment_process:
+      display_label: null
+      step: payment
+      weight: 8
+      wrapper_element: container
+      capture: true
     grouped_order_summary:
       display_label: null
       step: _disabled

--- a/web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.post_update.php
+++ b/web/modules/custom/myeventlane_checkout_flow/myeventlane_checkout_flow.post_update.php
@@ -40,3 +40,38 @@ function myeventlane_checkout_flow_post_update_use_mel_event_checkout(array &$sa
   $config->set('third_party_settings.commerce_checkout', $third_party);
   $config->save();
 }
+
+/**
+ * Enable Commerce Stripe stripe_review on the required review step.
+ *
+ * Commerce Stripe 2.2.1 attaches Payment Element only from stripe_review and
+ * hardcodes return URLs to step "review". Without this pane enabled on that
+ * step ID, card fields never render.
+ */
+function myeventlane_checkout_flow_post_update_enable_stripe_review(array &$sandbox): void {
+  $config = \Drupal::configFactory()->getEditable('commerce_checkout.commerce_checkout_flow.mel_event_checkout');
+  $panes = $config->get('configuration.panes') ?? [];
+
+  $panes['stripe_review'] = array_merge([
+    'display_label' => NULL,
+    'wrapper_element' => 'container',
+    'button_id' => 'edit-actions-next',
+    'auto_submit_review_form' => FALSE,
+    'setup_future_usage' => '',
+  ], $panes['stripe_review'] ?? [], [
+    'step' => 'review',
+    'weight' => 0,
+  ]);
+
+  $panes['payment_process'] = array_merge([
+    'display_label' => NULL,
+    'wrapper_element' => 'container',
+    'capture' => TRUE,
+  ], $panes['payment_process'] ?? [], [
+    'step' => 'payment',
+    'weight' => 8,
+  ]);
+
+  $config->set('configuration.panes', $panes);
+  $config->save();
+}

--- a/web/modules/custom/myeventlane_checkout_flow/src/Plugin/Commerce/CheckoutFlow/MelEventCheckoutFlow.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Plugin/Commerce/CheckoutFlow/MelEventCheckoutFlow.php
@@ -8,11 +8,11 @@ use Drupal\commerce_checkout\Plugin\Commerce\CheckoutFlow\CheckoutFlowWithPanesB
 use Drupal\Core\Form\FormStateInterface;
 
 /**
- * Provides a single-page checkout flow for MyEventLane events.
+ * Provides a checkout flow for MyEventLane events.
  *
- * This flow presents all checkout panes in a single step with a sidebar
- * for order summary and fee transparency, creating a "single page feel"
- * similar to Humanitix.
+ * Buyer/attendee details stay on a single checkout step. A dedicated review
+ * step is required by Commerce Stripe Payment Element (hard-coded return URL
+ * step ID "review" and stripe_review pane default_step).
  *
  * @CommerceCheckoutFlow(
  *   id = "mel_event_checkout",
@@ -34,7 +34,16 @@ final class MelEventCheckoutFlow extends CheckoutFlowWithPanesBase {
       'checkout' => [
         'label' => $this->t('Checkout'),
         'previous_label' => $this->t('Back to cart'),
-        'next_label' => $this->t('Complete booking'),
+        'next_label' => $this->t('Continue to checkout'),
+        'has_sidebar' => TRUE,
+      ],
+      // Machine ID must remain "review": Commerce Stripe hardcodes
+      // step => 'review' in Payment Element returnUrl, PaymentOffsiteForm,
+      // and Express Checkout. Label is "Payment" to keep customer UX clear.
+      'review' => [
+        'label' => $this->t('Payment'),
+        'next_label' => $this->t('Continue to payment'),
+        'previous_label' => $this->t('Back to details'),
         'has_sidebar' => TRUE,
       ],
     ] + $steps;
@@ -46,9 +55,14 @@ final class MelEventCheckoutFlow extends CheckoutFlowWithPanesBase {
   public function buildForm(array $form, FormStateInterface $form_state, $step_id = NULL): array {
     $form = parent::buildForm($form, $form_state, $step_id);
 
-    // Add wrapper classes for single-page styling.
-    $form['#attributes']['class'][] = 'mel-checkout-single-page';
+    // Add wrapper classes for single-page styling on the details step.
     $form['#attributes']['class'][] = 'mel-checkout-flow-mel-event';
+    if ($step_id === 'checkout') {
+      $form['#attributes']['class'][] = 'mel-checkout-single-page';
+    }
+    if ($step_id === 'review') {
+      $form['#attributes']['class'][] = 'mel-checkout-payment-step';
+    }
 
     return $form;
   }

--- a/web/modules/custom/myeventlane_commerce/src/Plugin/Commerce/PaymentGateway/StripeConnect.php
+++ b/web/modules/custom/myeventlane_commerce/src/Plugin/Commerce/PaymentGateway/StripeConnect.php
@@ -23,6 +23,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   label = @Translation("Stripe Connect (Vendor Payments)"),
  *   display_label = @Translation("Credit card"),
  *   forms = {
+ *     "offsite-payment" = "Drupal\commerce_stripe\PluginForm\OffsiteRedirect\PaymentOffsiteForm",
  *     "add-payment-method" = "Drupal\commerce_stripe\PluginForm\PaymentMethodAddForm",
  *   },
  *   payment_method_types = {"credit_card"},


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes checkout step flow and payment gateway plugin forms on the paid ticket path; regressions could block purchases or break Stripe redirects until config/post-updates and cache clear are applied.
> 
> **Overview**
> Fixes paid checkout where billing and gateway showed but **Stripe Payment Element card fields never rendered**.
> 
> **`mel_event_checkout`** now exposes a Commerce Stripe–required **`review` step** (customer label **Payment**): `MelEventCheckoutFlow::getSteps()` adds it, pane config enables **`stripe_review`** on `review` and **`payment_process`** on hidden `payment`, and checkout-step copy/CSS is split so details stay on `checkout` and card entry uses `mel-checkout-payment-step`. Billing/gateway collection remains on the first checkout step.
> 
> **`stripe_connect`** registers the missing **`offsite-payment`** form class (`PaymentOffsiteForm`) so offsite completion no longer fails plugin form resolution.
> 
> Deploy path: config import or post-update **`myeventlane_checkout_flow_post_update_enable_stripe_review`**, plus cache rebuild; rationale is documented in `docs/checkout/commerce-stripe-review-compat.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54b7a8e0a3c59a28c1899fea5c8eb4175a706c29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->