### PR TITLE
Feature/payment launch remediation

### DIFF
--- a/config/sync/commerce_payment.commerce_payment_gateway.mel_stripe_cc.yml
+++ b/config/sync/commerce_payment.commerce_payment_gateway.mel_stripe_cc.yml
@@ -1,7 +1,9 @@
 uuid: 5592f26a-985a-40c9-a373-02cd69d7180d
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - commerce_order
 id: mel_stripe_cc
 label: 'MEL - Manual'
 weight: null
@@ -15,5 +17,11 @@ configuration:
   instructions:
     value: 'This is a test Payment Gateway '
     format: plain_text
-conditions: {  }
+conditions:
+  -
+    plugin: current_user_role
+    configuration:
+      matching_strategy: any
+      roles:
+        administrator: administrator
 conditionOperator: AND

--- a/config/sync/commerce_payment.commerce_payment_gateway.stripe_pe_recurring.yml
+++ b/config/sync/commerce_payment.commerce_payment_gateway.stripe_pe_recurring.yml
@@ -3,6 +3,9 @@ langcode: en
 status: true
 dependencies:
   module:
+    - commerce_order
+    - commerce_price
+    - commerce_product
     - commerce_stripe
 id: stripe_pe_recurring
 label: 'Stripe (Payment Element) — Recurring'
@@ -37,4 +40,9 @@ conditions:
     configuration:
       currencies:
         - AUD
-conditionOperator: OR
+  -
+    plugin: order_variation_type
+    configuration:
+      variation_types:
+        - mel_pro_subscription_variation
+conditionOperator: AND

--- a/docs/adr/ADR-002-payment-runtime.md
+++ b/docs/adr/ADR-002-payment-runtime.md
@@ -1,0 +1,96 @@
+# ADR-002 — MEL Payment Runtime Architecture (Current)
+
+**Status:** Accepted as documentation of **current** runtime (not aspirational)  
+**Date:** 20 July 2026  
+**Deciders:** Audit Phase 1–2 (Engineering documentation)  
+**Evidence:** DDEV runtime inspection + repository map  
+**Related:** [`payment-critical-findings.md`](../architecture/payment-critical-findings.md), [`payment-runtime-map.md`](../architecture/payment-runtime-map.md), [`ADR-003-stripe-connect-strategy.md`](./ADR-003-stripe-connect-strategy.md)
+
+---
+
+## Context
+
+MEL is a Drupal 11 + Commerce 3 marketplace. Code contains both:
+
+1. A custom Stripe Connect destination-charge gateway plugin, and  
+2. A platform-collect + Transfer/ledger payout system.
+
+Only one of these is wired for customer checkout.
+
+---
+
+## Decision (describe current architecture)
+
+**MEL currently operates a platform-collect Commerce Stripe checkout with separate Connect Express onboarding and admin-driven Stripe Transfers for vendor payouts.**
+
+### Customer charging
+
+| Concern | Current runtime |
+| --- | --- |
+| Primary gateway | Entity `stripe`, plugin `stripe` (Card Element) |
+| Secondary Stripe gateway | Entity `stripe_pe_recurring`, plugin `stripe_payment_element`, `off_session` |
+| Test/manual gateway | Entity `mel_stripe_cc`, plugin `manual` (enabled; no currency condition) |
+| Custom Connect PE gateway | Plugin `stripe_connect` **discoverable**, **0 entities** |
+| Checkout flow (tickets/boost/Pro initial) | Order type `default` → `mel_event_checkout` |
+| Donation checkouts | `rsvp_donation` / `platform_donation` → flow `default` |
+| Gateway filtering | Currency AUD for `stripe`; Pro variation + AUD for `stripe_pe_recurring`; admin role for `mel_stripe_cc`; MEL `FilterPaymentGatewaysSubscriber` enforces launch matrix (remediation 20 Jul 2026) |
+
+### Platform Stripe features (non-checkout)
+
+| Concern | Current runtime |
+| --- | --- |
+| Facade | `myeventlane_core.stripe` (`StripeService`) |
+| Vendor onboarding | Connect Express Account Links via `StripeConnectController` |
+| Vendor contribution auto-bill | Off-session PaymentIntent via `VendorAutoBillingService` |
+| Pro billing portal | `ProBillingPortalService` |
+| Refund verification | `RefundProcessor` + platform client |
+| Payouts | `transfers.create` to connected accounts |
+
+### Vendor money movement
+
+| Concern | Current runtime |
+| --- | --- |
+| Model | Platform balance → Transfer |
+| Liability table | `myeventlane_payout_ledger` |
+| Row creation | Lazy insert in `PlatformMetricsService::buildKpis()` (not `ORDER_PAID`) |
+| Reconcile | `/stripe/webhook/payout` on `transfer.*` |
+
+### Post-purchase
+
+| Concern | Current runtime |
+| --- | --- |
+| Confirmation | Messaging queues (`OrderConfirmationQueueBuilder`) |
+| Tickets | `ORDER_PAID` ticket subscribers |
+| Wallet | Pass generation; **no** Stripe charge dependency |
+
+---
+
+## Consequences
+
+### Positive
+
+- Aligns with Commerce Stripe upgrade path for checkout.  
+- Express onboarding and Transfers are implemented and used.  
+- Wallet and messaging remain outside the charge path.
+
+### Negative / risks
+
+- Destination-charge code implies a different model than production wiring (CF-001).  
+- Ledger timing and scope are unsafe for unsupervised payouts (CF-006, CF-007).  
+- Multiple gateways apply to the same carts (CF-008).  
+- Credential drift between sync and active config (CF-005).
+
+---
+
+## Compliance with this ADR
+
+Any change that reintroduces destination charges at PaymentIntent time must go through **ADR-003** and create an explicit gateway entity — not silent reuse of Transfer assumptions.
+
+---
+
+## Validation references
+
+- Runtime gateway entities and plugins (Phase 2 `ddev drush php:eval`).  
+- Historical payments: tickets mostly `stripe`; also PE + manual.  
+- `ORDER_PAID` listeners list (no ledger writer).  
+- Ledger SQL by order type (donations/Boost/Pro present).

--- a/docs/adr/ADR-003-stripe-connect-strategy.md
+++ b/docs/adr/ADR-003-stripe-connect-strategy.md
@@ -1,0 +1,94 @@
+# ADR-003 — Stripe Connect Strategy (Option A vs Option B)
+
+**Status:** Proposed recommendation (evidence-backed); pending Product ratification  
+**Date:** 20 July 2026  
+**Related:** [`ADR-002-payment-runtime.md`](./ADR-002-payment-runtime.md), [`payment-critical-findings.md`](../architecture/payment-critical-findings.md)
+
+---
+
+## Context
+
+MEL needs a clear marketplace money model before launch.
+
+**Option A — Current wiring**  
+Commerce Stripe Payment Element / Card Element charges the **platform** account.  
+`StripeService` handles platform features (Connect Express onboarding, off-session vendor billing, Transfer payouts, portals, refund verify).  
+Vendor net is paid later via Stripe **Transfers** + `myeventlane_payout_ledger`.
+
+**Option B — True Connect destination charges**  
+Commerce gateway entity with plugin `stripe_connect` merges `transfer_data` / `application_fee_amount` onto PaymentIntents at checkout (`StripeConnect` + `StripeConnectPaymentService`).  
+Funds route to the connected account at charge time (minus application fee).
+
+Runtime fact: **Option B code exists; Option B entity does not.** Checkout today is Option A.
+
+---
+
+## Comparison
+
+| Dimension | Option A — Commerce Stripe + StripeService platform features | Option B — Destination-charge `stripe_connect` gateway |
+| --- | --- | --- |
+| **Complexity** | Checkout stays stock Commerce Stripe. Complexity lives in ledger, batch Transfers, fee rules, exclusions. | Checkout plugin must handle mixed carts, boost-only, donations, Connect readiness, refunds with Connect. |
+| **Maintenance** | Tracks `commerce_stripe` upgrades with less custom PI code. Custom finance code remains MEL-owned. | Custom plugin must track Payment Element base class changes; higher upgrade cost. |
+| **Drupal / Commerce compatibility** | Highest — entities `stripe` / `stripe_pe_recurring` already used. | Medium — extends contrib PE; must be registered as gateway entity and selected by conditions. |
+| **Testing** | Test platform charge + Transfer separately; ledger correctness is the hard suite. | Need end-to-end Connect test mode accounts, fee math, mixed carts, refunds, failed transfers. |
+| **Upgrade risk** | Commerce Stripe major upgrades mainly affect checkout panes/elements. | Base class / PI API shifts break MEL merge logic. |
+| **Marketplace capabilities** | Delayed vendor payout; platform float; flexible hold/clawback; admin batch control. | Instant destination routing; Stripe-native split; less platform float; different refund/dispute posture. |
+| **Long-term roadmap** | Good fit for controlled AU marketplace launch; can add destination charges later as a migration. | Better Stripe-native marketplace semantics; requires product commitment and retiring Transfer double-pay risk. |
+| **Matches current DDEV/prod wiring** | **Yes** | **No** (0 entities) |
+| **Launch readiness** | Closest — if ledger hardened and manual gateway disabled | **Not ready** — entity missing; validation unwired; refund/mixed-cart unproven |
+
+---
+
+## Evidence
+
+| Fact | Source |
+| --- | --- |
+| `stripe_connect` plugin exists and merges Connect PI params | `StripeConnect.php` |
+| Zero gateway entities use it | Phase 2 plugin manager: entities=0 |
+| Ticket/boost/donation payments use `stripe` (and sometimes PE/manual) | `commerce_payment` history |
+| Transfers implemented | `PayoutBatchWorkflowService` |
+| Ledger lazy + unfiltered | `PlatformMetricsService::buildKpis`; CF-006/007 |
+| Connect validation subscriber unwired | CF-003 |
+
+---
+
+## Recommendation
+
+**Recommend Option A for launch**, with mandatory product/ops constraints:
+
+1. Formally document platform-collect + Transfer as the marketplace model (this ADR + ADR-002).  
+2. Treat plugin `stripe_connect` and PI merge as **FUTURE / dormant** — do not create the entity for launch.  
+3. Before vendor payout go-live: fix ledger **timing** and **allowlist** (implementation post-audit).  
+4. Disable `mel_stripe_cc` in production; narrow gateway conditions (ticket vs Pro).  
+5. Keep Express onboarding via `StripeService`.  
+6. Keep `StripeConnectPaymentService` for reporting/validation helpers until fee SoT is unified.  
+7. Revisit Option B only after: gateway entity design, mixed-cart rules, refund policy, and an explicit plan to avoid double payout (destination + Transfer).
+
+### Why not Option B for launch
+
+- Not wired.  
+- Validation would not fail closed even if the existing subscriber were registered.  
+- Transfer tooling would become redundant or dangerous if left active.  
+- No runtime proof of destination-charge checkout in this environment.
+
+---
+
+## Consequences if Product chooses Option B instead
+
+Must complete before enabling:
+
+1. Create Commerce payment gateway entity `plugin: stripe_connect` with AUD + product conditions.  
+2. Retire or hard-block Card Element for vendor-revenue tickets.  
+3. Disable Transfer batches for orders already destination-charged (or disable Transfers entirely).  
+4. Wire fail-closed Connect readiness before payment.  
+5. Full Connect refund/dispute test plan.  
+6. New ADR superseding this recommendation.
+
+---
+
+## Decision log
+
+| Date | Note |
+| --- | --- |
+| 2026-07-20 | Audit recommends Option A; awaiting Product ratification |
+| 2026-07-20 | Launch remediation implements Option A constraints (gateway matrix, ledger insert allowlist, keep `stripe_connect` unwired). See `docs/release/payment-launch-remediation-report.md`. |

--- a/docs/architecture/payment-component-lifecycle.md
+++ b/docs/architecture/payment-component-lifecycle.md
@@ -1,0 +1,138 @@
+# MEL Payment Component Lifecycle
+
+**Status:** READ-ONLY Phase 2 launch documentation  
+**Date:** 20 July 2026  
+**Source of truth:** Phase 1 [`payment-runtime-map.md`](./payment-runtime-map.md) + Phase 2 DDEV runtime verification  
+**Critical findings:** [`payment-critical-findings.md`](./payment-critical-findings.md)
+
+Status values: `ACTIVE` · `ACTIVE (Platform)` · `ACTIVE (Commerce)` · `LEGACY` · `UNUSED` · `FUTURE` · `UNKNOWN`  
+Decision values: `Keep` · `Keep until post-launch` · `Remove after launch` · `Product decision` · `Needs investigation`
+
+---
+
+## Payment gateways & plugins
+
+| Component | Location | Purpose | Status | Decision | Launch Action | Evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| Commerce Stripe Card Element gateway entity `stripe` | Config entity; plugin `Drupal\commerce_stripe\Plugin\Commerce\PaymentGateway\Stripe` | Primary customer card checkout (tickets, boost, donations observed) | ACTIVE (Commerce) | Keep | Keep as platform collect gateway for launch (Option A); document deploy key injection | Runtime entity enabled; 129 completed payments; ticket payments majority |
+| Commerce Stripe Payment Element gateway entity `stripe_pe_recurring` | Config entity; plugin `StripePaymentElement` | Intended off-session / recurring; also used for tickets | ACTIVE (Commerce) | Product decision | Narrow conditions so tickets cannot casually select it; keep for Pro/recurring | Runtime `payment_method_usage=off_session`; 11 completed ticket payments on this gateway |
+| Manual gateway entity `mel_stripe_cc` | Config entity; plugin `manual` | Test / offline completion | ACTIVE | Remove after launch (prod) / Keep (local) | **Disable in production** before public checkout | Runtime enabled, no currency condition; 8 completed ticket payments |
+| Plugin `stripe_connect` | `myeventlane_commerce/.../StripeConnect.php` | Destination-charge Payment Element extension | FUTURE / UNUSED wiring | Keep until post-launch | Do not wire for launch without ADR Option B | Plugin discoverable; entities=0 (CF-001) |
+| Plugin `stripe` (contrib) | `commerce_stripe` | Card Element PaymentIntents | ACTIVE (Commerce) | Keep | Maintain Commerce Stripe upgrades | Module enabled |
+| Plugin `stripe_payment_element` (contrib) | `commerce_stripe` | Payment Element PaymentIntents | ACTIVE (Commerce) | Keep | Keep for PE / fast checkout / Pro | Module enabled; FastCheckout requires `StripePaymentElementInterface` |
+| Plugin `manual` (contrib) | `commerce_payment` | Manual payment recording | ACTIVE (Commerce) | Keep until post-launch | Hide/disable entity outside local | Entity `mel_stripe_cc` |
+
+---
+
+## Stripe platform services
+
+| Component | Location | Purpose | Status | Decision | Launch Action | Evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| `StripeService` (`myeventlane_core.stripe`) | `myeventlane_core/src/Service/StripeService.php` | Platform StripeClient facade: Connect accounts, off-session PI, SetupIntent, keys | ACTIVE (Platform) | Keep | Keep; treat unused methods as dormant | Service exists at runtime; callers: Connect, payouts, refunds verify, Pro portal, auto-bill |
+| `StripeService::createPaymentIntentForTicketSale()` | Same | Direct ticket PI (bypasses Commerce) | UNUSED | Keep until post-launch | Do not call; do not delete yet | No PHP callers (CF-004) |
+| `StripeService::createPaymentIntentForBoost()` | Same | Direct boost PI | UNUSED | Keep until post-launch | Do not call; do not delete yet | No PHP callers (CF-004) |
+| `StripeService::getOrCreateAccount()` | Same | Alternate Connect account helper | UNUSED | Keep until post-launch | Prefer `ensureConnectAccountIdForStore()` | No external callers proven |
+| `StripeConnectPaymentService` (`myeventlane_commerce.stripe_connect_payment`) | `myeventlane_commerce/src/Service/StripeConnectPaymentService.php` | Fee / `transfer_data` / Connect validation helpers | ACTIVE (partial) | Product decision | Keep calc/reporting; PI merge unused until Option B | Service exists; PI merge only via unwired plugin |
+| `StripeConnectValidationSubscriber` | `myeventlane_commerce/.../StripeConnectValidationSubscriber.php` | Log Connect readiness on checkout completion | UNUSED | Needs investigation | Do not rely on for launch gate | Not in services.yml; not in COMPLETION listeners |
+
+---
+
+## Checkout & fees
+
+| Component | Location | Purpose | Status | Decision | Launch Action | Evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| Checkout flow `mel_event_checkout` | `commerce_checkout.commerce_checkout_flow.mel_event_checkout` | Ticket/boost/Pro initial checkout UX | ACTIVE | Keep | Keep | Order type `default` → this flow (runtime) |
+| Checkout flow `default` | Commerce multistep | Donation checkouts | ACTIVE | Keep | Keep | `rsvp_donation` / `platform_donation` → `default` |
+| `PlatformFeeOrderProcessor` | `myeventlane_commerce/.../PlatformFeeOrderProcessor.php` | Platform fee adjustments on refresh | ACTIVE | Keep | Keep | Service `myeventlane_commerce.platform_fee_order_processor` |
+| `PlatformFeeOrderPresaveSubscriber` | `myeventlane_commerce/.../PlatformFeeOrderPresaveSubscriber.php` | Ensures fee refresh on save paths | ACTIVE | Keep | Keep | Tagged subscriber |
+| `FastCheckoutEligibility` | `myeventlane_checkout_flow/.../FastCheckoutEligibility.php` | Express/fast checkout only with PE gateway | ACTIVE | Keep | Document PE dependency | Requires `StripePaymentElementInterface` |
+
+---
+
+## Vendor billing & donations
+
+| Component | Location | Purpose | Status | Decision | Launch Action | Evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| `VendorAutoBillingService` | `myeventlane_donations/.../VendorAutoBillingService.php` | Off-session charge for MEL contribution invoices | ACTIVE (Platform) | Keep | Keep opt-in path; no default cron proven | Service exists; Drush/admin form callers |
+| `VendorContributionInvoiceService` | `myeventlane_donations/.../VendorContributionInvoiceService.php` | Invoice generation for MEL % | ACTIVE | Keep | Keep | Service `myeventlane_donations.vendor_contribution_invoice` |
+| `VendorMelPctContributionService` | `myeventlane_donations/.../VendorMelPctContributionService.php` | Accrue MEL % on paid ticket orders | ACTIVE | Keep | Keep | `ORDER_PAID` subscriber wired |
+| `VendorBillingPreferencesService` | `myeventlane_donations/.../VendorBillingPreferencesService.php` | Customer + SetupIntent for card-on-file | ACTIVE | Keep | Keep | Service exists |
+| `RsvpDonationService` (`myeventlane_donations.rsvp`) | donations module | RSVP donation order creation | ACTIVE | Keep | Keep | Order type `rsvp_donation` exists; payments on `stripe` |
+| Platform donation service (`myeventlane_donations.platform`) | donations module | Platform donation orders | ACTIVE | Keep | Keep | Order type `platform_donation`; payments on `stripe` |
+| `DonationPane` / `checkout_donation` | commerce/donations legacy UI | Legacy checkout donation pane | LEGACY | Keep until post-launch | Leave hidden (`isVisible()` FALSE per Phase 1) | Phase 1 map |
+| Organiser donation via `field_mel_donation` | Ticket booking path | MEL donation adjustment on ticket order | ACTIVE | Keep | Keep | Phase 1: `TicketSelectionForm::applyMelDonationToOrder()` |
+
+---
+
+## MEL Pro & billing portal
+
+| Component | Location | Purpose | Status | Decision | Launch Action | Evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| `ProSubscribeForm` | `myeventlane_pro/.../ProSubscribeForm.php` | Adds Pro variation to `default` cart | ACTIVE | Keep | Keep; expect PE gateway for off_session | Cart type `default` |
+| `ProSubscriptionSubscriber` | `myeventlane_pro/.../ProSubscriptionSubscriber.php` | Subscription entity lifecycle → entitlements | ACTIVE | Keep | Keep | Kernel tests + module enabled |
+| `ProBillingPortalService` (`myeventlane_pro.billing_portal`) | `myeventlane_pro/.../ProBillingPortalService.php` | Stripe Billing Portal via platform client | ACTIVE (Platform) | Keep | Keep | Service exists; uses `StripeService` |
+| `ProSubscriptionWebhookController` | `myeventlane_pro` route `/stripe/webhook/subscription` | Audit log Stripe subscription/invoice events | ACTIVE (optional) | Keep | Document as non-authoritative; set secret in prod | Phase 1: no Commerce state mutation |
+
+---
+
+## Refunds
+
+| Component | Location | Purpose | Status | Decision | Launch Action | Evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| `RefundProcessor` (`myeventlane_refunds.processor`) | `myeventlane_refunds/.../RefundProcessor.php` | Execute Commerce `refundPayment` + Stripe verify | ACTIVE | Keep | Keep | Service exists; buyer/vendor routes |
+| Boost refund subscriber | `myeventlane_boost.refund_subscriber` | Boost entitlement on refund | ACTIVE | Keep | Keep | Runtime service id present |
+
+---
+
+## Vendor Connect onboarding & payouts
+
+| Component | Location | Purpose | Status | Decision | Launch Action | Evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| `StripeConnectController` | `myeventlane_vendor/.../StripeConnectController.php` | Express Account Links onboarding | ACTIVE (Platform) | Keep | Keep | Routes `/stripe/connect`, `/stripe/callback` |
+| `PayoutBatchWorkflowService` | `myeventlane_admin_dashboard/.../PayoutBatchWorkflowService.php` | Draft→approve→execute Transfers | ACTIVE (Platform) | Keep | Keep only after ledger scope fix (CF-007) | Transfer create code |
+| `StripeWebhookController` (payout) | `/stripe/webhook/payout` | Reconcile `transfer.*` → ledger | ACTIVE (Platform) | Keep | Require webhook secret in staging/prod | Phase 1 webhook audit |
+| `VendorStripePayoutService` | `myeventlane_stripe` | Vendor-facing payout/balance display | ACTIVE | Keep | Keep (display) | Service `myeventlane_stripe.vendor_payout` |
+| `PlatformMetricsService` (`myeventlane_admin_dashboard.metrics`) | `.../PlatformMetricsService.php` | KPIs + **lazy ledger insert** | ACTIVE | Product decision | See ledger review — harden before payout launch | CF-006, CF-007 |
+
+---
+
+## Wallet
+
+| Component | Location | Purpose | Status | Decision | Launch Action | Evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| `myeventlane_wallet` module | `web/modules/custom/myeventlane_wallet` | Apple/Google pass generation | ACTIVE | Keep | Keep; independent of Stripe charge path | Module enabled; no Stripe charge APIs in module |
+| `PkPassBuilder` / `GoogleWalletBuilder` | wallet services | Build passes | ACTIVE | Keep | Keep | Services exist |
+| `WalletDownloadAccessChecker` | wallet | Deny void/refunded/cancelled | ACTIVE | Keep | Keep | `isWalletBlockedStatus()` |
+| Wallet links in confirmation email | `OrderConfirmationQueueBuilder` | Post-purchase CTAs | ACTIVE | Keep | Keep | Messaging service |
+
+---
+
+## Queues, workers, messaging
+
+| Component | Location | Purpose | Status | Decision | Launch Action | Evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| `OrderConfirmationQueueBuilder` | `myeventlane_messaging` | Build confirmation queue payloads (incl. wallet URLs) | ACTIVE | Keep | Keep | Used by place/paid subscribers |
+| `MessagingQueueWorker` | `myeventlane_messaging/.../MessagingQueueWorker.php` | Send queued messages | ACTIVE | Keep | Keep | Queue worker plugin |
+| `ReliableEmailQueueWorker` | `myeventlane_launch` | Launch reliable email | ACTIVE | Keep | Keep | Queue worker plugin |
+| Domain event payment/refund subscribers | `myeventlane_domain_events` | Project payment domain events | ACTIVE | Keep | Keep | Runtime services present |
+| Vendor auto-bill cron | — | Automatic invoice charging | UNKNOWN / not default | Needs investigation | Do not assume cron charges; use Drush/admin | No cron registration proven for auto-bill |
+
+---
+
+## Webhook controllers
+
+| Component | Location | Purpose | Status | Decision | Launch Action | Evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| Payout Transfer webhook | `myeventlane_admin_dashboard` `/stripe/webhook/payout` | Ledger reconcile | ACTIVE | Keep | Configure secret | Phase 1 Stage 8 |
+| Pro subscription webhook | `myeventlane_pro` `/stripe/webhook/subscription` | Audit only | ACTIVE (optional) | Keep | Document non-SoT | Phase 1 |
+| Commerce Stripe payment webhook | Contrib / gateway config | Async payment events | UNKNOWN for MEL checkout | Needs investigation | Do not rely on for ticket capture; checkout is synchronous | Gateway webhook secrets empty in DDEV; no MEL public payment webhook route proven |
+
+---
+
+## Legend notes
+
+- **ACTIVE (Platform)** = MEL custom Stripe API usage outside Commerce checkout charge path.  
+- **ACTIVE (Commerce)** = Drupal Commerce / Commerce Stripe checkout path.  
+- **UNUSED** = code present, no runtime wiring/callers proven.  
+- **FUTURE** = intended architecture not wired.  
+- Deletion requires the full dead-code checklist in [`payment-technical-debt.md`](./payment-technical-debt.md).

--- a/docs/architecture/payment-critical-findings.md
+++ b/docs/architecture/payment-critical-findings.md
@@ -1,0 +1,279 @@
+# MEL Payment Critical Findings
+
+**Status:** Audit finding + launch remediation applied (20 July 2026)  
+**Date:** 20 July 2026  
+**Environment:** Local DDEV (`ddev drush` runtime inspection)  
+**Scope:** Original audit was read-only; launch remediation on `feature/payment-launch-remediation` addresses CF-007/CF-008 insert/gateway scope and Phase 5 PaymentMethod auth mismatch  
+**Remediation report:** [`../release/payment-launch-remediation-report.md`](../release/payment-launch-remediation-report.md)
+
+**Related docs:**
+
+- [`payment-runtime-map.md`](./payment-runtime-map.md) (Phase 1)
+- [`payment-gateway-runtime.md`](./payment-gateway-runtime.md) (Phase 2)
+- [`payment-ledger-review.md`](./payment-ledger-review.md) (Phase 2)
+- [`payment-launch-risk-register.md`](../launch/payment-launch-risk-register.md)
+
+---
+
+## Summary
+
+Ticket (and related) checkout does **not** use the custom Stripe Connect destination-charge gateway. Customer payments are collected on the platform Stripe account via Commerce Stripe gateways. Vendor payouts are a **separate** Transfer/ledger workflow.
+
+Phase 2 runtime verification **strengthens** Phase 1 findings and adds a new financial-operations blocker: the payout ledger lazily inserts rows for **all** completed orders in a date window — including platform donations, RSVP donations, Boost, and MEL Pro — treating them as vendor payout liabilities with a flat commission cut.
+
+This is a **financial architecture / launch-risk** finding set. Whether production currently relies on the ledger/transfer model by design, or expected destination charges at PaymentIntent time, remains a stakeholder decision.
+
+---
+
+## Finding CF-001 — Destination-charge Connect gateway is unused
+
+### Severity
+
+**Critical (financial architecture)** — marketplace fund-routing path described in code is not the active Commerce checkout path.
+
+### Evidence
+
+| Claim | Evidence |
+| --- | --- |
+| Custom gateway plugin exists | `web/modules/custom/myeventlane_commerce/src/Plugin/Commerce/PaymentGateway/StripeConnect.php` — `@CommercePaymentGateway(id = "stripe_connect")` |
+| Plugin injects `application_fee_amount` + `transfer_data` | `StripeConnect::createPaymentIntent()` → `StripeConnectPaymentService::getConnectPaymentIntentParams()` |
+| **No Commerce payment gateway entity uses the plugin** | Runtime (Phase 2): discovered plugins show `stripe_connect` entities=0 |
+| Config sync has no `stripe_connect` gateway entity | Only gateways in `config/sync/`: `stripe`, `mel_stripe_cc`, `stripe_pe_recurring` |
+| Plugin is discoverable | Runtime plugin manager lists `stripe_connect` |
+
+### Runtime gateway entities (DDEV, 20 July 2026)
+
+| Entity ID | Plugin ID | Status |
+| --- | --- | --- |
+| `stripe` | `stripe` (Commerce Stripe Card Element) | enabled |
+| `stripe_pe_recurring` | `stripe_payment_element` | enabled |
+| `mel_stripe_cc` | `manual` | enabled |
+| *(none)* | `stripe_connect` | **no entity** |
+
+### Classification
+
+Destination-charge implementation via custom Commerce gateway: **UNUSED** (plugin ACTIVE in discovery, entity wiring ABSENT).
+
+---
+
+## Finding CF-002 — Alternate payout path exists (Transfers + ledger)
+
+### Severity
+
+**High** — vendor money movement is a Transfer/ledger model, not destination charges at checkout.
+
+### Evidence
+
+| Claim | Evidence |
+| --- | --- |
+| Admin batch executes Stripe Transfers | `PayoutBatchWorkflowService` — `$client->transfers->create([... 'destination' => $connectedAccountId ...])` |
+| Ledger table written | `PlatformMetricsService` inserts into `myeventlane_payout_ledger` |
+| Transfer webhooks reconcile ledger | Route `/stripe/webhook/payout` → `StripeWebhookController::handle()` |
+
+### Implication
+
+Observed architecture:
+
+1. Customer pays **platform** Stripe account (Commerce Stripe gateway).
+2. Platform records vendor liability in `myeventlane_payout_ledger`.
+3. Admin creates Stripe **Transfer** to vendor Connect account.
+4. Webhook reconciles ledger status.
+
+---
+
+## Finding CF-003 — Connect validation subscriber is unwired
+
+### Severity
+
+**High** (operational / financial control gap)
+
+### Evidence
+
+`StripeConnectValidationSubscriber` exists but:
+
+- No service definition / `event_subscriber` tag in `myeventlane_commerce.services.yml`.
+- Runtime (Phase 2): `CheckoutEvents::COMPLETION` listeners are only Commerce core/cart/log — **not** this class.
+
+Even if wired, the method only logs — it would still not block completion.
+
+---
+
+## Finding CF-004 — Direct ticket/boost PI helpers appear unused
+
+### Severity
+
+**Medium** (dead / parallel path risk)
+
+| Method | Callers outside definition |
+| --- | --- |
+| `StripeService::createPaymentIntentForTicketSale()` | **None found** |
+| `StripeService::createPaymentIntentForBoost()` | **None found** |
+
+Classification: **UNUSED**. Do not delete without the dead-code checklist.
+
+---
+
+## Finding CF-005 — Active gateway credentials drift from config sync
+
+### Severity
+
+**High** (ops / security / environment drift)
+
+| Source | `stripe` gateway keys |
+| --- | --- |
+| `config/sync/...stripe.yml` | Empty keys; no OAuth fields |
+| Active DDEV config | `authentication_method: stripe_connect`; non-empty keys/token; `stripe_user_id` set |
+| Env vars in this DDEV process | `MEL_STRIPE_*` unset |
+
+Secret values must never be committed or pasted into docs.
+
+---
+
+## Finding CF-006 — Payout ledger rows are not created on order place
+
+### Severity
+
+**Critical (financial operations)** — vendor liability recording is not tied to the payment lifecycle.
+
+### Evidence
+
+Repo-wide search for inserts into `myeventlane_payout_ledger` finds a single writer:
+
+- `PlatformMetricsService::buildKpis()` in `web/modules/custom/myeventlane_admin_dashboard/src/Service/PlatformMetricsService.php`
+- Insert runs as a side effect of KPI aggregation over completed orders in a date window when admin metrics paths execute.
+
+No `OrderEvents::ORDER_PAID` subscriber inserts ledger rows (Phase 2: 13 `ORDER_PAID` listeners listed; none are ledger writers).
+
+### Implication
+
+If admin KPI/payout screens are never loaded for a period, unpaid ledger rows for completed orders may not exist. Batch Transfer workflows that select from the ledger would then omit those orders until metrics code runs.
+
+---
+
+## Finding CF-007 — Ledger inserts ALL completed orders (including non-vendor-revenue)
+
+### Severity
+
+**Critical (financial operations / incorrect liabilities)** — Phase 2 runtime verification.
+
+### Evidence
+
+`PlatformMetricsService::buildKpis()` selects `commerce_order` where `state = completed` with **no order-type or product-type filter**, then inserts missing ledger rows with `commission = gross * commission_rate` and `status = unpaid`.
+
+Runtime ledger composition (DDEV, 20 Jul 2026):
+
+| Order type / product | Ledger presence |
+| --- | --- |
+| `default` | 98 unpaid + 46 approved |
+| `rsvp_donation` | 11 unpaid (e.g. order 495: gross 25, commission 2.50, net 22.50) |
+| `platform_donation` | 2 unpaid (e.g. order 474: gross 100, commission 10, net 90) |
+| Orders with `boost` order items | 16 ledger orders |
+| Orders with `mel_pro_subscription_variation` | 3 ledger orders |
+
+### Implication
+
+Platform-owned revenue (Boost, MEL Pro) and donations can appear as **vendor payout liabilities**. Executing Transfers against these rows could overpay vendors or misclassify platform income.
+
+### Classification
+
+Lazy ledger creation: **ACTIVE but incorrect scope** (audit).  
+**Remediation (insert path):** `PlatformMetricsService` now skips non-vendor-payable orders (Boost, platform/RSVP donation, MEL Pro, recurring). Historical polluted rows remain until ops cleanup. Timing (CF-006) unchanged.
+
+---
+
+## Finding CF-008 — Three gateways apply to every AUD cart; tickets charged on all three
+
+### Severity
+
+**Critical (checkout / ops)** — Phase 2 runtime verification.
+
+### Evidence
+
+Draft AUD carts (`loadMultipleForOrder`):
+
+- `mel_stripe_cc` (manual, **no currency condition**)
+- `stripe` (Card Element, AUD)
+- `stripe_pe_recurring` (Payment Element, AUD, `payment_method_usage: off_session`)
+
+Historical `commerce_payment` rows (completed) by variation type:
+
+| Gateway | `ticket_variation` | Other notable |
+| --- | --- | --- |
+| `stripe` | 105 | boost 17; Pro 0 in this cut |
+| `stripe_pe_recurring` | 11 | Pro 1 |
+| `mel_stripe_cc` | 8 | Pro 1 |
+
+RSVP donation order 520 and platform donation order 512 used gateway `stripe`.
+
+### Implication
+
+Commerce does **not** segregate ticket vs Pro vs test gateways by order type. Manual gateway can complete ticket orders without Stripe. Recurring PE gateway is usable for one-time ticket checkout.
+
+### Remediation (20 July 2026)
+
+| Control | Change |
+| --- | --- |
+| `mel_stripe_cc` | Condition `current_user_role: administrator` + filter subscriber |
+| `stripe_pe_recurring` | Conditions AUD **and** `mel_pro_subscription_variation`; filter removes PE from normal carts; removes Card Element from Pro/recurring |
+| Customers | Tickets/Boost/donations → `stripe`; MEL Pro/recurring → `stripe_pe_recurring` |
+
+---
+
+## Finding CF-009 — PaymentMethod resource_missing (Phase 5)
+
+### Severity
+
+**High (checkout)** when gateway `access_token` (Connect OAuth) is set while Elements uses platform `publishable_key`.
+
+### Evidence
+
+- Watchdog: `No such PaymentMethod: 'pm_…'` / `resource_missing` during checkout payment method create (`Stripe::doCreatePaymentMethod` → `PaymentMethod::retrieve`).
+- Same `pm_…` **retrieves OK** with platform `secret_key`; **fails** with gateway `access_token`.
+- Contrib prefers `access_token` over `secret_key` when non-empty (`commerce_stripe` `Stripe::init()`).
+
+### Remediation
+
+Clear `access_token` / use `authentication_method: api_keys` on entity `stripe` for Option A platform collect. Do not suppress the exception.
+
+---
+
+## What is NOT claimed
+
+- Not proven: production currently fails to pay vendors.
+- Not proven: destination charges were previously active and later removed.
+- Not proven: payout batches have already transferred donation/Boost/Pro ledger rows.
+- Not proven: how often `PlatformMetricsService::buildKpis()` runs in production (cron vs page load). Controllers that inject `myeventlane_admin_dashboard.metrics` are the proven callers.
+
+---
+
+## Required decisions before launch
+
+1. **Confirm intended marketplace model:**  
+   - **A)** Platform collect + Transfer/ledger (current wiring), or  
+   - **B)** Destination charges via `stripe_connect` gateway (code exists, not configured).
+2. If **A**: harden ledger creation on `ORDER_PAID` with **order/product allowlisting**; keep Transfer webhooks as payout truth; formally retire unused Connect PI merge for launch.
+3. If **B**: create/configure a Commerce payment gateway entity with `plugin: stripe_connect`, retire/condition Card Element for tickets, validate fee/transfer/refund math end-to-end.
+4. **Disable or condition `mel_stripe_cc`** outside local/testing before public checkout.
+5. **Narrow gateway conditions** so Pro/recurring uses PE off_session and ticket checkout uses a single intentional gateway.
+6. If Connect readiness must be a hard checkout gate: register a subscriber (or earlier pane/access check), wire it in `services.yml`, and fail closed.
+
+---
+
+## Audit continuation
+
+Phase 2 launch documentation set:
+
+| Document | Path |
+| --- | --- |
+| Component lifecycle | `docs/architecture/payment-component-lifecycle.md` |
+| Runtime matrix | `docs/architecture/payment-runtime-matrix.md` |
+| Gateway runtime | `docs/architecture/payment-gateway-runtime.md` |
+| Sequence diagrams | `docs/architecture/payment-sequence-diagrams.md` |
+| Ledger review | `docs/architecture/payment-ledger-review.md` |
+| Wallet boundary | `docs/architecture/wallet-payment-boundary.md` |
+| Risk register | `docs/launch/payment-launch-risk-register.md` |
+| Technical debt | `docs/architecture/payment-technical-debt.md` |
+| ADRs | `docs/adr/ADR-002-payment-runtime.md`, `docs/adr/ADR-003-stripe-connect-strategy.md` |
+| Executive summary | `docs/launch/payment-executive-summary.md` |
+
+This critical-findings file must be read first when assessing Connect / vendor fund routing / payout readiness.

--- a/docs/architecture/payment-gateway-runtime.md
+++ b/docs/architecture/payment-gateway-runtime.md
@@ -1,0 +1,174 @@
+# MEL Payment Gateway Runtime Verification
+
+**Status:** Phase 2 audit + launch remediation update  
+**Date:** 20 July 2026  
+**Commands:** `ddev drush php:eval` entity/plugin/order probes  
+**Critical:** [`payment-critical-findings.md`](./payment-critical-findings.md) CF-001, CF-008, CF-009  
+**Remediation:** [`../release/payment-launch-remediation-report.md`](../release/payment-launch-remediation-report.md)
+
+---
+
+## 1. Gateway entities (active config)
+
+| Entity ID | Label | Plugin ID | Enabled | Weight | Conditions | Payment method types | Notable config |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `stripe` | MEL - Stripe CC | `stripe` | Yes | null | `current_currency: AUD` | `credit_card` | `mode=test`; `authentication_method=stripe_connect`; publishable/secret/access_token present; webhook secret empty |
+| `stripe_pe_recurring` | Stripe (Payment Element) — Recurring | `stripe_payment_element` | Yes | 0 | `current_currency: AUD` | `stripe_card` | `payment_method_usage=off_session`; `capture_method=automatic`; `express_checkout.enable_on_cart=false`; API keys present; webhook signing secret empty |
+| `mel_stripe_cc` | MEL - Manual | `manual` | Yes | null | **none** | `credit_card` | No Stripe keys |
+
+**Hidden / unwired plugin**
+
+| Plugin ID | Provider | Entities | Notes |
+| --- | --- | --- | --- |
+| `stripe_connect` | `myeventlane_commerce` | **0** | Discoverable; never presented because no gateway entity |
+
+---
+
+## 2. Discovered plugins
+
+| Plugin ID | Class | Entities using it |
+| --- | --- | --- |
+| `stripe` | `Drupal\commerce_stripe\Plugin\Commerce\PaymentGateway\Stripe` | 1 (`stripe`) |
+| `stripe_payment_element` | `Drupal\commerce_stripe\Plugin\Commerce\PaymentGateway\StripePaymentElement` | 1 (`stripe_pe_recurring`) |
+| `stripe_connect` | `Drupal\myeventlane_commerce\Plugin\Commerce\PaymentGateway\StripeConnect` | 0 |
+| `manual` | `Drupal\commerce_payment\Plugin\Commerce\PaymentGateway\Manual` | 1 (`mel_stripe_cc`) |
+
+---
+
+## 3. What customers actually get (by flow)
+
+### Method
+
+1. Inspect draft-cart `loadMultipleForOrder()` applicability (what Commerce will offer).  
+2. Inspect historical `commerce_payment` rows (what was selected/completed).  
+3. Map order types / item variation types.
+
+### Ticket checkout
+
+| Question | Answer | Evidence |
+| --- | --- | --- |
+| Applicable gateways (AUD draft) | `mel_stripe_cc`, `stripe`, `stripe_pe_recurring` | Draft orders 580, 569, 538, 537 |
+| Dominant completed gateway | `stripe` | 105 completed payments on `ticket_variation` |
+| Also used for tickets | `stripe_pe_recurring` (11), `mel_stripe_cc` (8) | Payment×variation aggregate |
+| Why Commerce offers them | All three `applies()` = Y on AUD drafts; no MEL filter subscriber; method types differ in UI | Runtime applies probes; Phase 1 Stage 2 |
+
+**Why `stripe` is selected most often:** checkout panes (`payment_information` / `stripe_review` / `payment_process` on `mel_event_checkout`) present Card Element (`credit_card`) as the primary path for standard checkout. Fast checkout prefers PE when eligible.
+
+### Boost checkout
+
+| Question | Answer | Evidence |
+| --- | --- | --- |
+| Applicable | Same three AUD gateways | Draft `default` carts |
+| Observed completed | `stripe` | Payment 420: boost_duration via `stripe` |
+| Aggregate | 17 completed boost payments on `stripe` | Payment×variation |
+
+### MEL Pro
+
+| Question | Answer | Evidence |
+| --- | --- | --- |
+| Cart/order type for subscribe | `default` → `mel_event_checkout` | `ProSubscribeForm` + order type config |
+| Observed completed | `stripe_pe_recurring` (payment 424); also `mel_stripe_cc` (423) | Payment history |
+| Forced to PE? | **No** — conditions are currency-only | No order-type gateway conditions |
+| Recurring renewals | Order type `recurring`, no checkout flow | Runtime order type; gateway still applicable by currency if charged through Commerce |
+
+### Platform donation
+
+| Question | Answer | Evidence |
+| --- | --- | --- |
+| Order type / flow | `platform_donation` / `default` | Runtime |
+| Observed gateway | `stripe` | Order 512 payment |
+| Applicable | All three on AUD | Same condition logic |
+
+### RSVP donation
+
+| Question | Answer | Evidence |
+| --- | --- | --- |
+| Order type / flow | `rsvp_donation` / `default` | Runtime |
+| Observed gateway | `stripe` | Order 520 payment |
+
+---
+
+## 4. Express checkout
+
+| Item | Runtime value | Implication |
+| --- | --- | --- |
+| `stripe_pe_recurring` `express_checkout.enable_on_cart` | `false` | Cart-level express buttons disabled in gateway config |
+| Fast checkout (MEL) | Requires PE gateway implementing `StripePaymentElementInterface` | `FastCheckoutEligibility::isUsableStripeGateway()` — uses `stripe_pe_recurring` when applicable |
+| Card Element gateway `stripe` | Not PE | Not usable for MEL fast checkout confirm path |
+
+---
+
+## 5. Recurring availability
+
+| Item | Value |
+| --- | --- |
+| `stripe_pe_recurring.payment_method_usage` | `off_session` |
+| Commerce Recurring module | enabled |
+| Intent | Store payment method for renewals / off-session |
+| Gap | Same PE gateway is also selectable for one-time tickets (CF-008) |
+
+---
+
+## 6. AUD restrictions
+
+| Gateway | AUD-only? |
+| --- | --- |
+| `stripe` | Yes (`current_currency: AUD`) |
+| `stripe_pe_recurring` | Yes |
+| `mel_stripe_cc` | **No** — always applies when enabled |
+
+Non-AUD carts would still see the manual gateway if it remains enabled.
+
+---
+
+## 7. Why Commerce selected each gateway (mechanism)
+
+### Before remediation (audit)
+
+```text
+Order in checkout
+  → PaymentGatewayStorage::loadMultipleForOrder(order)
+      → conditions only (AUD / none)
+  → No MEL FilterPaymentGateways subscriber
+  → UI method-type split
+```
+
+### After remediation (launch)
+
+```text
+Order in checkout
+  → PaymentGatewayStorage::loadMultipleForOrder(order)
+      → gateway.applies(order) via conditions
+           mel_stripe_cc → administrator role
+           stripe → AUD
+           stripe_pe_recurring → AUD AND mel_pro_subscription_variation
+  → MEL FilterPaymentGatewaysSubscriber
+           remove mel_stripe_cc unless administrator
+           remove stripe_pe_recurring unless Pro/recurring
+           remove stripe when Pro/recurring
+  → UI / pane filters by payment method type
+  → Customer picks remaining gateway
+```
+
+**Target consequence:** ticket/boost/donations → `stripe`; MEL Pro/recurring → `stripe_pe_recurring`; manual admin-only.
+
+---
+
+## 8. Config sync vs active (reminder)
+
+| Field | Sync YAML `stripe` | Active DDEV `stripe` |
+| --- | --- | --- |
+| Keys | empty | present |
+| `authentication_method` | absent | `stripe_connect` |
+| `access_token` / `stripe_user_id` | absent | present |
+
+See CF-005. Never export secrets.
+
+---
+
+## 9. Launch actions (documentation only)
+
+1. Decide single intentional ticket gateway.  
+2. Disable `mel_stripe_cc` in production.  
+3. Add order-type or product conditions (post-decision implementation — out of scope here).  
+4. Keep `stripe_connect` plugin unwired unless Option B is chosen ([ADR-003](../adr/ADR-003-stripe-connect-strategy.md)).

--- a/docs/architecture/payment-ledger-review.md
+++ b/docs/architecture/payment-ledger-review.md
@@ -1,0 +1,134 @@
+# MEL Payment Ledger Review
+
+**Status:** Audit + launch remediation (insert eligibility)  
+**Date:** 20 July 2026  
+**Table:** `myeventlane_payout_ledger`  
+**Primary writer:** `Drupal\myeventlane_admin_dashboard\Service\PlatformMetricsService::buildKpis()`  
+**Service ID:** `myeventlane_admin_dashboard.metrics`  
+**Critical findings:** CF-006, CF-007  
+**Remediation:** [`../release/payment-launch-remediation-report.md`](../release/payment-launch-remediation-report.md)
+
+---
+
+## 1. Does PlatformMetricsService lazily create ledger rows?
+
+**Yes.**
+
+### Evidence
+
+In `PlatformMetricsService::buildKpis(int $days)`:
+
+1. Selects `commerce_order` rows with `state = completed` in a date window.  
+2. Loads existing `myeventlane_payout_ledger.order_id` values for those orders.  
+3. For each missing order, **inserts** a row with `status = unpaid`, computing:
+   - `gross` = order `total_price__number`
+   - `commission` = `gross * commission_rate` (from `myeventlane_admin_dashboard.settings`)
+   - `net` = `gross - commission`
+
+Comment in class (Phase 1): “Ensures ledger row exists for each completed order (inserts unpaid if missing).”
+
+### Callers (proven)
+
+Injected into admin controllers/services including:
+
+- `PlatformControlCentreController`
+- `FinancialController`
+- `FinancialExportController`
+- `PayoutController`
+- `ProReportingBuilder`
+
+**Not proven:** automatic cron invocation of `buildKpis()`.  
+**Not present:** any `ORDER_PAID` listener that inserts ledger rows (Phase 2 listed 13 `ORDER_PAID` listeners; none are ledger writers).
+
+### Runtime volume (DDEV, 20 Jul 2026)
+
+| Metric | Value |
+| --- | --- |
+| Total ledger rows | 157 |
+| Unpaid | 111 |
+| Approved | 46 |
+
+---
+
+## 2. Advantages of lazy KPI insert
+
+| Advantage | Why |
+| --- | --- |
+| Simple | Single insert site; no checkout coupling |
+| Backfill | Opening admin finance/KPI views can create missing rows for a window |
+| Low checkout latency | No ledger write on hot payment path |
+| Idempotent-ish | Skips `order_id` already present |
+
+---
+
+## 3. Disadvantages
+
+| Disadvantage | Why |
+| --- | --- |
+| Not payment-lifecycle-bound | Paid orders may lack rows until an admin metrics path runs |
+| Window-limited | Only orders in the KPI `days` window are considered |
+| Unfiltered scope | **All** completed orders — including donations, Boost, Pro (CF-007) |
+| Wrong economics | Flat `commission_rate` on gross may not match ticket fee model / Connect fee math |
+| Ops opacity | Payout batch may silently omit recent sales |
+| Dual truth risk | Finance KPIs and payout eligibility share a side-effecting method |
+
+---
+
+## 4. Launch risk
+
+| Risk | Severity | Notes |
+| --- | --- | --- |
+| Vendors unpaid because row missing | Critical | CF-006 |
+| Vendors overpaid / wrong liabilities (donations, Boost, Pro in ledger) | Critical | CF-007 — runtime confirmed |
+| Ops assumes ledger == ticket sales | High | Matrix shows contamination |
+| Relying on admin page hits as “settlement job” | High | Fragile in production |
+
+**Recommendation for payout operations at launch:** treat current ledger population as **not launch-safe** until scope + timing are fixed (implementation out of scope for this audit).
+
+---
+
+## 5. Recommendation
+
+### Keep for launch?
+
+**Keep the Transfer + ledger architecture (Option A)** as the intended marketplace model for launch — it matches wired gateways.
+
+**Do not treat lazy KPI insert as an acceptable long-term guarantee** for payout correctness.
+
+| Option | Recommendation |
+| --- | --- |
+| Keep lazy insert unchanged for launch | **No** for vendor payout go-live |
+| Move to `ORDER_PAID` after launch | **Yes — preferred hardening**, with allowlisting |
+| Minimum launch ops mitigation (no code in this phase) | Product/ops must confirm: (1) which order types belong on ledger; (2) who runs metrics/backfill before batches; (3) manual exclusion of donation/Boost/Pro rows |
+
+### Launch remediation (CF-007 insert scope) — implemented
+
+`buildKpis()` still lazy-inserts, but only when `OrderItemClassifier::isPayoutLedgerEligibleOrder()` is TRUE:
+
+| Eligible | Not eligible |
+| --- | --- |
+| `ticket_variation` revenue | Boost |
+| `checkout_donation` organiser lines | Platform donation orders/items |
+| (organiser tip via ticket order adjustments included in ticket order gross) | RSVP donation orders |
+| | MEL Pro / `recurring` |
+| | Platform fees / system adjustments / support invoices |
+
+**Not done in this remediation:** move writer to `ORDER_PAID` (CF-006); delete/fix historical polluted rows.
+
+### Preferred post-launch design
+
+1. On `ORDER_PAID` (or place), insert ledger row for payout-eligible orders only.  
+2. Idempotent unique key on `order_id`.  
+3. KPI/backfill becomes repair, not authority.  
+4. Align commission source of truth with platform fee / MEL % model.
+
+---
+
+## 6. Confidence
+
+| Claim | Confidence |
+| --- | --- |
+| Lazy insert exists | High (code + runtime rows) |
+| Only writer for inserts | High (repo search Phase 1; not re-litigated) |
+| Contaminates non-ticket orders | High (SQL Phase 2) |
+| Production cron frequency | **Not proven** |

--- a/docs/architecture/payment-runtime-map.md
+++ b/docs/architecture/payment-runtime-map.md
@@ -1,0 +1,698 @@
+# MEL Payment Runtime Map
+
+**Status:** READ-ONLY architecture audit  
+**Date:** 20 July 2026  
+**Platform:** Drupal 11 · Drupal Commerce 3 · Commerce Stripe 2.2.1 · PHP 8.x · DDEV  
+**Language:** Australian English  
+
+**Related critical report (read first):** [`payment-critical-findings.md`](./payment-critical-findings.md)
+
+**Validation performed:**
+
+- `ddev drush cr` — success  
+- Read-only `ddev drush` entity/config/plugin inspection  
+- Repository search of custom modules and `config/sync`  
+
+**Rules used in this document:**
+
+- Every operational claim cites source path, class/method, config ID, and/or runtime evidence.  
+- Where proof is incomplete: **Not proven.**  
+- Secret values are redacted. Never commit gateway secrets.
+
+---
+
+## Executive summary
+
+| Concern | Proven state (DDEV, 20 Jul 2026) |
+| --- | --- |
+| Active Commerce Stripe gateways | `stripe` (Card Element, customers); `stripe_pe_recurring` (Pro/recurring); `mel_stripe_cc` (admin-only after remediation) |
+| Custom Connect destination-charge gateway | Plugin `stripe_connect` **exists**; **0** gateway entities use it → destination charges **UNUSED** at checkout |
+| Vendor fund movement | Stripe **Transfers** + `myeventlane_payout_ledger` (admin batch / transfer controllers) |
+| Ledger row creation | Lazy insert inside `PlatformMetricsService::buildKpis()` — **not** on `ORDER_PAID` |
+| Ticket / Boost / Pro initial checkout order type | `default` → checkout flow `mel_event_checkout` |
+| Recurring renewals | Order type `recurring` (Commerce Recurring); no checkout flow on order type |
+| Wallet modules | Pass generation / email CTAs after purchase — **no** Stripe charge APIs found in `myeventlane_wallet` |
+| Duplicate payment paths | Parallel models exist: Commerce Stripe checkout vs unused Connect PI helpers vs Transfer payouts |
+
+---
+
+## Stage 1 — Payment entry points
+
+### 1.1 Inventory
+
+| Payment type | Active path proven? | Primary modules |
+| --- | --- | --- |
+| Ticket purchases | Yes | `myeventlane_commerce`, `myeventlane_checkout_flow`, `commerce_stripe` |
+| Boost purchases | Yes | `myeventlane_boost`, Commerce cart/checkout |
+| MEL Pro subscriptions | Yes (initial cart); renewals via Commerce Recurring | `myeventlane_pro`, `commerce_recurring` |
+| Donations (RSVP / platform / organiser / MEL %) | Partially mapped | `myeventlane_donations` |
+| Refunds | Yes | `myeventlane_refunds` + Commerce gateway `refundPayment()` |
+| Vendor onboarding (Connect Express) | Yes | `myeventlane_vendor` + `StripeService` |
+| Vendor payouts | Yes (Transfer model) | `myeventlane_admin_dashboard`, `myeventlane_stripe` |
+| Off-session billing | Yes (vendor MEL contribution auto-bill) | `VendorAutoBillingService` |
+| Wallet-related **payment** actions | No payment charge path found | `myeventlane_wallet` (pass/JWT only) |
+| Apple / Google Wallet payment dependencies | None proven | Wallet links in confirmation email only |
+
+---
+
+### 1.2 Ticket purchase
+
+| Aspect | Evidence |
+| --- | --- |
+| User journey | Public book → cart → Commerce checkout → Stripe → place/paid → confirmation + optional wallet CTAs |
+| Route | `myeventlane_commerce.book` → `/event/{node}/book` (`myeventlane_commerce.routing.yml`) |
+| Controller | `Drupal\myeventlane_commerce\Controller\BookController::book` |
+| Checkout flow | Order type `default` → `checkout_flow: mel_event_checkout` (runtime + `config/sync/commerce_order.commerce_order_type.default.yml`) |
+| Checkout plugin | `mel_event_checkout` — `Drupal\myeventlane_checkout_flow\Plugin\Commerce\CheckoutFlow\MelEventCheckoutFlow` |
+| Key panes | `payment_information` (checkout), `stripe_review` (review), `payment_process` (payment, capture=true) — `commerce_checkout.commerce_checkout_flow.mel_event_checkout` |
+| Order type | `default` |
+| Payment gateway (typical) | Entity `stripe`, plugin `stripe` (Card Element). Fast-checkout path requires Payment Element (`StripePaymentElementInterface`) — see Stage 2 |
+| Stripe API | Via Commerce Stripe plugin (PaymentIntent creation inside contrib), **not** MEL `StripeConnect` |
+| Webhook | No MEL ticket-payment webhook proven. Contrib `commerce_stripe_webhook_event` enabled; public Stripe webhook route for Commerce payments **not** found as a named public route |
+| Completion | Commerce place transition; `StripeConnectValidationSubscriber` exists but is **unwired** (not in services.yml; not a COMPLETION listener at runtime) |
+| Confirmation email | `OrderPlacedSubscriber` → `OrderConfirmationQueueBuilder` on `commerce_order.place.post_transition` |
+| Wallet generation | Email may include Apple/Google wallet URLs via `OrderConfirmationQueueBuilder` + `myeventlane_wallet` services — **after** payment, not during charge |
+| Events | `OrderEvents::ORDER_PAID` consumers (capacity, messaging PDF recovery, etc.) |
+| Queue / cron | Messaging queues for confirmation; ticket PDF merge at send time (messaging module) |
+
+```mermaid
+sequenceDiagram
+  participant Buyer
+  participant Book as BookController
+  participant Cart as Commerce cart
+  participant CO as mel_event_checkout
+  participant GW as Gateway stripe (Card Element)
+  participant Stripe as Stripe API
+  participant Place as Order place
+  participant Mail as OrderPlacedSubscriber
+  participant Wallet as myeventlane_wallet
+
+  Buyer->>Book: GET /event/{node}/book
+  Book->>Cart: Add ticket order items
+  Buyer->>CO: Checkout (payment_information / payment_process)
+  CO->>GW: Create/confirm payment
+  GW->>Stripe: PaymentIntent (platform account)
+  Stripe-->>GW: succeeded
+  CO->>Place: place transition
+  Place->>Mail: commerce_order.place.post_transition
+  Mail->>Wallet: Build wallet CTA URLs (optional)
+  Note over Stripe,Place: No transfer_data from StripeConnect plugin (entity absent)
+  Note over Place: StripeConnectValidationSubscriber not registered
+```
+
+---
+
+### 1.3 Boost purchase
+
+| Aspect | Evidence |
+| --- | --- |
+| User journey | Vendor selects boost → cart line item → Commerce checkout → on paid, entitlement activated |
+| Routes / UI | `BoostController` + forms `BoostSelectForm` / `BoostPurchaseForm` |
+| Cart | `CartManager` / `CartProvider` add boost variation; redirect `commerce_checkout.form` |
+| Order type | Cart uses default Commerce cart path (boost line item bundle `boost`) — **Not proven** every boost order is exclusively `default`, but forms use standard cart APIs without creating `recurring` orders |
+| Gateway | Same Commerce gateway pool as other `default` checkouts (no Boost-specific gateway filter found) |
+| Stripe Connect gate | `StripeChecker` + controller checks `field_stripe_connected` before purchase UX |
+| Connect on PI | `StripeConnectPaymentService::orderRequiresConnect()` skips boost-only Connect requirement |
+| Completion UX | `BoostCheckoutRedirectSubscriber` → boost success page |
+| Entitlement | `BoostOrderSubscriber` on `OrderEvents::ORDER_PAID` → `BoostEntitlementManager` |
+| Confirmation email | `OrderPlacedSubscriber` detects boost-only and uses dedicated boost template |
+| Direct PI helper | `StripeService::createPaymentIntentForBoost()` — **no callers** → UNUSED |
+
+```mermaid
+sequenceDiagram
+  participant Vendor
+  participant Form as BoostSelectForm/BoostPurchaseForm
+  participant Cart as Commerce cart
+  participant CO as Checkout
+  participant Stripe as Stripe (via Commerce GW)
+  participant Paid as ORDER_PAID
+  participant Ent as BoostEntitlementManager
+  participant Mail as OrderPlacedSubscriber
+
+  Vendor->>Form: Choose boost duration
+  Form->>Cart: addOrderItem(boost)
+  Form->>CO: Redirect commerce_checkout.form
+  CO->>Stripe: Charge platform account
+  CO->>Paid: Order paid
+  Paid->>Ent: Activate entitlement
+  CO->>Mail: Place → boost confirmation email
+```
+
+---
+
+### 1.4 MEL Pro subscription
+
+| Aspect | Evidence |
+| --- | --- |
+| User journey | Pro overview → `ProSubscribeForm` → cart `default` → checkout → Commerce Recurring subscription entity |
+| Form | `Drupal\myeventlane_pro\Form\ProSubscribeForm` |
+| Cart | `$this->cartProvider->getCart('default', $store, $user)` — **order type `default` for initial purchase** |
+| Variation type | `mel_pro_subscription_variation` (logged in form) |
+| Renewals | Order type `recurring`, workflow `order_recurring` (`commerce_order.commerce_order_type.recurring`) |
+| Gateway intent | Entity `stripe_pe_recurring`, plugin `stripe_payment_element`, `payment_method_usage: off_session` |
+| Lifecycle | `ProSubscriptionSubscriber` on Commerce Recurring subscription insert/update |
+| Billing portal | `ProBillingPortalService` uses `StripeService::getPlatformClient()` |
+| Webhook | `/stripe/webhook/subscription` → `ProSubscriptionWebhookController` — **audit logging only**; does not mutate Commerce state |
+| Confirmation | Messaging/Commerce receipts — Pro-specific mail path **Not fully enumerated here** |
+
+```mermaid
+sequenceDiagram
+  participant Vendor
+  participant Form as ProSubscribeForm
+  participant Cart as Cart type default
+  participant CO as Checkout
+  participant PE as stripe_pe_recurring (PE)
+  participant CR as commerce_recurring
+  participant Stripe as Stripe
+  participant Hook as ProSubscriptionWebhookController
+
+  Vendor->>Form: Subscribe
+  Form->>Cart: addEntity(Pro variation)
+  Form->>CO: commerce_checkout.checkout
+  Note over CO,PE: Gateway selection not forced in MEL code; PE intended for off_session
+  CO->>Stripe: Initial payment / setup
+  CO->>CR: Subscription entity
+  Stripe-->>Hook: subscription.*/invoice.* (audit only if secret set)
+```
+
+---
+
+### 1.5 Donations
+
+| Subtype | Evidence |
+| --- | --- |
+| RSVP donation | Order type `rsvp_donation`, checkout flow `default` (runtime). `RsvpDonationService`; `RsvpDonationCheckoutRedirectSubscriber` |
+| Platform donation | Order type `platform_donation`, checkout flow `default`. `VendorWizardPlatformDonationSubscriber` on `ORDER_PAID` |
+| Organiser donation | Current ticket booking path: `TicketSelectionForm::applyMelDonationToOrder()` → `field_mel_donation` + adjustment `source_id: myeventlane_order_donation`. Legacy `checkout_donation` item type / `DonationPane` still exist (`DonationPane::isVisible()` always FALSE). Connect fee math in `StripeConnectPaymentService` unused at PI time (see critical findings) |
+| Vendor MEL % / invoices | `VendorMelPctContributionService`, invoice services; payment method save via `VendorMelSavePaymentMethodController` + SetupIntent |
+| Auto-billing | `VendorAutoBillingService::attemptAutoCharge()` → `StripeService::createPaymentIntentOffSession()`; triggered from Drush commands / admin invoice form — **not** proven on cron by default |
+
+```mermaid
+sequenceDiagram
+  participant Actor
+  participant Checkout as Commerce checkout
+  participant Stripe as Stripe (Commerce or StripeService)
+  participant Paid as ORDER_PAID subscribers
+
+  alt Attendee/platform donation checkout
+    Actor->>Checkout: Donate (order type rsvp_donation / platform_donation)
+    Checkout->>Stripe: Commerce payment
+    Checkout->>Paid: Mark wizard / contribution state
+  else Vendor MEL auto-bill
+    Actor->>Stripe: createPaymentIntentOffSession (opt-in only)
+  end
+```
+
+---
+
+### 1.6 Refunds
+
+| Aspect | Evidence |
+| --- | --- |
+| Buyer request | Route `myeventlane_refunds.buyer_refund` → `/my-tickets/order/{commerce_order}/refund` |
+| Vendor refund | `myeventlane_refunds.vendor_refund` → `/vendor/orders/{commerce_order}/refund` |
+| Approval flow | Refund request approve/reject routes under `/vendor/events/{node}/refund-requests/...` |
+| Execution | `RefundProcessor::refundPayment()` → `$plugin->refundPayment($payment, $price)` |
+| Stripe verify | `RefundProcessor` also uses `StripeService::getPlatformClient()` to list/confirm refunds |
+| Email / notify | Messaging + optional `RefundNotificationTriggerService` |
+| Queue | Refund module uses queue factory (retry route `myeventlane_refunds.retry`) |
+
+```mermaid
+sequenceDiagram
+  participant Actor as Buyer/Vendor/Admin
+  participant RP as RefundProcessor
+  participant GW as Payment gateway plugin
+  Stripe as Stripe API
+
+  Actor->>RP: Request / approve refund
+  RP->>GW: refundPayment(payment, amount)
+  GW->>Stripe: Refund API (Commerce Stripe)
+  RP->>Stripe: Confirm refund id via platform client
+  RP->>Actor: Status + notifications
+```
+
+---
+
+### 1.7 Vendor onboarding (Stripe Connect Express)
+
+| Aspect | Evidence |
+| --- | --- |
+| Routes | `/stripe/connect`, `/stripe/callback`, `/stripe/manage`, `/vendor/onboard/stripe`, return/refresh paths — `myeventlane_vendor.routing.yml` |
+| Controller | `StripeConnectController` (`connect`, `callback`, `manage`) |
+| Onboard page | `VendorOnboardStripeController::stripe` |
+| Service | `myeventlane_core.stripe` → `ensureConnectAccountIdForStore`, `createAccountLink`, `getAccountStatus`, `applyConnectStatusToCommerceStore`, `createLoginLink` |
+| Account type | Express (`createConnectAccount(..., 'express')`) |
+| Store fields | `field_stripe_account_id`, `field_stripe_connected`, `field_stripe_status` |
+| Access | `StripeConnectAccess` |
+| OAuth (Commerce Stripe platform) | Separate: `commerce_stripe.connect.oauth_*` routes for gateway Connect OAuth — used by gateway entity auth, not vendor Express Account Links |
+
+```mermaid
+sequenceDiagram
+  participant Vendor
+  participant Ctrl as StripeConnectController
+  participant Svc as StripeService
+  participant Stripe as Stripe Connect API
+  participant Store as commerce_store
+
+  Vendor->>Ctrl: GET /stripe/connect
+  Ctrl->>Svc: ensureConnectAccountIdForStore
+  Svc->>Stripe: accounts.create (express)
+  Ctrl->>Svc: createAccountLink
+  Svc->>Stripe: accountLinks.create
+  Stripe-->>Vendor: Hosted onboarding
+  Vendor->>Ctrl: /stripe/callback
+  Ctrl->>Svc: getAccountStatus + applyConnectStatusToCommerceStore
+  Ctrl->>Store: Persist connected/charges flags
+```
+
+---
+
+### 1.8 Vendor payouts
+
+| Aspect | Evidence |
+| --- | --- |
+| Model | Platform holds funds; admin creates Stripe **Transfer** to connected account |
+| Ledger | Table `myeventlane_payout_ledger` |
+| Ledger create | `PlatformMetricsService::buildKpis()` lazy insert (see CF-006) |
+| Batch workflow | `PayoutBatchWorkflowService` — draft → pending → approved → executed |
+| Transfer create | `$client->transfers->create(['destination' => $connectedAccountId, ...])` |
+| Controllers | `PayoutController`, `PayoutBatchController`, `PayoutTransferController`, `PayoutActionController` |
+| Vendor UI | `/vendor/payouts` (`myeventlane_vendor.console.payouts`); balance via `VendorStripeBalanceService` / `VendorStripePayoutService` (payouts.list on connected account) |
+| Webhook reconcile | `/stripe/webhook/payout` |
+
+```mermaid
+sequenceDiagram
+  participant Admin
+  participant Metrics as PlatformMetricsService
+  participant Ledger as myeventlane_payout_ledger
+  participant Batch as PayoutBatchWorkflowService
+  participant Stripe as Stripe Transfers
+  participant Hook as StripeWebhookController
+
+  Note over Metrics,Ledger: Ledger rows often created when KPIs run
+  Admin->>Batch: Create/approve/execute batch
+  Batch->>Stripe: transfers.create(destination=acct_...)
+  Stripe-->>Hook: transfer.paid / failed / created
+  Hook->>Ledger: Mark paid (idempotent checks)
+```
+
+---
+
+### 1.9 Off-session billing
+
+| Path | Evidence | Status |
+| --- | --- | --- |
+| Vendor MEL contribution auto-charge | `VendorAutoBillingService` + SetupIntent collection | ACTIVE when opted in |
+| Pro recurring renewals | `stripe_pe_recurring` `payment_method_usage: off_session` + Commerce Recurring | ACTIVE (module enabled); end-to-end charge in this audit run **Not proven** |
+| Fast checkout | Requires Payment Element gateway | ACTIVE code path |
+
+---
+
+### 1.10 Wallet modules
+
+| Claim | Evidence |
+| --- | --- |
+| No Stripe charge in wallet module | `myeventlane_wallet` builders/controllers deal with pass/JWT presentation |
+| Post-payment dependency | Confirmation email embeds wallet URLs (`OrderConfirmationQueueBuilder`) |
+| Payment gateway dependency | **None proven** |
+
+---
+
+## Stage 2 — Commerce payment gateway audit
+
+### 2.1 Configured gateway entities
+
+| Machine name | Label | Plugin ID | Conditions | Payment method types | Auth | Webhook secret (runtime DDEV) | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `stripe` | MEL - Stripe CC | `stripe` | `current_currency: AUD` | `credit_card` | **Remediation:** `api_keys` (empty `access_token`); sync YAML still empty secrets | empty | enabled |
+| `stripe_pe_recurring` | Stripe (Payment Element) — Recurring | `stripe_payment_element` | AUD **and** `order_variation_type: mel_pro_subscription_variation` | `stripe_card` | API keys | empty | enabled |
+| `mel_stripe_cc` | MEL - Manual | `manual` | `current_user_role: administrator` | `credit_card` | n/a | n/a | enabled (admin-only) |
+
+Sources: `config/sync/commerce_payment.commerce_payment_gateway.*.yml` + runtime `ddev drush` entity load.
+
+### 2.2 Discovered plugins (not all have entities)
+
+| Plugin ID | Provider | Class | Entities using it |
+| --- | --- | --- | --- |
+| `stripe` | commerce_stripe | `Drupal\commerce_stripe\Plugin\Commerce\PaymentGateway\Stripe` | `stripe` |
+| `stripe_payment_element` | commerce_stripe | `...StripePaymentElement` | `stripe_pe_recurring` |
+| `stripe_connect` | myeventlane_commerce | `Drupal\myeventlane_commerce\Plugin\Commerce\PaymentGateway\StripeConnect` | **0** |
+| `manual` | commerce_payment | Manual | `mel_stripe_cc` |
+
+### 2.3 How Commerce chooses gateways
+
+1. `PaymentGatewayStorage::loadMultipleForOrder($order)` evaluates each gateway’s **conditions** (`applies($order)`).  
+2. MEL `FilterPaymentGatewaysSubscriber` enforces the launch gateway matrix (after conditions).  
+3. `stripe` requires AUD; `stripe_pe_recurring` requires AUD **and** Pro variation; `mel_stripe_cc` requires administrator.  
+4. UI further splits by **payment method type**: Card Element (`credit_card`) vs Payment Element (`stripe_card`).  
+5. Fast checkout explicitly requires `StripePaymentElementInterface` — unavailable on ticket carts once PE is Pro-scoped (expected).
+
+### 2.4 Cross-use questions
+
+| Question | Answer | Evidence |
+| --- | --- | --- |
+| Can ticket checkout ever use the recurring gateway (`stripe_pe_recurring`)? | **Yes at condition level** (AUD only). Segregated by `stripe_card` method type and by which panes/UX are used. Fast checkout **prefers** Payment Element. Standard Card Element path uses `credit_card` → entity `stripe`. | Gateway conditions; `FastCheckoutEligibility`; method types runtime |
+| Can Pro subscriptions ever use the ticket gateway (`stripe`)? | **Yes for initial subscribe** — `ProSubscribeForm` builds a **`default`** cart (same order type/checkout pool as tickets). No MEL code forces `stripe_pe_recurring` by order type. | `ProSubscribeForm` cart type `default`; no order-type gateway conditions |
+
+### 2.5 Stores / currency
+
+Runtime stores are overwhelmingly `AUD`. Gateway currency condition matches. Store-level gateway assignment: **Not proven** (Commerce typically uses global gateway entities + conditions, not per-store gateway entities here).
+
+---
+
+## Stage 3 — Stripe runtime API usage
+
+| API surface | Caller(s) | Flow | Classification |
+| --- | --- | --- | --- |
+| `StripeClient` via `StripeService::getPlatformClient()` | Connect, payouts, refunds verify, Pro portal, billing prefs, auto-bill, webhooks | Platform secret | ACTIVE |
+| PaymentIntent (Commerce Stripe plugins) | Contrib Card Element / Payment Element during checkout | Tickets, boost, Pro initial, donations | ACTIVE |
+| PaymentIntent (`createPaymentIntentForTicketSale`) | None outside `StripeService` | — | UNUSED |
+| PaymentIntent (`createPaymentIntentForBoost`) | None outside `StripeService` | — | UNUSED |
+| PaymentIntent off-session | `VendorAutoBillingService` | MEL invoices | ACTIVE |
+| SetupIntent | `VendorBillingPreferencesService` / save PM controller | Card on file | ACTIVE |
+| Customer | `VendorBillingPreferencesService::createCustomer` | Billing prefs | ACTIVE |
+| Account / AccountLink / LoginLink | `StripeConnectController` via `StripeService` | Vendor onboarding | ACTIVE |
+| Transfer | `PayoutBatchWorkflowService`, payout controllers | Vendor payouts | ACTIVE |
+| Application fee (PI params) | `StripeConnectPaymentService::getConnectPaymentIntentParams` | Only via unused gateway plugin | UNUSED at checkout |
+| Application fee (calc helper) | `StripeConnectPaymentService`, `VendorFinanceSummaryBuilder` | Reporting / unused PI path | PARTIALLY ACTIVE (calc/reporting) |
+| Refund | Commerce gateway `refundPayment` + Stripe list verify in `RefundProcessor` | Refunds | ACTIVE |
+| Payout (connected account list) | `VendorStripePayoutService` | Vendor dashboard display | ACTIVE |
+| Subscription / Invoice (Stripe objects) | Pro webhook **logs** types; Commerce Recurring owns state | Pro | ACTIVE (Commerce); webhook audit OPTIONAL |
+| Charge (legacy Charge API) | **Not found** in custom MEL payment code | — | UNKNOWN / unused in custom code |
+| Webhook constructEvent | Payout + Pro subscription controllers | Signature verify | ACTIVE (when secrets configured) |
+
+---
+
+## Stage 4 — Stripe Connect audit
+
+| Component | Role | Runtime status |
+| --- | --- | --- |
+| Plugin `StripeConnect` | Extends Payment Element; merges Connect PI params | Plugin discoverable; **no entity** → UNUSED for checkout |
+| `StripeConnectPaymentService` | Fee/transfer_data calculation; validation helpers | Service ACTIVE for validation/logging/reporting; PI merge UNUSED |
+| `StripeConnectController` | Express onboarding | ACTIVE |
+| `StripeConnectValidationSubscriber` | Intended Connect check on checkout complete | UNUSED (class present; not registered as event subscriber) |
+| Vendor Express accounts | `field_stripe_account_id` on store | ACTIVE onboarding |
+| Destination charges | Intended in plugin | **UNUSED** |
+| Application fees on PI | Intended in plugin | **UNUSED** at charge time |
+| Transfers | Admin payout path | ACTIVE |
+| Commerce Stripe OAuth on gateway `stripe` | `authentication_method: stripe_connect` in **active** DDEV config | ACTIVE locally; **drift vs sync** |
+
+**Is custom StripeConnect gateway active?**  
+Plugin: yes (discovery). Commerce payment gateway entity: **no**.
+
+**Destination charge implementation classification:** **UNUSED** (code present, not wired). See CF-001.
+
+---
+
+## Stage 5 — `StripeService` audit
+
+**Service ID:** `myeventlane_core.stripe`  
+**Class:** `Drupal\myeventlane_core\Service\StripeService`  
+**Definition:** `web/modules/custom/myeventlane_core/myeventlane_core.services.yml`
+
+| Public method | Callers (proven) | Classification |
+| --- | --- | --- |
+| `getPlatformClient()` | Payouts, refunds, Pro portal, billing, webhooks, internal | ACTIVE |
+| `getOrCreateAccount()` | **No external callers** | UNUSED |
+| `getPlatformPublishableKey()` | `VendorMelSavePaymentMethodController` | ACTIVE |
+| `ensureConnectAccountIdForStore()` | `StripeConnectController` | ACTIVE |
+| `applyConnectStatusToCommerceStore()` | `StripeConnectController` | ACTIVE |
+| `createConnectAccount()` | Internal from ensure/getOrCreate | ACTIVE (via ensure) |
+| `createAccountLink()` | `StripeConnectController` | ACTIVE |
+| `createLoginLink()` | `StripeConnectController` | ACTIVE |
+| `validateAccountDashboardEligibility()` | Dashboard + internal | ACTIVE |
+| `resolveStripeManageDestination()` | `StripeConnectController` | ACTIVE |
+| `resolveManageDestinationFromEligibility()` | Unit tests + internal | ACTIVE |
+| `createLoginLinkIfEligible()` | Internal path | ACTIVE / low external use |
+| `getAccountStatus()` | Connect controllers | ACTIVE |
+| `createPaymentIntentForTicketSale()` | None | UNUSED |
+| `createPaymentIntentForBoost()` | None | UNUSED |
+| `calculateApplicationFee()` | `StripeConnectPaymentService` | ACTIVE (helper) |
+| `createCustomer()` | `VendorBillingPreferencesService` | ACTIVE |
+| `createSetupIntent()` | Billing prefs | ACTIVE |
+| `createPaymentIntentOffSession()` | `VendorAutoBillingService` | ACTIVE |
+| `getPaymentMethodLast4()` | Billing prefs | ACTIVE |
+| `maskAccountId()` | Logging callers | ACTIVE |
+
+```mermaid
+flowchart TD
+  SS[StripeService]
+  SC[StripeConnectController]
+  VP[VendorAutoBilling / BillingPrefs]
+  PO[PayoutBatch / Transfer controllers]
+  RF[RefundProcessor]
+  PR[ProBillingPortalService]
+  SCP[StripeConnectPaymentService]
+  UNUSED1[createPaymentIntentForTicketSale]
+  UNUSED2[createPaymentIntentForBoost]
+  UNUSED3[getOrCreateAccount]
+
+  SC --> SS
+  VP --> SS
+  PO --> SS
+  RF --> SS
+  PR --> SS
+  SCP --> SS
+  SS -.-> UNUSED1
+  SS -.-> UNUSED2
+  SS -.-> UNUSED3
+```
+
+---
+
+## Stage 6 — Runtime call graphs
+
+### 6.1 Ticket purchase
+
+`BookController` → Cart APIs → `MelEventCheckoutFlow` panes → Commerce Payment (`stripe` / optionally PE) → Commerce Stripe PaymentIntent → Order place → `OrderPlacedSubscriber` / `OrderConfirmationQueueBuilder` → optional wallet URL builders → `ORDER_PAID` subscribers (tickets, capacity, PDF recovery, MEL % accrual, etc.).
+
+**Not in path:** `StripeConnectValidationSubscriber` (unwired).
+
+**Not in path:** `StripeConnect::createPaymentIntent`, `createPaymentIntentForTicketSale`.
+
+### 6.2 Boost purchase
+
+`BoostController` / `BoostSelectForm` / `BoostPurchaseForm` → Cart → Checkout → Commerce Stripe → `ORDER_PAID` → `BoostOrderSubscriber` → `BoostEntitlementManager` → `OrderPlacedSubscriber` (boost mail) → `BoostCheckoutRedirectSubscriber`.
+
+### 6.3 Subscription purchase
+
+`ProSubscribeForm` → Cart `default` → Checkout → (intended) Payment Element gateway → Commerce Recurring subscription → `ProSubscriptionSubscriber` → entitlement reconciler services. Renewals: Commerce Recurring + off_session PE gateway.
+
+### 6.4 Donation
+
+Checkout order types `rsvp_donation` / `platform_donation` / line items on default → Commerce payment → `ORDER_PAID` donation subscribers. Organiser donation Connect fee math exists in `StripeConnectPaymentService` but PI merge unused.
+
+### 6.5 Refund
+
+Routes → forms/controllers → `RefundProcessor` → gateway `refundPayment` → Stripe → verify via `getPlatformClient` → messaging/notifications/queue retry.
+
+### 6.6 Vendor billing (MEL contribution)
+
+Save PM: `VendorMelSavePaymentMethodController` → SetupIntent.  
+Charge: admin/Drush → `VendorAutoBillingService::attemptAutoCharge` → off-session PI → invoice apply.
+
+---
+
+## Stage 7 — Environment configuration matrix
+
+### 7.1 Credential sources
+
+| Source | What it sets | Used by |
+| --- | --- | --- |
+| Active Commerce gateway entity config | `secret_key`, `publishable_key`, optional `access_token` | Commerce Stripe plugins; also first hit in `StripeService::getPlatformSecretKey()` lookup list |
+| `settings.mel_shared_session.php` | Overlays `MEL_STRIPE_*` env onto `stripe`, `stripe_myeventlane_v2`, `stripe_pe_recurring` | All consumers of those config keys when env set |
+| `settings.php` | Optional `STRIPE_PK` / `STRIPE_SK` overlays (documented in `environment-configuration.md`) | Gateway config override |
+| `myeventlane_core.stripe_settings` | `platform_secret_key` fallback | `StripeService` if gateways empty |
+| `MEL_STRIPE_SECRET_KEY` / `MEL_STRIPE_PUBLISHABLE_KEY` / `MEL_STRIPE_WEBHOOK_SECRET` | Env fallbacks | `StripeService::melGetEnv`; settings overlay |
+| `myeventlane_admin_dashboard.settings` `stripe_webhook_secret` | Payout webhook | `StripeWebhookController` |
+| `myeventlane_pro.settings` `subscription_webhook_secret` | Pro audit webhook | `ProSubscriptionWebhookController` |
+
+### 7.2 DDEV runtime (20 Jul 2026)
+
+| Item | Result |
+| --- | --- |
+| `MEL_STRIPE_*` env | unset |
+| Gateway `stripe` keys | present in active config (lengths non-zero); sync YAML empty |
+| Gateway `stripe` auth | `authentication_method=stripe_connect` (active only) |
+| `stripe_pe_recurring` keys | present active; sync empty |
+| Payout webhook secret | empty |
+| Pro subscription webhook secret | empty |
+| `myeventlane_core.stripe_settings` platform key | empty |
+
+### 7.3 Matrix: which credentials feed which subsystem
+
+| Subsystem | Primary credential source |
+| --- | --- |
+| Commerce Stripe Card Element (`stripe`) | Gateway entity config (± env overlay) |
+| Commerce Stripe Payment Element (`stripe_pe_recurring`) | Gateway entity config (± env overlay) |
+| `StripeService` platform client | Gateway secret lookup order then config then env |
+| Vendor Express onboarding | Same platform secret via `StripeService` |
+| Subscriptions (Commerce) | Gateway used at checkout / recurring — typically PE keys |
+| Payout Transfers | `StripeService::getPlatformClient()` |
+| Payout webhook verify | `myeventlane_admin_dashboard.settings:stripe_webhook_secret` |
+| Pro audit webhook | `myeventlane_pro.settings:subscription_webhook_secret` |
+
+**Configuration drift:** sync vs active for `stripe` OAuth fields — see CF-005.
+
+---
+
+## Stage 8 — Webhook audit
+
+| Endpoint | Route name | Controller | Events | Signature | Idempotency | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| `/stripe/webhook/payout` | `myeventlane_admin_dashboard.stripe_payout_webhook` | `StripeWebhookController` (+ `StripeWebhookControllerDecorator`) | `transfer.paid`, `transfer.failed`, `transfer.created` | `Webhook::constructEvent` + admin setting secret | Decorator keyvalue `myeventlane_webhook_events` + ledger status checks | Rejects if secret empty |
+| `/stripe/webhook/subscription` | `myeventlane_pro.subscription_webhook` | `ProSubscriptionWebhookController` | Any verified event; audit log if enabled | Pro settings secret | None beyond Stripe retries | **No Commerce state changes** |
+| Commerce Stripe payment webhooks | Named public route **not found** | Contrib webhook event admin UI exists | Not proven for MEL checkout | Gateway `webhook_signing_secret` empty in DDEV | — | Payment completion appears synchronous in checkout |
+| Postmark | `/webhooks/postmark/*` | Messaging | Delivery/bounce | Shared header secret | — | Not Stripe |
+
+### Duplicate processing
+
+| Webhook | Duplicate possible? | Mitigation |
+| --- | --- | --- |
+| Payout | Reduced | Decorator skips processed event IDs; ledger paid+same transfer idempotent; mismatch logged critical |
+| Pro subscription | Yes (log spam) | Audit-only; low financial risk |
+| Commerce payment | Not proven | — |
+
+---
+
+## Stage 9 — Dead code / component classification
+
+| Component | Classification | Proof notes |
+| --- | --- | --- |
+| Gateway entity `stripe` | ACTIVE | Runtime enabled |
+| Gateway entity `stripe_pe_recurring` | ACTIVE | Runtime enabled |
+| Gateway entity `mel_stripe_cc` | ACTIVE (test/manual) | Runtime enabled; dangerous if shown in prod checkout |
+| Plugin `stripe_connect` | FUTURE / UNUSED wiring | Discoverable; 0 entities |
+| `StripeConnectPaymentService` | PARTIAL | Validation/reporting ACTIVE; PI merge UNUSED |
+| `StripeConnectValidationSubscriber` | UNUSED | Class exists; not tagged/registered; runtime COMPLETION listeners exclude it |
+| `StripeService::createPaymentIntentForTicketSale` | UNUSED | No callers |
+| `StripeService::createPaymentIntentForBoost` | UNUSED | No callers |
+| `StripeService::getOrCreateAccount` | UNUSED | No external callers (`ensureConnectAccountIdForStore` used instead) |
+| Transfer payout stack | ACTIVE | Controllers + batch service |
+| Ledger KPI side-effect insert | ACTIVE but fragile | Only insert site found |
+| Pro subscription webhook | ACTIVE optional | Secrets empty locally |
+| Wallet payment charge code | UNUSED / N/A | No Stripe charge API |
+
+**Deletion rule:** Do not delete UNUSED items without proving: no callers, no service refs, no routes, no plugin manager use, no reflection, no queues, no subscribers. This audit lists candidates only.
+
+---
+
+## Stage 10 — Technical debt
+
+| Component | Problem | Impact | Risk | Recommendation | Priority | Evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| `stripe_connect` plugin unwired | Destination charges never applied | Vendor funds not split at PaymentIntent | Critical financial architecture | Choose Option A or B in ADR; wire or formally retire | P0 | CF-001 |
+| Ledger via KPI side effect | Orders may lack ledger rows | Vendors unpaid until metrics run | Critical ops | Insert ledger on `ORDER_PAID` with idempotency | P0 | CF-006 |
+| Connect validation unwired | No Connect check on checkout complete | Operational / support debt | High | Register subscriber or earlier hard gate if required | P1 | CF-003 |
+| Dual Stripe gateway entities same currency | Ambiguous checkout selection | Wrong UX / method type confusion | High | Add order-type or product conditions | P1 | Stage 2 |
+| Manual gateway enabled | Test gateway may appear | Accidental unpaid “success” | High | Disable outside local | P1 | Runtime entity |
+| Config sync vs active secrets/OAuth | Drift / restore risk | Broken payments after cim | High | Document deploy secret injection; never export secrets | P1 | CF-005 |
+| Unused PI helper methods | Parallel mental model | Wrong fixes applied to dead code | Medium | Mark deprecated; keep until ADR | P2 | Stage 5 |
+| Pro webhook audit-only | False sense of reconcile | Ops confusion | Medium | Document Commerce Recurring as SoT | P2 | Controller docblock |
+| Payout webhook secret empty (DDEV) | No local webhook verify | Local reconcile untestable | Medium | Set via env/settings for staging | P2 | Runtime config |
+| Application fee calc vs Transfer commission | Two fee models | Wrong economics | High | Align fee source of truth with chosen architecture | P1 | Connect service vs `commission_rate` in metrics |
+
+---
+
+## Stage 11 — Architecture Decision Record
+
+### ADR: MEL marketplace payment architecture
+
+**Date:** 20 July 2026  
+**Status:** Proposed (audit recommendation)  
+**Context:** Code contains a destination-charge Connect gateway **and** a Transfer/ledger payout system, but only the latter is wired to runtime Commerce gateway entities. Ticket checkout charges the platform account via Commerce Stripe Card Element.
+
+### Option A — Official Commerce Stripe only (platform collect)
+
+**Customer checkout:** Commerce Payment Element (and/or Card Element) on platform account.  
+**Custom code retains:** Vendor Express onboarding, Stripe Connect account status, off-session vendor billing, Transfer/ledger finance, reporting.
+
+| Dimension | Assessment |
+| --- | --- |
+| Complexity | Lower for checkout; finance complexity stays in ledger/Transfers |
+| Maintainability | Aligns with Commerce Stripe upgrades |
+| Risk | Ledger creation must be hardened (CF-006); manual ops for payouts |
+| Commerce compatibility | Highest |
+| Launch readiness | Closest to **current wiring** if ledger guaranteed |
+
+### Option B — Marketplace destination charges
+
+**Customer checkout:** Custom `stripe_connect` gateway entity (Payment Element + `transfer_data` / `application_fee_amount`).  
+**Custom code:** Onboarding + fee math already largely in `StripeConnectPaymentService`.
+
+| Dimension | Assessment |
+| --- | --- |
+| Complexity | Higher checkout correctness (mixed carts, boost-only, donations) |
+| Maintainability | Custom plugin must track Commerce Stripe base class changes |
+| Risk | Misconfigured fees/transfers; refund complexity with Connect |
+| Commerce compatibility | Medium (extends contrib PE) |
+| Launch readiness | **Not ready** — entity missing; validation non-blocking |
+
+### Comparison
+
+| | Option A | Option B |
+| --- | --- | --- |
+| Matches current entities | Yes | No |
+| Uses existing Transfer tooling | Yes | Partially redundant |
+| Uses existing Connect PI merge | No (retire/ignore) | Yes (wire entity) |
+| Launch risk if chosen “as-is” | Ledger gaps | Charges without vendor split |
+
+### Recommendation
+
+**Recommend Option A for launch**, with mandatory hardening:
+
+1. Treat `plugin: stripe_connect` as **future/unused** until explicitly productised.  
+2. Guarantee ledger creation on paid ticket (and other vendor-revenue) orders.  
+3. Keep Express onboarding + Transfer payouts as the vendor money path.  
+4. Narrow gateway conditions so Pro/recurring uses PE off_session and ticket checkout uses a single intentional gateway.  
+5. Disable `mel_stripe_cc` outside local/testing.  
+6. Revisit Option B only after fee/refund/mixed-cart acceptance tests and a gateway entity in config.
+
+**Evidence basis:** CF-001–CF-006; runtime `entities_with_plugin_stripe_connect=0`; Transfer execution in `PayoutBatchWorkflowService`; ticket checkout on `mel_event_checkout` + gateway `stripe`.
+
+---
+
+## Duplicate paths and launch risks (checklist)
+
+| Risk | Proven? |
+| --- | --- |
+| Duplicate destination charge + Transfer for same order | Destination path unwired → double Connect split **not** currently possible via that plugin |
+| Duplicate gateway choice (Card vs PE) | Possible at AUD condition level |
+| Config drift secrets/OAuth | Proven on DDEV active vs sync |
+| Ledger missing for paid orders | Proven single lazy writer |
+| Wallet charges money | Not found |
+| Webhooks required for ticket capture | Not proven; checkout appears synchronous |
+
+---
+
+## Appendix A — Key file index
+
+| Path | Role |
+| --- | --- |
+| `web/modules/custom/myeventlane_commerce/src/Plugin/Commerce/PaymentGateway/StripeConnect.php` | Unused Connect PE gateway plugin |
+| `web/modules/custom/myeventlane_commerce/src/Service/StripeConnectPaymentService.php` | Fee/transfer_data builder |
+| `web/modules/custom/myeventlane_core/src/Service/StripeService.php` | Platform Stripe facade |
+| `web/modules/custom/myeventlane_vendor/src/Controller/StripeConnectController.php` | Express onboarding |
+| `web/modules/custom/myeventlane_admin_dashboard/src/Service/PayoutBatchWorkflowService.php` | Transfer batches |
+| `web/modules/custom/myeventlane_admin_dashboard/src/Controller/StripeWebhookController.php` | Transfer webhooks |
+| `web/modules/custom/myeventlane_admin_dashboard/src/Service/PlatformMetricsService.php` | Ledger insert |
+| `web/modules/custom/myeventlane_refunds/src/Service/RefundProcessor.php` | Refunds |
+| `web/modules/custom/myeventlane_pro/src/Form/ProSubscribeForm.php` | Pro cart bootstrap |
+| `web/modules/custom/myeventlane_pro/src/Controller/ProSubscriptionWebhookController.php` | Audit webhook |
+| `web/modules/custom/myeventlane_donations/src/Service/VendorAutoBillingService.php` | Off-session charges |
+| `web/sites/default/settings.mel_shared_session.php` | Env → gateway key overlay |
+| `config/sync/commerce_payment.commerce_payment_gateway.*.yml` | Exported gateway skeletons |
+
+---
+
+## Appendix B — Runtime commands used (read-only)
+
+```bash
+ddev drush cr
+ddev drush pm:list --status=enabled --filter=stripe
+ddev drush config:get commerce_payment.commerce_payment_gateway.stripe
+ddev drush config:get commerce_payment.commerce_payment_gateway.stripe_pe_recurring
+ddev drush php:eval '# gateway/plugin/order-type/route probes (redacted secrets)'
+```
+
+No configuration export/import, module install/uninstall, or code changes were performed for this audit beyond writing documentation under `docs/architecture/`.

--- a/docs/architecture/payment-runtime-matrix.md
+++ b/docs/architecture/payment-runtime-matrix.md
@@ -1,0 +1,56 @@
+# MEL Payment Runtime Matrix
+
+**Status:** Phase 2 audit + launch remediation update  
+**Date:** 20 July 2026  
+**Evidence:** DDEV entity/payment history + Phase 1 runtime map + remediation runtime probes  
+**Critical:** [`payment-critical-findings.md`](./payment-critical-findings.md)  
+**Remediation:** [`../release/payment-launch-remediation-report.md`](../release/payment-launch-remediation-report.md)
+
+---
+
+## Matrix
+
+| Payment Type | Order Type | Checkout Flow | Gateway (observed / applicable) | Stripe Object | Payment Method | Webhook | Confirmation | Wallet | Queue Worker | Cron | Ledger | Status |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Ticket | `default` | `mel_event_checkout` | **Typical:** `stripe` (Card Element). **Also observed:** `stripe_pe_recurring`, `mel_stripe_cc`. **Applicable on AUD draft:** all three | PaymentIntent (Commerce Stripe) | `credit_card` or `stripe_card` | No MEL ticket webhook proven; capture synchronous in checkout | `OrderPlacedSubscriber` → `OrderConfirmationQueueBuilder` | Post-pay Apple/Google CTA/download | Messaging queue | Not required for charge | Lazy KPI insert (includes tickets) | ACTIVE — gateway ambiguity (CF-008) |
+| Boost | `default` (boost order item) | `mel_event_checkout` | Observed: `stripe`. Applicable: all AUD gateways | PaymentIntent (Commerce) | `credit_card` typical | Same as ticket | Boost-specific template via place subscriber | N/A (not a ticket pass) | Messaging | Not required | **Incorrectly eligible** for ledger rows (16 orders) | ACTIVE charge; ledger scope risk |
+| MEL Pro | `default` initial; renewals `recurring` | Initial: `mel_event_checkout`; renewals: none | Observed initial: `stripe_pe_recurring` (and once `mel_stripe_cc`). Applicable: all AUD | PaymentIntent / Setup for off_session; Commerce Recurring owns renewals | `stripe_card` intended | `/stripe/webhook/subscription` audit-only | Commerce/messaging; Pro subscriber entitlements | N/A | Messaging / Recurring internals | Commerce Recurring schedule (module enabled) | **Incorrectly eligible** (3 Pro variation orders in ledger) | ACTIVE; gateway not forced |
+| Platform Donation | `platform_donation` | `default` | Observed: `stripe`. Applicable: all AUD + manual | PaymentIntent (Commerce) | `credit_card` | None MEL-specific proven | `VendorWizardPlatformDonationSubscriber` on `ORDER_PAID` | N/A | Messaging as applicable | No | **In ledger as unpaid liability** (CF-007) | ACTIVE charge; ledger wrong |
+| RSVP Donation | `rsvp_donation` | `default` | Observed: `stripe` | PaymentIntent (Commerce) | `credit_card` | None MEL-specific | `RsvpDonationConfirmationSubscriber` on `ORDER_PAID` | N/A | Messaging | No | **In ledger as unpaid liability** (CF-007) | ACTIVE charge; ledger wrong |
+| Vendor Contribution Invoice | Custom invoice entity/table (MEL %) — not standard ticket order | N/A (admin/Drush + vendor billing UX) | Not Commerce checkout; off-session via `StripeService` | PaymentIntent off-session; SetupIntent for PM save | Saved Stripe PM | None for charge success path proven | Invoice status update in donations services | N/A | None proven for charge | **Not proven** on cron; Drush/admin | Separate contribution tables — not `myeventlane_payout_ledger` | ACTIVE when opted in |
+| Vendor Auto Billing | Same invoice path | N/A | `VendorAutoBillingService` → `createPaymentIntentOffSession` | PaymentIntent `off_session` | Saved PM | None proven | Invoice apply on success | N/A | None proven | Not proven default cron | N/A (invoice domain) | ACTIVE (manual/Drush trigger) |
+| Refund | Original order type | N/A (post-purchase) | Gateway of original payment (`refundPayment`) | Refund (Commerce Stripe + verify via platform client) | N/A | None required for sync refund | Messaging / refund notifications | Download denied if ticket `refunded`/`void`/`cancelled` | Refund retry queue path exists | No | Ledger payout interaction **Not proven** on refund | ACTIVE |
+| Vendor Onboarding | N/A (store fields) | N/A | N/A (not a Commerce payment) | Connect Express Account + AccountLink | N/A | None for AccountLink return (callback route) | Store fields updated on callback | N/A | No | No | N/A | ACTIVE |
+| Vendor Payout | N/A (ledger rows) | N/A | N/A | Transfer to connected account | N/A | `/stripe/webhook/payout` (`transfer.paid/failed/created`) | Admin UI / ledger status | N/A | No | No (admin batch) | `myeventlane_payout_ledger` | ACTIVE path; **blocked for safe launch** until CF-006/007 resolved |
+
+---
+
+## Gateway selection rules (summary)
+
+1. `PaymentGatewayStorage::loadMultipleForOrder($order)` evaluates gateway **conditions**.
+2. MEL `FilterPaymentGatewaysSubscriber` then applies the launch matrix (customers: tickets/boost/donations → `stripe`; Pro/recurring → `stripe_pe_recurring`; manual → administrators only).
+3. `stripe` requires currency **AUD**.
+4. `stripe_pe_recurring` requires AUD **and** Pro variation type (config); filter also scopes PE / removes Card Element for Pro.
+5. `mel_stripe_cc` requires administrator role (config + filter).
+6. UI further splits by payment method type (`credit_card` vs `stripe_card`).
+7. Fast checkout requires a Payment Element plugin instance — **not available on ticket carts after remediation** (expected).
+
+---
+
+## Status key
+
+| Status | Meaning |
+| --- | --- |
+| ACTIVE | Proven runtime path |
+| ACTIVE — caveats | Works but has architecture risks called out |
+| ACTIVE path; blocked… | Code path exists; launch ops unsafe until findings resolved |
+
+---
+
+## Evidence anchors
+
+- Order types / checkout flows: runtime `commerce_order_type` load (Phase 2).
+- Historical gateways: `commerce_payment` aggregates (Phase 2).
+- Draft applicability: `loadMultipleForOrder` on draft carts 580/569/554 (Phase 2).
+- Ledger composition: SQL join ledger ↔ order type (Phase 2) — CF-007.
+- Wallet decoupling: no Stripe charge APIs under `myeventlane_wallet` (Phase 1/2).

--- a/docs/architecture/payment-sequence-diagrams.md
+++ b/docs/architecture/payment-sequence-diagrams.md
@@ -1,0 +1,302 @@
+# MEL Payment Sequence Diagrams
+
+**Status:** READ-ONLY Phase 2  
+**Date:** 20 July 2026  
+**Basis:** Phase 1 runtime map + Phase 2 DDEV verification  
+**Note:** Diagrams show the **wired** runtime, not the unused `stripe_connect` destination-charge path.
+
+---
+
+## 1. Ticket purchase
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor Customer
+  participant Browser
+  participant Drupal as Drupal (BookController)
+  participant Commerce as Commerce cart/checkout
+  participant Gateway as Payment Gateway (stripe typical)
+  participant Stripe as Stripe API
+  participant Webhook as Webhook
+  participant Email as Messaging queue
+  participant Wallet as myeventlane_wallet
+  participant Ledger as Payout ledger
+  participant Queue as Queue worker
+
+  Customer->>Browser: Book tickets
+  Browser->>Drupal: GET /event/{node}/book
+  Drupal->>Commerce: Add ticket order items (order type default)
+  Customer->>Commerce: mel_event_checkout panes
+  Commerce->>Gateway: payment_information / payment_process
+  Gateway->>Stripe: PaymentIntent (platform account)
+  Stripe-->>Gateway: succeeded
+  Note over Webhook: No MEL ticket payment webhook required for capture
+  Commerce->>Commerce: place + ORDER_PAID
+  Commerce->>Email: OrderConfirmationQueueBuilder enqueue
+  Email->>Queue: MessagingQueueWorker
+  Queue->>Customer: Confirmation email (+ optional wallet URLs)
+  Customer->>Wallet: Download pass (post-payment, issued ticket)
+  Note over Ledger: Ledger row NOT created on ORDER_PAID<br/>May appear later via PlatformMetricsService KPIs
+```
+
+---
+
+## 2. Boost purchase
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor Vendor
+  participant Browser
+  participant Drupal as Boost forms/controller
+  participant Commerce as Commerce cart/checkout
+  participant Gateway as Gateway stripe
+  participant Stripe as Stripe API
+  participant Email as Messaging
+  participant Ledger as Payout ledger
+  participant Queue as Queue worker
+
+  Vendor->>Browser: Select boost
+  Browser->>Drupal: BoostSelect/Purchase form
+  Drupal->>Commerce: Add boost order item → checkout
+  Commerce->>Gateway: Charge
+  Gateway->>Stripe: PaymentIntent (platform)
+  Stripe-->>Gateway: succeeded
+  Commerce->>Commerce: ORDER_PAID → BoostEntitlementManager
+  Commerce->>Email: Boost confirmation template
+  Email->>Queue: Send
+  Note over Ledger: Boost orders can incorrectly enter ledger (CF-007)
+```
+
+---
+
+## 3. MEL Pro
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor Vendor
+  participant Browser
+  participant Drupal as ProSubscribeForm
+  participant Commerce as Cart default + Recurring
+  participant Gateway as stripe_pe_recurring (intended)
+  participant Stripe as Stripe API
+  participant Webhook as /stripe/webhook/subscription
+  participant Email as Email/Messaging
+  participant Ledger as Payout ledger
+
+  Vendor->>Browser: Subscribe
+  Browser->>Drupal: ProSubscribeForm
+  Drupal->>Commerce: Add mel_pro_subscription_variation
+  Commerce->>Gateway: Initial payment / PM save (off_session)
+  Gateway->>Stripe: PaymentIntent / Setup
+  Stripe-->>Gateway: succeeded
+  Commerce->>Commerce: Subscription entity + ProSubscriptionSubscriber
+  Note over Webhook: Audit log only — does not mutate Commerce
+  Stripe-->>Webhook: subscription.*/invoice.* (if secret set)
+  Commerce->>Email: Receipts / messaging as configured
+  Note over Ledger: Pro orders can incorrectly enter ledger (CF-007)
+```
+
+---
+
+## 4. Platform donation
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor Customer
+  participant Browser
+  participant Drupal as Donations / wizard
+  participant Commerce as Order type platform_donation
+  participant Gateway as Gateway stripe
+  participant Stripe as Stripe API
+  participant Email as Messaging
+  participant Ledger as Payout ledger
+
+  Customer->>Browser: Donate to platform
+  Browser->>Commerce: Checkout flow default
+  Commerce->>Gateway: Charge
+  Gateway->>Stripe: PaymentIntent
+  Stripe-->>Gateway: succeeded
+  Commerce->>Commerce: ORDER_PAID → VendorWizardPlatformDonationSubscriber
+  Commerce->>Email: Confirmation as configured
+  Note over Ledger: KPI path may insert unpaid vendor liability (CF-007)
+```
+
+---
+
+## 5. RSVP donation
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor Customer
+  participant Browser
+  participant Drupal as RsvpDonationService
+  participant Commerce as Order type rsvp_donation
+  participant Gateway as Gateway stripe
+  participant Stripe as Stripe API
+  participant Email as RsvpDonationConfirmationSubscriber
+  participant Ledger as Payout ledger
+
+  Customer->>Browser: RSVP donate
+  Browser->>Drupal: Create/attach donation order
+  Drupal->>Commerce: Checkout flow default
+  Commerce->>Gateway: Charge
+  Gateway->>Stripe: PaymentIntent
+  Stripe-->>Gateway: succeeded
+  Commerce->>Email: ORDER_PAID confirmation
+  Note over Ledger: KPI path may insert unpaid vendor liability (CF-007)
+```
+
+---
+
+## 6. Refund
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor Actor as Buyer/Vendor/Admin
+  participant Browser
+  participant Drupal as Refund routes/forms
+  participant Commerce as commerce_payment
+  participant Gateway as Original payment gateway plugin
+  participant Stripe as Stripe API
+  participant Email as Notifications/Messaging
+  participant Wallet as WalletDownloadAccessChecker
+  participant Queue as Refund retry queue
+
+  Actor->>Browser: Request / approve refund
+  Browser->>Drupal: RefundProcessor
+  Drupal->>Gateway: refundPayment(payment, amount)
+  Gateway->>Stripe: Refund API
+  Drupal->>Stripe: Verify via StripeService platform client
+  Stripe-->>Drupal: Refund id / status
+  Drupal->>Commerce: Update payment/order state
+  Drupal->>Email: Notify parties
+  Note over Wallet: Ticket status refunded/void/cancelled → wallet download denied
+  Drupal->>Queue: Retry path if needed
+```
+
+---
+
+## 7. Vendor auto billing
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor Admin as Admin/Drush operator
+  participant Drupal as VendorAutoBillingService
+  participant Commerce as (none — not checkout)
+  participant Gateway as (none — StripeService)
+  participant Stripe as Stripe API
+  participant Email as Invoice/billing messaging
+  participant Ledger as Contribution tables (not payout ledger)
+
+  Note over Admin,Drupal: Triggered from admin form / Drush — cron not proven
+  Admin->>Drupal: attemptAutoCharge(invoiceId)
+  Drupal->>Stripe: createPaymentIntentOffSession (saved PM)
+  Stripe-->>Drupal: succeeded / requires_action / failed
+  Drupal->>Ledger: Apply to MEL contribution invoice
+  Drupal->>Email: Notify as configured
+```
+
+---
+
+## 8. Vendor onboarding (Connect Express)
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor Vendor
+  participant Browser
+  participant Drupal as StripeConnectController
+  participant Commerce as commerce_store fields
+  participant Gateway as (not used)
+  participant Stripe as Stripe Connect API
+
+  Vendor->>Browser: Start onboarding
+  Browser->>Drupal: GET /stripe/connect
+  Drupal->>Stripe: accounts.create (express) via StripeService
+  Drupal->>Stripe: accountLinks.create
+  Stripe-->>Browser: Hosted onboarding
+  Browser->>Drupal: /stripe/callback
+  Drupal->>Stripe: getAccountStatus
+  Drupal->>Commerce: field_stripe_account_id / connected / status
+```
+
+---
+
+## 9. Vendor payout
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor Admin
+  participant Browser
+  participant Drupal as PayoutBatchWorkflowService
+  participant Commerce as (order history only)
+  participant Gateway as (not checkout)
+  participant Stripe as Stripe Transfers API
+  participant Webhook as /stripe/webhook/payout
+  participant Ledger as myeventlane_payout_ledger
+
+  Note over Ledger: Rows often created lazily by PlatformMetricsService KPIs
+  Admin->>Browser: Create / approve payout batch
+  Browser->>Drupal: Execute batch
+  Drupal->>Ledger: Select unpaid rows
+  Drupal->>Stripe: transfers.create(destination=acct_...)
+  Stripe-->>Webhook: transfer.created / paid / failed
+  Webhook->>Ledger: Update status (idempotent checks)
+```
+
+---
+
+## 10. Wallet generation
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor Customer
+  participant Browser
+  participant Drupal as WalletApple/Google controllers
+  participant Commerce as Order item (route key only)
+  participant Gateway as (none)
+  participant Stripe as (none)
+  participant Email as Confirmation email CTAs
+  participant Wallet as PkPass / Google builders
+  participant Queue as Messaging (email only)
+
+  Note over Stripe,Gateway: Wallet never charges Stripe
+  Commerce->>Email: After paid order — wallet URLs optional
+  Email->>Queue: Send confirmation
+  Customer->>Browser: Add to Wallet / download
+  Browser->>Drupal: Wallet route + access check
+  Drupal->>Commerce: Resolve order item → issued ticket
+  alt Ticket void/refunded/cancelled
+    Drupal-->>Browser: 403 not eligible
+  else Eligible
+    Drupal->>Wallet: Build signed pass / JWT
+    Wallet-->>Browser: .pkpass or Google save URL
+  end
+```
+
+---
+
+## Participant coverage checklist
+
+| Participant | Appears in |
+| --- | --- |
+| Customer / Vendor / Admin | All relevant flows |
+| Browser | All |
+| Drupal | All |
+| Commerce | Ticket, Boost, Pro, Donations, Refund, Wallet (route only) |
+| Payment Gateway | Ticket, Boost, Pro, Donations, Refund |
+| Stripe | All money / Connect / Transfer flows |
+| Webhook | Pro (audit), Payout; not ticket capture |
+| Email | Ticket, Boost, Pro, Donations, Refund, Wallet CTA |
+| Wallet | Ticket confirmation + Wallet generation |
+| Ledger | Ticket note, Boost/Pro/Donation risk notes, Payout |
+| Queue | Ticket, Boost, Refund retry, Wallet email |

--- a/docs/architecture/payment-technical-debt.md
+++ b/docs/architecture/payment-technical-debt.md
@@ -1,0 +1,90 @@
+# MEL Payment Technical Debt Register
+
+**Status:** READ-ONLY Phase 2  
+**Date:** 20 July 2026  
+**Rule:** Never recommend deleting code unless runtime evidence proves: no callers, no service definition, no routing, no plugin manager use, no event subscriber, no queue worker, no reflection, no DI, no Commerce registration.
+
+---
+
+## Safe after launch
+
+| Item | Problem | Evidence | Suggested action |
+| --- | --- | --- | --- |
+| `StripeService::createPaymentIntentForTicketSale()` | Dead direct PI path | No callers (CF-004) | Deprecate in docs; delete only after full dead-code checklist |
+| `StripeService::createPaymentIntentForBoost()` | Dead direct PI path | No callers | Same |
+| `StripeService::getOrCreateAccount()` | Superseded by `ensureConnectAccountIdForStore()` | No external callers | Same |
+| Pro subscription webhook spam on retries | Audit-only, no idempotency store | Phase 1 Stage 8 | Add idempotency or reduce log noise |
+| Dual fee calculators (Connect service vs metrics `commission_rate`) | Confusing SoT | Phase 1 Stage 10 | Unify after model A confirmed |
+| Fast checkout vs Card Element dual UX | Two PE/CE paths | FastCheckout + mel_event_checkout panes | Simplify UX after gateway conditions fixed |
+| DonationPane / checkout_donation legacy | Hidden pane still in codebase | Phase 1 donations map | Remove after confirming no config enables it |
+
+---
+
+## Needs product decision
+
+| Item | Problem | Evidence | Decision needed |
+| --- | --- | --- | --- |
+| Option A vs Option B marketplace model | Destination charges unused; Transfers active | CF-001, CF-002 | Which model is launch truth? |
+| Connect hard gate at checkout | Subscriber unwired; log-only even if wired | CF-003 | Must vendors be Connect-ready before selling? |
+| Manual gateway in non-local envs | Tickets completed without Stripe | CF-008 | Allow any prod manual completion? |
+| Organiser donation economics | Fee math in unused Connect PI path | Phase 1 | How donations affect vendor net |
+| Boost/Pro in payout ledger | Platform SKUs treated as vendor liabilities | CF-007 | Never? Always exclude? |
+| RSVP/platform donations in ledger | Donation nets marked unpaid to stores | CF-007 | Exclude from payout ledger |
+
+---
+
+## Needs architecture decision
+
+| Item | Problem | Evidence | Decision needed |
+| --- | --- | --- | --- |
+| Ledger write timing | Lazy KPI vs `ORDER_PAID` | CF-006; ledger review | Primary writer + backfill role |
+| Ledger eligibility rules | Unfiltered completed orders | CF-007 | Allowlist by order type / purchased entity |
+| Gateway condition matrix | All AUD gateways apply to all carts | CF-008; gateway runtime | Order-type / product conditions |
+| Commerce Stripe OAuth auth on `stripe` entity | Active uses `authentication_method=stripe_connect` vs sync keys | CF-005 | Canonical credential pattern for deploy |
+| Payment webhook strategy | Secrets empty; sync capture assumed | Phase 1 Stage 8 | Required for launch or post-launch? |
+| Custom `stripe_connect` plugin retention | Extends PE; entity absent | CF-001 | Future Option B vs delete later |
+
+See ADRs:
+
+- [`ADR-002-payment-runtime.md`](../adr/ADR-002-payment-runtime.md)  
+- [`ADR-003-stripe-connect-strategy.md`](../adr/ADR-003-stripe-connect-strategy.md)
+
+---
+
+## Legacy
+
+| Item | Notes | Evidence |
+| --- | --- | --- |
+| `DonationPane` always invisible | Legacy checkout donation UI | Phase 1 |
+| `checkout_donation` item type | Parallel to `field_mel_donation` adjustment | Phase 1 |
+| Direct PI helpers on `StripeService` | Pre-Commerce or alternate design remnant | CF-004 |
+| StripeConnect plugin form annotations referencing offsite forms | Plugin extends PE but annotation still lists offsite form keys | `StripeConnect.php` annotation |
+
+---
+
+## Dormant
+
+| Item | Why dormant | Do not delete yet |
+| --- | --- | --- |
+| Plugin `stripe_connect` | Discoverable; 0 entities | Commerce registration exists |
+| `StripeConnectValidationSubscriber` class | No service tag | May be wired later for hard gate |
+| `StripeConnectPaymentService::getConnectPaymentIntentParams()` PI merge | Only called from unwired plugin | Service still used for validation/reporting paths |
+| Pro webhook without secret | Endpoint exists; rejects/unusable without secret | Route + controller registered |
+| Express checkout on PE gateway | `enable_on_cart=false` | Config present for future enablement |
+
+---
+
+## Deletion checklist (mandatory)
+
+Before any deletion PR:
+
+1. Repo-wide PHP/YML/Twig search for class, method, service id, plugin id, route name.  
+2. Runtime: `plugin.manager.commerce_payment_gateway` definitions.  
+3. Runtime: `Drupal::hasService()` / container service ids.  
+4. Runtime: event dispatcher listeners.  
+5. Runtime: queue worker plugin discovery.  
+6. Config sync + active config entities.  
+7. Tests referencing the symbol.  
+8. Reflection / serialized plugin ids in DB (payment gateway plugin field).  
+
+If any check is positive → **Keep until post-launch** or **Needs investigation**, not delete.

--- a/docs/architecture/wallet-payment-boundary.md
+++ b/docs/architecture/wallet-payment-boundary.md
@@ -1,0 +1,115 @@
+# MEL Wallet ↔ Payment Boundary
+
+**Status:** READ-ONLY Phase 2  
+**Date:** 20 July 2026  
+**Modules:** `myeventlane_wallet`, `myeventlane_tickets`, `myeventlane_messaging`  
+**Related:** [`apple-wallet-presentation.md`](./apple-wallet-presentation.md)
+
+---
+
+## Verdict
+
+**Wallet is completely decoupled from Stripe checkout charging.**
+
+Wallet never creates PaymentIntents, Charges, SetupIntents, Customers, Transfers, or Refunds. It consumes **issued ticket entitlements** and presentation/signing configuration after a purchase has already produced ticket rows.
+
+---
+
+## What Wallet depends on
+
+| Dependency | Role | Evidence |
+| --- | --- | --- |
+| Issued `myeventlane_ticket` entity | Operational authority for pass content + eligibility | `WalletTicketResolver` — “issued myeventlane_ticket rows are the operational authority” |
+| Commerce order item | Compatibility **route key** only (`/wallet/.../{commerce_order_item}`) | Controllers + resolver |
+| Order / purchaser identity | Access control (uid / email match) | `WalletDownloadAccessChecker` |
+| Ticket status + fulfilment status | Block void / refunded / fulfilment-cancelled | `isWalletBlockedStatus()` |
+| Ticket PDF expiry setting | Optional time window (`myeventlane_tickets.settings:pdf_expiry_days`) | `isExpired()` |
+| Wallet config + env credentials | Apple pass type / certs; Google issuer / service account | `WalletPresentationGate`, settings form |
+| `WalletEventPresentation` | Event/venue/attendee projection for pass fields | Presentation service |
+| `PkPassBuilder` / `GoogleWalletBuilder` / `WalletSigner` | Assemble + sign artifacts | Wallet services |
+| Messaging (optional) | Confirmation email may embed wallet URLs | `OrderConfirmationQueueBuilder` + wallet action builder |
+| QR / ticket payload services | Admission barcode content (outside Stripe) | Presentation docs; Universal ticket builders |
+
+---
+
+## What Wallet never depends on
+
+| Non-dependency | Proof |
+| --- | --- |
+| Stripe PaymentIntent / Charge APIs | No Stripe charge/client usage under `myeventlane_wallet` (Phase 1/2 search) |
+| Commerce payment gateway entity | No gateway load in wallet builders/controllers |
+| Payment state machine | Access uses ticket status/fulfilment, not `commerce_payment` state |
+| Connect account / Transfers / ledger | No references in wallet module payment path |
+| Checkout flow / panes | Passes are post-purchase downloads/links |
+| Webhook controllers | Wallet does not subscribe to Stripe webhooks |
+
+---
+
+## When passes become available
+
+```text
+Checkout payment succeeds
+  → Commerce place / ORDER_PAID
+  → Ticket issuance (myeventlane_tickets OrderPaidSubscriber path)
+  → Confirmation email may include wallet CTAs (if presentation gate allows)
+  → Customer hits wallet route
+  → Resolver picks issued ticket
+  → Access checker allows
+  → Builder generates signed pass
+```
+
+**Prerequisites for customer-visible actions:**
+
+1. Ticket row exists for the order item.  
+2. Ticket not wallet-blocked.  
+3. Not past PDF/wallet expiry window (if configured).  
+4. Account authorised (purchaser / matching guest email / admin permission).  
+5. Provider credentials ready (`WalletPresentationGate`).
+
+If no issued ticket exists, legacy order-item-only path may still run with weaker checks — documented as compatibility in `WalletDownloadAccessChecker`.
+
+---
+
+## How revoked / void tickets are handled
+
+`WalletDownloadAccessChecker::isWalletBlockedStatus()` returns TRUE when:
+
+- Ticket `status` is `STATUS_VOID` or `STATUS_REFUNDED`, or  
+- Fulfilment status is `FULFILMENT_CANCELLED`.
+
+On blocked status:
+
+- Download asserts **AccessDenied** with message: “This ticket is no longer eligible for wallet download.”  
+- Applies even to admins for minting (comment: “including admins”).  
+- Resolver prefers eligible tickets; if all blocked, returns a blocked row so the checker can deny with the correct message.
+
+**Not proven in this audit:** Apple/Google push updates that remotely invalidate an already-installed pass. Boundary documented here is **download/mint eligibility**, not Wallet network voiding.
+
+---
+
+## How refunds affect Wallet
+
+| Stage | Effect |
+| --- | --- |
+| Refund executes via `RefundProcessor` | Payment/order/ticket domain updates (refund module + ticket status transitions as implemented there) |
+| Ticket becomes `refunded` / void / fulfilment cancelled | Subsequent wallet downloads denied |
+| Already-downloaded pass on phone | **Not proven** to auto-remove; MEL gate is server-side re-mint/download |
+
+Wallet does **not** call Stripe Refund APIs.
+
+---
+
+## Confirmation: decoupling from Stripe checkout
+
+| Question | Answer |
+| --- | --- |
+| Does wallet run during PaymentIntent creation? | **No** |
+| Does wallet require a specific gateway (`stripe` vs PE)? | **No** |
+| Can a manually completed order (`mel_stripe_cc`) still get wallet if tickets issued? | **Yes, in principle** — wallet keys off tickets/access, not gateway id (gateway risk is commerce/ops, not wallet coupling) |
+| Is wallet a payment method? | **No** |
+
+---
+
+## Launch note
+
+Wallet launch readiness is independent of Connect destination-charge wiring. It **does** depend on reliable ticket issuance after paid orders and correct refund→ticket status transitions. See [`wallet-go-live.md`](../launch/wallet-go-live.md) for non-payment wallet ops.

--- a/docs/launch/payment-executive-summary.md
+++ b/docs/launch/payment-executive-summary.md
@@ -1,0 +1,165 @@
+# MEL Payment Architecture — Executive Summary
+
+**Date:** 20 July 2026  
+**Audience:** Founder · Technical Lead · Future Developer  
+**Scope:** Launch readiness of payment / Stripe / Connect / ledger / wallet  
+**Mode:** Audit docs + launch remediation on `feature/payment-launch-remediation` (see `docs/release/payment-launch-remediation-report.md`)
+
+---
+
+## 1. Architecture overview
+
+MyEventLane charges customers on the **platform Stripe account** through Drupal Commerce Stripe gateways, then pays vendors later with Stripe **Transfers** against a payout ledger. Vendors onboard via **Stripe Connect Express**. Wallet passes are generated **after** tickets exist and do not participate in charging.
+
+```text
+Customer → Commerce checkout → Stripe PaymentIntent (platform)
+                ↓
+         Order paid → tickets / email / wallet CTAs
+                ↓
+    (later) Admin metrics may insert ledger rows
+                ↓
+         Admin Transfer batch → vendor Connect account
+                ↓
+         Payout webhook updates ledger
+```
+
+A custom destination-charge gateway (`stripe_connect`) exists in code but is **not configured**. It is not part of today’s runtime.
+
+---
+
+## 2. Current runtime (verified in DDEV)
+
+| Area | Reality |
+| --- | --- |
+| Ticket / Boost checkout | Order type `default`, flow `mel_event_checkout` |
+| Dominant ticket gateway | `stripe` (Card Element) |
+| Also used for tickets | `stripe_pe_recurring` (Payment Element), `mel_stripe_cc` (manual) |
+| MEL Pro initial purchase | Same `default` cart; observed on PE gateway |
+| Donations | `rsvp_donation` / `platform_donation` → flow `default` → mostly `stripe` |
+| Connect destination charges | Plugin present, **0** gateway entities |
+| Vendor payouts | Transfers + `myeventlane_payout_ledger` |
+| Ledger creation | Lazy side effect of admin KPI code — not on `ORDER_PAID` |
+| Wallet | Decoupled from Stripe checkout |
+
+Full detail: `docs/architecture/payment-runtime-map.md`, `payment-gateway-runtime.md`, `payment-runtime-matrix.md`.
+
+---
+
+## 3. Launch readiness
+
+| Capability | Ready? | Notes |
+| --- | --- | --- |
+| Collect ticket money (platform Stripe) | **Yes** (post-remediation) | Manual admin-only; PE scoped to Pro; keep platform api_keys on `stripe` |
+| Boost / Pro / donations charging | **Yes** (gateway matrix) | Boost/donations → `stripe`; Pro → `stripe_pe_recurring` |
+| Vendor Connect onboarding | **Yes** (feature-complete path) | Express Account Links via `StripeService` |
+| Vendor payouts | **Conditional** | New ledger inserts scoped; historical pollution + CF-006 timing remain |
+| Destination-charge marketplace | **No** | Not wired; do not enable for launch |
+| Wallet after purchase | **Yes** (payment-boundary) | Depends on ticket issuance/refund status, not Stripe PI |
+| Webhooks for Transfers | **Ops-dependent** | Secrets must be set in real environments |
+
+---
+
+## 4. Known risks (genuine blockers)
+
+Read first: `docs/architecture/payment-critical-findings.md`.
+
+1. **Model ambiguity** — Code suggests Connect destination charges; runtime is platform collect + Transfer.  
+2. **Manual gateway** — Real ticket orders completed without Stripe in this environment.  
+3. **Ledger gaps** — Rows created when KPIs run, not when orders pay.  
+4. **Ledger pollution** — Donations, Boost, and Pro appear as unpaid vendor liabilities.  
+5. **Deploy credential drift** — Sync YAML empty keys vs active OAuth-style gateway auth.  
+6. **Gateway sprawl** — Ticket carts can use Card Element, Payment Element (off_session), or manual.
+
+Risk register: `docs/launch/payment-launch-risk-register.md`.
+
+---
+
+## 5. Future roadmap
+
+| Horizon | Work |
+| --- | --- |
+| Pre-launch (ops/config — out of this audit’s write scope) | Ratify Option A; disable manual gateway in prod; set secrets/webhooks; freeze payout batches until ledger rules clear |
+| Immediately post-launch | Ledger write on `ORDER_PAID` with allowlist; gateway conditions by product/order type; fee SoT cleanup |
+| Later | Revisit true destination charges only via ADR-003 Option B with Transfer double-pay controls |
+| Ongoing | Keep Commerce Stripe current; treat unused PI helpers / Connect plugin as dormant until checklist deletion |
+
+ADRs: `docs/adr/ADR-002-payment-runtime.md`, `docs/adr/ADR-003-stripe-connect-strategy.md`.
+
+---
+
+## 6. Technical debt (short)
+
+| Bucket | Examples |
+| --- | --- |
+| Safe after launch | Dead `createPaymentIntentForTicketSale/Boost`; legacy donation pane |
+| Product decision | A vs B; Connect hard gate; what belongs on ledger |
+| Architecture decision | Ledger writer; gateway condition matrix; webhook strategy |
+| Dormant | `stripe_connect` plugin; unwired validation subscriber |
+
+Detail: `docs/architecture/payment-technical-debt.md`.
+
+---
+
+## 7. Recommended post-launch work (priority)
+
+1. **Ledger v2** — Insert on paid vendor-revenue orders only; KPI becomes backfill.  
+2. **Gateway policy** — One ticket gateway; PE reserved for Pro/recurring; manual local-only.  
+3. **Fee alignment** — Single commission/application-fee definition for finance reports.  
+4. **Connect gate** — If required, fail closed before payment (not log-only).  
+5. **Option B evaluation** — Only after A is stable and product demands instant splits.
+
+---
+
+## 8. Confidence score
+
+| Topic | Confidence |
+| --- | --- |
+| Checkout uses platform Commerce Stripe (not destination-charge plugin) | **High** |
+| Transfers + ledger are the payout path | **High** |
+| Ledger lazy + contaminated in this DB | **High** |
+| Production cron/frequency of KPI inserts | **Low** (not proven) |
+| Production webhook secrets / deploy overlays | **Environment-specific** — verify per env |
+| Wallet ↔ Stripe decoupling | **High** |
+
+**Overall architecture understanding confidence: 8/10**  
+**Overall payout operational safety confidence: 3/10** until CF-006/007 addressed.
+
+---
+
+## 9. Go / No-Go recommendation
+
+### Ticket & donation collection (platform Stripe)
+
+**Conditional GO** — if Product accepts **Option A**, production disables `mel_stripe_cc`, and deploy injects working Stripe credentials.
+
+### Vendor payouts (Transfers)
+
+**NO-GO** — until ledger eligibility and creation guarantees are fixed or manually controlled with a written finance SOP that excludes non-vendor-revenue orders.
+
+### Destination-charge Connect checkout
+
+**NO-GO** — not configured; do not enable for launch.
+
+### Wallet
+
+**GO** from a payment-boundary perspective (not a Stripe charge dependency). Separate wallet credential/go-live checklist still applies.
+
+---
+
+## 10. Document index for a new developer
+
+| Doc | Purpose |
+| --- | --- |
+| `docs/architecture/payment-critical-findings.md` | Blockers first |
+| `docs/architecture/payment-runtime-map.md` | Full Phase 1 map |
+| `docs/architecture/payment-component-lifecycle.md` | Every component status |
+| `docs/architecture/payment-runtime-matrix.md` | Flow × gateway × webhook × ledger |
+| `docs/architecture/payment-gateway-runtime.md` | Why Commerce picks gateways |
+| `docs/architecture/payment-sequence-diagrams.md` | Mermaid sequences |
+| `docs/architecture/payment-ledger-review.md` | Lazy ledger analysis |
+| `docs/architecture/wallet-payment-boundary.md` | Wallet isolation |
+| `docs/architecture/payment-technical-debt.md` | Debt buckets |
+| `docs/adr/ADR-002-*.md` / `ADR-003-*.md` | Current vs Connect strategy |
+| `docs/launch/payment-launch-risk-register.md` | Risks & owners |
+
+No assumptions: every operational claim in this set cites code path and/or DDEV runtime evidence dated 20 July 2026.

--- a/docs/launch/payment-launch-risk-register.md
+++ b/docs/launch/payment-launch-risk-register.md
@@ -1,0 +1,60 @@
+# MEL Payment Launch Risk Register
+
+**Status:** READ-ONLY Phase 2  
+**Date:** 20 July 2026  
+**Audience:** Founder, Technical Lead, Launch Manager  
+**Evidence base:** [`payment-critical-findings.md`](../architecture/payment-critical-findings.md), Phase 2 DDEV verification
+
+**Launch blocker column:** `Yes` only for genuine blockers to safe public money movement / vendor payouts. Ticket collection may still operate under Option A with ops constraints.
+
+---
+
+## Register
+
+| Risk | Likelihood | Impact | Mitigation | Evidence | Owner | Launch Blocker |
+| --- | --- | --- | --- | --- | --- | --- |
+| Destination-charge Connect gateway unused; funds stay on platform | Certain (current wiring) | High — marketplace split not at PI time | Accept Option A (platform collect + Transfer) explicitly; do not market destination charges | CF-001; entities_with_plugin_stripe_connect=0 | Product + Tech Lead | **Yes** until model A/B decided and communicated |
+| Ledger rows missing until admin KPI runs | High | Critical — vendors omitted from payouts | Ops backfill SOP before batches; post-launch `ORDER_PAID` insert | CF-006; `PlatformMetricsService::buildKpis` | Tech Lead + Ops | **Yes** for **vendor payout** go-live |
+| Ledger includes donations, Boost, Pro as unpaid vendor net | Certain in DDEV data (historical) | Critical — wrong Transfers / economics | **Partial mitigate:** new inserts allowlisted; historical rows remain — do not unrestricted batch | CF-007; remediation report | Tech Lead + Finance | **Yes** until historical cleanup |
+| Manual gateway enabled; tickets completable without Stripe | High (already used) | Critical — unpaid “completed” tickets | **Mitigated:** admin role condition + filter subscriber; entity preserved | CF-008; remediation report | Tech Lead | **Mitigated** for customer checkout |
+| Ticket checkout can use Pro PE off_session gateway | High (11 ticket payments) | High — wrong PM usage / UX / renewals confusion | **Mitigated:** PE conditions + filter; Pro/recurring forced to PE | CF-008; remediation report | Tech Lead | **Mitigated** |
+| Card Element uses Connect access_token vs platform publishable key | Certain when token set | Critical — `No such PaymentMethod` at checkout | **Mitigated (env):** clear access_token; api_keys auth for Option A | CF-009 | DevOps + Tech Lead | **Mitigated** when deploy keeps token empty |
+| Connect validation subscriber unwired | Certain | Medium–High — vendors sell without Connect readiness | Product: hard gate vs soft; wire fail-closed if required | CF-003; COMPLETION listeners | Product + Tech Lead | Conditional — **Yes** if Connect required before sale |
+| Config sync vs active gateway auth/keys drift | High | High — broken payments after deploy from sync alone | Deploy runbook: inject secrets/OAuth; never commit secrets | CF-005 | DevOps | **Yes** if prod deploy uses empty sync keys without overlay |
+| Payout webhook secret empty (local; may be empty elsewhere) | Medium | High — ledger not reconciled from Transfers | Set secrets in staging/prod; verify signature path | Phase 1 Stage 8; DDEV empty | DevOps | **Yes** for automated payout reconcile |
+| Pro subscription webhook audit-only mistaken for SoT | Medium | Medium — false ops confidence | Document Commerce Recurring as authority | Pro webhook controller behaviour | Tech Lead | No |
+| Application fee calc exists but unused at charge time | Certain | Medium — reporting vs reality diverge | Align fee SoT with Option A Transfers | `StripeConnectPaymentService` vs metrics `commission_rate` | Finance + Tech | Conditional |
+| Unused direct PI helpers confuse future fixes | Medium | Medium — wrong code path edited | Mark dormant in docs; no delete yet | CF-004 | Tech Lead | No |
+| Double destination charge + Transfer | Low today | Critical if Option B wired carelessly | Keep `stripe_connect` entity absent until ADR; never enable both splits | CF-001 + Transfer stack | Tech Lead | No (today); **Yes** if Option B without retiring Transfers |
+| Wallet download after refund still possible | Low–Medium | Medium — invalid admission artifact | Ticket status must flip; access checker blocks void/refunded | `WalletDownloadAccessChecker` | Tech Lead | No (payment); ticket status QA required |
+| Off-session vendor auto-bill not on cron | Medium | Medium — invoices unpaid | Explicit Drush/admin process | No cron proven | Ops | No |
+| Commerce payment webhooks unused / secrets empty | Medium | Medium — async edge cases | Confirm sync checkout sufficient; add webhooks if needed later | Gateway webhook secrets empty | Tech Lead | No for sync-happy path |
+| Refund complexity under future Connect destination charges | Low now | High later | Stay on Option A for launch | ADR-003 | Tech Lead | No (current model) |
+
+---
+
+## Genuine launch blockers (highlight)
+
+1. **Marketplace model decision (A vs B)** — CF-001.  
+2. **Production manual gateway** — CF-008.  
+3. **Ledger correctness (timing + order-type scope)** — CF-006, CF-007 — blocks **safe vendor payouts**.  
+4. **Deployable Stripe credentials** — CF-005.  
+5. **Payout webhook secrets** — for Transfer reconcile.
+
+### Explicit non-blockers for ticket *collection* (if Option A accepted)
+
+- Unused `stripe_connect` plugin (as long as Transfers are the payout plan).  
+- Wallet Stripe decoupling (wallet is fine architecturally).  
+- Pro audit webhook being non-mutating.
+
+---
+
+## Suggested ownership defaults
+
+| Owner | Scope |
+| --- | --- |
+| Product | A vs B model; Connect hard-gate policy |
+| Tech Lead | Gateway conditions; ledger design; ADR close-out |
+| Finance | Commission/net definitions; payout batch policy |
+| DevOps | Secrets, webhooks, env overlays |
+| Ops | Pre-batch ledger review until automation exists |

--- a/docs/release/payment-config-reconciliation.md
+++ b/docs/release/payment-config-reconciliation.md
@@ -1,0 +1,149 @@
+# Payment Configuration Reconciliation
+
+**Date:** 20 July 2026  
+**Branch:** `feature/payment-launch-remediation`  
+**Authority:** ADR-002, ADR-003 (Option A), `payment-launch-remediation-report.md`, `payment-launch-remediation-precommit-audit.md`  
+**Mode:** Read-only — no `cex`, no config writes, no code changes
+
+---
+
+## 1. Which config is the intended launch state?
+
+**Tracked `config/sync` (including the current working-tree edits to two gateway files) represents the intended launch structure.**
+
+Active DDEV gateway configuration does **not**.
+
+| Source | Role for launch |
+| --- | --- |
+| **Tracked sync** | Source of truth for entity IDs, plugins, conditions, PE usage flags, empty secret placeholders |
+| **Active DDEV** | Environment-only credentials + currently **drifted / unsafe** shape — must be repaired by import/overlay, **never** by exporting into git |
+
+This matches Option A (ADR-003): platform-collect Commerce Stripe + Transfers; custom `stripe_connect` plugin stays unwired (0 entities).
+
+---
+
+## 2. Intended launch matrix (normative)
+
+| Entity ID | Plugin | Enabled | Conditions | Auth (runtime) | Payment method usage | Webhooks (gateway) | Customer visibility |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `stripe` | `stripe` (Card Element) | Yes | AUD | Platform **API keys** (`secret_key` + matching `publishable_key`); **`access_token` empty** | N/A (Card Element) | Gateway webhook secret may be empty if sync checkout is used | Tickets, Boost, donations |
+| `stripe_pe_recurring` | `stripe_payment_element` | Yes | AUD **AND** `mel_pro_subscription_variation` | Platform API keys (same rule) | `off_session` | `webhook_signing_secret` empty in sync OK unless PE webhooks required | MEL Pro / recurring only |
+| `mel_stripe_cc` | `manual` | Yes (preserved) | `current_user_role: administrator` | N/A | N/A | N/A | Administrators only |
+| *(none)* | `stripe_connect` | — | — | — | — | — | Must remain absent |
+
+Secrets belong in env / active overlay only — always empty strings in tracked YAML.
+
+---
+
+## 3. Tracked sync (working tree) vs intended
+
+| File | Matches intended structure? | Needs further edit before commit? |
+| --- | --- | --- |
+| `config/sync/commerce_payment.commerce_payment_gateway.stripe.yml` | **Yes** — plugin `stripe`, AUD, empty keys, no `access_token` | **No** |
+| `config/sync/commerce_payment.commerce_payment_gateway.stripe_pe_recurring.yml` | **Yes** (WT) — PE, `off_session`, AUD + Pro variation, `AND`, empty keys | **No further edit** — already updated; include in commit |
+| `config/sync/commerce_payment.commerce_payment_gateway.mel_stripe_cc.yml` | **Yes** (WT) — manual, admin role, empty of secrets | **No further edit** — already updated; include in commit |
+
+### Sync file details verified
+
+| Field | `stripe` sync | `stripe_pe_recurring` sync (WT) | `mel_stripe_cc` sync (WT) |
+| --- | --- | --- | --- |
+| Entity present in sync | Yes | Yes | Yes |
+| Plugin | `stripe` | `stripe_payment_element` | `manual` |
+| Status | `true` | `true` | `true` |
+| Conditions | `current_currency: AUD` | AUD + `order_variation_type: mel_pro_subscription_variation` | `current_user_role: administrator` |
+| conditionOperator | `OR` (single condition) | `AND` | `AND` |
+| payment_method_types | `credit_card` | `stripe_card` | `credit_card` |
+| payment_method_usage | n/a | `off_session` | n/a |
+| capture_method | n/a | `automatic` | n/a |
+| authentication_method | unset (no OAuth fields) | unset | n/a |
+| publishable_key / secret_key | `''` | `''` | n/a |
+| access_token | absent | absent | n/a |
+| webhook_signing_secret | absent | `''` | n/a |
+| express_checkout.enable_on_cart | n/a | `false` | n/a |
+
+**No secrets present in tracked sync.**
+
+---
+
+## 4. Active DDEV vs intended (runtime probe, secrets redacted)
+
+**Entities loaded:** `stripe`, `stripe_pe_recurring` only.  
+**Plugins discoverable:** `manual`, `stripe`, `stripe_connect`, `stripe_payment_element`.  
+**`stripe_connect` entities:** 0 (correct — keep dormant).
+
+| Check | Intended | Active DDEV | OK? |
+| --- | --- | --- | --- |
+| Entity `stripe` exists | Yes | Yes | Yes |
+| Entity `stripe` plugin | `stripe` (Card Element) | **`stripe_payment_element`** | **No** |
+| Entity `stripe` PM types | `credit_card` | **`stripe_card`** | **No** |
+| Entity `stripe` auth | API keys; empty access_token | **`stripe_connect` + access_token set; secret_key empty** | **No** |
+| Entity `stripe` payment_method_usage | n/a | `on_session` | Drift (wrong plugin) |
+| Entity `stripe` webhook secret | optional empty | empty | OK |
+| Entity `stripe_pe_recurring` conditions | AUD + Pro variation, AND | AUD + Pro variation, AND | **Yes** |
+| Entity `stripe_pe_recurring` usage | `off_session` | `off_session` | **Yes** |
+| Entity `stripe_pe_recurring` auth | API keys | **`stripe_connect` + access_token; secret_key empty** | **No** |
+| Entity `stripe_pe_recurring` webhook | empty OK | empty | OK |
+| Entity `mel_stripe_cc` exists | Yes | **MISSING** | **No** |
+| Commerce Stripe init prefers | `secret_key` | **`access_token`** on both Stripe entities | **No** (reintroduces CF-009 class failure) |
+
+**Conclusion:** Active config is environment drift / corruption relative to Option A launch. It must **not** be exported. Repair by importing sync structure + injecting platform keys (empty `access_token`), not by `cex`.
+
+---
+
+## 5. Sync files that need updating (for git)
+
+| Sync file | Action | Why |
+| --- | --- | --- |
+| `commerce_payment.commerce_payment_gateway.mel_stripe_cc.yml` | **Commit working-tree version** | Adds administrator role condition (CF-008) |
+| `commerce_payment.commerce_payment_gateway.stripe_pe_recurring.yml` | **Commit working-tree version** | Adds Pro variation condition + `AND` (CF-008 / recurring scope) |
+| `commerce_payment.commerce_payment_gateway.stripe.yml` | **Do not change / do not export** | Already matches intended Card Element + AUD + empty secrets. Active wrong plugin/auth must not overwrite this file |
+
+No other Commerce payment gateway sync files need updates for this remediation.
+
+---
+
+## 6. Verification checklist (launch intent)
+
+| Area | Sync (WT) | Active DDEV | Launch gate |
+| --- | --- | --- | --- |
+| Gateway entities | 3 defined | 2 present (`mel_stripe_cc` missing) | Sync wins; restore via `cim` of sync entity |
+| Gateway plugins | `stripe` / PE / `manual` | `stripe` entity wrongly PE | Sync wins |
+| Gateway conditions | Admin / AUD / AUD+Pro | PE conditions OK; manual absent; primary wrong | Sync + filter subscriber |
+| Authentication method | No Connect token in sync | Connect token preferred on both Stripe entities | Env repair required |
+| Payment method usage | PE `off_session` | PE recurring OK; primary wrongly `on_session` PE | Sync wins for primary = Card Element |
+| Webhook configuration | Empty gateway secrets in sync | Empty | Acceptable for sync-capture Option A; payout/Pro webhooks are separate settings |
+| Secrets in tracked config | None | Present in active only | Do not write active secrets to git |
+
+---
+
+## 7. Required environment repair (not a git export)
+
+Before trusting DDEV/runtime verification again:
+
+1. Import sync gateway entities (especially recreate `mel_stripe_cc`, restore `stripe` plugin to Card Element) **without** committing any re-export that contains keys.  
+2. Inject platform `publishable_key` + `secret_key` via existing env overlay / Commerce UI.  
+3. Ensure `access_token` and `stripe_user_id` are **empty** on Option A checkout gateways.  
+4. Confirm `authentication_method` resolves to API-key path (Commerce Stripe uses `secret_key` when `access_token` empty).  
+5. Re-probe: entity IDs, plugins, conditions, anon/admin gateway matrix.  
+6. **Never** `drush cex` from this DDEV until active structural shape matches sync and secrets are confirmed scrubbed from export preview.
+
+---
+
+## 8. Commit guidance
+
+**Include in payment remediation commit (config):**
+
+- `config/sync/commerce_payment.commerce_payment_gateway.mel_stripe_cc.yml`  
+- `config/sync/commerce_payment.commerce_payment_gateway.stripe_pe_recurring.yml`
+
+**Exclude:**
+
+- Any export of active `stripe` / PE YAML with keys or `access_token`  
+- Unrelated config  
+- Changes to `stripe.yml` driven by current active drift  
+
+Tracked sync (WT) = intended launch structure. Active DDEV = repair separately.
+
+---
+
+READY TO COMMIT

--- a/docs/release/payment-launch-remediation-plan.md
+++ b/docs/release/payment-launch-remediation-plan.md
@@ -1,0 +1,113 @@
+# Payment Launch Remediation Plan
+
+**Branch:** `feature/payment-launch-remediation`  
+**Date:** 20 July 2026  
+**Authority:** Payment architecture audit docs + ADR-002 / ADR-003 (Option A)  
+**Backups:** `backups/payment-launch-remediation-20260720/`
+
+---
+
+## Current state
+
+| Area | Proven runtime |
+| --- | --- |
+| Gateways on AUD carts | `mel_stripe_cc` (manual, no conditions), `stripe` (Card Element), `stripe_pe_recurring` (PE off_session) |
+| MEL filtering | None (`FilterPaymentGateways` unused in MEL) |
+| Ledger insert | `PlatformMetricsService::buildKpis()` inserts **all** completed orders |
+| Connect destination charges | Plugin present, **0** entities — remains dormant |
+| Stripe Card Element auth (DDEV) | `access_token` set → API uses Connect OAuth token while Elements uses platform `publishable_key` → `No such PaymentMethod` |
+| Wallet | Unchanged / decoupled from charging |
+
+---
+
+## Target state
+
+| Journey | Gateway | Ledger |
+| --- | --- | --- |
+| Tickets | `stripe` only (customers) | Eligible (vendor-payable) |
+| Boost | `stripe` only | **Not** eligible |
+| Platform donation | `stripe` only | **Not** eligible |
+| RSVP donation | `stripe` only | **Not** eligible |
+| MEL Pro / recurring | `stripe_pe_recurring` only | **Not** eligible |
+| Organiser donation (on ticket / `checkout_donation`) | with ticket cart → `stripe` | Eligible with ticket revenue |
+| Manual `mel_stripe_cc` | Administrators only | N/A |
+| Stripe Connect destination charges | Still unwired | N/A |
+| Wallet | Unchanged | N/A |
+
+### Ledger eligibility rules (authoritative for this remediation)
+
+**Eligible (insert unpaid liability):**
+
+1. Order type is **not** `platform_donation`, `rsvp_donation`, or `recurring`.
+2. Order contains at least one of:
+   - purchased entity bundle `ticket_variation`, or
+   - order item type `checkout_donation` (organiser donation line).
+
+**Not eligible:**
+
+- Boost (`boost` / `boost_duration` / `boost_upgrade`)
+- Platform donation orders / items
+- RSVP donation orders
+- MEL Pro (`mel_pro_subscription_variation`) and `recurring` orders
+- Platform fees / system adjustments / support invoices (never inserted as ledger rows)
+
+**Existing polluted ledger rows:** left in place (no financial deletion). Ops must not batch-pay non-vendor rows until a separate cleanup is approved.
+
+---
+
+## Rollback plan
+
+1. Restore gateway YAML from `backups/payment-launch-remediation-20260720/`.
+2. Restore `PlatformMetricsService.php` from the same backup directory.
+3. Remove `FilterPaymentGatewaysSubscriber` + service definition.
+4. Revert `OrderItemClassifier` payout-ledger methods.
+5. `ddev drush cr` (and `cim` if config was imported).
+6. Re-apply environment Stripe secrets via existing deploy overlay (never from git).
+
+Active DDEV `access_token` clear is **environment-only** — re-set via Commerce UI / deploy secrets if rollback of that env fix is required.
+
+---
+
+## Deployment order
+
+1. Deploy code (classifier, gateway filter subscriber, ledger eligibility).
+2. Import config: gateway conditions for `mel_stripe_cc` and `stripe_pe_recurring`.
+3. Cache rebuild.
+4. **Per environment:** ensure Commerce gateway `stripe` has **empty** `access_token` and uses platform `secret_key` + matching `publishable_key` (Option A).
+5. Smoke-test each payment journey.
+6. Do **not** enable `stripe_connect` gateway entity.
+7. Do **not** run unrestricted payout batches until polluted historical ledger rows are reviewed.
+
+---
+
+## Regression checklist
+
+- [ ] Ticket checkout offers only `stripe` to anonymous/customer
+- [ ] Boost checkout offers only `stripe`
+- [ ] Platform / RSVP donation checkout offers only `stripe`
+- [ ] MEL Pro checkout offers `stripe_pe_recurring` (not Card Element / manual)
+- [ ] Recurring order type still sees PE gateway
+- [ ] Admin can still see `mel_stripe_cc` when role `administrator`
+- [ ] New Boost / Pro / platform donation / RSVP completed orders do **not** gain ledger rows
+- [ ] New ticket completed orders **do** gain ledger rows when KPIs run
+- [ ] Confirmation email + wallet CTAs still work after ticket pay
+- [ ] Refund path unchanged
+- [ ] Vendor Connect onboarding unchanged
+- [ ] No destination-charge PI params at checkout
+
+---
+
+## Expected runtime behaviour
+
+```text
+loadMultipleForOrder(order)
+  → gateway conditions (currency / variation / role)
+  → MEL FilterPaymentGatewaysSubscriber
+       removes mel_stripe_cc unless administrator
+       removes stripe_pe_recurring unless Pro/recurring
+       removes stripe when order is Pro/recurring-only
+  → customer pays on platform Stripe account
+  → later: PlatformMetricsService inserts ledger only if payout-eligible
+```
+
+Fast checkout (PE-only) will **not** activate for ticket carts after PE is scoped to Pro — expected side effect of CF-008; standard Card Element checkout remains.

--- a/docs/release/payment-launch-remediation-precommit-audit.md
+++ b/docs/release/payment-launch-remediation-precommit-audit.md
@@ -1,0 +1,336 @@
+# Payment Launch Remediation — Pre-Commit Audit
+
+**Branch:** `feature/payment-launch-remediation`  
+**HEAD:** `54b7a8e0a` — `fix(checkout): restore Commerce Stripe Payment Element compatibility`  
+**Audit date:** 20 July 2026  
+**Mode:** Read-only working-tree audit (no stage/commit/restore performed for this audit)  
+**This file:** deliverable only; created after inspection
+
+---
+
+## Verdict
+
+**Yes — the intended payment remediation changes in the working tree can be isolated into a clean commit.**
+
+There are **no dirty wallet, checkout template, or SCSS files** in the working tree.  
+There are **no secret literals** in the unstaged diffs or untracked remediation/docs files scanned for this audit.
+
+**Caveats (do not ignore):**
+
+1. Branch tip is **identical** to `fix/mel-stripe-payment-element-compat` / `origin/fix/mel-stripe-payment-element-compat`. A PR of this branch tip against `main` would also ship prior wallet + checkout history already on that tip — not only the uncommitted remediation.
+2. **Active DDEV config currently diverges badly** from tracked `config/sync` (see § Active vs sync). Do **not** run `drush cex` from this environment into the remediation commit.
+3. Local remediation backups under `backups/` are gitignored and currently **empty** (not commit candidates).
+
+---
+
+## Working-tree inventory (complete)
+
+### Modified (unstaged)
+
+| Path |
+| --- |
+| `config/sync/commerce_payment.commerce_payment_gateway.mel_stripe_cc.yml` |
+| `config/sync/commerce_payment.commerce_payment_gateway.stripe_pe_recurring.yml` |
+| `web/modules/custom/myeventlane_admin_dashboard/myeventlane_admin_dashboard.info.yml` |
+| `web/modules/custom/myeventlane_admin_dashboard/myeventlane_admin_dashboard.services.yml` |
+| `web/modules/custom/myeventlane_admin_dashboard/src/Service/PlatformMetricsService.php` |
+| `web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml` |
+| `web/modules/custom/myeventlane_commerce/src/Service/OrderItemClassifier.php` |
+
+### Untracked
+
+| Path |
+| --- |
+| `web/modules/custom/myeventlane_commerce/src/EventSubscriber/FilterPaymentGatewaysSubscriber.php` |
+| `web/modules/custom/myeventlane_commerce/tests/src/Unit/FilterPaymentGatewaysSubscriberTest.php` |
+| `web/modules/custom/myeventlane_commerce/tests/src/Unit/OrderItemClassifierPayoutLedgerTest.php` |
+| `docs/adr/ADR-002-payment-runtime.md` |
+| `docs/adr/ADR-003-stripe-connect-strategy.md` |
+| `docs/architecture/payment-component-lifecycle.md` |
+| `docs/architecture/payment-critical-findings.md` |
+| `docs/architecture/payment-gateway-runtime.md` |
+| `docs/architecture/payment-ledger-review.md` |
+| `docs/architecture/payment-runtime-map.md` |
+| `docs/architecture/payment-runtime-matrix.md` |
+| `docs/architecture/payment-sequence-diagrams.md` |
+| `docs/architecture/payment-technical-debt.md` |
+| `docs/architecture/wallet-payment-boundary.md` |
+| `docs/launch/payment-executive-summary.md` |
+| `docs/launch/payment-launch-risk-register.md` |
+| `docs/release/payment-launch-remediation-plan.md` |
+| `docs/release/payment-launch-remediation-report.md` |
+| `docs/release/payment-launch-remediation-precommit-audit.md` *(this file)* |
+
+### Staged
+
+None.
+
+---
+
+## Classification
+
+### 1. Payment launch remediation (code + config)
+
+**Include in the payment remediation commit:**
+
+| Path | Role |
+| --- | --- |
+| `config/sync/commerce_payment.commerce_payment_gateway.mel_stripe_cc.yml` | Admin-only manual gateway conditions |
+| `config/sync/commerce_payment.commerce_payment_gateway.stripe_pe_recurring.yml` | Restrict PE to Pro variation + AUD |
+| `web/modules/custom/myeventlane_commerce/src/Service/OrderItemClassifier.php` | Ledger eligibility + recurring helper |
+| `web/modules/custom/myeventlane_commerce/src/EventSubscriber/FilterPaymentGatewaysSubscriber.php` | Gateway matrix filter |
+| `web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml` | Register filter subscriber |
+| `web/modules/custom/myeventlane_commerce/tests/src/Unit/FilterPaymentGatewaysSubscriberTest.php` | Unit tests |
+| `web/modules/custom/myeventlane_commerce/tests/src/Unit/OrderItemClassifierPayoutLedgerTest.php` | Unit tests |
+| `web/modules/custom/myeventlane_admin_dashboard/src/Service/PlatformMetricsService.php` | Ledger insert allowlist |
+| `web/modules/custom/myeventlane_admin_dashboard/myeventlane_admin_dashboard.services.yml` | DI for classifier/logger |
+| `web/modules/custom/myeventlane_admin_dashboard/myeventlane_admin_dashboard.info.yml` | Depend on `myeventlane_commerce` |
+
+**Not modified / not to invent for this commit:**
+
+- `config/sync/commerce_payment.commerce_payment_gateway.stripe.yml` — **unchanged** in working tree (still Card Element plugin + empty keys in sync).
+
+### 2. Wallet work
+
+| Finding | Detail |
+| --- | --- |
+| Working-tree wallet code/assets | **None dirty** |
+| Wallet templates/services/JS | **No changes** vs `HEAD` |
+| Docs only | `docs/architecture/wallet-payment-boundary.md` is payment-audit documentation (boundary), not wallet product code |
+
+**Conclusion:** No wallet implementation files belong in (or contaminate) the remediation commit.
+
+### 3. Checkout work
+
+| Finding | Detail |
+| --- | --- |
+| Working-tree checkout templates / SCSS | **None dirty** |
+| Checkout modules | **No working-tree changes** |
+| Branch history | `HEAD` *is* the PE checkout compatibility fix commit (`54b7a8e0a`). That commit is already on the branch tip / shared with `fix/mel-stripe-payment-element-compat`, but it is **not** an uncommitted working-tree change |
+
+**Conclusion:** Uncommitted tree has no checkout UX/template/SCSS edits. PR base selection still matters (see recommended split).
+
+### 4. Documentation
+
+All untracked under `docs/adr/`, `docs/architecture/payment-*.md`, `docs/architecture/wallet-payment-boundary.md`, `docs/launch/payment-*.md`, `docs/release/payment-launch-remediation-*.md`.
+
+**Recommendation:** Prefer a **second commit** (or separate docs PR) so code review stays focused. Acceptable to include with code if product wants one remediation PR.
+
+### 5. Local-only or temporary files
+
+| Path | Status | Action |
+| --- | --- | --- |
+| `backups/` | gitignored (`.gitignore:81`); directory present, **empty** now | Exclude |
+| `.ddev/` generated/runtime | ignored | Exclude |
+| `web/sites/default/settings.php`, `settings.ddev.php`, etc. | ignored | Exclude |
+| `web/core/`, `web/modules/contrib/` | ignored | Exclude |
+| `.codex/` | **Absent** | N/A |
+| `.tmp-reconciliation-backups/` | **Absent** | N/A |
+
+### 6. Unrelated or unsafe changes
+
+| Item | Verdict |
+| --- | --- |
+| `web/update.php` | Tracked; **not dirty** |
+| `web/sites/development.services.yml` | Tracked; **not dirty** |
+| Active DDEV gateway mutation (`access_token`, plugin drift, missing `mel_stripe_cc`) | **Unsafe to export**; not present as tracked file changes |
+| Branch tip containing prior wallet/checkout commits vs `main` | Historical coupling — isolate remediation files for commit, and choose PR base carefully |
+
+### 7. Secrets / configuration risks
+
+| Check | Result |
+| --- | --- |
+| Secret literals in unstaged `git diff` | **None** (`sk_*` / `pk_*` / `whsec_*` / non-empty `access_token:` values) |
+| Secret literals in untracked remediation/docs files (pattern scan) | **None** |
+| Tracked sync gateway YAML keys | Empty strings only (`publishable_key: ''`, `secret_key: ''`, PE `webhook_signing_secret: ''`) |
+| Active DDEV `stripe` / `stripe_pe_recurring` | **Non-empty** publishable key + `access_token` lengths observed (107); `authentication_method=stripe_connect`; **not** in git |
+| Active `mel_stripe_cc` entity | **MISSING** in DDEV entity storage (sync still has it) |
+| Active `stripe` plugin id | **`stripe_payment_element`** in DDEV — differs from sync plugin `stripe` |
+| Risk of `drush cex` now | **High** — would risk exporting wrong plugin/auth shape and/or secret material into sync |
+
+**Do not commit** any active-config dump, private settings, or gateway YAML with non-empty Stripe keys.
+
+---
+
+## Exact intended files for the payment remediation commit
+
+```text
+config/sync/commerce_payment.commerce_payment_gateway.mel_stripe_cc.yml
+config/sync/commerce_payment.commerce_payment_gateway.stripe_pe_recurring.yml
+web/modules/custom/myeventlane_admin_dashboard/myeventlane_admin_dashboard.info.yml
+web/modules/custom/myeventlane_admin_dashboard/myeventlane_admin_dashboard.services.yml
+web/modules/custom/myeventlane_admin_dashboard/src/Service/PlatformMetricsService.php
+web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
+web/modules/custom/myeventlane_commerce/src/Service/OrderItemClassifier.php
+web/modules/custom/myeventlane_commerce/src/EventSubscriber/FilterPaymentGatewaysSubscriber.php
+web/modules/custom/myeventlane_commerce/tests/src/Unit/FilterPaymentGatewaysSubscriberTest.php
+web/modules/custom/myeventlane_commerce/tests/src/Unit/OrderItemClassifierPayoutLedgerTest.php
+```
+
+Optional same-PR docs commit (or follow-up):
+
+```text
+docs/adr/ADR-002-payment-runtime.md
+docs/adr/ADR-003-stripe-connect-strategy.md
+docs/architecture/payment-component-lifecycle.md
+docs/architecture/payment-critical-findings.md
+docs/architecture/payment-gateway-runtime.md
+docs/architecture/payment-ledger-review.md
+docs/architecture/payment-runtime-map.md
+docs/architecture/payment-runtime-matrix.md
+docs/architecture/payment-sequence-diagrams.md
+docs/architecture/payment-technical-debt.md
+docs/architecture/wallet-payment-boundary.md
+docs/launch/payment-executive-summary.md
+docs/launch/payment-launch-risk-register.md
+docs/release/payment-launch-remediation-plan.md
+docs/release/payment-launch-remediation-report.md
+docs/release/payment-launch-remediation-precommit-audit.md
+```
+
+---
+
+## Exact files that must be excluded
+
+```text
+# Never stage from this tree for remediation
+backups/**
+.ddev/**
+web/sites/default/settings.php
+web/sites/default/settings.ddev.php
+web/sites/default/files/**
+web/core/**
+web/modules/contrib/**
+
+# Not dirty, but must remain untouched / not "fixed" into this commit
+web/update.php
+web/sites/development.services.yml
+web/modules/custom/myeventlane_wallet/**
+web/themes/custom/**/checkout*
+web/themes/custom/**/*.scss   # no dirty SCSS in tree; do not add unrelated theme work
+
+# Do not export/overwrite into commit from active DDEV
+# (especially) config/sync/commerce_payment.commerce_payment_gateway.stripe.yml
+# if generated by cex while access_token / wrong plugin are active
+```
+
+Also exclude any future files matching `.codex/` or `.tmp-reconciliation-backups/` if they appear.
+
+---
+
+## Config export required?
+
+| Question | Answer |
+| --- | --- |
+| Is a fresh `drush cex` required before commit? | **No — do not cex from current DDEV** |
+| Are the intended gateway condition changes already in tracked sync YAML? | **Yes** (working-tree edits to `mel_stripe_cc` + `stripe_pe_recurring`) |
+| Should `stripe.yml` sync be updated in this commit? | **No** unless separately decided; it is unmodified and must stay secret-free |
+
+**Deploy path:** commit sync YAML as edited → on target env `drush cim` for those two gateways → **separately** ensure active `stripe` uses platform API keys (empty `access_token`) without exporting secrets.
+
+---
+
+## Active config vs tracked sync config
+
+| Gateway | Sync (working tree) | Active DDEV (entity load, 20 Jul 2026) | Match? |
+| --- | --- | --- | --- |
+| `stripe` | plugin `stripe`; AUD; empty keys; no access_token fields in YAML | plugin **`stripe_payment_element`**; AUD; pk/access_token non-empty; `auth=stripe_connect` | **No** |
+| `stripe_pe_recurring` | PE; AUD **and** Pro variation; `conditionOperator: AND`; empty keys | PE; AUD **and** Pro variation; `AND`; pk/access_token non-empty | Conditions **yes**; credentials/auth **no** (active has secrets) |
+| `mel_stripe_cc` | manual; admin role condition; `status: true` | **Entity MISSING** | **No** |
+
+**Implication:** Remediation code/tests can be committed from the working tree safely. Runtime verification on this DDEV instance is **not trustworthy** until active gateways are repaired to match Option A (`stripe` Card Element entity present, `mel_stripe_cc` present, empty `access_token`). That repair is an **environment** action, not a sync-secret commit.
+
+---
+
+## Secret exposure findings
+
+1. **Tracked remediation diffs:** no Stripe secret material.  
+2. **Untracked docs/code for this work:** no live key literals in pattern scan.  
+3. **Active config only:** Stripe credentials present in DB/config storage (expected for local); lengths observed, values not recorded here.  
+4. **Historical docs elsewhere in repo** mention `sk_test_…` patterns in audits; out of scope for this working-tree commit, not introduced by these dirty files.  
+5. **Highest near-term risk:** accidental `cex` or copying active gateway YAML into `config/sync`.
+
+---
+
+## Recommended commit split
+
+### Option A (preferred)
+
+1. **Commit 1 — payment remediation code/config/tests**  
+   Exact file list in § “Exact intended files for the payment remediation commit”.
+2. **Commit 2 — payment architecture / launch / release docs**  
+   Exact docs list above (including this precommit audit).
+
+### Option B
+
+Single commit with code + docs (acceptable if one remediation PR is required).
+
+### Branch / PR hygiene (separate from working-tree isolation)
+
+Because `feature/payment-launch-remediation` currently points at the same commit as `fix/mel-stripe-payment-element-compat`:
+
+- For a **payment-only PR onto `main`**, create/reset the branch from `main` (or current production base) and apply only the intended files, **or** rebase/cherry-pick carefully so checkout/wallet history is not re-opened.
+- Do **not** assume “commit the dirty files on this tip” yields a payment-only PR against `main`.
+
+---
+
+## Rollback-safe next commands
+
+Read-only / safe inspection (no mutation):
+
+```bash
+git status -sb
+git diff --stat
+git diff -- config/sync/commerce_payment.commerce_payment_gateway.*.yml
+git ls-files --others --exclude-standard
+```
+
+Stage **only** the intended remediation files (when ready to commit — not run by this audit):
+
+```bash
+git add \
+  config/sync/commerce_payment.commerce_payment_gateway.mel_stripe_cc.yml \
+  config/sync/commerce_payment.commerce_payment_gateway.stripe_pe_recurring.yml \
+  web/modules/custom/myeventlane_admin_dashboard/myeventlane_admin_dashboard.info.yml \
+  web/modules/custom/myeventlane_admin_dashboard/myeventlane_admin_dashboard.services.yml \
+  web/modules/custom/myeventlane_admin_dashboard/src/Service/PlatformMetricsService.php \
+  web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml \
+  web/modules/custom/myeventlane_commerce/src/Service/OrderItemClassifier.php \
+  web/modules/custom/myeventlane_commerce/src/EventSubscriber/FilterPaymentGatewaysSubscriber.php \
+  web/modules/custom/myeventlane_commerce/tests/src/Unit/FilterPaymentGatewaysSubscriberTest.php \
+  web/modules/custom/myeventlane_commerce/tests/src/Unit/OrderItemClassifierPayoutLedgerTest.php
+
+git status
+git diff --cached --stat
+```
+
+**Avoid until env is known-safe:**
+
+```bash
+# DO NOT run for this commit from current DDEV:
+# ddev drush cex
+# ddev drush config:export
+```
+
+Unstage without discarding work:
+
+```bash
+git restore --staged -- <paths>
+```
+
+Discard is **not** recommended here; keep working tree intact until commit intent is confirmed.
+
+---
+
+## Summary answers
+
+| Question | Answer |
+| --- | --- |
+| Can payment remediation be isolated into a clean commit? | **Yes** (working tree) |
+| Wallet work in dirty tree? | **No** |
+| Checkout templates/SCSS in dirty tree? | **No** |
+| Config export required? | **No** — commit existing sync edits; **do not cex** now |
+| Active differs from sync? | **Yes — materially** (plugin/auth/secrets; `mel_stripe_cc` missing) |
+| Secrets in tracked dirty/untracked remediation files? | **No** |
+| `.codex/` / `.tmp-reconciliation-backups/` | **Absent** |
+| `web/update.php` / `development.services.yml` | Tracked, **clean** |

--- a/docs/release/payment-launch-remediation-report.md
+++ b/docs/release/payment-launch-remediation-report.md
@@ -1,0 +1,148 @@
+# Payment Launch Remediation — Implementation Report
+
+**Branch:** `feature/payment-launch-remediation`  
+**Date:** 20 July 2026  
+**Plan:** [`payment-launch-remediation-plan.md`](./payment-launch-remediation-plan.md)  
+**Architecture authority:** Option A (ADR-003) — platform collect + Transfer/ledger; Connect destination charges remain dormant.
+
+---
+
+## 1. Summary
+
+Launch blockers CF-008 (gateway sprawl) and CF-007 (ledger pollution on insert) are remediated with small, reversible changes. Phase 5 `No such PaymentMethod` is an environment credential mismatch (Connect `access_token` preferred over platform `secret_key`); active DDEV gateway was corrected to `api_keys`.
+
+| Success criterion | Result |
+| --- | --- |
+| Ticket → `stripe` | Pass (order 580 anon) |
+| Boost → `stripe` | Pass (temp draft cart) |
+| MEL Pro → `stripe_pe_recurring` | Pass (temp draft cart) |
+| Recurring → `stripe_pe_recurring` only | Pass (order 554) |
+| Manual unavailable to customers | Pass (anon ticket); admin still sees `mel_stripe_cc` |
+| Ledger insert vendor-payable only | Pass (classifier + insert gate) |
+| Wallet unchanged | Pass (no wallet code touched) |
+| Stripe Connect destination charges dormant | Pass (no `stripe_connect` entity) |
+
+---
+
+## 2. Files changed
+
+| Path | Change |
+| --- | --- |
+| `web/modules/custom/myeventlane_commerce/src/Service/OrderItemClassifier.php` | Payout ledger eligibility + recurring-gateway helpers |
+| `web/modules/custom/myeventlane_commerce/src/EventSubscriber/FilterPaymentGatewaysSubscriber.php` | **New** — launch gateway matrix filter |
+| `web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml` | Register filter subscriber |
+| `web/modules/custom/myeventlane_commerce/tests/src/Unit/OrderItemClassifierPayoutLedgerTest.php` | **New** unit tests |
+| `web/modules/custom/myeventlane_commerce/tests/src/Unit/FilterPaymentGatewaysSubscriberTest.php` | **New** unit tests |
+| `web/modules/custom/myeventlane_admin_dashboard/src/Service/PlatformMetricsService.php` | Skip ledger insert unless payout-eligible |
+| `web/modules/custom/myeventlane_admin_dashboard/myeventlane_admin_dashboard.services.yml` | Inject classifier + logger |
+| `web/modules/custom/myeventlane_admin_dashboard/myeventlane_admin_dashboard.info.yml` | Depend on `myeventlane_commerce` |
+| `config/sync/commerce_payment.commerce_payment_gateway.mel_stripe_cc.yml` | Admin role condition |
+| `config/sync/commerce_payment.commerce_payment_gateway.stripe_pe_recurring.yml` | AUD **and** Pro variation type |
+| `docs/release/payment-launch-remediation-plan.md` | Plan + rollback |
+| Architecture / launch docs | Before/after updates (see §7) |
+
+**Backups:** `backups/payment-launch-remediation-20260720/`
+
+---
+
+## 3. Config changed
+
+### Exported (config/sync)
+
+1. **`mel_stripe_cc`** — `current_user_role: administrator` (entity preserved, `status: true`).
+2. **`stripe_pe_recurring`** — `conditionOperator: AND` with `current_currency: AUD` + `order_variation_type: mel_pro_subscription_variation`.
+
+### Active environment only (not exported secrets)
+
+3. **`stripe` gateway** — cleared `access_token` / `stripe_user_id`; `authentication_method: api_keys` so Commerce Stripe uses platform `secret_key` matching Elements `publishable_key`.
+
+**Deploy note:** After `cim`, re-inject Stripe keys via existing env overlay. Do **not** reintroduce a Connect OAuth `access_token` on the platform Card Element gateway under Option A.
+
+---
+
+## 4. Runtime verification
+
+| Probe | Evidence |
+| --- | --- |
+| Anon ticket cart 580 | gateways=`[stripe]`, ledger eligible=Y |
+| Temp boost draft | gateways=`[stripe]`, ledger=N |
+| Temp Pro draft | gateways=`[stripe_pe_recurring]`, ledger=N |
+| Recurring order 554 | gateways=`[stripe_pe_recurring]` |
+| Admin + ticket | gateways=`[mel_stripe_cc,stripe]` |
+| Filter subscriber registered | `FilterPaymentGatewaysSubscriber` listening |
+| Completed zero-balance orders | Empty gateway list via Commerce `ZeroBalanceOrderSubscriber` (expected) |
+| Sample ledger math | `gross * 0.1 = commission`, `net = gross - commission` — OK on recent rows |
+| PM retrieve after auth fix | `secret_key` retrieves `pm_1Tv7ms…` OK; prior failure was `access_token` account mismatch |
+
+**Side effect (expected):** Ticket fast checkout (PE-only) no longer finds a PE gateway on ticket carts. Standard Card Element checkout remains.
+
+**Manual browser checkout:** Not fully exercised in this session (CLI/temp carts + unit tests). Recommended before merge: one live ticket, boost, donation, and Pro payment in DDEV.
+
+---
+
+## 5. Regression results
+
+```text
+ddev drush cr — success
+PHPUnit (9 tests): OrderItemClassifierPayoutLedgerTest + FilterPaymentGatewaysSubscriberTest — OK
+```
+
+PHPUnit reported existing PHPUnit deprecation notices (11); no new assertion failures.
+
+PHPStan: not run in this session.  
+Full Functional/Kernel Commerce suite: not run in this session.
+
+---
+
+## 6. Outstanding risks
+
+| Risk | Severity | Notes |
+| --- | --- | --- |
+| CF-006 — ledger still lazy on KPI, not `ORDER_PAID` | High (payout ops) | Scope filter fixed; timing unchanged |
+| Historical polluted ledger rows (Boost/Pro/donations) | High if batched | Not deleted; ops must exclude before Transfers |
+| Flat `commission_rate` vs platform fee / MEL % | Medium | Internal ledger math consistent; may not match fee UX |
+| Deploy `cim` wiping keys / reintroducing `access_token` | High | Runbook: inject keys; keep access_token empty for Option A |
+| Fast checkout disabled for tickets | Low–Medium UX | Intentional with PE scoped to Pro |
+| DDEV project root moved to this worktree for verification | Ops | Restore main project listing if needed: unlist/start from preferred path |
+
+---
+
+## 7. Documentation updates
+
+Updated / added:
+
+- `docs/release/payment-launch-remediation-plan.md`
+- `docs/release/payment-launch-remediation-report.md` (this file)
+- `docs/architecture/payment-critical-findings.md` — remediation status
+- `docs/architecture/payment-runtime-matrix.md` — target gateways
+- `docs/architecture/payment-gateway-runtime.md` — filter subscriber
+- `docs/architecture/payment-ledger-review.md` — eligibility rules
+- `docs/launch/payment-launch-risk-register.md` — mitigated rows
+- `docs/launch/payment-executive-summary.md` — post-remediation readiness
+- `docs/adr/ADR-002-payment-runtime.md` — runtime note for filter + ledger scope
+
+---
+
+## 8. Deployment checklist
+
+1. Merge/deploy code on `feature/payment-launch-remediation`.
+2. `drush cim` for gateway condition YAML (or apply conditions manually).
+3. Ensure active `stripe` has empty `access_token` and matching platform pk/sk.
+4. `drush cr`.
+5. Smoke: ticket, boost, platform donation, RSVP donation, MEL Pro, refund, vendor onboarding (no Connect PI).
+6. Confirm wallet CTA still appears on ticket confirmation.
+7. **Do not** run unrestricted payout batches until historical ledger cleanup SOP is done.
+8. Confirm `stripe_connect` gateway entity still absent.
+
+---
+
+## 9. Rollback procedure
+
+See plan § Rollback. Quick path:
+
+1. Restore files from `backups/payment-launch-remediation-20260720/`.
+2. Remove `FilterPaymentGatewaysSubscriber` + service.
+3. Revert classifier / metrics / info.yml dependency.
+4. Re-import previous gateway YAML.
+5. `drush cr`.
+6. Env-only: restore prior `stripe` auth only if intentionally required (not recommended for Option A).

--- a/web/modules/custom/myeventlane_admin_dashboard/myeventlane_admin_dashboard.info.yml
+++ b/web/modules/custom/myeventlane_admin_dashboard/myeventlane_admin_dashboard.info.yml
@@ -9,6 +9,7 @@ dependencies:
   - drupal:views
   - commerce_order:commerce_order
   - myeventlane_analytics:myeventlane_analytics
+  - myeventlane_commerce:myeventlane_commerce
   - myeventlane_core:myeventlane_core
   - myeventlane_escalations:myeventlane_escalations
   - myeventlane_event:myeventlane_event

--- a/web/modules/custom/myeventlane_admin_dashboard/myeventlane_admin_dashboard.services.yml
+++ b/web/modules/custom/myeventlane_admin_dashboard/myeventlane_admin_dashboard.services.yml
@@ -7,6 +7,8 @@ services:
       - '@cache.default'
       - '@config.factory'
       - '@datetime.time'
+      - '@myeventlane_commerce.order_item_classifier'
+      - '@logger.channel.myeventlane_admin_dashboard'
 
   myeventlane_admin_dashboard.financial_export_controller:
     class: Drupal\myeventlane_admin_dashboard\Controller\FinancialExportController

--- a/web/modules/custom/myeventlane_admin_dashboard/src/Service/PlatformMetricsService.php
+++ b/web/modules/custom/myeventlane_admin_dashboard/src/Service/PlatformMetricsService.php
@@ -18,7 +18,9 @@ use Psr\Log\LoggerInterface;
  *
  * Commission is computed from config (commission_rate); ledger stores gross,
  * commission, net per order. Ledger rows are auto-created when getKpis runs,
- * but only for payout-eligible vendor revenue (CF-007 remediation).
+ * but only for payout-eligible vendor revenue (CF-007 remediation). Gross is
+ * the sum of eligible line totals (+ booking Contribution adjustments), never
+ * the full order total (so mixed carts exclude Boost / platform revenue).
  */
 final class PlatformMetricsService {
 
@@ -228,8 +230,18 @@ final class PlatformMetricsService {
         continue;
       }
 
+      // Line-level eligible gross only (excludes Boost / platform revenue on
+      // mixed carts). Do not use order total_price__number.
+      $gross = $this->orderItemClassifier->getPayoutLedgerEligibleGross($order);
+      if ($gross <= 0) {
+        $this->logger->info('Payout ledger skip: order @oid type=@type has no positive vendor-payable gross.', [
+          '@oid' => (string) $orderId,
+          '@type' => $order->bundle(),
+        ]);
+        continue;
+      }
+
       $storeId = (int) ($o['store_id'] ?? 0);
-      $gross = round((float) ($o['total_price__number'] ?? 0), 2);
       $commission = round($gross * $commissionRate, 2);
       $net = round($gross - $commission, 2);
       $created = (int) ($o['placed'] ?? $now);

--- a/web/modules/custom/myeventlane_admin_dashboard/src/Service/PlatformMetricsService.php
+++ b/web/modules/custom/myeventlane_admin_dashboard/src/Service/PlatformMetricsService.php
@@ -4,17 +4,21 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_admin_dashboard\Service;
 
+use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\myeventlane_commerce\Service\OrderItemClassifier;
+use Psr\Log\LoggerInterface;
 
 /**
  * Platform-level metrics: KPIs, revenue series, vendor ranking, payout liability.
  *
  * Commission is computed from config (commission_rate); ledger stores gross,
- * commission, net per order. Ledger rows are auto-created when getKpis runs.
+ * commission, net per order. Ledger rows are auto-created when getKpis runs,
+ * but only for payout-eligible vendor revenue (CF-007 remediation).
  */
 final class PlatformMetricsService {
 
@@ -35,12 +39,15 @@ final class PlatformMetricsService {
     private readonly CacheBackendInterface $cache,
     private readonly ConfigFactoryInterface $configFactory,
     private readonly TimeInterface $time,
+    private readonly OrderItemClassifier $orderItemClassifier,
+    private readonly LoggerInterface $logger,
   ) {}
 
   /**
    * Returns KPI tile data for the last N days.
    *
-   * Ensures ledger row exists for each completed order (inserts unpaid if missing).
+   * Ensures ledger row exists for each completed payout-eligible order
+   * (inserts unpaid if missing).
    *
    * @return array{
    *   total_orders: int,
@@ -156,7 +163,7 @@ final class PlatformMetricsService {
   }
 
   /**
-   * Builds KPI data. Ensures ledger rows exist for completed orders.
+   * Builds KPI data. Ensures ledger rows exist for payout-eligible orders.
    */
   private function buildKpis(int $days): array {
     if (!$this->database->schema()->tableExists('commerce_order')) {
@@ -196,12 +203,31 @@ final class PlatformMetricsService {
       ->fetchCol();
     $existing = array_map('intval', $existing);
 
-    // Auto-create ledger rows for orders without one.
+    $orderStorage = $this->entityTypeManager->getStorage('commerce_order');
+
+    // Auto-create ledger rows for payout-eligible orders without one.
     foreach ($orders as $o) {
       $orderId = (int) ($o['order_id'] ?? 0);
       if ($orderId <= 0 || in_array($orderId, $existing, TRUE)) {
         continue;
       }
+
+      $order = $orderStorage->load($orderId);
+      if (!$order instanceof OrderInterface) {
+        $this->logger->error('Payout ledger skip: commerce order @oid could not be loaded.', [
+          '@oid' => (string) $orderId,
+        ]);
+        continue;
+      }
+
+      if (!$this->orderItemClassifier->isPayoutLedgerEligibleOrder($order)) {
+        $this->logger->info('Payout ledger skip: order @oid type=@type is not vendor-payable revenue.', [
+          '@oid' => (string) $orderId,
+          '@type' => $order->bundle(),
+        ]);
+        continue;
+      }
+
       $storeId = (int) ($o['store_id'] ?? 0);
       $gross = round((float) ($o['total_price__number'] ?? 0), 2);
       $commission = round($gross * $commissionRate, 2);

--- a/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
+++ b/web/modules/custom/myeventlane_commerce/myeventlane_commerce.services.yml
@@ -14,6 +14,15 @@ services:
   myeventlane_commerce.order_item_classifier:
     class: Drupal\myeventlane_commerce\Service\OrderItemClassifier
 
+  myeventlane_commerce.filter_payment_gateways_subscriber:
+    class: Drupal\myeventlane_commerce\EventSubscriber\FilterPaymentGatewaysSubscriber
+    arguments:
+      - '@myeventlane_commerce.order_item_classifier'
+      - '@current_user'
+      - '@logger.channel.myeventlane_commerce'
+    tags:
+      - { name: event_subscriber }
+
   myeventlane_commerce.ticket_backed_order_item_classifier:
     class: Drupal\myeventlane_commerce\Service\TicketBackedOrderItemClassifier
     arguments:

--- a/web/modules/custom/myeventlane_commerce/src/EventSubscriber/FilterPaymentGatewaysSubscriber.php
+++ b/web/modules/custom/myeventlane_commerce/src/EventSubscriber/FilterPaymentGatewaysSubscriber.php
@@ -16,12 +16,13 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  *
  * Target:
  * - Customers: tickets / boost / donations → stripe
- * - MEL Pro / recurring → stripe_pe_recurring
+ * - MEL Pro / recurring (Pro-only carts) → stripe_pe_recurring
+ * - Mixed ticket + Pro carts → stripe (Card Element); PE removed
  * - mel_stripe_cc → administrators only (preserved for local/admin testing)
  *
- * Fail-safe: never remove Card Element for a recurring cart unless the PE
- * recurring gateway is still present after Commerce conditions. Otherwise
- * checkout can end with zero gateways (missing config/currency/variation).
+ * Fail-safe: never remove Card Element for an exclusive recurring cart unless
+ * the PE recurring gateway is still present after Commerce conditions.
+ * Otherwise checkout can end with zero gateways (missing config/currency).
  */
 final class FilterPaymentGatewaysSubscriber implements EventSubscriberInterface {
 
@@ -57,11 +58,20 @@ final class FilterPaymentGatewaysSubscriber implements EventSubscriberInterface 
     }
 
     $requiresRecurring = $this->orderItemClassifier->requiresRecurringPaymentGateway($order);
+    $exclusiveRecurring = $this->orderItemClassifier->requiresExclusiveRecurringPaymentGateway($order);
     $isAdministrator = $this->currentUser->hasRole('administrator');
     $hasRecurringGateway = $this->gatewayListContains($gateways, self::RECURRING_GATEWAY_ID);
     $removed = [];
 
-    if ($requiresRecurring && !$hasRecurringGateway) {
+    if ($requiresRecurring && !$exclusiveRecurring) {
+      $this->logger->warning('Mixed Pro cart order @oid keeps @card and drops @pe so non-Pro lines are not charged off_session.', [
+        '@oid' => (string) ($order->id() ?? 'new'),
+        '@card' => self::CARD_GATEWAY_ID,
+        '@pe' => self::RECURRING_GATEWAY_ID,
+      ]);
+    }
+
+    if ($exclusiveRecurring && !$hasRecurringGateway) {
       $this->logger->warning('Recurring cart order @oid has no @pe gateway after Commerce conditions; retaining @card if present so checkout is not empty.', [
         '@oid' => (string) ($order->id() ?? 'new'),
         '@pe' => self::RECURRING_GATEWAY_ID,
@@ -78,33 +88,36 @@ final class FilterPaymentGatewaysSubscriber implements EventSubscriberInterface 
         continue;
       }
 
-      if ($gatewayId === self::RECURRING_GATEWAY_ID && !$requiresRecurring) {
+      // PE only for Pro-only / recurring renewals — not mixed ticket + Pro carts.
+      if ($gatewayId === self::RECURRING_GATEWAY_ID && !$exclusiveRecurring) {
         unset($gateways[$id]);
         $removed[] = $gatewayId;
         continue;
       }
 
-      // Only strip Card Element when PE recurring is actually available.
-      if ($gatewayId === self::CARD_GATEWAY_ID && $requiresRecurring && $hasRecurringGateway) {
+      // Only strip Card Element when the cart is exclusive recurring and PE is available.
+      if ($gatewayId === self::CARD_GATEWAY_ID && $exclusiveRecurring && $hasRecurringGateway) {
         unset($gateways[$id]);
         $removed[] = $gatewayId;
       }
     }
 
     if ($removed !== []) {
-      $this->logger->info('Filtered payment gateways for order @oid: removed @removed (recurring=@recurring, admin=@admin, pe_present=@pe).', [
+      $this->logger->info('Filtered payment gateways for order @oid: removed @removed (recurring=@recurring, exclusive=@exclusive, admin=@admin, pe_present=@pe).', [
         '@oid' => (string) ($order->id() ?? 'new'),
         '@removed' => implode(',', array_unique($removed)),
         '@recurring' => $requiresRecurring ? '1' : '0',
+        '@exclusive' => $exclusiveRecurring ? '1' : '0',
         '@admin' => $isAdministrator ? '1' : '0',
         '@pe' => $hasRecurringGateway ? '1' : '0',
       ]);
     }
 
     if ($gateways === []) {
-      $this->logger->error('Payment gateway filter left order @oid with zero gateways (recurring=@recurring, admin=@admin).', [
+      $this->logger->error('Payment gateway filter left order @oid with zero gateways (recurring=@recurring, exclusive=@exclusive, admin=@admin).', [
         '@oid' => (string) ($order->id() ?? 'new'),
         '@recurring' => $requiresRecurring ? '1' : '0',
+        '@exclusive' => $exclusiveRecurring ? '1' : '0',
         '@admin' => $isAdministrator ? '1' : '0',
       ]);
     }

--- a/web/modules/custom/myeventlane_commerce/src/EventSubscriber/FilterPaymentGatewaysSubscriber.php
+++ b/web/modules/custom/myeventlane_commerce/src/EventSubscriber/FilterPaymentGatewaysSubscriber.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_commerce\EventSubscriber;
+
+use Drupal\commerce_payment\Event\FilterPaymentGatewaysEvent;
+use Drupal\commerce_payment\Event\PaymentEvents;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\myeventlane_commerce\Service\OrderItemClassifier;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Restricts Commerce payment gateways to the launch Option A matrix.
+ *
+ * Target:
+ * - Customers: tickets / boost / donations → stripe
+ * - MEL Pro / recurring → stripe_pe_recurring
+ * - mel_stripe_cc → administrators only (preserved for local/admin testing)
+ */
+final class FilterPaymentGatewaysSubscriber implements EventSubscriberInterface {
+
+  private const MANUAL_GATEWAY_ID = 'mel_stripe_cc';
+
+  private const RECURRING_GATEWAY_ID = 'stripe_pe_recurring';
+
+  private const CARD_GATEWAY_ID = 'stripe';
+
+  public function __construct(
+    private readonly OrderItemClassifier $orderItemClassifier,
+    private readonly AccountProxyInterface $currentUser,
+    private readonly LoggerInterface $logger,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      PaymentEvents::FILTER_PAYMENT_GATEWAYS => ['onFilterPaymentGateways', -100],
+    ];
+  }
+
+  /**
+   * Filters gateways after Commerce condition evaluation.
+   */
+  public function onFilterPaymentGateways(FilterPaymentGatewaysEvent $event): void {
+    $order = $event->getOrder();
+    $gateways = $event->getPaymentGateways();
+    if ($gateways === []) {
+      return;
+    }
+
+    $requiresRecurring = $this->orderItemClassifier->requiresRecurringPaymentGateway($order);
+    $isAdministrator = $this->currentUser->hasRole('administrator');
+    $removed = [];
+
+    foreach ($gateways as $id => $gateway) {
+      $gatewayId = $gateway->id();
+
+      if ($gatewayId === self::MANUAL_GATEWAY_ID && !$isAdministrator) {
+        unset($gateways[$id]);
+        $removed[] = $gatewayId;
+        continue;
+      }
+
+      if ($gatewayId === self::RECURRING_GATEWAY_ID && !$requiresRecurring) {
+        unset($gateways[$id]);
+        $removed[] = $gatewayId;
+        continue;
+      }
+
+      if ($gatewayId === self::CARD_GATEWAY_ID && $requiresRecurring) {
+        unset($gateways[$id]);
+        $removed[] = $gatewayId;
+      }
+    }
+
+    if ($removed !== []) {
+      $this->logger->info('Filtered payment gateways for order @oid: removed @removed (recurring=@recurring, admin=@admin).', [
+        '@oid' => (string) ($order->id() ?? 'new'),
+        '@removed' => implode(',', array_unique($removed)),
+        '@recurring' => $requiresRecurring ? '1' : '0',
+        '@admin' => $isAdministrator ? '1' : '0',
+      ]);
+    }
+
+    $event->setPaymentGateways($gateways);
+  }
+
+}

--- a/web/modules/custom/myeventlane_commerce/src/EventSubscriber/FilterPaymentGatewaysSubscriber.php
+++ b/web/modules/custom/myeventlane_commerce/src/EventSubscriber/FilterPaymentGatewaysSubscriber.php
@@ -18,6 +18,10 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * - Customers: tickets / boost / donations → stripe
  * - MEL Pro / recurring → stripe_pe_recurring
  * - mel_stripe_cc → administrators only (preserved for local/admin testing)
+ *
+ * Fail-safe: never remove Card Element for a recurring cart unless the PE
+ * recurring gateway is still present after Commerce conditions. Otherwise
+ * checkout can end with zero gateways (missing config/currency/variation).
  */
 final class FilterPaymentGatewaysSubscriber implements EventSubscriberInterface {
 
@@ -54,7 +58,16 @@ final class FilterPaymentGatewaysSubscriber implements EventSubscriberInterface 
 
     $requiresRecurring = $this->orderItemClassifier->requiresRecurringPaymentGateway($order);
     $isAdministrator = $this->currentUser->hasRole('administrator');
+    $hasRecurringGateway = $this->gatewayListContains($gateways, self::RECURRING_GATEWAY_ID);
     $removed = [];
+
+    if ($requiresRecurring && !$hasRecurringGateway) {
+      $this->logger->warning('Recurring cart order @oid has no @pe gateway after Commerce conditions; retaining @card if present so checkout is not empty.', [
+        '@oid' => (string) ($order->id() ?? 'new'),
+        '@pe' => self::RECURRING_GATEWAY_ID,
+        '@card' => self::CARD_GATEWAY_ID,
+      ]);
+    }
 
     foreach ($gateways as $id => $gateway) {
       $gatewayId = $gateway->id();
@@ -71,22 +84,47 @@ final class FilterPaymentGatewaysSubscriber implements EventSubscriberInterface 
         continue;
       }
 
-      if ($gatewayId === self::CARD_GATEWAY_ID && $requiresRecurring) {
+      // Only strip Card Element when PE recurring is actually available.
+      if ($gatewayId === self::CARD_GATEWAY_ID && $requiresRecurring && $hasRecurringGateway) {
         unset($gateways[$id]);
         $removed[] = $gatewayId;
       }
     }
 
     if ($removed !== []) {
-      $this->logger->info('Filtered payment gateways for order @oid: removed @removed (recurring=@recurring, admin=@admin).', [
+      $this->logger->info('Filtered payment gateways for order @oid: removed @removed (recurring=@recurring, admin=@admin, pe_present=@pe).', [
         '@oid' => (string) ($order->id() ?? 'new'),
         '@removed' => implode(',', array_unique($removed)),
+        '@recurring' => $requiresRecurring ? '1' : '0',
+        '@admin' => $isAdministrator ? '1' : '0',
+        '@pe' => $hasRecurringGateway ? '1' : '0',
+      ]);
+    }
+
+    if ($gateways === []) {
+      $this->logger->error('Payment gateway filter left order @oid with zero gateways (recurring=@recurring, admin=@admin).', [
+        '@oid' => (string) ($order->id() ?? 'new'),
         '@recurring' => $requiresRecurring ? '1' : '0',
         '@admin' => $isAdministrator ? '1' : '0',
       ]);
     }
 
     $event->setPaymentGateways($gateways);
+  }
+
+  /**
+   * Whether a gateway entity id is present in the filtered list.
+   *
+   * @param array<string|\Drupal\commerce_payment\Entity\PaymentGatewayInterface> $gateways
+   *   Gateway entities keyed by entity id or numeric index.
+   */
+  private function gatewayListContains(array $gateways, string $gatewayId): bool {
+    foreach ($gateways as $gateway) {
+      if ($gateway->id() === $gatewayId) {
+        return TRUE;
+      }
+    }
+    return FALSE;
   }
 
 }

--- a/web/modules/custom/myeventlane_commerce/src/Service/OrderItemClassifier.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/OrderItemClassifier.php
@@ -315,7 +315,10 @@ class OrderItemClassifier {
   }
 
   /**
-   * Whether the order should use the recurring Payment Element gateway.
+   * Whether the order contains MEL Pro / recurring inventory.
+   *
+   * True when any line is MEL Pro (including mixed ticket + Pro carts).
+   * Use requiresExclusiveRecurringPaymentGateway() before stripping Card Element.
    */
   public function requiresRecurringPaymentGateway(OrderInterface $order): bool {
     if ($order->bundle() === 'recurring') {
@@ -327,6 +330,31 @@ class OrderItemClassifier {
       }
     }
     return FALSE;
+  }
+
+  /**
+   * Whether the order may use PE recurring exclusively (no Card Element).
+   *
+   * True for Commerce Recurring renewals and Pro-only carts. False for mixed
+   * carts (e.g. tickets + MEL Pro) so ticket lines are not charged on the
+   * off_session Payment Element gateway.
+   */
+  public function requiresExclusiveRecurringPaymentGateway(OrderInterface $order): bool {
+    if ($order->bundle() === 'recurring') {
+      return TRUE;
+    }
+
+    $hasPro = FALSE;
+    foreach ($order->getItems() as $item) {
+      if ($this->isMelPro($item)) {
+        $hasPro = TRUE;
+        continue;
+      }
+      // Any non-Pro line blocks exclusive PE (tickets, boost, donations, etc.).
+      return FALSE;
+    }
+
+    return $hasPro;
   }
 
 }

--- a/web/modules/custom/myeventlane_commerce/src/Service/OrderItemClassifier.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/OrderItemClassifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_commerce\Service;
 
+use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\commerce_order\Entity\OrderItemInterface;
 
 /**
@@ -48,6 +49,25 @@ class OrderItemClassifier {
     'checkout_donation',
     'platform_donation',
     'rsvp_donation',
+  ];
+
+  /**
+   * Product variation type for ticket revenue.
+   */
+  private const TICKET_VARIATION_TYPE = 'ticket_variation';
+
+  /**
+   * Product variation type for MEL Pro.
+   */
+  private const MEL_PRO_VARIATION_TYPE = 'mel_pro_subscription_variation';
+
+  /**
+   * Order types that must never create payout ledger liabilities.
+   */
+  private const PAYOUT_LEDGER_EXCLUDED_ORDER_TYPES = [
+    'platform_donation',
+    'rsvp_donation',
+    'recurring',
   ];
 
   /**
@@ -140,6 +160,88 @@ class OrderItemClassifier {
    */
   public function isPlatformDonation(OrderItemInterface $item): bool {
     return in_array($item->bundle(), self::PLATFORM_DONATION_TYPES, TRUE);
+  }
+
+  /**
+   * Checks if an order item is MEL Pro subscription inventory.
+   */
+  public function isMelPro(OrderItemInterface $item): bool {
+    $purchasedEntity = $item->getPurchasedEntity();
+    if (!$purchasedEntity) {
+      return FALSE;
+    }
+    return $purchasedEntity->getEntityTypeId() === 'commerce_product_variation'
+      && $purchasedEntity->bundle() === self::MEL_PRO_VARIATION_TYPE;
+  }
+
+  /**
+   * Checks if an order item is ticket variation revenue.
+   */
+  public function isTicketRevenue(OrderItemInterface $item): bool {
+    if ($this->isBoost($item) || $this->isDonation($item) || $this->isMelPro($item)) {
+      return FALSE;
+    }
+    $purchasedEntity = $item->getPurchasedEntity();
+    if (!$purchasedEntity) {
+      return FALSE;
+    }
+    return $purchasedEntity->getEntityTypeId() === 'commerce_product_variation'
+      && $purchasedEntity->bundle() === self::TICKET_VARIATION_TYPE;
+  }
+
+  /**
+   * Whether a line item may justify a vendor payout ledger row.
+   *
+   * Launch rules (CF-007 remediation):
+   * - Ticket revenue (`ticket_variation`)
+   * - Organiser donation line (`checkout_donation`)
+   *
+   * Explicitly not eligible: Boost, platform donation, RSVP donation lines,
+   * MEL Pro, fees/adjustments (not order items).
+   */
+  public function isPayoutLedgerEligibleItem(OrderItemInterface $item): bool {
+    if ($this->isBoost($item) || $this->isPlatformDonation($item) || $this->isMelPro($item)) {
+      return FALSE;
+    }
+    // RSVP donation lines are organiser-labelled historically but belong to
+    // non-vendor order types excluded at order level; do not allow alone.
+    if ($item->bundle() === 'rsvp_donation') {
+      return FALSE;
+    }
+    if ($item->bundle() === 'checkout_donation') {
+      return TRUE;
+    }
+    return $this->isTicketRevenue($item);
+  }
+
+  /**
+   * Whether an order may receive a payout ledger liability row.
+   */
+  public function isPayoutLedgerEligibleOrder(OrderInterface $order): bool {
+    if (in_array($order->bundle(), self::PAYOUT_LEDGER_EXCLUDED_ORDER_TYPES, TRUE)) {
+      return FALSE;
+    }
+    foreach ($order->getItems() as $item) {
+      if ($this->isPayoutLedgerEligibleItem($item)) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Whether the order should use the recurring Payment Element gateway.
+   */
+  public function requiresRecurringPaymentGateway(OrderInterface $order): bool {
+    if ($order->bundle() === 'recurring') {
+      return TRUE;
+    }
+    foreach ($order->getItems() as $item) {
+      if ($this->isMelPro($item)) {
+        return TRUE;
+      }
+    }
+    return FALSE;
   }
 
 }

--- a/web/modules/custom/myeventlane_commerce/src/Service/OrderItemClassifier.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/OrderItemClassifier.php
@@ -6,6 +6,7 @@ namespace Drupal\myeventlane_commerce\Service;
 
 use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\myeventlane_core\Commerce\OperationalProductBundles;
 
 /**
  * Canonical order item classifier for Commerce revenue and checkout logic.
@@ -60,6 +61,22 @@ class OrderItemClassifier {
    * Product variation type for MEL Pro.
    */
   private const MEL_PRO_VARIATION_TYPE = 'mel_pro_subscription_variation';
+
+  /**
+   * Operational variation types that are vendor-payable (merchandise / add-ons).
+   *
+   * Mirrors OperationalVariationStockResolver::OPERATIONAL_VARIATION_BUNDLES.
+   * Product-bundle check via OperationalProductBundles is preferred when the
+   * purchased entity still resolves a product.
+   *
+   * @var list<string>
+   */
+  private const OPERATIONAL_VARIATION_TYPES = [
+    'operational_merchandise_var',
+    'operational_bundle_var',
+    'hospitality_package_var',
+    'timed_collection_var',
+  ];
 
   /**
    * Order types that must never create payout ledger liabilities.
@@ -190,10 +207,38 @@ class OrderItemClassifier {
   }
 
   /**
+   * Checks if an order item is operational merchandise / add-on vendor revenue.
+   *
+   * Includes event-scoped extras sold as Commerce products (merch, packages,
+   * hospitality, timed collection). These are not tickets and must not flow
+   * through ticket issuance, but under platform-collect + Transfer they are
+   * still vendor-payable and must justify a payout ledger row.
+   */
+  public function isOperationalVendorRevenue(OrderItemInterface $item): bool {
+    if ($this->isBoost($item) || $this->isDonation($item) || $this->isMelPro($item)) {
+      return FALSE;
+    }
+
+    $purchasedEntity = $item->getPurchasedEntity();
+    if (!$purchasedEntity
+      || $purchasedEntity->getEntityTypeId() !== 'commerce_product_variation') {
+      return FALSE;
+    }
+
+    $product = $purchasedEntity->getProduct();
+    if ($product && OperationalProductBundles::isOperationalProductBundle($product->bundle())) {
+      return TRUE;
+    }
+
+    return in_array($purchasedEntity->bundle(), self::OPERATIONAL_VARIATION_TYPES, TRUE);
+  }
+
+  /**
    * Whether a line item may justify a vendor payout ledger row.
    *
    * Launch rules (CF-007 remediation):
    * - Ticket revenue (`ticket_variation`)
+   * - Operational merchandise / bundle add-ons (vendor extras)
    * - Organiser donation line (`checkout_donation`)
    *
    * Explicitly not eligible: Boost, platform donation, RSVP donation lines,
@@ -211,7 +256,7 @@ class OrderItemClassifier {
     if ($item->bundle() === 'checkout_donation') {
       return TRUE;
     }
-    return $this->isTicketRevenue($item);
+    return $this->isTicketRevenue($item) || $this->isOperationalVendorRevenue($item);
   }
 
   /**

--- a/web/modules/custom/myeventlane_commerce/src/Service/OrderItemClassifier.php
+++ b/web/modules/custom/myeventlane_commerce/src/Service/OrderItemClassifier.php
@@ -275,6 +275,46 @@ class OrderItemClassifier {
   }
 
   /**
+   * Sums vendor-payable gross for payout ledger liability.
+   *
+   * Uses eligible line totals only — never the order total — so mixed carts
+   * (e.g. tickets + Boost) do not record Boost or other platform revenue as
+   * vendor payout liability. Also includes the booking Contribution adjustment
+   * (`myeventlane_order_donation`) when present on the order.
+   *
+   * Excludes: Boost, platform/RSVP donation lines, MEL Pro, platform fees and
+   * other non-eligible adjustments.
+   */
+  public function getPayoutLedgerEligibleGross(OrderInterface $order): float {
+    if (in_array($order->bundle(), self::PAYOUT_LEDGER_EXCLUDED_ORDER_TYPES, TRUE)) {
+      return 0.0;
+    }
+
+    $gross = 0.0;
+    foreach ($order->getItems() as $item) {
+      if (!$this->isPayoutLedgerEligibleItem($item)) {
+        continue;
+      }
+      $totalPrice = $item->getTotalPrice();
+      if ($totalPrice) {
+        $gross += (float) $totalPrice->getNumber();
+      }
+    }
+
+    foreach ($order->getAdjustments() as $adjustment) {
+      if ((string) $adjustment->getSourceId() !== 'myeventlane_order_donation') {
+        continue;
+      }
+      $amount = $adjustment->getAmount();
+      if ($amount) {
+        $gross += (float) $amount->getNumber();
+      }
+    }
+
+    return round($gross, 2);
+  }
+
+  /**
    * Whether the order should use the recurring Payment Element gateway.
    */
   public function requiresRecurringPaymentGateway(OrderInterface $order): bool {

--- a/web/modules/custom/myeventlane_commerce/tests/src/Unit/FilterPaymentGatewaysSubscriberTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Unit/FilterPaymentGatewaysSubscriberTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_commerce\Unit;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_payment\Entity\PaymentGatewayInterface;
+use Drupal\commerce_payment\Event\FilterPaymentGatewaysEvent;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\myeventlane_commerce\EventSubscriber\FilterPaymentGatewaysSubscriber;
+use Drupal\myeventlane_commerce\Service\OrderItemClassifier;
+use Drupal\Tests\UnitTestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_commerce\EventSubscriber\FilterPaymentGatewaysSubscriber
+ * @group myeventlane_commerce
+ */
+final class FilterPaymentGatewaysSubscriberTest extends UnitTestCase {
+
+  /**
+   * @covers ::onFilterPaymentGateways
+   */
+  public function testTicketCartKeepsStripeOnlyForCustomers(): void {
+    $subscriber = $this->createSubscriber(requiresRecurring: FALSE, isAdmin: FALSE);
+    $gateways = [
+      'mel_stripe_cc' => $this->gateway('mel_stripe_cc'),
+      'stripe' => $this->gateway('stripe'),
+      'stripe_pe_recurring' => $this->gateway('stripe_pe_recurring'),
+    ];
+    $event = new FilterPaymentGatewaysEvent($gateways, $this->createMock(OrderInterface::class));
+    $subscriber->onFilterPaymentGateways($event);
+    $remaining = array_keys($event->getPaymentGateways());
+    $this->assertSame(['stripe'], $remaining);
+  }
+
+  /**
+   * @covers ::onFilterPaymentGateways
+   */
+  public function testProCartKeepsRecurringOnly(): void {
+    $subscriber = $this->createSubscriber(requiresRecurring: TRUE, isAdmin: FALSE);
+    $gateways = [
+      'mel_stripe_cc' => $this->gateway('mel_stripe_cc'),
+      'stripe' => $this->gateway('stripe'),
+      'stripe_pe_recurring' => $this->gateway('stripe_pe_recurring'),
+    ];
+    $event = new FilterPaymentGatewaysEvent($gateways, $this->createMock(OrderInterface::class));
+    $subscriber->onFilterPaymentGateways($event);
+    $remaining = array_keys($event->getPaymentGateways());
+    $this->assertSame(['stripe_pe_recurring'], $remaining);
+  }
+
+  /**
+   * @covers ::onFilterPaymentGateways
+   */
+  public function testAdministratorKeepsManualGatewayOnTicketCart(): void {
+    $subscriber = $this->createSubscriber(requiresRecurring: FALSE, isAdmin: TRUE);
+    $gateways = [
+      'mel_stripe_cc' => $this->gateway('mel_stripe_cc'),
+      'stripe' => $this->gateway('stripe'),
+      'stripe_pe_recurring' => $this->gateway('stripe_pe_recurring'),
+    ];
+    $event = new FilterPaymentGatewaysEvent($gateways, $this->createMock(OrderInterface::class));
+    $subscriber->onFilterPaymentGateways($event);
+    $remaining = array_keys($event->getPaymentGateways());
+    sort($remaining);
+    $this->assertSame(['mel_stripe_cc', 'stripe'], $remaining);
+  }
+
+  private function createSubscriber(bool $requiresRecurring, bool $isAdmin): FilterPaymentGatewaysSubscriber {
+    $classifier = $this->createMock(OrderItemClassifier::class);
+    $classifier->method('requiresRecurringPaymentGateway')->willReturn($requiresRecurring);
+
+    $account = $this->createMock(AccountProxyInterface::class);
+    $account->method('hasRole')->with('administrator')->willReturn($isAdmin);
+
+    $logger = $this->createMock(LoggerInterface::class);
+    return new FilterPaymentGatewaysSubscriber($classifier, $account, $logger);
+  }
+
+  private function gateway(string $id): PaymentGatewayInterface {
+    $gateway = $this->createMock(PaymentGatewayInterface::class);
+    $gateway->method('id')->willReturn($id);
+    return $gateway;
+  }
+
+}

--- a/web/modules/custom/myeventlane_commerce/tests/src/Unit/FilterPaymentGatewaysSubscriberTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Unit/FilterPaymentGatewaysSubscriberTest.php
@@ -52,6 +52,28 @@ final class FilterPaymentGatewaysSubscriberTest extends UnitTestCase {
   }
 
   /**
+   * Recurring cart without PE must keep Card Element (avoid empty checkout).
+   *
+   * @covers ::onFilterPaymentGateways
+   */
+  public function testProCartKeepsStripeWhenRecurringGatewayMissing(): void {
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->once())
+      ->method('warning')
+      ->with($this->stringContains('no @pe gateway'));
+
+    $subscriber = $this->createSubscriber(requiresRecurring: TRUE, isAdmin: FALSE, logger: $logger);
+    $gateways = [
+      'mel_stripe_cc' => $this->gateway('mel_stripe_cc'),
+      'stripe' => $this->gateway('stripe'),
+    ];
+    $event = new FilterPaymentGatewaysEvent($gateways, $this->createMock(OrderInterface::class));
+    $subscriber->onFilterPaymentGateways($event);
+    $remaining = array_keys($event->getPaymentGateways());
+    $this->assertSame(['stripe'], $remaining);
+  }
+
+  /**
    * @covers ::onFilterPaymentGateways
    */
   public function testAdministratorKeepsManualGatewayOnTicketCart(): void {
@@ -68,14 +90,14 @@ final class FilterPaymentGatewaysSubscriberTest extends UnitTestCase {
     $this->assertSame(['mel_stripe_cc', 'stripe'], $remaining);
   }
 
-  private function createSubscriber(bool $requiresRecurring, bool $isAdmin): FilterPaymentGatewaysSubscriber {
+  private function createSubscriber(bool $requiresRecurring, bool $isAdmin, ?LoggerInterface $logger = NULL): FilterPaymentGatewaysSubscriber {
     $classifier = $this->createMock(OrderItemClassifier::class);
     $classifier->method('requiresRecurringPaymentGateway')->willReturn($requiresRecurring);
 
     $account = $this->createMock(AccountProxyInterface::class);
     $account->method('hasRole')->with('administrator')->willReturn($isAdmin);
 
-    $logger = $this->createMock(LoggerInterface::class);
+    $logger ??= $this->createMock(LoggerInterface::class);
     return new FilterPaymentGatewaysSubscriber($classifier, $account, $logger);
   }
 

--- a/web/modules/custom/myeventlane_commerce/tests/src/Unit/FilterPaymentGatewaysSubscriberTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Unit/FilterPaymentGatewaysSubscriberTest.php
@@ -23,7 +23,11 @@ final class FilterPaymentGatewaysSubscriberTest extends UnitTestCase {
    * @covers ::onFilterPaymentGateways
    */
   public function testTicketCartKeepsStripeOnlyForCustomers(): void {
-    $subscriber = $this->createSubscriber(requiresRecurring: FALSE, isAdmin: FALSE);
+    $subscriber = $this->createSubscriber(
+      requiresRecurring: FALSE,
+      exclusiveRecurring: FALSE,
+      isAdmin: FALSE,
+    );
     $gateways = [
       'mel_stripe_cc' => $this->gateway('mel_stripe_cc'),
       'stripe' => $this->gateway('stripe'),
@@ -39,7 +43,11 @@ final class FilterPaymentGatewaysSubscriberTest extends UnitTestCase {
    * @covers ::onFilterPaymentGateways
    */
   public function testProCartKeepsRecurringOnly(): void {
-    $subscriber = $this->createSubscriber(requiresRecurring: TRUE, isAdmin: FALSE);
+    $subscriber = $this->createSubscriber(
+      requiresRecurring: TRUE,
+      exclusiveRecurring: TRUE,
+      isAdmin: FALSE,
+    );
     $gateways = [
       'mel_stripe_cc' => $this->gateway('mel_stripe_cc'),
       'stripe' => $this->gateway('stripe'),
@@ -49,6 +57,34 @@ final class FilterPaymentGatewaysSubscriberTest extends UnitTestCase {
     $subscriber->onFilterPaymentGateways($event);
     $remaining = array_keys($event->getPaymentGateways());
     $this->assertSame(['stripe_pe_recurring'], $remaining);
+  }
+
+  /**
+   * Mixed ticket + Pro must keep Card Element and drop off_session PE.
+   *
+   * @covers ::onFilterPaymentGateways
+   */
+  public function testMixedProAndTicketCartKeepsStripeOnly(): void {
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->once())
+      ->method('warning')
+      ->with($this->stringContains('Mixed Pro cart'));
+
+    $subscriber = $this->createSubscriber(
+      requiresRecurring: TRUE,
+      exclusiveRecurring: FALSE,
+      isAdmin: FALSE,
+      logger: $logger,
+    );
+    $gateways = [
+      'mel_stripe_cc' => $this->gateway('mel_stripe_cc'),
+      'stripe' => $this->gateway('stripe'),
+      'stripe_pe_recurring' => $this->gateway('stripe_pe_recurring'),
+    ];
+    $event = new FilterPaymentGatewaysEvent($gateways, $this->createMock(OrderInterface::class));
+    $subscriber->onFilterPaymentGateways($event);
+    $remaining = array_keys($event->getPaymentGateways());
+    $this->assertSame(['stripe'], $remaining);
   }
 
   /**
@@ -62,7 +98,12 @@ final class FilterPaymentGatewaysSubscriberTest extends UnitTestCase {
       ->method('warning')
       ->with($this->stringContains('no @pe gateway'));
 
-    $subscriber = $this->createSubscriber(requiresRecurring: TRUE, isAdmin: FALSE, logger: $logger);
+    $subscriber = $this->createSubscriber(
+      requiresRecurring: TRUE,
+      exclusiveRecurring: TRUE,
+      isAdmin: FALSE,
+      logger: $logger,
+    );
     $gateways = [
       'mel_stripe_cc' => $this->gateway('mel_stripe_cc'),
       'stripe' => $this->gateway('stripe'),
@@ -77,7 +118,11 @@ final class FilterPaymentGatewaysSubscriberTest extends UnitTestCase {
    * @covers ::onFilterPaymentGateways
    */
   public function testAdministratorKeepsManualGatewayOnTicketCart(): void {
-    $subscriber = $this->createSubscriber(requiresRecurring: FALSE, isAdmin: TRUE);
+    $subscriber = $this->createSubscriber(
+      requiresRecurring: FALSE,
+      exclusiveRecurring: FALSE,
+      isAdmin: TRUE,
+    );
     $gateways = [
       'mel_stripe_cc' => $this->gateway('mel_stripe_cc'),
       'stripe' => $this->gateway('stripe'),
@@ -90,9 +135,15 @@ final class FilterPaymentGatewaysSubscriberTest extends UnitTestCase {
     $this->assertSame(['mel_stripe_cc', 'stripe'], $remaining);
   }
 
-  private function createSubscriber(bool $requiresRecurring, bool $isAdmin, ?LoggerInterface $logger = NULL): FilterPaymentGatewaysSubscriber {
+  private function createSubscriber(
+    bool $requiresRecurring,
+    bool $exclusiveRecurring,
+    bool $isAdmin,
+    ?LoggerInterface $logger = NULL,
+  ): FilterPaymentGatewaysSubscriber {
     $classifier = $this->createMock(OrderItemClassifier::class);
     $classifier->method('requiresRecurringPaymentGateway')->willReturn($requiresRecurring);
+    $classifier->method('requiresExclusiveRecurringPaymentGateway')->willReturn($exclusiveRecurring);
 
     $account = $this->createMock(AccountProxyInterface::class);
     $account->method('hasRole')->with('administrator')->willReturn($isAdmin);

--- a/web/modules/custom/myeventlane_commerce/tests/src/Unit/OrderItemClassifierPayoutLedgerTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Unit/OrderItemClassifierPayoutLedgerTest.php
@@ -233,6 +233,7 @@ final class OrderItemClassifierPayoutLedgerTest extends UnitTestCase {
 
   /**
    * @covers ::requiresRecurringPaymentGateway
+   * @covers ::requiresExclusiveRecurringPaymentGateway
    */
   public function testRequiresRecurringForMelPro(): void {
     $variation = $this->createMock(ProductVariationInterface::class);
@@ -248,6 +249,40 @@ final class OrderItemClassifierPayoutLedgerTest extends UnitTestCase {
     $order->method('bundle')->willReturn('default');
     $order->method('getItems')->willReturn([$item]);
     $this->assertTrue($this->classifier->requiresRecurringPaymentGateway($order));
+    $this->assertTrue($this->classifier->requiresExclusiveRecurringPaymentGateway($order));
+  }
+
+  /**
+   * Mixed ticket + Pro requires recurring presence but not exclusive PE.
+   *
+   * @covers ::requiresRecurringPaymentGateway
+   * @covers ::requiresExclusiveRecurringPaymentGateway
+   */
+  public function testMixedTicketAndProIsNotExclusiveRecurring(): void {
+    $ticketVariation = $this->createMock(ProductVariationInterface::class);
+    $ticketVariation->method('getEntityTypeId')->willReturn('commerce_product_variation');
+    $ticketVariation->method('bundle')->willReturn('ticket_variation');
+    $ticketVariation->method('getProduct')->willReturn(NULL);
+
+    $ticketItem = $this->createMock(OrderItemInterface::class);
+    $ticketItem->method('bundle')->willReturn('default');
+    $ticketItem->method('getPurchasedEntity')->willReturn($ticketVariation);
+
+    $proVariation = $this->createMock(ProductVariationInterface::class);
+    $proVariation->method('getEntityTypeId')->willReturn('commerce_product_variation');
+    $proVariation->method('bundle')->willReturn('mel_pro_subscription_variation');
+    $proVariation->method('getProduct')->willReturn(NULL);
+
+    $proItem = $this->createMock(OrderItemInterface::class);
+    $proItem->method('bundle')->willReturn('default');
+    $proItem->method('getPurchasedEntity')->willReturn($proVariation);
+
+    $order = $this->createMock(OrderInterface::class);
+    $order->method('bundle')->willReturn('default');
+    $order->method('getItems')->willReturn([$ticketItem, $proItem]);
+
+    $this->assertTrue($this->classifier->requiresRecurringPaymentGateway($order));
+    $this->assertFalse($this->classifier->requiresExclusiveRecurringPaymentGateway($order));
   }
 
 }

--- a/web/modules/custom/myeventlane_commerce/tests/src/Unit/OrderItemClassifierPayoutLedgerTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Unit/OrderItemClassifierPayoutLedgerTest.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\myeventlane_commerce\Unit;
 
+use Drupal\commerce_order\Adjustment;
 use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_price\Price;
 use Drupal\commerce_product\Entity\ProductInterface;
 use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\Component\Plugin\PluginManagerInterface;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\myeventlane_commerce\Service\OrderItemClassifier;
 use Drupal\Tests\UnitTestCase;
 
@@ -148,6 +152,83 @@ final class OrderItemClassifierPayoutLedgerTest extends UnitTestCase {
     $order->method('bundle')->willReturn('platform_donation');
     $order->method('getItems')->willReturn([$item]);
     $this->assertFalse($this->classifier->isPayoutLedgerEligibleOrder($order));
+  }
+
+  /**
+   * Ticket + Boost carts stay eligible, but Boost dollars are not ledger gross.
+   *
+   * @covers ::isPayoutLedgerEligibleOrder
+   * @covers ::getPayoutLedgerEligibleGross
+   */
+  public function testMixedTicketAndBoostGrossExcludesBoost(): void {
+    $ticketVariation = $this->createMock(ProductVariationInterface::class);
+    $ticketVariation->method('getEntityTypeId')->willReturn('commerce_product_variation');
+    $ticketVariation->method('bundle')->willReturn('ticket_variation');
+    $ticketVariation->method('getProduct')->willReturn(NULL);
+
+    $ticketItem = $this->createMock(OrderItemInterface::class);
+    $ticketItem->method('bundle')->willReturn('default');
+    $ticketItem->method('getPurchasedEntity')->willReturn($ticketVariation);
+    $ticketItem->method('getTotalPrice')->willReturn(new Price('80.00', 'AUD'));
+
+    $boostItem = $this->createMock(OrderItemInterface::class);
+    $boostItem->method('bundle')->willReturn('boost');
+    $boostItem->method('getPurchasedEntity')->willReturn(NULL);
+    $boostItem->method('getTotalPrice')->willReturn(new Price('25.00', 'AUD'));
+
+    $order = $this->createMock(OrderInterface::class);
+    $order->method('bundle')->willReturn('default');
+    $order->method('getItems')->willReturn([$ticketItem, $boostItem]);
+    $order->method('getAdjustments')->willReturn([]);
+
+    $this->assertTrue($this->classifier->isPayoutLedgerEligibleOrder($order));
+    $this->assertSame(80.0, $this->classifier->getPayoutLedgerEligibleGross($order));
+  }
+
+  /**
+   * Booking Contribution adjustment is vendor-payable and included in gross.
+   *
+   * @covers ::getPayoutLedgerEligibleGross
+   */
+  public function testEligibleGrossIncludesMelOrderDonationAdjustment(): void {
+    $adjustmentTypeManager = $this->createMock(PluginManagerInterface::class);
+    $adjustmentTypeManager->method('getDefinitions')->willReturn([
+      'custom' => ['id' => 'custom'],
+    ]);
+    $container = new ContainerBuilder();
+    $container->set('plugin.manager.commerce_adjustment_type', $adjustmentTypeManager);
+    \Drupal::setContainer($container);
+
+    try {
+      $ticketVariation = $this->createMock(ProductVariationInterface::class);
+      $ticketVariation->method('getEntityTypeId')->willReturn('commerce_product_variation');
+      $ticketVariation->method('bundle')->willReturn('ticket_variation');
+      $ticketVariation->method('getProduct')->willReturn(NULL);
+
+      $ticketItem = $this->createMock(OrderItemInterface::class);
+      $ticketItem->method('bundle')->willReturn('default');
+      $ticketItem->method('getPurchasedEntity')->willReturn($ticketVariation);
+      $ticketItem->method('getTotalPrice')->willReturn(new Price('50.00', 'AUD'));
+
+      $contribution = new Adjustment([
+        'type' => 'custom',
+        'label' => 'Contribution',
+        'amount' => new Price('10.00', 'AUD'),
+        'included' => FALSE,
+        'locked' => TRUE,
+        'source_id' => 'myeventlane_order_donation',
+      ]);
+
+      $order = $this->createMock(OrderInterface::class);
+      $order->method('bundle')->willReturn('default');
+      $order->method('getItems')->willReturn([$ticketItem]);
+      $order->method('getAdjustments')->willReturn([$contribution]);
+
+      $this->assertSame(60.0, $this->classifier->getPayoutLedgerEligibleGross($order));
+    }
+    finally {
+      \Drupal::unsetContainer();
+    }
   }
 
   /**

--- a/web/modules/custom/myeventlane_commerce/tests/src/Unit/OrderItemClassifierPayoutLedgerTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Unit/OrderItemClassifierPayoutLedgerTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_commerce\Unit;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\myeventlane_commerce\Service\OrderItemClassifier;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_commerce\Service\OrderItemClassifier
+ * @group myeventlane_commerce
+ */
+final class OrderItemClassifierPayoutLedgerTest extends UnitTestCase {
+
+  private OrderItemClassifier $classifier;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->classifier = new OrderItemClassifier();
+  }
+
+  /**
+   * @covers ::isPayoutLedgerEligibleItem
+   */
+  public function testCheckoutDonationIsLedgerEligible(): void {
+    $item = $this->createMock(OrderItemInterface::class);
+    $item->method('bundle')->willReturn('checkout_donation');
+    $item->method('getPurchasedEntity')->willReturn(NULL);
+    $this->assertTrue($this->classifier->isPayoutLedgerEligibleItem($item));
+  }
+
+  /**
+   * @covers ::isPayoutLedgerEligibleItem
+   */
+  public function testBoostIsNotLedgerEligible(): void {
+    $item = $this->createMock(OrderItemInterface::class);
+    $item->method('bundle')->willReturn('boost');
+    $item->method('getPurchasedEntity')->willReturn(NULL);
+    $this->assertFalse($this->classifier->isPayoutLedgerEligibleItem($item));
+  }
+
+  /**
+   * @covers ::isPayoutLedgerEligibleItem
+   */
+  public function testTicketVariationIsLedgerEligible(): void {
+    $variation = $this->createMock(ProductVariationInterface::class);
+    $variation->method('getEntityTypeId')->willReturn('commerce_product_variation');
+    $variation->method('bundle')->willReturn('ticket_variation');
+    $variation->method('getProduct')->willReturn(NULL);
+
+    $item = $this->createMock(OrderItemInterface::class);
+    $item->method('bundle')->willReturn('default');
+    $item->method('getPurchasedEntity')->willReturn($variation);
+    $this->assertTrue($this->classifier->isPayoutLedgerEligibleItem($item));
+  }
+
+  /**
+   * @covers ::isPayoutLedgerEligibleItem
+   */
+  public function testMelProIsNotLedgerEligible(): void {
+    $variation = $this->createMock(ProductVariationInterface::class);
+    $variation->method('getEntityTypeId')->willReturn('commerce_product_variation');
+    $variation->method('bundle')->willReturn('mel_pro_subscription_variation');
+    $variation->method('getProduct')->willReturn(NULL);
+
+    $item = $this->createMock(OrderItemInterface::class);
+    $item->method('bundle')->willReturn('default');
+    $item->method('getPurchasedEntity')->willReturn($variation);
+    $this->assertFalse($this->classifier->isPayoutLedgerEligibleItem($item));
+  }
+
+  /**
+   * @covers ::isPayoutLedgerEligibleOrder
+   */
+  public function testPlatformDonationOrderTypeExcluded(): void {
+    $item = $this->createMock(OrderItemInterface::class);
+    $item->method('bundle')->willReturn('checkout_donation');
+    $item->method('getPurchasedEntity')->willReturn(NULL);
+
+    $order = $this->createMock(OrderInterface::class);
+    $order->method('bundle')->willReturn('platform_donation');
+    $order->method('getItems')->willReturn([$item]);
+    $this->assertFalse($this->classifier->isPayoutLedgerEligibleOrder($order));
+  }
+
+  /**
+   * @covers ::requiresRecurringPaymentGateway
+   */
+  public function testRequiresRecurringForMelPro(): void {
+    $variation = $this->createMock(ProductVariationInterface::class);
+    $variation->method('getEntityTypeId')->willReturn('commerce_product_variation');
+    $variation->method('bundle')->willReturn('mel_pro_subscription_variation');
+    $variation->method('getProduct')->willReturn(NULL);
+
+    $item = $this->createMock(OrderItemInterface::class);
+    $item->method('bundle')->willReturn('default');
+    $item->method('getPurchasedEntity')->willReturn($variation);
+
+    $order = $this->createMock(OrderInterface::class);
+    $order->method('bundle')->willReturn('default');
+    $order->method('getItems')->willReturn([$item]);
+    $this->assertTrue($this->classifier->requiresRecurringPaymentGateway($order));
+  }
+
+}

--- a/web/modules/custom/myeventlane_commerce/tests/src/Unit/OrderItemClassifierPayoutLedgerTest.php
+++ b/web/modules/custom/myeventlane_commerce/tests/src/Unit/OrderItemClassifierPayoutLedgerTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\myeventlane_commerce\Unit;
 
 use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_product\Entity\ProductInterface;
 use Drupal\commerce_product\Entity\ProductVariationInterface;
 use Drupal\myeventlane_commerce\Service\OrderItemClassifier;
 use Drupal\Tests\UnitTestCase;
@@ -56,6 +57,68 @@ final class OrderItemClassifierPayoutLedgerTest extends UnitTestCase {
     $item->method('bundle')->willReturn('default');
     $item->method('getPurchasedEntity')->willReturn($variation);
     $this->assertTrue($this->classifier->isPayoutLedgerEligibleItem($item));
+  }
+
+  /**
+   * @covers ::isPayoutLedgerEligibleItem
+   * @covers ::isOperationalVendorRevenue
+   */
+  public function testOperationalMerchandiseVariationIsLedgerEligible(): void {
+    $product = $this->createMock(ProductInterface::class);
+    $product->method('bundle')->willReturn('operational_merchandise');
+
+    $variation = $this->createMock(ProductVariationInterface::class);
+    $variation->method('getEntityTypeId')->willReturn('commerce_product_variation');
+    $variation->method('bundle')->willReturn('operational_merchandise_var');
+    $variation->method('getProduct')->willReturn($product);
+
+    $item = $this->createMock(OrderItemInterface::class);
+    $item->method('bundle')->willReturn('default');
+    $item->method('getPurchasedEntity')->willReturn($variation);
+    $this->assertTrue($this->classifier->isOperationalVendorRevenue($item));
+    $this->assertTrue($this->classifier->isPayoutLedgerEligibleItem($item));
+  }
+
+  /**
+   * @covers ::isPayoutLedgerEligibleItem
+   * @covers ::isOperationalVendorRevenue
+   */
+  public function testOperationalBundleVariationIsLedgerEligible(): void {
+    $product = $this->createMock(ProductInterface::class);
+    $product->method('bundle')->willReturn('operational_bundle');
+
+    $variation = $this->createMock(ProductVariationInterface::class);
+    $variation->method('getEntityTypeId')->willReturn('commerce_product_variation');
+    $variation->method('bundle')->willReturn('operational_bundle_var');
+    $variation->method('getProduct')->willReturn($product);
+
+    $item = $this->createMock(OrderItemInterface::class);
+    $item->method('bundle')->willReturn('default');
+    $item->method('getPurchasedEntity')->willReturn($variation);
+    $this->assertTrue($this->classifier->isOperationalVendorRevenue($item));
+    $this->assertTrue($this->classifier->isPayoutLedgerEligibleItem($item));
+  }
+
+  /**
+   * @covers ::isPayoutLedgerEligibleOrder
+   */
+  public function testMerchOnlyOrderIsLedgerEligible(): void {
+    $product = $this->createMock(ProductInterface::class);
+    $product->method('bundle')->willReturn('operational_merchandise');
+
+    $variation = $this->createMock(ProductVariationInterface::class);
+    $variation->method('getEntityTypeId')->willReturn('commerce_product_variation');
+    $variation->method('bundle')->willReturn('operational_merchandise_var');
+    $variation->method('getProduct')->willReturn($product);
+
+    $item = $this->createMock(OrderItemInterface::class);
+    $item->method('bundle')->willReturn('default');
+    $item->method('getPurchasedEntity')->willReturn($variation);
+
+    $order = $this->createMock(OrderInterface::class);
+    $order->method('bundle')->willReturn('default');
+    $order->method('getItems')->willReturn([$item]);
+    $this->assertTrue($this->classifier->isPayoutLedgerEligibleOrder($order));
   }
 
   /**

--- a/web/modules/custom/myeventlane_pro/src/Form/ProSubscribeForm.php
+++ b/web/modules/custom/myeventlane_pro/src/Form/ProSubscribeForm.php
@@ -7,6 +7,7 @@ namespace Drupal\myeventlane_pro\Form;
 use Drupal\commerce_cart\CartManagerInterface;
 use Drupal\commerce_cart\CartProviderInterface;
 use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_order\Entity\OrderItemInterface;
 use Drupal\Core\Access\AccessManagerInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -24,8 +25,17 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * State-changing action (cart add) happens inside submitForm(), which is
  * POST-only and automatically CSRF-protected by Form API.
+ *
+ * Pro must check out alone on stripe_pe_recurring (off_session). The shared
+ * default cart may already hold tickets/boost; those lines are cleared before
+ * Pro is added so mixed carts cannot be charged entirely on PE.
  */
 final class ProSubscribeForm extends FormBase {
+
+  /**
+   * Variation bundle that identifies MEL Pro subscription inventory.
+   */
+  private const MEL_PRO_VARIATION_TYPE = 'mel_pro_subscription_variation';
 
   public function __construct(
     private readonly AccountProxyInterface $currentUser,
@@ -108,7 +118,7 @@ final class ProSubscribeForm extends FormBase {
         'No active Pro variation found (configure a published commerce variation of type @type or set pro_variation_sku). Configured SKU: @sku',
         [
           '@sku' => $this->productResolver->getConfiguredSku() ?: '(empty)',
-          '@type' => 'mel_pro_subscription_variation',
+          '@type' => self::MEL_PRO_VARIATION_TYPE,
         ],
       );
       $this->messenger()->addError($this->t('Pro subscription is not currently available.'));
@@ -151,6 +161,20 @@ final class ProSubscribeForm extends FormBase {
       $cart->save();
     }
 
+    // Pro must not share a cart with tickets/boost/etc. Mixed carts would either
+    // charge tickets on off_session PE or charge Pro without a dedicated PE path.
+    if ($this->cartHasNonProItems($cart)) {
+      $this->logger->notice(
+        'Clearing non-Pro lines from cart @order_id before Pro subscribe for user @uid.',
+        [
+          '@order_id' => (string) $cart->id(),
+          '@uid' => (string) $currentUid,
+        ],
+      );
+      $this->cartManager->emptyCart($cart);
+      $this->messenger()->addStatus($this->t('Your previous cart items were removed so Pro can be checked out on its own. Add tickets again after your subscription is active if needed.'));
+    }
+
     $this->cartManager->addEntity($cart, $variation);
     // Persist customer ownership defensively after cart mutations.
     if ((int) $cart->getCustomerId() !== $currentUid) {
@@ -167,6 +191,30 @@ final class ProSubscribeForm extends FormBase {
       ],
     );
     $form_state->setRedirectUrl($this->buildCheckoutRedirectUrl($cart));
+  }
+
+  /**
+   * Whether the cart contains any line that is not MEL Pro.
+   */
+  private function cartHasNonProItems(OrderInterface $cart): bool {
+    foreach ($cart->getItems() as $item) {
+      if (!$this->isMelProOrderItem($item)) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Whether an order item is MEL Pro subscription inventory.
+   */
+  private function isMelProOrderItem(OrderItemInterface $item): bool {
+    $purchasedEntity = $item->getPurchasedEntity();
+    if (!$purchasedEntity) {
+      return FALSE;
+    }
+    return $purchasedEntity->getEntityTypeId() === 'commerce_product_variation'
+      && $purchasedEntity->bundle() === self::MEL_PRO_VARIATION_TYPE;
   }
 
   /**

--- a/web/modules/custom/myeventlane_wallet/src/Service/WalletActionBuilder.php
+++ b/web/modules/custom/myeventlane_wallet/src/Service/WalletActionBuilder.php
@@ -146,7 +146,9 @@ final class WalletActionBuilder {
       return $url->toString();
     }
     catch (\Throwable) {
-      return $fallback;
+      // Site-relative fallbacks are valid on rendered pages but unusable in
+      // email clients. Omit the CTA URL when an absolute URL was required.
+      return $absolute ? '' : $fallback;
     }
   }
 
@@ -163,7 +165,9 @@ final class WalletActionBuilder {
       return $url->toString();
     }
     catch (\Throwable) {
-      return '/' . ltrim($relative, '/');
+      // Same absolute-mode rule as routeUrl(): never emit a host-relative badge
+      // src for email surfaces.
+      return $absolute ? NULL : '/' . ltrim($relative, '/');
     }
   }
 

--- a/web/modules/custom/myeventlane_wallet/src/Service/WalletActionBuilder.php
+++ b/web/modules/custom/myeventlane_wallet/src/Service/WalletActionBuilder.php
@@ -146,8 +146,9 @@ final class WalletActionBuilder {
       return $url->toString();
     }
     catch (\Throwable) {
-      // Site-relative fallbacks are valid on rendered pages but unusable in
-      // email clients. Omit the CTA URL when an absolute URL was required.
+      // Site-relative wallet routes are valid on rendered pages but unusable in
+      // email clients. Omit the CTA URL when an absolute URL was required;
+      // OrderConfirmationQueueBuilder recovers via absoluteWalletUrl() instead.
       return $absolute ? '' : $fallback;
     }
   }
@@ -157,6 +158,7 @@ final class WalletActionBuilder {
     if ($relative === NULL) {
       return NULL;
     }
+    $relative_url = '/' . ltrim($relative, '/');
     try {
       $url = Url::fromUri('base:/' . ltrim($relative, '/'), ['absolute' => $absolute]);
       if ($absolute) {
@@ -165,9 +167,12 @@ final class WalletActionBuilder {
       return $url->toString();
     }
     catch (\Throwable) {
-      // Same absolute-mode rule as routeUrl(): never emit a host-relative badge
-      // src for email surfaces.
-      return $absolute ? NULL : '/' . ltrim($relative, '/');
+      // Keep the site-relative asset path when absolute generation fails.
+      // Confirmation email assembly rewrites this through
+      // walletEmailBadgeUrl()/buildPublicUrl() onto the public domain. Returning
+      // NULL here would drop branded Google Wallet images even when the file
+      // exists. (Unlike wallet route CTAs, badge paths are recoverable.)
+      return $relative_url;
     }
   }
 

--- a/web/modules/custom/myeventlane_wallet/tests/src/Unit/WalletActionBuilderTest.php
+++ b/web/modules/custom/myeventlane_wallet/tests/src/Unit/WalletActionBuilderTest.php
@@ -100,15 +100,16 @@ final class WalletActionBuilderTest extends UnitTestCase {
   }
 
   /**
-   * Absolute mode must not emit host-relative route or badge fallbacks.
+   * Absolute mode omits relative wallet routes but keeps recoverable badge paths.
    *
-   * Unit tests lack a full URL generator, so generation throws and previously
-   * returned `/wallet/...` / `/modules/...` paths that email clients cannot
-   * resolve. Absolute mode must omit those values instead.
+   * Unit tests lack a full URL generator, so generation throws. Wallet route
+   * CTAs must not emit host-relative `/wallet/...` fallbacks for email. Badge
+   * assets keep their site-relative path so OrderConfirmationQueueBuilder can
+   * rewrite them through walletEmailBadgeUrl()/buildPublicUrl().
    *
    * @covers ::buildForOrderItem
    */
-  public function testAbsoluteModeOmitsRelativeFallbacks(): void {
+  public function testAbsoluteModeOmitsRelativeRouteFallbacksButKeepsBadgePaths(): void {
     $this->writeAppleCredentials();
     $this->writeServiceAccount();
     new Settings([
@@ -130,8 +131,6 @@ final class WalletActionBuilderTest extends UnitTestCase {
       'show_wallet_in_email' => TRUE,
     ]);
 
-    // Committed badge assets must be discoverable so resolveBadgeUrl() enters
-    // the URI-generation catch path rather than returning early for missing files.
     $this->assertFileExists(
       DRUPAL_ROOT . '/modules/custom/myeventlane_wallet/assets/web/add-to-apple-wallet.svg',
     );
@@ -141,9 +140,15 @@ final class WalletActionBuilderTest extends UnitTestCase {
 
     $actions = $builder->buildForOrderItem(55, WalletActionBuilder::SURFACE_EMAIL, TRUE);
     $this->assertSame('', $actions['apple']['url']);
-    $this->assertNull($actions['apple']['badge']);
     $this->assertSame('', $actions['google']['url']);
-    $this->assertNull($actions['google']['badge']);
+    $this->assertSame(
+      '/modules/custom/myeventlane_wallet/assets/web/add-to-apple-wallet.svg',
+      $actions['apple']['badge']['src'],
+    );
+    $this->assertSame(
+      '/modules/custom/myeventlane_wallet/assets/web/add-to-google-wallet.png',
+      $actions['google']['badge']['src'],
+    );
   }
 
   /**

--- a/web/modules/custom/myeventlane_wallet/tests/src/Unit/WalletActionBuilderTest.php
+++ b/web/modules/custom/myeventlane_wallet/tests/src/Unit/WalletActionBuilderTest.php
@@ -100,6 +100,53 @@ final class WalletActionBuilderTest extends UnitTestCase {
   }
 
   /**
+   * Absolute mode must not emit host-relative route or badge fallbacks.
+   *
+   * Unit tests lack a full URL generator, so generation throws and previously
+   * returned `/wallet/...` / `/modules/...` paths that email clients cannot
+   * resolve. Absolute mode must omit those values instead.
+   *
+   * @covers ::buildForOrderItem
+   */
+  public function testAbsoluteModeOmitsRelativeFallbacks(): void {
+    $this->writeAppleCredentials();
+    $this->writeServiceAccount();
+    new Settings([
+      'myeventlane_wallet' => [
+        'apple_certificate_path' => $this->tempDir . '/pass_cert.pem',
+        'apple_private_key_path' => $this->tempDir . '/pass_key.pem',
+        'apple_wwdr_certificate_path' => $this->tempDir . '/wwdr.pem',
+        'google_service_account_json_path' => $this->tempDir . '/sa.json',
+      ],
+    ]);
+
+    $builder = $this->builder([
+      'apple_enabled' => TRUE,
+      'google_enabled' => TRUE,
+      'apple_team_id' => 'ABCDE12345',
+      'apple_pass_type_id' => 'pass.com.example.mel',
+      'google_issuer_id' => '3388000000000000000',
+      'show_wallet_buttons' => TRUE,
+      'show_wallet_in_email' => TRUE,
+    ]);
+
+    // Committed badge assets must be discoverable so resolveBadgeUrl() enters
+    // the URI-generation catch path rather than returning early for missing files.
+    $this->assertFileExists(
+      DRUPAL_ROOT . '/modules/custom/myeventlane_wallet/assets/web/add-to-apple-wallet.svg',
+    );
+    $this->assertFileExists(
+      DRUPAL_ROOT . '/modules/custom/myeventlane_wallet/assets/web/add-to-google-wallet.png',
+    );
+
+    $actions = $builder->buildForOrderItem(55, WalletActionBuilder::SURFACE_EMAIL, TRUE);
+    $this->assertSame('', $actions['apple']['url']);
+    $this->assertNull($actions['apple']['badge']);
+    $this->assertSame('', $actions['google']['url']);
+    $this->assertNull($actions['google']['badge']);
+  }
+
+  /**
    * @covers ::buildForOrderItem
    */
   public function testEmailSurfaceRespectsEmailFlag(): void {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes live checkout gateway selection and vendor payout liability calculation—financially sensitive paths where misconfiguration could block payments or misstate vendor payables; historical polluted ledger rows are explicitly not cleaned.
> 
> **Overview**
> Implements **Option A** launch remediation for checkout gateway sprawl and incorrect payout ledger rows, plus extensive payment architecture documentation.
> 
> **Checkout gateways:** Sync config restricts `mel_stripe_cc` to administrators and `stripe_pe_recurring` to AUD carts with MEL Pro variation (`AND`). A new `FilterPaymentGatewaysSubscriber` enforces the matrix at runtime—customers get Card Element `stripe` for tickets/boost/donations; Pro-only or recurring carts get PE; mixed ticket+Pro keeps `stripe` and drops off_session PE; manual gateway only for admins.
> 
> **Payout ledger:** `OrderItemClassifier` gains payout eligibility (tickets, operational merch, organiser donation lines; excludes Boost, donations order types, Pro) and **line-level** gross (mixed carts exclude Boost; includes `myeventlane_order_donation` adjustments). `PlatformMetricsService` only lazy-inserts ledger rows when eligible and uses that gross instead of full order total.
> 
> **Related product fixes:** `ProSubscribeForm` empties non-Pro lines before adding Pro so checkout can stay on PE alone. `WalletActionBuilder` avoids bogus relative wallet URLs in email and keeps recoverable badge paths.
> 
> **Docs:** Adds ADRs, critical findings, runtime maps, risk register, and release remediation/plan/report artifacts (read-only audit + deployment guidance).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ed1d5919ce0544019e1b115bf0df0b8d5f7b670. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->