### PR TITLE
refactor: Phase 2B Workstream 1+2A canonical ownership

### DIFF
--- a/docs/adr/ADR-0008-canonical-event-ownership.md
+++ b/docs/adr/ADR-0008-canonical-event-ownership.md
@@ -2,8 +2,7 @@
 
 ## Status
 
-Proposed (Phase 2B.1 discovery).  
-**Accepted for planning.** Implementation must not begin until Workstream 1 tests land.
+**Accepted.** Workstream 1 (canonical API) and Workstream 2A (attendee ownership) implemented on `feature/mel-canonical-ownership-api`.
 
 ## Date
 

--- a/docs/adr/ADR-0008-canonical-event-ownership.md
+++ b/docs/adr/ADR-0008-canonical-event-ownership.md
@@ -1,0 +1,145 @@
+# ADR-0008: Canonical Event Ownership
+
+## Status
+
+Proposed (Phase 2B.1 discovery).  
+**Accepted for planning.** Implementation must not begin until Workstream 1 tests land.
+
+## Date
+
+2026-07-21
+
+## Context
+
+MyEventLane organiser surfaces answer “Can this organiser manage this event?” through multiple overlapping implementations:
+
+- **Workspace parity** via `EventVendorAccessChecker::accountHasWorkspaceParityForEvent()` (author **or** vendor entity owner **or** `field_vendor_users` on the event’s `field_event_vendor`)
+- **Managed event ID sets** via `UserVendorMembershipQuery::getManagedEventNodeIds()` for Views, KPIs, and list isolation
+- **Controller-local asserts** such as `VendorConsoleBaseController::assertEventOwnership()` that duplicate parity inline
+- **Team-partial private helpers** that check author + `field_vendor_users` but **omit vendor entity owner** (attendees export, waitlist, boost workspace, messaging, RSVP QR)
+- **Store / Commerce ownership** via `VendorOwnershipResolver` used as a primary gate for refunds (and as an OR path in some comms/check-in flows)
+- **Console-trust-only routes** (`VendorConsoleAccess`) that defer event ownership to controllers
+- **Permission-only routes** (legacy check-in, vendor API, some QR validate) with ownership enforced only inside controllers
+
+Phase 2A.2 hardened RSVP list scope, attendee exports, and check-in bind without unifying these models. Continuing to add features against divergent helpers will recreate IDOR and PII gaps.
+
+Existing ADR material lives under `docs/architecture/` (ADR-0001). This decision is filed at `docs/adr/` per Phase 2B.1 deliverable path; numbering continues the platform ADR series as **0008**.
+
+Evidence inventory: `docs/implementation/phase2b-ownership-consolidation.md`.
+
+## Decision
+
+Adopt a single canonical ownership stack for organiser event management:
+
+```text
+Route
+  ↓
+Custom Access
+  ↓
+EventVendorAccessChecker::accountHasWorkspaceParityForEvent()
+  ↓
+Business logic
+```
+
+### Canonical APIs
+
+1. **Per-event decision (required for mutations and PII reads):**  
+   `EventVendorAccessCheckerInterface::accountHasWorkspaceParityForEvent()`
+
+2. **Bulk / list / KPI scoping:**  
+   `UserVendorMembershipQueryInterface::getManagedEventNodeIds()`
+
+These two MUST remain semantically aligned for modern events keyed by `field_event_vendor`. Any intentional divergence (e.g. legacy `field_vendor`) must be explicit, tested, and documented.
+
+### Composition rules
+
+1. HTTP mutation and PII read routes use parity (or a thin domain wrapper such as `MelAttendeeOperationsAccess` / `VendorManagedEventConsoleAccess` that calls parity).
+2. List/query surfaces use managed-event ID scoping and fail closed on empty sets.
+3. No new private “is my event?” helpers. Controllers may keep fail-loud asserts that **delegate** to the checker.
+4. `VendorOwnershipResolver` answers Commerce store questions only. For refunds and similar finance operations, store/order constraints are **additional AND** conditions after parity — never a substitute that widens or replaces workspace membership.
+5. `VendorConsoleAccess` remains the organiser console trust/onboarding gate. It is **not** event ownership.
+6. Staff bypasses stay on callers via named permissions (`administer nodes`, `administer event attendees`, `administer commerce_order`, domain admin perms). The parity checker itself does not grant admin.
+7. Soft redirects and UI hiding are never access control.
+
+## Alternatives
+
+### A — Keep multiple ownership helpers; document only
+
+Rejected. Documentation without consolidation has already allowed team-partial vs parity drift (vendor entity owner gaps) and permission-only route gaps.
+
+### B — Make `VendorOwnershipResolver` (store) the canonical model
+
+Rejected. Store linkage is necessary for Commerce refunds and finance, but many organisers operate as vendor entity owners or team members where store resolution is incomplete or secondary. Store-primary access incorrectly frames event management as store ownership.
+
+### C — Rely on Drupal node grants / `node.update` alone
+
+Rejected. Node grants are commonly author-centric. Event Studio and vendor console product intent requires workspace parity for vendor entity owners and team members without requiring them to be the node author. `EventStudioAccess` already documents this explicitly.
+
+### D — Single mega access service for all domains
+
+Rejected as a first step. Prefer a small canonical parity API plus thin domain wrappers (`MelAttendeeOperationsAccess`, ticket `EventAccess`, refund resolver with AND constraints) so product permissions remain separable.
+
+## Consequences
+
+### Positive
+
+- One answer for organiser event reach across Studio, console, attendees, exports, check-in, messaging, API, and waitlist
+- Reduced IDOR/PII regression risk from copy-pasted `field_vendor_users` loops
+- Clear place for refunds to add store/order constraints without inventing a second membership model
+- Route-layer ownership becomes testable and menu-safe
+
+### Negative / costs
+
+- Migration touches many modules (estimated 40–75 files across three workstreams)
+- Aligning team-partial helpers to full parity **correctly widens** access for vendor entity owners who are not listed in `field_vendor_users` on those surfaces
+- Refund AND-with-parity may change edge cases for accounts that previously matched only via store or only via author rules — must be locked in tests before merge
+- Temporary double gates (route + controller assert) until cleanup
+
+## Benefits
+
+- Security: consistent fail-closed event scope for PII and mutations
+- Maintainability: delete divergent private helpers after tests pass
+- Product clarity: “workspace parity” is the organiser contract; store is Commerce
+- Testability: one parity matrix reused by domain wrappers
+
+## Migration
+
+Documented in `docs/implementation/phase2b-ownership-consolidation.md`:
+
+| Workstream | Focus | Behaviour intent |
+|---|---|---|
+| **1** | Lock canonical API + equivalence tests; thin-wrap console assert | Preserve behaviour |
+| **2** | Align attendees, waitlist, messaging, boost vendor path, QR, charts, ACH, refunds AND, API | Preserve stranger deny; fix vendor-owner gaps; lock refund edges |
+| **3** | Route `_custom_access` (check-in, console event tabs), order IDOR, CSRF follow-up | Preserve deny; move enforcement earlier |
+
+Do **not** combine with Commerce role/permission strip (Phase 2A remaining / 2C) unless a hard dependency is documented.
+
+## Compatibility
+
+- Existing callers of `EventVendorAccessChecker` remain valid
+- `VendorConsoleBaseController::assertEventOwnership()` remains until it becomes a pure delegate, then optional defense-in-depth
+- `VendorOwnershipResolver` remains for store resolution
+- `MelAttendeeOperationsAccess` remains the preferred attendee ops façade
+- Legacy `field_vendor` on managed-set queries: decide explicitly in Workstream 1 tests (keep with documented widen **or** remove after data audit)
+- Public Boost purchase author-only path may remain a product exception; vendor workspace Boost must use parity
+
+## Future work
+
+- Workstream 1–3 implementation PRs (no behaviour change in the ADR/docs-only stage)
+- Phase 2B.5 product backlog: permission/config cleanup after PO sign-off
+- Optional: per-request memoisation of parity results
+- Optional: deprecate and remove controller asserts once route access coverage is complete
+- CSRF hardening for legacy check-in (`docs/security/follow-up-checkin-csrf.md`) with or immediately after route ownership (2B.3)
+
+## References
+
+- `docs/implementation/phase2b-ownership-consolidation.md`
+- `docs/implementation/phase2b-ownership-consolidation-plan.md`
+- `docs/audits/vendor-permission-inventory.md`
+- `docs/audits/vendor-route-access-audit.md`
+- `docs/audits/vendor-pii-exposure-audit.md`
+- `docs/vendor-console-v2-access-matrix.md`
+- `web/modules/custom/myeventlane_vendor/src/Service/EventVendorAccessChecker.php`
+- `web/modules/custom/myeventlane_vendor/src/Service/UserVendorMembershipQuery.php`
+- `web/modules/custom/myeventlane_checkout_flow/src/Service/VendorOwnershipResolver.php`
+- `web/modules/custom/myeventlane_checkout_flow/src/Service/MelAttendeeOperationsAccess.php`

--- a/docs/implementation/phase2b-ownership-consolidation.md
+++ b/docs/implementation/phase2b-ownership-consolidation.md
@@ -1,0 +1,598 @@
+# Phase 2B — Ownership Architecture Consolidation
+
+**Date:** 2026-07-21  
+**Status:** Workstream 1 implemented (behaviour-neutral canonical API lock)  
+**Branch evidence:** `feature/mel-canonical-ownership-api`  
+**Prerequisite:** Phase 2A.2 security hotfix (RSVP isolation, export hardening, check-in bind)  
+**Companion plan (shorter):** `docs/implementation/phase2b-ownership-consolidation-plan.md`  
+**ADR:** `docs/adr/ADR-0008-canonical-event-ownership.md`
+
+---
+
+## Stage 0 — Repository safety
+
+| Check | Result |
+|---|---|
+| Repository root | `/Users/anna/myeventlane-wt-apple-wallet-poster` |
+| Implementation branch | `feature/mel-canonical-ownership-api` (cut from `origin/main`) |
+| Prior note | Stale `fix/mel-vendor-access-and-create-flow` had diverged from `origin/main` after PR #698 merge; Workstream 1 restarted on current main |
+| Runtime modified in Workstream 1? | **Yes** — thin wrapper + tests only (behaviour-neutral) |
+
+---
+
+## Objective
+
+Consolidate organiser ownership into one canonical model so every organiser-facing surface answers the same question:
+
+> Can this organiser manage this event?
+
+**Non-goals for Phase 2B.1 (this stage):**
+
+- No PHP / YAML / services / routing / Views / permission changes
+- No config export
+- No behaviour change
+- No Commerce role strip (Phase 2A remaining / 2C)
+
+---
+
+## Stage 1 — Ownership inventory
+
+### Legend — ownership models
+
+| Model ID | Meaning |
+|---|---|
+| **Parity** | Author **or** vendor entity owner **or** `field_vendor_users` on event’s `field_event_vendor` |
+| **Managed-set** | Bulk event IDs via author ∪ vendor-linked events |
+| **Team-partial** | Author **or** `field_vendor_users` only — **misses vendor entity owner** |
+| **Author-only** | Node `uid` match only |
+| **Store** | Commerce store ↔ vendor ↔ event (`VendorOwnershipResolver`) |
+| **Console-trust** | Role/permission/onboarding for `/vendor/*` — **not** event-scoped |
+| **Permission-only** | Route `_permission` with no event ownership at route layer |
+| **Admin-bypass** | Named staff permissions on callers (`administer nodes`, attendee/commerce admin, etc.) |
+
+---
+
+### 1.1 Canonical / preferred services
+
+#### EventVendorAccessChecker
+
+| | |
+|---|---|
+| **File** | `web/modules/custom/myeventlane_vendor/src/Service/EventVendorAccessChecker.php` |
+| **Interface** | `EventVendorAccessCheckerInterface` |
+| **Method** | `accountHasWorkspaceParityForEvent(NodeInterface, AccountInterface): bool` |
+| **Ownership model** | **Parity** (no admin, no store) |
+| **Callers** | `VendorManagedEventConsoleAccess`, `MelAttendeeOperationsAccess`, `EventStudioAccess`, `EventTicketsAccess` / `EventAccess`, `VendorEventAccess`, `AttendeeCsvExportAccess`, export controllers, analytics `accessEvent`, check-in `assertEventAccess`, vendor comms (partial), many Event Studio forms |
+| **Strengths** | Small, interface-injected, documented as workspace parity, unit-tested |
+| **Weaknesses** | Ignores legacy `field_vendor`; duplicated inline in console base; not yet used by all surfaces |
+| **Future state** | **Canonical per-event decision API** |
+
+#### UserVendorMembershipQuery
+
+| | |
+|---|---|
+| **File** | `web/modules/custom/myeventlane_vendor/src/Service/UserVendorMembershipQuery.php` |
+| **Methods** | `getVendorIdsForUser()`, `getManagedEventNodeIds($uid, $publishedOnly)` |
+| **Ownership model** | **Managed-set** (author ∪ `field_event_vendor` IN vendor IDs; optional legacy `field_vendor`) |
+| **Callers** | `RsvpOrganiserViewScope`, dashboard / metrics / ticket sales / RSVP stats aggregators |
+| **Strengths** | Correct list/KPI scoping pattern; fail-soft empty set |
+| **Weaknesses** | Legacy `field_vendor` can widen vs parity; node query uses `accessCheck(FALSE)` intentionally |
+| **Future state** | **Canonical bulk/list API**; must stay semantically aligned with parity |
+
+#### MelAttendeeOperationsAccess
+
+| | |
+|---|---|
+| **File** | `web/modules/custom/myeventlane_checkout_flow/src/Service/MelAttendeeOperationsAccess.php` |
+| **Methods** | `canViewAttendees`, `canExportAttendees`, `canCheckInAttendees`, `canCancelAttendance`, `canViewAttendeeRow`, `hasAnyOperationalAccess` |
+| **Ownership model** | **Admin-bypass** + **Parity** |
+| **Callers** | `MelAttendeeCheckinManager`, door / ops controller paths |
+| **Strengths** | Action-named, fail-closed, already uses checker |
+| **Weaknesses** | Not yet wired into older attendee/waitlist controllers; all actions share one resolve |
+| **Future state** | **Canonical attendee ops policy** wrapping parity |
+
+#### VendorManagedEventConsoleAccess
+
+| | |
+|---|---|
+| **File** | `web/modules/custom/myeventlane_vendor/src/Access/VendorManagedEventConsoleAccess.php` |
+| **Method** | `access(RouteMatch, Account)` |
+| **Ownership model** | **Console-trust** composed with **Parity** + `administer nodes` |
+| **Callers** | Selected vendor routing (`vendor_managed_event_console`) e.g. archive |
+| **Strengths** | Correct target composition for `{event}` console routes |
+| **Weaknesses** | Under-used; most console event tabs still console-only + controller assert |
+| **Future state** | Preferred `_custom_access` for managed-event console routes |
+
+#### VendorConsoleAccess
+
+| | |
+|---|---|
+| **File** | `web/modules/custom/myeventlane_vendor/src/Access/VendorConsoleAccess.php` |
+| **Method** | `access(RouteMatch, Account)` |
+| **Ownership model** | **Console-trust** / onboarding / path namespace — **not** event ownership |
+| **Callers** | Most `/vendor/*` routes; composed by managed-event and boost workspace access |
+| **Strengths** | Menu vs request path parity; onboarding deadlock avoidance |
+| **Weaknesses** | Easy to mistake for event ownership |
+| **Future state** | Keep as console entry gate only |
+
+---
+
+### 1.2 Store / refund path
+
+#### VendorOwnershipResolver
+
+| | |
+|---|---|
+| **File** | `web/modules/custom/myeventlane_checkout_flow/src/Service/VendorOwnershipResolver.php` |
+| **Methods** | `vendorOwnsEvent(Store, Event)`, `getStoreForUser(Account)` |
+| **Ownership model** | **Store** |
+| **Callers** | `RefundAccessResolver`, vendor check-in (store path), vendor comms (OR with parity), messaging fallbacks |
+| **Strengths** | Correct Commerce question: “does this store sell this event?” |
+| **Weaknesses** | Not workspace parity; team without resolvable store can fail |
+| **Future state** | **Implementation detail / additional constraint** — never sole event-management gate |
+
+#### RefundAccessResolver
+
+| | |
+|---|---|
+| **File** | `web/modules/custom/myeventlane_refunds/src/Service/RefundAccessResolver.php` |
+| **Methods** | `vendorCanManageEvent`, `vendorCanRefundOrderForEvent`, `accessManageEvent`, `accessRefundOrder` |
+| **Ownership model** | Author **OR** **Store** (+ commerce admin); order-state + event-item binding for refunds |
+| **Callers** | Refund forms, `VendorOrdersController`, refund route access checks, `RefundProcessor` |
+| **Strengths** | Order binding and refundable-state guards |
+| **Weaknesses** | ≠ parity; team without store may be denied; author allowed without store |
+| **Future state** | **Parity AND store/order constraints** |
+
+---
+
+### 1.3 Domain access checkers
+
+| Component | File | Method | Model | Callers | Strengths | Weaknesses | Future |
+|---|---|---|---|---|---|---|---|
+| **EventStudioAccess** | `myeventlane_event_studio/.../EventStudioAccess.php` | `access` | Admin + vendor context + **Parity** | Studio routes | Avoids node-grant-only trap | Extra vendor-resolve can deny when no vendor entity | Keep; ensure not stricter than parity without product reason |
+| **EventTicketsAccess** | `myeventlane_tickets/.../EventTicketsAccess.php` | `access` | Ticket perms + **Parity** | Tickets workspace routes | Stronger product gate | Dual permission paths | Keep; ownership via checker |
+| **VendorEventAccess** | `myeventlane_rsvp/.../VendorEventAccess.php` | `access` | RSVP perm + **Parity** | RSVP vendor routes | Uses checker | Parallel QR private helper drifts | Keep; delete private duplicates |
+| **TicketOperationsAccess** | `myeventlane_tickets/.../TicketOperationsAccess.php` | `accessResend` | Ticket/console + **Parity** | Resend routes | Event-scoped | Narrow surface today | Keep pattern |
+| **AttendeeCsvExportAccess** | `myeventlane_views/.../AttendeeCsvExportAccess.php` | `access` | Capability + **Parity** on download | Legacy CSV route | No existence leak | Query-param event id | Keep until retired |
+| **BoostRouteAccess** | `myeventlane_boost/.../BoostRouteAccess.php` | `access`, `accessVendorWorkspace`, `accountManagesEvent` | Public: **Author-only**; vendor: **Team-partial** | Boost routes | Separates public purchase vs console | Vendor path **misses vendor entity owner** | Vendor path → checker |
+
+---
+
+### 1.4 Controllers and private helpers
+
+| Component | File | Method | Model | Notes | Future |
+|---|---|---|---|---|---|
+| **VendorConsoleBaseController** | `myeventlane_vendor/.../VendorConsoleBaseController.php` | `assertEventOwnership` | **Parity** (inline duplicate) + console trust | Used by most console event controllers | Thin wrapper over checker |
+| **ManageEventControllerBase** | `myeventlane_vendor/.../ManageEventControllerBase.php` | `access` | Admin / author+edit-own / vendor owner+team (inline) | Author path requires edit-own; team does not | Delegate to checker + explicit perms |
+| **VendorEventTicketsBaseController** | `myeventlane_tickets/.../VendorEventTicketsBaseController.php` | inherited assert | Parity duplicate | Tickets override can allow `EventAccess` first | Keep base; ownership via checker |
+| **CheckInController** | `myeventlane_checkin/.../CheckInController.php` | `assertEventAccess` | Admin **or** **Parity** | Routes still **permission-only** | Move to `_custom_access` |
+| **VendorAttendeeController** | `myeventlane_event_attendees/.../VendorAttendeeController.php` | `access` / `accessAttendee` | **Team-partial** | Misses vendor entity owner | → MelAttendeeOperationsAccess / parity |
+| **WaitlistManagementController** | same module | `access` | **Team-partial** | Same gap | → parity |
+| **VendorNotifyForm** | `myeventlane_messaging/.../VendorNotifyForm.php` | `assertEventOwnership` | **Team-partial** | Private | → checker |
+| **MessageAttendeesController** | `myeventlane_pro/.../MessageAttendeesController.php` | `assertAccess` | Private owner/team | Route console-only | → checker |
+| **QrCheckinController** | `myeventlane_rsvp/.../QrCheckinController.php` | `canManageEvent` | **Team-partial** | Validate route permission-only | → checker; route `_custom_access` |
+| **VendorApiBaseController** | `myeventlane_api/.../VendorApiBaseController.php` | `vendorOwnsEvent` | Vendor link **or** author==vendor owner — **no team** | Route permission-only | Align API user with parity |
+| **ChartDataController** | `myeventlane_reporting/.../ChartDataController.php` | `access` | **Author-only** at route; methods call full assert | Drift: team/vendor-owner denied at access, assert would allow | Align access with parity |
+| **EventWizardBaseForm / EventContentForm** | event wizard forms | author asserts | **Author-only** | Narrower than Studio parity | Align or document intentional |
+
+---
+
+### 1.5 Entity access handlers and Views
+
+| Component | File | Model | Future |
+|---|---|---|---|
+| **EventAttendeeAccessControlHandler** | `myeventlane_event_attendees/.../EventAttendeeAccessControlHandler.php` | Author + own-attendee perms; admin attendee | Align with MelAttendeeOperationsAccess / parity |
+| Ticket ACHs (`TicketGroup`, `AccessCode`, settings, purchase surface) | `myeventlane_tickets/...` | Via `EventAccess` → parity | Keep |
+| **RedemptionLogAccessControlHandler** | tickets | Custom helpers + check-in perm | Align helpers with checker |
+| **VendorAccessControlHandler** | vendor entity | Vendor **entity** owner only for update/delete | Keep intentional (≠ event parity) |
+| Views `vendor_store_access` | `myeventlane_views` | Store owner / admin | Coarse page gate only |
+| Views `myeventlane_rsvp_vendor_access` | RSVP | Permission-only page | Row isolation via `RsvpOrganiserViewScope` |
+
+#### RsvpOrganiserViewScope
+
+| | |
+|---|---|
+| **File** | `web/modules/custom/myeventlane_rsvp/src/Service/RsvpOrganiserViewScope.php` |
+| **Methods** | `accountBypassesOrganiserScope`, `getManagedEventIds`, `applyToViewsQuery` |
+| **Model** | **Managed-set** + staff bypass; fail-closed `1=0` |
+| **Future** | Keep list gate; prove ≡ parity |
+
+---
+
+### 1.6 Domain summary
+
+| Domain | Primary model today | Classification |
+|---|---|---|
+| Event Studio | Parity (+ vendor context) | Service-based + route-based |
+| Orders (console) | Console-trust + controller parity assert | Controller-local (route incomplete) |
+| Attendees | Mixed: assert / team-partial / Mel ops | Duplicated |
+| Exports | Mostly parity (Phase 2A.2) | Service/route-based (good) |
+| Refunds | Author OR store | Store-only hybrid (divergent) |
+| Messaging | Team-partial / parity OR store | Duplicated / inconsistent |
+| Check-in | Permission-only route + parity in controller (legacy); store / team-partial elsewhere | Controller-local gap |
+| Analytics | Parity on event dashboard; console assert | Mostly aligned |
+| Reporting charts | Author-only access callback | Author-only drift |
+| Vendor API | Vendor link / owner UID; no team | Controller-local; inconsistent |
+| Waitlist | Team-partial | Inconsistent |
+| Questions | Studio parity / manage-event clone | Mostly service-based |
+| Boost | Author-only public; team-partial vendor | Inconsistent |
+| Dashboard | Managed-set queries | Service-based (list) |
+
+---
+
+### 1.7 Semantic mismatch: parity vs managed-set
+
+| Signal | Workspace parity | Managed event IDs |
+|---|---|---|
+| Event author | Yes | Yes |
+| Vendor entity owner | Yes | Yes (via vendor ID set) |
+| `field_vendor_users` | Yes | Yes |
+| Legacy `field_vendor` | **No** | **Yes** (if field exists) |
+| Store | No | No |
+
+**Implication:** Modern `field_event_vendor` events should match. Divergence: legacy field widening on lists, or callers using store / team-partial instead of either API.
+
+---
+
+## Stage 2 — Dependency graph
+
+### Target shape
+
+```text
+Route
+  ↓
+Custom Access (_custom_access)
+  ↓
+EventVendorAccessChecker  (parity)
+  ↓  [optional AND]
+VendorOwnershipResolver / order-state / product perms
+  ↓
+Business logic
+```
+
+### Current shape (simplified)
+
+```mermaid
+flowchart TB
+  subgraph routeLayer [Route layer]
+    VC[VendorConsoleAccess<br/>console trust only]
+    VME[VendorManagedEventConsoleAccess<br/>console + parity]
+    ESA[EventStudioAccess]
+    ETA[EventTicketsAccess]
+    RSVP[VendorEventAccess]
+    EXP[Export custom access]
+    REF[RefundAccessResolver]
+    BOOST[BoostRouteAccess]
+    PERM[Permission-only routes]
+  end
+
+  subgraph ownership [Ownership implementations]
+    EVAC[EventVendorAccessChecker<br/>CANONICAL]
+    UVMQ[UserVendorMembershipQuery]
+    ASSERT[VendorConsoleBaseController<br/>assertEventOwnership DUPLICATE]
+    VOR[VendorOwnershipResolver]
+    PRIV[Private team-partial / author-only helpers]
+  end
+
+  VC --> ASSERT
+  VME --> EVAC
+  ESA --> EVAC
+  ETA --> EVAC
+  RSVP --> EVAC
+  EXP --> EVAC
+  REF --> VOR
+  BOOST --> PRIV
+  PERM --> ASSERT
+  PERM --> PRIV
+  UVMQ --> Dash[Dashboard / RSVP Views]
+  ASSERT --> ConsoleBiz[Orders Attendees Analytics]
+  EVAC --> StudioBiz[Studio Exports Tickets]
+  PRIV --> WaitMsg[Waitlist Messaging API QR]
+  VOR --> RefundBiz[Refunds]
+```
+
+### Duplicated ownership implementations
+
+1. `EventVendorAccessChecker` ↔ `VendorConsoleBaseController::assertEventOwnership` (intentional clone)
+2. `ManageEventControllerBase::access` (inline clone)
+3. Team-partial private loops (miss vendor entity owner):
+   - `VendorAttendeeController::access`
+   - `WaitlistManagementController::access`
+   - `BoostRouteAccess::accountManagesEvent`
+   - `VendorNotifyForm::assertEventOwnership`
+   - `QrCheckinController::canManageEvent`
+   - (and related messaging helpers)
+4. `RefundAccessResolver` + `VendorOwnershipResolver` (store model parallel to parity)
+5. `VendorCommsController` parity **OR** store (union)
+6. `VendorApiBaseController::vendorOwnsEvent` (vendor link / owner; no team)
+7. `ChartDataController::access` (author-only vs assert parity)
+8. Event Studio form author-only checks vs `EventStudioAccess` parity
+9. Tickets: route `EventTicketsAccess` + controller assert (defense-in-depth double)
+
+### Controllers that perform ownership directly
+
+(Representative — not exhaustive of every subclass)
+
+- `VendorConsoleBaseController` and subclasses (workspace, orders, order view, overview, settings, RSVP, analytics, attendees, archive, tickets, addon orders, boost exports, reporting controllers)
+- `CheckInController` (`assertEventAccess`)
+- `VendorEventOperationsController`
+- `EventTicketsController` / ticket check-in surfaces
+- `VendorAttendeeController`, `WaitlistManagementController`
+- `VendorOrderController`, `AttendeeExportController`, `AttendeeCsvController`
+- `AnalyticsDashboardController::accessEvent`
+- `ChartDataController`, `EventInsightsController`, `ExportCentreController`
+- `MessageAttendeesController`, `VendorNotifyForm`
+- `BoostController` / `WizardController`
+- `VendorApiBaseController` (+ event/attendee/export API)
+- `QrCheckinController`
+- Event Studio publish/autosave/governance controllers
+- `ManageEventControllerBase`
+
+### Route gaps (permission/console-only → ownership only in controller)
+
+| Gap | Route pattern | Route gate | Ownership later |
+|---|---|---|---|
+| Legacy check-in | `myeventlane_checkin.*` | `_permission` | Controller parity |
+| RSVP QR validate | `myeventlane_rsvp.checkin_validate` | `_permission` | Private team-partial |
+| Most console event tabs | orders, workspace, RSVP, settings, analytics, attendees list, door | `VendorConsoleAccess` only | `assertEventOwnership` |
+| Boost wizard | wizard steps | console only | assert |
+| Message attendees | pro message route | console only | private assert |
+| Vendor API | `myeventlane_api.vendor.*` | `access vendor api` | `vendorOwnsEvent` |
+
+**Already route-hardened with parity:** Event Studio, tickets workspace, RSVP vendor event routes, CSV/export access (Phase 2A.2), analytics per-event `accessEvent`, archive via `VendorManagedEventConsoleAccess`.
+
+---
+
+## Stage 3 — Behaviour matrix
+
+**Legend:** `Y` = allowed under typical organiser setup · `N` = denied · `P` = partial / path-dependent · `—` = not applicable  
+**Actors:** Author = event node owner · Vendor owner = vendor entity owner (may ≠ author) · Vendor team = `field_vendor_users` · Store owner = Commerce store owner without parity · Authenticated = unrelated logged-in user
+
+| Surface | Author | Vendor owner | Vendor team | Admin | Store owner | Anonymous | Authenticated | Current result | Future result |
+|---|---|---|---|---|---|---|---|---|---|
+| **Event Studio** | Y | Y | Y | Y | N | N | N | Parity + vendor context | Parity (+ console trust where needed) |
+| **Orders** | Y | Y | Y | Y | N | N | N | Console + controller parity | Route managed-event access + parity; order IDOR bind |
+| **Attendees** | Y | P | Y | Y | N | N | N | Mixed: assert vs team-partial (owner gap on export) | MelAttendeeOperationsAccess → parity |
+| **Exports** | Y | Y | Y | Y | N | N | N | Mostly parity (2A.2) | Keep parity; Mel export policy |
+| **Refunds** | Y | P | P | Y | P | N | N | Author OR store | Parity **AND** store/order rules |
+| **Messaging** | Y | P | Y | Y | P | N | N | Team-partial / parity OR store | Parity; store only as extra |
+| **Check-in** | Y | Y | Y | Y | P | N | N | Route permission + controller parity (legacy); other paths diverge | Route `_custom_access` → Mel ops / parity |
+| **Analytics** | Y | Y | Y | Y | N | N | N | Parity / console assert | Parity |
+| **API** | Y | Y | N | Y | N | N | N | Vendor link / owner UID | Parity for API account |
+| **Waitlist** | Y | N | Y | Y | N | N | N | Team-partial (owner miss) | Parity |
+| **Questions** | Y | Y | Y | Y | N | N | N | Studio parity / manage clone | Parity via Studio / checker |
+| **Boost** | Y | N* | Y* | Y | N | N | N | Public author-only; vendor team-partial (*vendor owner miss on workspace) | Public TBD; vendor → parity |
+| **Dashboard** | Y | Y | Y | Y | N | N | N | Managed-set scoping | Managed-set ≡ parity |
+
+\*Boost public purchase path remains author-oriented by product design today; vendor workspace path should not omit vendor entity owner.
+
+---
+
+## Stage 4 — Canonical ownership model
+
+### Preferred stack
+
+```text
+Route
+  ↓
+Custom Access
+  ↓
+EventVendorAccessChecker::accountHasWorkspaceParityForEvent()
+  ↓
+Business logic
+```
+
+### Role of each layer
+
+| Layer | Responsibility |
+|---|---|
+| **Route `_permission` / Pro gates** | Product capability (e.g. manage refunds, Pro analytics) — never event membership alone |
+| **VendorConsoleAccess** | Organiser console trust + onboarding — never event membership |
+| **VendorManagedEventConsoleAccess / EventStudioAccess / MelAttendeeOperationsAccess** | Compose console/product gates with **parity** |
+| **EventVendorAccessChecker** | **Canonical** answer to “can this account manage this event?” |
+| **UserVendorMembershipQuery** | Canonical bulk membership for Views/KPIs; must ≡ parity |
+| **VendorOwnershipResolver** | Commerce store linkage — **additional** constraint for refunds/finance |
+| **Controller assert** | Fail-loud defense-in-depth **calling** checker — no private membership loops |
+
+### Where VendorOwnershipResolver remains appropriate
+
+- Refund eligibility after parity (AND)
+- Finance / store-scoped aggregations
+- Explicit “which store sells this event?” questions
+
+### Where it must not be primary
+
+- Attendee PII
+- Check-in
+- Messaging
+- Event Studio / console event tabs
+- Waitlist / questions / boost vendor workspace
+- Vendor API event scope
+
+### Staff bypass policy
+
+- Explicit named permissions only (`administer nodes`, `administer event attendees`, `administer commerce_order`, domain admin perms)
+- Never silent widen inside the parity checker itself
+
+---
+
+## Stage 5 — Migration plan (workstreams)
+
+### Workstream 1 — Lock the canonical API (no behaviour change)
+
+**Outcome:** Single public ownership contract + equivalence tests; deprecate new private helpers by convention.
+
+| Item | Detail |
+|---|---|
+| Scope | Document + tests around `EventVendorAccessChecker` and `UserVendorMembershipQuery`; thin `assertEventOwnership` → checker (behaviour-preserving) |
+| Estimated files | 8–15 (`EventVendorAccessChecker*`, `UserVendorMembershipQuery*`, `VendorConsoleBaseController`, unit/kernel tests, this ADR/docs) |
+| Expected tests | Parity matrix: author, vendor owner, team, stranger, staff; managed-set ≡ parity (published/unpublished); legacy `field_vendor` policy test |
+| Risk | Low if assert becomes pure delegate |
+| Rollback | Revert thin-wrapper PR; no route changes |
+
+**Maps to plan IDs:** 2B.1
+
+### Workstream 2 — Align divergent callers (preserve intended allow/deny)
+
+**Outcome:** Replace team-partial / author-only / store-primary event-management gates with parity (plus AND store for refunds).
+
+| Item | Detail |
+|---|---|
+| Scope | Attendees, waitlist, messaging, boost vendor workspace, QR check-in helper, ChartData access, EventAttendee ACH, RefundAccessResolver AND parity, Vendor API team parity |
+| Estimated files | 20–35 across attendees, messaging, boost, rsvp, reporting, refunds, api, event_attendees ACH |
+| Expected tests | Kernel A/B organiser isolation per surface; refund: team with store, team without store, author-only, stranger; vendor entity owner on waitlist/export/boost |
+| Risk | Medium — fixing vendor-owner gaps **widens** access for vendor entity owners on team-partial surfaces (correctness fix, not silent broaden for strangers). Refund AND may **narrow** team-without-store if previously store-OR author paths differed — matrix must lock expected product behaviour first |
+| Rollback | Revert per-module PR; keep Workstream 1 tests as baseline |
+
+**Maps to plan IDs:** 2B.2 (+ parts of messaging/API/boost)
+
+### Workstream 3 — Route-layer ownership + order IDOR
+
+**Outcome:** Move ownership from controller-only to `_custom_access`; close order detail IDOR; optional CSRF follow-up for legacy check-in.
+
+| Item | Detail |
+|---|---|
+| Scope | Expand `VendorManagedEventConsoleAccess` (or Mel ops access) on console `{event}` routes; check-in routes; RSVP validate; order detail bind to event/vendor stores; CSRF see `docs/security/follow-up-checkin-csrf.md` |
+| Estimated files | 15–25 (routing YAML, access services, order view controller, check-in, tests) |
+| Expected tests | Static routing safety (check-in requires `_custom_access`); kernel IDOR on foreign order IDs; regression Phase 2A.2 suite |
+| Risk | Medium — menu link visibility may change when route access gains parity; cache contexts must include user + event |
+| Rollback | Revert routing + access service wiring; controllers still assert as backstop until removed in a later cleanup |
+
+**Maps to plan IDs:** 2B.3, 2B.4  
+**Deferred product backlog:** 2B.5 (permission/config cleanup after PO sign-off)
+
+### Cross-cutting risks
+
+| Risk | Mitigation |
+|---|---|
+| Edge membership behaviour change | Parity matrix tests before/after; separate PRs per workstream |
+| Refund false allow if store dropped | Keep store as **AND** with parity |
+| Performance of repeated parity | Per-request memoisation; managed-set for lists |
+| Scope creep into Commerce role strip | Keep role YAML out of Phase 2B PRs |
+| Legacy check-in CSRF | Tracked separately; land with or immediately after 2B.3 |
+| Soft redirects mistaken for access | Never treat messenger redirect as ACL |
+
+### Expected modules touched (implementation later)
+
+`myeventlane_vendor`, `myeventlane_event_attendees`, `myeventlane_refunds`, `myeventlane_checkin`, `myeventlane_messaging`, `myeventlane_tickets`, `myeventlane_rsvp`, `myeventlane_boost`, `myeventlane_api`, `myeventlane_reporting`, `myeventlane_pro`, `myeventlane_vendor_comms`, `myeventlane_checkout_flow`, `myeventlane_checkout_paragraph`, `myeventlane_views` (regression only)
+
+### Rollback strategy (global)
+
+1. Prefer small reversible PRs per workstream  
+2. Keep controller asserts until route access proven  
+3. No config/permission strip in ownership PRs  
+4. Feature flag only if a widen/narrow cannot be proven with fixtures  
+
+---
+
+## Stage 6 — ADR
+
+See: [`docs/adr/ADR-0008-canonical-event-ownership.md`](../adr/ADR-0008-canonical-event-ownership.md)
+
+---
+
+## Stage 7 — Validation
+
+### Workstream 1 validation (executed)
+
+| Check | Result |
+|---|---|
+| `php -l` on changed PHP | Pass |
+| Focused phpunit ownership tests | Pass (21 tests) |
+| PHPCS on changed module files | Pass (0 errors) |
+| `ddev drush cr` | Pass |
+| Service `myeventlane_vendor.event_access_checker` | Resolves; implements interface |
+| Constructor optional 4th param | Compatible with existing 3-arg subclass calls |
+| YAML / routing / services / Views / permissions | Unchanged |
+| Config export | Not required |
+| `scripts/check-webroot-safety.sh` | Pass |
+| Runtime behaviour | **Unchanged** for event-bundle organiser matrix |
+
+```bash
+ddev exec vendor/bin/phpunit -c web/core \
+  web/modules/custom/myeventlane_vendor/tests/src/Unit/EventVendorAccessCheckerTest.php \
+  web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorConsoleBaseControllerOwnershipEquivalenceTest.php
+```
+
+---
+
+## Exit criteria
+
+- [x] Workstream 1: thin `assertEventOwnership` → `EventVendorAccessChecker`; equivalence tests  
+- [ ] Call-site inventory closed; no divergent private ownership helpers for console PII/mutations  
+- [ ] Parity ≡ managed-set proven in tests (legacy field policy explicit)  
+- [ ] Check-in routes ownership at route layer; Phase 2A.2 bind retained  
+- [ ] Attendee + refund parity aligned  
+- [ ] Order detail IDOR tests green  
+- [ ] CSRF follow-up fixed or still explicitly deferred  
+
+---
+
+## Workstream 1 — Implementation log (2026-07-21)
+
+### Wrappers migrated
+
+| Class | Current ownership call | Canonical replacement | Behaviour change? |
+|---|---|---|---|
+| `VendorConsoleBaseController::assertEventOwnership()` | Inline author + vendor owner + `field_vendor_users` | `EventVendorAccessChecker::accountHasWorkspaceParityForEvent()` after console trust + `administer nodes` | **No** for event bundles (matrix locked in unit tests) |
+| `EventVendorAccessChecker` | Already canonical | Docs/interface clarified as canonical API | No |
+| `ManageEventControllerBase::access()` | Inline parity + **author requires `edit own event content`** | Deferred — not wrapped | N/A (stop: wrapping would widen authors lacking edit-own) |
+| Team-partial helpers (attendees, waitlist, messaging, boost, QR, API) | Private loops | Deferred to Workstream 2 | N/A |
+
+### Duplicate ownership removed
+
+- Inline membership loop inside `VendorConsoleBaseController::assertEventOwnership()` replaced by canonical checker call.
+- Method signature, `AccessDeniedHttpException`, console-trust prelude, and `administer nodes` bypass retained.
+- Helper method **not deleted** (defense-in-depth wrapper).
+
+### Behaviour equivalence (event bundles)
+
+| Actor | Legacy inline | Canonical checker | Wrapper (`assertEventOwnership`) |
+|---|---|---|---|
+| Event author | Allow | Allow | Allow |
+| Vendor entity owner | Allow | Allow | Allow |
+| Vendor team member | Allow | Allow | Allow |
+| Unrelated organiser | Deny | Deny | Deny |
+| Authenticated non-organiser | Deny | Deny | Deny |
+| Anonymous | Deny (also fails console trust) | Deny | Deny (console trust) |
+| Administrator (`administer nodes`) | Allow (caller bypass) | Deny (by design) | Allow (caller bypass retained) |
+
+**Edge note (not a production caller path):** checker returns FALSE for non-`event` bundles even when UID matches author; pre-wrapper assert allowed any-bundle authors. Console callers pass event nodes only — no route/menu change.
+
+### Cache verification
+
+| Surface | Changed? |
+|---|---|
+| Route `_custom_access` / requirements | No |
+| Menu / local tasks / local actions / breadcrumbs | No |
+| `AccessResult` cache contexts/tags/max-age | No — `assertEventOwnership` remains void/exception (never returned cache metadata) |
+| `ManageEventControllerBase::access()` cache metadata | Untouched |
+
+### Tests added / extended
+
+- `EventVendorAccessCheckerTest` — anonymous, authenticated non-organiser, admin-without-membership, non-event bundle
+- `VendorConsoleBaseControllerOwnershipEquivalenceTest` — legacy ≡ checker ≡ wrapper for author / vendor owner / team / stranger / non-organiser; admin bypass; anonymous deny
+
+### Remaining Workstream 2
+
+- Align team-partial / author-only / store-primary gates (attendees, waitlist, messaging, boost vendor path, QR, charts, ACH, refunds AND parity, vendor API)
+- Prove managed-set ≡ parity (legacy `field_vendor` policy)
+- Carefully compose `ManageEventControllerBase::access()` with checker **without** dropping `edit own event content`
+
+### Remaining Workstream 3
+
+- Route `_custom_access` for check-in + console event tabs
+- Order detail IDOR bind
+- CSRF follow-up for legacy check-in (or keep deferred)
+
+---
+
+## Related documents
+
+- `docs/implementation/phase2b-ownership-consolidation-plan.md`
+- `docs/audits/vendor-permission-inventory.md`
+- `docs/audits/vendor-route-access-audit.md`
+- `docs/audits/vendor-pii-exposure-audit.md`
+- `docs/vendor-console-v2-access-matrix.md`
+- `docs/implementation/vendor-permission-hardening-phase2-plan.md`
+- `docs/security/follow-up-checkin-csrf.md`

--- a/docs/implementation/phase2b-ownership-consolidation.md
+++ b/docs/implementation/phase2b-ownership-consolidation.md
@@ -1,9 +1,9 @@
 # Phase 2B — Ownership Architecture Consolidation
 
 **Date:** 2026-07-21  
-**Status:** Workstream 1 implemented (behaviour-neutral canonical API lock)  
+**Status:** Workstream 2A implemented (attendee ownership consolidation)  
 **Branch evidence:** `feature/mel-canonical-ownership-api`  
-**Prerequisite:** Phase 2A.2 security hotfix (RSVP isolation, export hardening, check-in bind)  
+**Prerequisite:** Phase 2A.2 security hotfix (RSVP isolation, export hardening, check-in bind); Workstream 1 canonical API  
 **Companion plan (shorter):** `docs/implementation/phase2b-ownership-consolidation-plan.md`  
 **ADR:** `docs/adr/ADR-0008-canonical-event-ownership.md`
 
@@ -519,12 +519,89 @@ ddev exec vendor/bin/phpunit -c web/core \
 ## Exit criteria
 
 - [x] Workstream 1: thin `assertEventOwnership` → `EventVendorAccessChecker`; equivalence tests  
-- [ ] Call-site inventory closed; no divergent private ownership helpers for console PII/mutations  
-- [ ] Parity ≡ managed-set proven in tests (legacy field policy explicit)  
+- [x] Workstream 2A: attendee / waitlist / messaging / QR / ACH ownership → Mel → checker (or checker where Mel is cycle-blocked)  
+- [x] Parity ≡ managed-set proven for modern `field_event_vendor` events; legacy `field_vendor` widen documented (no reconciliation invented)  
+- [ ] Call-site inventory closed for non-attendee surfaces (Workstream 2B)  
 - [ ] Check-in routes ownership at route layer; Phase 2A.2 bind retained  
-- [ ] Attendee + refund parity aligned  
+- [ ] Refund parity AND store aligned (Workstream 2B)  
 - [ ] Order detail IDOR tests green  
 - [ ] CSRF follow-up fixed or still explicitly deferred  
+
+---
+
+## Workstream 2A — Attendee ownership consolidation (2026-07-21)
+
+### Scope
+
+Attendee-facing organiser workflows only. Excluded: refunds, Boost, charts, analytics, APIs, Event Studio, Commerce permissions, route conversions, check-in route refactoring.
+
+### Components migrated
+
+| Class | Current ownership model | Canonical replacement | Behaviour change |
+|---|---|---|---|
+| `VendorAttendeeController::access` / `accessAttendee` | Team-partial (author + `field_vendor_users`) | Product gates + `EventVendorAccessChecker` (Mel delegate; Mel lives in `checkout_flow` which depends on this module) | **Vendor entity owner** gains access when `view own event attendees` holds |
+| `WaitlistManagementController::access` | Team-partial | Staff bypass preserved + `EventVendorAccessChecker` | **Vendor entity owner** gains access |
+| `VendorNotifyForm::assertEventOwnership` | Team-partial | Staff bypass + `MelAttendeeOperationsAccess::accountHasOrganiserOwnership` → checker | **Vendor entity owner** gains access |
+| `MessageAttendeesController::assertAccess` | Private owner/team (already included vendor entity owner) | Pro gate + Mel ownership hop | **None** for organisers (cleanup only) |
+| `QrCheckinController::canManageEvent` | Team-partial | RSVP perms + Mel ownership hop | **Vendor entity owner** gains access when `manage own event rsvps` holds |
+| `EventAttendeeAccessControlHandler` | Author-only + own-attendee perms | Same product perms + checker parity | **Vendor entity owner / team** gain entity view/update/delete when product perms hold |
+| `AttendeeExportController` / `AttendeeCsvExportAccess` | Already parity (Phase 2A.2) | Unchanged (already `EventVendorAccessChecker`) | None |
+
+### Ownership paths removed
+
+- Private author / `field_vendor_users` loops in attendee list, waitlist, notify form, QR validate
+- Private `resolveEventVendor` / `isVendorMember` helpers on `MessageAttendeesController`
+
+### Intentional behavioural improvements
+
+- Vendor entity owners (not listed on `field_vendor_users`) can use attendee list, waitlist, notify, QR validate, and attendee entity ACH where they previously could not
+- Unrelated organisers remain denied; customer-facing behaviour unchanged; routes/menus/Commerce permissions unchanged
+
+### Module dependency note
+
+`myeventlane_checkout_flow` depends on `myeventlane_event_attendees`, so attendee controllers cannot hard-inject `MelAttendeeOperationsAccess` without a cycle. Those surfaces call `EventVendorAccessChecker` directly — the same service Mel delegates to. Messaging / Pro / RSVP inject Mel.
+
+### Mel API addition
+
+- `MelAttendeeOperationsAccessInterface::accountHasOrganiserOwnership()` — ownership-only hop (no staff/product gates) so callers preserve their existing admin and permission composition
+
+### Equivalence verification
+
+- `ManagedSetWorkspaceParityEquivalenceTest`: for modern `field_event_vendor` events, managed-set membership ⇔ workspace parity across author / vendor owner / team / stranger / anon
+- Legacy `field_vendor` managed-set widen vs parity is an **explicit documented divergence**; no reconciliation invented in 2A
+
+### Cache verification (before → after)
+
+| Surface | Cache contexts | Cache tags / deps | max-age | Menu / local tasks |
+|---|---|---|---|---|
+| `VendorAttendeeController::access` | Unchanged (`user` on allow; perms on admin) | Unchanged (`addCacheableDependency($node)`) | Unchanged | Unchanged |
+| `WaitlistManagementController::access` | Unchanged (`cachePerPermissions`) | Unchanged (node dep) | Unchanged | Unchanged |
+| `EventAttendeeAccessControlHandler` | Unchanged (`user` / perms) | Unchanged (entity dep) | Unchanged | N/A |
+| Notify / Message / QR asserts | N/A (exceptions) | N/A | N/A | Unchanged |
+| Routes / YAML | Unchanged | Unchanged | Unchanged | Unchanged |
+
+### Tests added
+
+- `VendorAttendeeAccessOwnershipTest`
+- `WaitlistManagementAccessOwnershipTest`
+- `EventAttendeeAccessControlHandlerOwnershipTest`
+- `VendorNotifyFormOwnershipTest`
+- `MessageAttendeesOwnershipTest`
+- `QrCheckinOwnershipTest`
+- `ManagedSetWorkspaceParityEquivalenceTest`
+- Extended: `MelAttendeeOperationsAccessTest`, `AttendeeExportAccessTest`
+
+### Remaining Workstream 2B
+
+- Boost vendor workspace path, ChartData access, RefundAccessResolver AND parity, Vendor API team parity
+- `ManageEventControllerBase::access()` composition without dropping `edit own event content`
+- Optional: move Mel into `event_attendees` to eliminate cycle soft-path
+
+### Remaining Workstream 3
+
+- Route `_custom_access` for check-in + console event tabs
+- Order detail IDOR bind
+- CSRF follow-up for legacy check-in (or keep deferred)
 
 ---
 
@@ -573,17 +650,9 @@ ddev exec vendor/bin/phpunit -c web/core \
 - `EventVendorAccessCheckerTest` — anonymous, authenticated non-organiser, admin-without-membership, non-event bundle
 - `VendorConsoleBaseControllerOwnershipEquivalenceTest` — legacy ≡ checker ≡ wrapper for author / vendor owner / team / stranger / non-organiser; admin bypass; anonymous deny
 
-### Remaining Workstream 2
+### Remaining after Workstream 1 (superseded by 2A log above)
 
-- Align team-partial / author-only / store-primary gates (attendees, waitlist, messaging, boost vendor path, QR, charts, ACH, refunds AND parity, vendor API)
-- Prove managed-set ≡ parity (legacy `field_vendor` policy)
-- Carefully compose `ManageEventControllerBase::access()` with checker **without** dropping `edit own event content`
-
-### Remaining Workstream 3
-
-- Route `_custom_access` for check-in + console event tabs
-- Order detail IDOR bind
-- CSRF follow-up for legacy check-in (or keep deferred)
+See **Workstream 2A** and **Remaining Workstream 2B / 3** sections.
 
 ---
 

--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/MelAttendeeOperationsAccess.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/MelAttendeeOperationsAccess.php
@@ -105,6 +105,13 @@ final class MelAttendeeOperationsAccess implements MelAttendeeOperationsAccessIn
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function accountHasOrganiserOwnership(NodeInterface $event, AccountInterface $account): bool {
+    return $this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($event, $account);
+  }
+
+  /**
    * Internal: shared resolution. Returns a fully cacheable AccessResult.
    */
   private function resolve(string $action, NodeInterface $event, AccountInterface $account): AccessResultInterface {

--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/MelAttendeeOperationsAccessInterface.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/MelAttendeeOperationsAccessInterface.php
@@ -18,16 +18,43 @@ use Drupal\node\NodeInterface;
  */
 interface MelAttendeeOperationsAccessInterface {
 
+  /**
+   * Whether the account can view attendees for an event.
+   */
   public function canViewAttendees(NodeInterface $event, AccountInterface $account): AccessResultInterface;
 
+  /**
+   * Whether the account can export attendees for an event.
+   */
   public function canExportAttendees(NodeInterface $event, AccountInterface $account): AccessResultInterface;
 
+  /**
+   * Whether the account can check attendees in for an event.
+   */
   public function canCheckInAttendees(NodeInterface $event, AccountInterface $account): AccessResultInterface;
 
+  /**
+   * Whether the account can cancel an attendance for an event.
+   */
   public function canCancelAttendance(NodeInterface $event, AccountInterface $account): AccessResultInterface;
 
+  /**
+   * Whether the account can view a single attendee row.
+   */
   public function canViewAttendeeRow(EventAttendee $attendee, AccountInterface $account): AccessResultInterface;
 
+  /**
+   * Whether any operational attendee action is allowed for the event.
+   */
   public function hasAnyOperationalAccess(NodeInterface $event, AccountInterface $account): AccessResultInterface;
+
+  /**
+   * Whether the account has organiser workspace parity for the event.
+   *
+   * Ownership-only hop (no staff bypass, no product permissions). Callers keep
+   * their existing admin/product gates and cache metadata; this replaces
+   * private author/team loops.
+   */
+  public function accountHasOrganiserOwnership(NodeInterface $event, AccountInterface $account): bool;
 
 }

--- a/web/modules/custom/myeventlane_checkout_flow/tests/src/Unit/MelAttendeeOperationsAccessTest.php
+++ b/web/modules/custom/myeventlane_checkout_flow/tests/src/Unit/MelAttendeeOperationsAccessTest.php
@@ -23,8 +23,7 @@ use Drupal\Tests\UnitTestCase;
 final class MelAttendeeOperationsAccessTest extends UnitTestCase {
 
   /**
-   * Sets up a container with cache_contexts_manager so AccessResult::cacheXxx
-   * methods can validate cache context tokens without bootstrapping Drupal.
+   * Sets up cache_contexts_manager for AccessResult without full bootstrap.
    */
   protected function setUp(): void {
     parent::setUp();
@@ -107,6 +106,18 @@ final class MelAttendeeOperationsAccessTest extends UnitTestCase {
   }
 
   /**
+   * @covers ::accountHasOrganiserOwnership
+   */
+  public function testAccountHasOrganiserOwnershipDelegatesToChecker(): void {
+    $event = $this->mockNode('event');
+    $account = $this->createMock(AccountInterface::class);
+    $access = $this->makeAccess(workspaceParity: TRUE);
+    $this->assertTrue($access->accountHasOrganiserOwnership($event, $account));
+    $denied = $this->makeAccess(workspaceParity: FALSE);
+    $this->assertFalse($denied->accountHasOrganiserOwnership($event, $account));
+  }
+
+  /**
    * @covers ::canViewAttendeeRow
    */
   public function testAttendeeRowWithoutEventFailsClosed(): void {
@@ -121,6 +132,9 @@ final class MelAttendeeOperationsAccessTest extends UnitTestCase {
     $this->assertTrue($result->isForbidden());
   }
 
+  /**
+   * Builds MelAttendeeOperationsAccess with a stubbed parity checker.
+   */
   private function makeAccess(bool $workspaceParity): MelAttendeeOperationsAccess {
     $checker = $this->createMock(EventVendorAccessCheckerInterface::class);
     $checker->method('accountHasWorkspaceParityForEvent')->willReturn($workspaceParity);
@@ -130,6 +144,9 @@ final class MelAttendeeOperationsAccessTest extends UnitTestCase {
     );
   }
 
+  /**
+   * Builds a stub node of the given bundle.
+   */
   private function mockNode(string $bundle): NodeInterface {
     $event = $this->createMock(NodeInterface::class);
     $event->method('bundle')->willReturn($bundle);

--- a/web/modules/custom/myeventlane_checkout_paragraph/tests/src/Unit/AttendeeExportAccessTest.php
+++ b/web/modules/custom/myeventlane_checkout_paragraph/tests/src/Unit/AttendeeExportAccessTest.php
@@ -23,6 +23,16 @@ final class AttendeeExportAccessTest extends TestCase {
     $this->assertTrue($this->decide(FALSE, 'event', TRUE));
   }
 
+  public function testVendorEntityOwnerAllowedViaParity(): void {
+    // Workstream 2A: export already used EventVendorAccessChecker (Phase 2A.2).
+    // Vendor entity owner is allowed when parity is TRUE.
+    $this->assertTrue($this->decide(FALSE, 'event', TRUE));
+  }
+
+  public function testUnrelatedOrganiserDenied(): void {
+    $this->assertFalse($this->decide(FALSE, 'event', FALSE));
+  }
+
   public function testAdminAllowed(): void {
     $this->assertTrue($this->decide(TRUE, 'event', FALSE));
   }

--- a/web/modules/custom/myeventlane_event_attendees/src/Controller/VendorAttendeeController.php
+++ b/web/modules/custom/myeventlane_event_attendees/src/Controller/VendorAttendeeController.php
@@ -15,6 +15,7 @@ use Drupal\myeventlane_event_attendees\Entity\EventAttendee;
 use Drupal\myeventlane_event_attendees\Service\AttendanceManagerInterface;
 use Drupal\myeventlane_event_attendees\Service\MelAttendeeExportBuilder;
 use Drupal\myeventlane_event_attendees\Service\VendorAttendeePresentationService;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessCheckerInterface;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -52,6 +53,7 @@ final class VendorAttendeeController extends ControllerBase {
     private readonly MelAttendeeExportBuilder $exportBuilder,
     private readonly mixed $melAttendeeCheckinManager,
     private readonly CsrfTokenGenerator $csrfToken,
+    private readonly EventVendorAccessCheckerInterface $eventVendorAccessChecker,
   ) {}
 
   /**
@@ -67,14 +69,17 @@ final class VendorAttendeeController extends ControllerBase {
         ? $container->get('myeventlane_checkout_flow.attendee_checkin_manager')
         : NULL,
       $container->get('csrf_token'),
+      // MelAttendeeOperationsAccess lives in checkout_flow (depends on this
+      // module); ownership uses the same canonical checker Mel delegates to.
+      $container->get('myeventlane_vendor.event_access_checker'),
     );
   }
 
   /**
    * Access check for vendor attendee routes.
    *
-   * Aligned with VendorEventAccess: owner, vendor users (field_event_vendor →
-   * field_vendor_users), or admin can access.
+   * Product gates preserved; organiser membership is workspace parity via
+   * EventVendorAccessChecker (MelAttendeeOperationsAccess delegate).
    */
   public function access(NodeInterface $node, AccountInterface $account): AccessResultInterface {
     // Must be an event node.
@@ -91,25 +96,11 @@ final class VendorAttendeeController extends ControllerBase {
       return AccessResult::forbidden('You do not have access to view attendees for this event.');
     }
 
-    // Event owner.
-    if ((int) $node->getOwnerId() === (int) $account->id()) {
+    // Canonical workspace parity: author, vendor entity owner, or team.
+    if ($this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($node, $account)) {
       return AccessResult::allowed()
         ->cachePerUser()
         ->addCacheableDependency($node);
-    }
-
-    // Vendor user via field_event_vendor → field_vendor_users (aligns with VendorEventAccess).
-    if ($node->hasField('field_event_vendor') && !$node->get('field_event_vendor')->isEmpty()) {
-      $vendor = $node->get('field_event_vendor')->entity;
-      if ($vendor && $vendor->hasField('field_vendor_users')) {
-        foreach ($vendor->get('field_vendor_users')->getValue() as $item) {
-          if (isset($item['target_id']) && (int) $item['target_id'] === (int) $account->id()) {
-            return AccessResult::allowed()
-              ->cachePerUser()
-              ->addCacheableDependency($node);
-          }
-        }
-      }
     }
 
     return AccessResult::forbidden('You do not have access to view attendees for this event.');
@@ -118,7 +109,7 @@ final class VendorAttendeeController extends ControllerBase {
   /**
    * Access check for single attendee operations.
    *
-   * Reuses same policy as access(): owner, vendor users, or admin.
+   * Reuses same policy as access(): admin, product permission, or parity.
    */
   public function accessAttendee(EventAttendee $event_attendee, AccountInterface $account): AccessResultInterface {
     $event = $event_attendee->getEvent();
@@ -371,6 +362,7 @@ final class VendorAttendeeController extends ControllerBase {
    * not registered (e.g. minimal install profiles).
    *
    * @return array<string, mixed>
+   *   Empty attendee list render payload.
    */
   private function governedEmptyAttendees(): array {
     if (\Drupal::hasService('myeventlane_surface.governed_operational_templates')) {
@@ -580,6 +572,7 @@ final class VendorAttendeeController extends ControllerBase {
    * suitable for both JSON and flash-message rendering.
    *
    * @return array{0: bool, 1: string, 2: \Stringable|string}
+   *   Tuple of success flag, machine reason, and user message.
    */
   private function performAttendeeCheckIn(EventAttendee $event_attendee): array {
     $name = $event_attendee->getName();

--- a/web/modules/custom/myeventlane_event_attendees/src/Controller/WaitlistManagementController.php
+++ b/web/modules/custom/myeventlane_event_attendees/src/Controller/WaitlistManagementController.php
@@ -8,6 +8,7 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\myeventlane_event_attendees\Service\AttendanceWaitlistManager;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessCheckerInterface;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -23,6 +24,7 @@ final class WaitlistManagementController extends ControllerBase {
    */
   public function __construct(
     private readonly AttendanceWaitlistManager $waitlistManager,
+    private readonly EventVendorAccessCheckerInterface $eventVendorAccessChecker,
   ) {}
 
   /**
@@ -31,6 +33,9 @@ final class WaitlistManagementController extends ControllerBase {
   public static function create(ContainerInterface $container): static {
     return new static(
       $container->get('myeventlane_event_attendees.waitlist'),
+      // MelAttendeeOperationsAccess lives in checkout_flow (depends on this
+      // module); ownership uses the same canonical checker Mel delegates to.
+      $container->get('myeventlane_vendor.event_access_checker'),
     );
   }
 
@@ -155,6 +160,9 @@ final class WaitlistManagementController extends ControllerBase {
   /**
    * Access callback for waitlist management.
    *
+   * Staff bypass and cache metadata preserved; organiser membership is
+   * workspace parity via EventVendorAccessChecker (Mel delegate).
+   *
    * @param \Drupal\node\NodeInterface $node
    *   The event node.
    * @param \Drupal\Core\Session\AccountInterface $account
@@ -173,21 +181,9 @@ final class WaitlistManagementController extends ControllerBase {
       return AccessResult::allowed()->cachePerPermissions();
     }
 
-    // Check if user owns the event.
-    if ((int) $node->getOwnerId() === (int) $account->id()) {
+    // Canonical workspace parity: author, vendor entity owner, or team.
+    if ($this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($node, $account)) {
       return AccessResult::allowed()->cachePerPermissions()->addCacheableDependency($node);
-    }
-
-    // Check vendor association via field_event_vendor.
-    if ($node->hasField('field_event_vendor') && !$node->get('field_event_vendor')->isEmpty()) {
-      $vendor = $node->get('field_event_vendor')->entity;
-      if ($vendor && $vendor->hasField('field_vendor_users')) {
-        foreach ($vendor->get('field_vendor_users')->getValue() as $item) {
-          if (isset($item['target_id']) && (int) $item['target_id'] === (int) $account->id()) {
-            return AccessResult::allowed()->cachePerPermissions()->addCacheableDependency($node);
-          }
-        }
-      }
     }
 
     return AccessResult::forbidden()->cachePerPermissions()->addCacheableDependency($node);

--- a/web/modules/custom/myeventlane_event_attendees/src/EventAttendeeAccessControlHandler.php
+++ b/web/modules/custom/myeventlane_event_attendees/src/EventAttendeeAccessControlHandler.php
@@ -6,13 +6,43 @@ namespace Drupal\myeventlane_event_attendees;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityAccessControlHandler;
+use Drupal\Core\Entity\EntityHandlerInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessCheckerInterface;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Access control handler for the event_attendee entity.
+ *
+ * Product permissions stay on this handler; organiser membership uses
+ * workspace parity via EventVendorAccessChecker (MelAttendeeOperationsAccess
+ * delegate). Cache metadata shape is preserved from the prior author-only
+ * implementation.
  */
-class EventAttendeeAccessControlHandler extends EntityAccessControlHandler {
+class EventAttendeeAccessControlHandler extends EntityAccessControlHandler implements EntityHandlerInterface {
+
+  /**
+   * Constructs the access control handler.
+   */
+  public function __construct(
+    EntityTypeInterface $entity_type,
+    private readonly EventVendorAccessCheckerInterface $eventVendorAccessChecker,
+  ) {
+    parent::__construct($entity_type);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type): static {
+    return new static(
+      $entity_type,
+      $container->get('myeventlane_vendor.event_access_checker'),
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -26,11 +56,12 @@ class EventAttendeeAccessControlHandler extends EntityAccessControlHandler {
     }
 
     $event = $entity->getEvent();
-    $isOwner = $event && (int) $event->getOwnerId() === (int) $account->id();
+    $hasParity = $event instanceof NodeInterface
+      && $this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($event, $account);
 
     switch ($operation) {
       case 'view':
-        if ($isOwner && $account->hasPermission('view own event attendees')) {
+        if ($hasParity && $account->hasPermission('view own event attendees')) {
           return AccessResult::allowed()
             ->cachePerUser()
             ->addCacheableDependency($entity);
@@ -39,7 +70,7 @@ class EventAttendeeAccessControlHandler extends EntityAccessControlHandler {
 
       case 'update':
       case 'delete':
-        if ($isOwner && $account->hasPermission('manage own event attendees')) {
+        if ($hasParity && $account->hasPermission('manage own event attendees')) {
           return AccessResult::allowed()
             ->cachePerUser()
             ->addCacheableDependency($entity);

--- a/web/modules/custom/myeventlane_event_attendees/tests/src/Unit/EventAttendeeAccessControlHandlerOwnershipTest.php
+++ b/web/modules/custom/myeventlane_event_attendees/tests/src/Unit/EventAttendeeAccessControlHandlerOwnershipTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_attendees\Unit;
+
+use Drupal\Core\Cache\Context\CacheContextsManager;
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\myeventlane_event_attendees\Entity\EventAttendee;
+use Drupal\myeventlane_event_attendees\EventAttendeeAccessControlHandler;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessCheckerInterface;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Ownership matrix for EventAttendeeAccessControlHandler.
+ *
+ * @covers \Drupal\myeventlane_event_attendees\EventAttendeeAccessControlHandler
+ *
+ * @group myeventlane_event_attendees
+ */
+final class EventAttendeeAccessControlHandlerOwnershipTest extends UnitTestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $cacheContextsManager = $this->createMock(CacheContextsManager::class);
+    $cacheContextsManager->method('assertValidTokens')->willReturn(TRUE);
+    $container = new ContainerBuilder();
+    $container->set('cache_contexts_manager', $cacheContextsManager);
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * Verifies view access for admin, product permission, and parity actors.
+   *
+   * @dataProvider viewActorProvider
+   */
+  public function testViewAccess(
+    bool $isAdmin,
+    bool $hasViewOwn,
+    bool $hasParity,
+    bool $expectedAllowed,
+  ): void {
+    $handler = $this->handler($hasParity);
+    $method = new \ReflectionMethod(EventAttendeeAccessControlHandler::class, 'checkAccess');
+    $method->setAccessible(TRUE);
+    $result = $method->invoke($handler, $this->attendee(), 'view', $this->account($isAdmin, $hasViewOwn, FALSE));
+    $this->assertSame($expectedAllowed, $result->isAllowed());
+  }
+
+  /**
+   * Vendor owners with view-own + parity may view attendee entities.
+   */
+  public function testVendorOwnerWithViewOwnAllowed(): void {
+    $handler = $this->handler(hasParity: TRUE);
+    $method = new \ReflectionMethod(EventAttendeeAccessControlHandler::class, 'checkAccess');
+    $method->setAccessible(TRUE);
+    $result = $method->invoke(
+      $handler,
+      $this->attendee(),
+      'view',
+      $this->account(FALSE, TRUE, FALSE),
+    );
+    $this->assertTrue($result->isAllowed());
+  }
+
+  /**
+   * Unrelated organisers without parity remain denied on view.
+   */
+  public function testUnrelatedDenied(): void {
+    $handler = $this->handler(hasParity: FALSE);
+    $method = new \ReflectionMethod(EventAttendeeAccessControlHandler::class, 'checkAccess');
+    $method->setAccessible(TRUE);
+    $result = $method->invoke(
+      $handler,
+      $this->attendee(),
+      'view',
+      $this->account(FALSE, TRUE, FALSE),
+    );
+    $this->assertFalse($result->isAllowed());
+  }
+
+  /**
+   * Actor matrix for entity view access.
+   *
+   * @return \Generator
+   *   Cases: admin, view-own, parity, expected allow.
+   */
+  public static function viewActorProvider(): \Generator {
+    yield 'admin' => [TRUE, FALSE, FALSE, TRUE];
+    yield 'parity + view own' => [FALSE, TRUE, TRUE, TRUE];
+    yield 'parity without view own' => [FALSE, FALSE, TRUE, FALSE];
+    yield 'view own without parity' => [FALSE, TRUE, FALSE, FALSE];
+  }
+
+  /**
+   * Builds a handler with a stubbed parity checker.
+   */
+  private function handler(bool $hasParity): EventAttendeeAccessControlHandler {
+    $checker = $this->createMock(EventVendorAccessCheckerInterface::class);
+    $checker->method('accountHasWorkspaceParityForEvent')->willReturn($hasParity);
+    $entityType = $this->createMock(EntityTypeInterface::class);
+    $entityType->method('id')->willReturn('event_attendee');
+    $entityType->method('getListCacheContexts')->willReturn([]);
+    return new EventAttendeeAccessControlHandler($entityType, $checker);
+  }
+
+  /**
+   * Builds a stub attendee bound to an event.
+   */
+  private function attendee(): EventAttendee {
+    $event = $this->createMock(NodeInterface::class);
+    $event->method('bundle')->willReturn('event');
+    $event->method('id')->willReturn(1);
+
+    $attendee = $this->createMock(EventAttendee::class);
+    $attendee->method('getEvent')->willReturn($event);
+    $attendee->method('getCacheContexts')->willReturn([]);
+    $attendee->method('getCacheTags')->willReturn(['event_attendee:1']);
+    $attendee->method('getCacheMaxAge')->willReturn(-1);
+    return $attendee;
+  }
+
+  /**
+   * Builds a stub account with attendee product permissions.
+   */
+  private function account(bool $isAdmin, bool $hasViewOwn, bool $hasManageOwn): AccountInterface {
+    $account = $this->createMock(AccountInterface::class);
+    $account->method('id')->willReturn(20);
+    $account->method('hasPermission')->willReturnCallback(
+      static function (string $permission) use ($isAdmin, $hasViewOwn, $hasManageOwn): bool {
+        return match ($permission) {
+          'administer event attendees' => $isAdmin,
+          'view own event attendees' => $hasViewOwn,
+          'manage own event attendees' => $hasManageOwn,
+          default => FALSE,
+        };
+      },
+    );
+    return $account;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_attendees/tests/src/Unit/VendorAttendeeAccessOwnershipTest.php
+++ b/web/modules/custom/myeventlane_event_attendees/tests/src/Unit/VendorAttendeeAccessOwnershipTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_attendees\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Ownership matrix for VendorAttendeeController::access.
+ *
+ * Mirrors product gates + EventVendorAccessChecker parity without constructing
+ * the controller (final collaborator services cannot be doubled).
+ *
+ * @group myeventlane_event_attendees
+ */
+final class VendorAttendeeAccessOwnershipTest extends TestCase {
+
+  /**
+   * Verifies allow/deny for admin, product permission, and parity actors.
+   *
+   * @dataProvider actorProvider
+   */
+  public function testAccessMatrix(
+    bool $isAdmin,
+    bool $hasViewOwn,
+    bool $hasParity,
+    bool $expectedAllowed,
+  ): void {
+    $this->assertSame($expectedAllowed, $this->decide($isAdmin, $hasViewOwn, $hasParity));
+  }
+
+  /**
+   * Vendor owners with view-own + parity are allowed (intentional widen).
+   */
+  public function testVendorEntityOwnerGainsAccessWhereTeamPartialDenied(): void {
+    $this->assertTrue($this->decide(FALSE, TRUE, TRUE));
+  }
+
+  /**
+   * Unrelated organisers without parity remain denied.
+   */
+  public function testUnrelatedOrganiserDenied(): void {
+    $this->assertFalse($this->decide(FALSE, TRUE, FALSE));
+  }
+
+  /**
+   * Source wiring must use the canonical checker and drop team-partial loops.
+   */
+  public function testControllerWiresCanonicalChecker(): void {
+    $raw = (string) file_get_contents(dirname(__DIR__, 3) . '/src/Controller/VendorAttendeeController.php');
+    $this->assertStringContainsString('EventVendorAccessCheckerInterface', $raw);
+    $this->assertStringContainsString('accountHasWorkspaceParityForEvent', $raw);
+    $this->assertStringNotContainsString("field_vendor_users')->getValue()", $raw);
+  }
+
+  /**
+   * Actor matrix for attendee list access.
+   *
+   * @return \Generator
+   *   Cases: admin, view-own, parity, expected allow.
+   */
+  public static function actorProvider(): \Generator {
+    yield 'admin' => [TRUE, FALSE, FALSE, TRUE];
+    yield 'author/parity with view own' => [FALSE, TRUE, TRUE, TRUE];
+    yield 'parity without view own' => [FALSE, FALSE, TRUE, FALSE];
+    yield 'view own without parity' => [FALSE, TRUE, FALSE, FALSE];
+    yield 'unrelated' => [FALSE, TRUE, FALSE, FALSE];
+  }
+
+  /**
+   * Mirrors VendorAttendeeController::access without AccessResult/container.
+   */
+  private function decide(bool $isAdmin, bool $hasViewOwn, bool $hasParity): bool {
+    if ($isAdmin) {
+      return TRUE;
+    }
+    if (!$hasViewOwn) {
+      return FALSE;
+    }
+    return $hasParity;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_attendees/tests/src/Unit/WaitlistManagementAccessOwnershipTest.php
+++ b/web/modules/custom/myeventlane_event_attendees/tests/src/Unit/WaitlistManagementAccessOwnershipTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_attendees\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Ownership matrix for WaitlistManagementController::access.
+ *
+ * @group myeventlane_event_attendees
+ */
+final class WaitlistManagementAccessOwnershipTest extends TestCase {
+
+  /**
+   * Verifies allow/deny for staff bypass and parity actors.
+   *
+   * @dataProvider actorProvider
+   */
+  public function testAccessMatrix(
+    int $uid,
+    bool $administerNodes,
+    bool $hasParity,
+    bool $expectedAllowed,
+  ): void {
+    $this->assertSame(
+      $expectedAllowed,
+      $this->decide($uid, $administerNodes, $hasParity),
+    );
+  }
+
+  /**
+   * Source wiring must use the canonical checker and drop team-partial loops.
+   */
+  public function testControllerWiresCanonicalChecker(): void {
+    $raw = (string) file_get_contents(dirname(__DIR__, 3) . '/src/Controller/WaitlistManagementController.php');
+    $this->assertStringContainsString('EventVendorAccessCheckerInterface', $raw);
+    $this->assertStringContainsString('accountHasWorkspaceParityForEvent', $raw);
+    $this->assertStringNotContainsString("field_vendor_users')->getValue()", $raw);
+  }
+
+  /**
+   * Actor matrix for waitlist management access.
+   *
+   * @return \Generator
+   *   Cases: uid, administer nodes, parity, expected allow.
+   */
+  public static function actorProvider(): \Generator {
+    yield 'admin administer nodes' => [2, TRUE, FALSE, TRUE];
+    yield 'uid 1 bypass' => [1, FALSE, FALSE, TRUE];
+    yield 'vendor owner / parity' => [20, FALSE, TRUE, TRUE];
+    yield 'team / parity' => [30, FALSE, TRUE, TRUE];
+    yield 'unrelated organiser' => [40, FALSE, FALSE, FALSE];
+    yield 'anonymous' => [0, FALSE, FALSE, FALSE];
+  }
+
+  /**
+   * Mirrors WaitlistManagementController::access without AccessResult.
+   */
+  private function decide(int $uid, bool $administerNodes, bool $hasParity): bool {
+    if ($administerNodes || $uid === 1) {
+      return TRUE;
+    }
+    return $hasParity;
+  }
+
+}

--- a/web/modules/custom/myeventlane_messaging/src/Form/VendorNotifyForm.php
+++ b/web/modules/custom/myeventlane_messaging/src/Form/VendorNotifyForm.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_messaging\Form;
 
-use Drupal\Core\Form\FormBase;
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
-use Drupal\node\NodeInterface;
+use Drupal\myeventlane_checkout_flow\Service\MelAttendeeOperationsAccessInterface;
 use Drupal\myeventlane_messaging\Service\AttendeeRecipientResolver;
 use Drupal\myeventlane_messaging\Service\MessagingManager;
-use Drupal\myeventlane_vendor\Controller\VendorConsoleBaseController;
+use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
@@ -35,6 +35,8 @@ final class VendorNotifyForm extends FormBase {
    *   The messaging manager.
    * @param \Drupal\Core\Database\Connection $database
    *   The database connection.
+   * @param \Drupal\myeventlane_checkout_flow\Service\MelAttendeeOperationsAccessInterface $attendeeOperationsAccess
+   *   Canonical attendee operations access (delegates to workspace parity).
    */
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
@@ -42,6 +44,7 @@ final class VendorNotifyForm extends FormBase {
     private readonly AttendeeRecipientResolver $recipientResolver,
     private readonly MessagingManager $messagingManager,
     private readonly Connection $database,
+    private readonly MelAttendeeOperationsAccessInterface $attendeeOperationsAccess,
   ) {}
 
   /**
@@ -54,6 +57,7 @@ final class VendorNotifyForm extends FormBase {
       $container->get('myeventlane_messaging.attendee_recipient_resolver'),
       $container->get('myeventlane_messaging.manager'),
       $container->get('database'),
+      $container->get('myeventlane_checkout_flow.attendee_operations_access'),
     );
   }
 
@@ -67,7 +71,7 @@ final class VendorNotifyForm extends FormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, NodeInterface $event = NULL): array {
+  public function buildForm(array $form, FormStateInterface $form_state, ?NodeInterface $event = NULL): array {
     if (!$event) {
       throw new AccessDeniedHttpException('Event not found.');
     }
@@ -232,6 +236,9 @@ final class VendorNotifyForm extends FormBase {
   /**
    * Asserts that the current user can manage the given event.
    *
+   * Staff bypass preserved; organiser membership via Mel attendee ops
+   * → EventVendorAccessChecker workspace parity.
+   *
    * @param \Drupal\node\NodeInterface $event
    *   The event node.
    *
@@ -246,21 +253,8 @@ final class VendorNotifyForm extends FormBase {
       return;
     }
 
-    // Owner check.
-    if ((int) $event->getOwnerId() === $uid) {
+    if ($this->attendeeOperationsAccess->accountHasOrganiserOwnership($event, $this->currentUser)) {
       return;
-    }
-
-    // Vendor membership check via field_event_vendor -> field_vendor_users.
-    if ($event->hasField('field_event_vendor') && !$event->get('field_event_vendor')->isEmpty()) {
-      $vendor = $event->get('field_event_vendor')->entity;
-      if ($vendor && $vendor->hasField('field_vendor_users')) {
-        foreach ($vendor->get('field_vendor_users')->getValue() as $item) {
-          if (isset($item['target_id']) && (int) $item['target_id'] === $uid) {
-            return;
-          }
-        }
-      }
     }
 
     throw new AccessDeniedHttpException('You do not have permission to notify attendees for this event.');

--- a/web/modules/custom/myeventlane_messaging/tests/src/Unit/VendorNotifyFormOwnershipTest.php
+++ b/web/modules/custom/myeventlane_messaging/tests/src/Unit/VendorNotifyFormOwnershipTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_messaging\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Ownership assert for VendorNotifyForm via MelAttendeeOperationsAccess.
+ *
+ * @group myeventlane_messaging
+ */
+final class VendorNotifyFormOwnershipTest extends TestCase {
+
+  /**
+   * Verifies staff bypass and Mel ownership hop allow/deny.
+   *
+   * @dataProvider actorProvider
+   */
+  public function testAssertOwnershipMatrix(
+    bool $isAdmin,
+    bool $uidIsOne,
+    bool $hasOwnership,
+    bool $expectedAllowed,
+  ): void {
+    $this->assertSame($expectedAllowed, $this->decide($isAdmin, $uidIsOne, $hasOwnership));
+  }
+
+  /**
+   * Source wiring must use Mel ownership and drop team-partial loops.
+   */
+  public function testFormWiresMelOwnershipHop(): void {
+    $raw = (string) file_get_contents(dirname(__DIR__, 3) . '/src/Form/VendorNotifyForm.php');
+    $this->assertStringContainsString('MelAttendeeOperationsAccessInterface', $raw);
+    $this->assertStringContainsString('accountHasOrganiserOwnership', $raw);
+    $this->assertStringNotContainsString("field_vendor_users')->getValue()", $raw);
+  }
+
+  /**
+   * Actor matrix for notify form ownership.
+   *
+   * @return \Generator
+   *   Cases: admin, uid1, ownership, expected allow.
+   */
+  public static function actorProvider(): \Generator {
+    yield 'admin' => [TRUE, FALSE, FALSE, TRUE];
+    yield 'uid 1' => [FALSE, TRUE, FALSE, TRUE];
+    yield 'vendor owner / team' => [FALSE, FALSE, TRUE, TRUE];
+    yield 'unrelated organiser' => [FALSE, FALSE, FALSE, FALSE];
+  }
+
+  /**
+   * Mirrors VendorNotifyForm::assertEventOwnership allow/deny.
+   */
+  private function decide(bool $isAdmin, bool $uidIsOne, bool $hasOwnership): bool {
+    if ($isAdmin || $uidIsOne) {
+      return TRUE;
+    }
+    return $hasOwnership;
+  }
+
+}

--- a/web/modules/custom/myeventlane_pro/myeventlane_pro.info.yml
+++ b/web/modules/custom/myeventlane_pro/myeventlane_pro.info.yml
@@ -17,5 +17,6 @@ dependencies:
   - state_machine:state_machine
   - advancedqueue:advancedqueue
   - myeventlane_messaging:myeventlane_messaging
+  - myeventlane_checkout_flow:myeventlane_checkout_flow
   - myeventlane_vendor:myeventlane_vendor
   - myeventlane_boost:myeventlane_boost

--- a/web/modules/custom/myeventlane_pro/src/Controller/MessageAttendeesController.php
+++ b/web/modules/custom/myeventlane_pro/src/Controller/MessageAttendeesController.php
@@ -8,10 +8,12 @@ use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
+use Drupal\myeventlane_checkout_flow\Service\MelAttendeeOperationsAccessInterface;
 use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\myeventlane_pro\Form\MessageAttendeesForm;
 use Drupal\myeventlane_pro\Service\ProAccessService;
 use Drupal\myeventlane_vendor\Controller\VendorConsoleBaseController;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessCheckerInterface;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -33,8 +35,10 @@ final class MessageAttendeesController extends VendorConsoleBaseController {
     MessengerInterface $messenger,
     private readonly ProAccessService $proAccess,
     private readonly FormBuilderInterface $formBuilder,
+    private readonly MelAttendeeOperationsAccessInterface $attendeeOperationsAccess,
+    ?EventVendorAccessCheckerInterface $eventVendorAccessChecker = NULL,
   ) {
-    parent::__construct($domain_detector, $current_user, $messenger);
+    parent::__construct($domain_detector, $current_user, $messenger, $eventVendorAccessChecker);
   }
 
   /**
@@ -47,6 +51,8 @@ final class MessageAttendeesController extends VendorConsoleBaseController {
       $container->get('messenger'),
       $container->get('myeventlane_pro.pro_access'),
       $container->get('form_builder'),
+      $container->get('myeventlane_checkout_flow.attendee_operations_access'),
+      $container->get('myeventlane_vendor.event_access_checker'),
     );
   }
 
@@ -83,6 +89,9 @@ final class MessageAttendeesController extends VendorConsoleBaseController {
   /**
    * Asserts the current user can message attendees of this event.
    *
+   * Pro product gate preserved; organiser membership via
+   * MelAttendeeOperationsAccess → EventVendorAccessChecker.
+   *
    * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
    */
   private function assertAccess(NodeInterface $node): void {
@@ -100,42 +109,9 @@ final class MessageAttendeesController extends VendorConsoleBaseController {
       throw new AccessDeniedHttpException();
     }
 
-    if ((int) $node->getOwnerId() !== $uid) {
-      $vendor = $this->resolveEventVendor($node);
-      if (!$vendor || !$this->isVendorMember($vendor, $uid)) {
-        throw new AccessDeniedHttpException();
-      }
+    if (!$this->attendeeOperationsAccess->accountHasOrganiserOwnership($node, $account)) {
+      throw new AccessDeniedHttpException();
     }
-  }
-
-  /**
-   * Resolves the vendor entity for an event.
-   */
-  private function resolveEventVendor(NodeInterface $node): ?object {
-    if ($node->hasField('field_event_vendor') && !$node->get('field_event_vendor')->isEmpty()) {
-      return $node->get('field_event_vendor')->entity;
-    }
-    if ($node->hasField('field_vendor') && !$node->get('field_vendor')->isEmpty()) {
-      return $node->get('field_vendor')->entity;
-    }
-    return NULL;
-  }
-
-  /**
-   * Checks if the user is a member of the vendor.
-   */
-  private function isVendorMember(object $vendor, int $uid): bool {
-    if ($vendor->hasField('uid') && (int) $vendor->get('uid')->target_id === $uid) {
-      return TRUE;
-    }
-    if ($vendor->hasField('field_vendor_users')) {
-      foreach ($vendor->get('field_vendor_users')->getValue() as $item) {
-        if (isset($item['target_id']) && (int) $item['target_id'] === $uid) {
-          return TRUE;
-        }
-      }
-    }
-    return FALSE;
   }
 
 }

--- a/web/modules/custom/myeventlane_pro/tests/src/Unit/MessageAttendeesOwnershipTest.php
+++ b/web/modules/custom/myeventlane_pro/tests/src/Unit/MessageAttendeesOwnershipTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_pro\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Ownership assert for MessageAttendeesController via Mel facade.
+ *
+ * @group myeventlane_pro
+ */
+final class MessageAttendeesOwnershipTest extends TestCase {
+
+  /**
+   * Verifies Pro gate plus Mel ownership hop allow/deny.
+   *
+   * @dataProvider actorProvider
+   */
+  public function testAssertAccessMatrix(
+    bool $hasPro,
+    int $uid,
+    bool $hasOwnership,
+    bool $expectedAllowed,
+  ): void {
+    $this->assertSame($expectedAllowed, $this->decide($hasPro, $uid, $hasOwnership));
+  }
+
+  /**
+   * Source wiring must use Mel and remove private vendor helpers.
+   */
+  public function testControllerWiresMelOwnershipHop(): void {
+    $raw = (string) file_get_contents(dirname(__DIR__, 3) . '/src/Controller/MessageAttendeesController.php');
+    $this->assertStringContainsString('MelAttendeeOperationsAccessInterface', $raw);
+    $this->assertStringContainsString('accountHasOrganiserOwnership', $raw);
+    $this->assertStringNotContainsString('isVendorMember', $raw);
+    $this->assertStringNotContainsString('resolveEventVendor', $raw);
+  }
+
+  /**
+   * Actor matrix for Pro message attendees access.
+   *
+   * @return \Generator
+   *   Cases: Pro feature, uid, ownership, expected allow.
+   */
+  public static function actorProvider(): \Generator {
+    yield 'pro + ownership' => [TRUE, 20, TRUE, TRUE];
+    yield 'pro without ownership' => [TRUE, 20, FALSE, FALSE];
+    yield 'ownership without pro' => [FALSE, 20, TRUE, FALSE];
+    yield 'anonymous' => [TRUE, 0, TRUE, FALSE];
+    yield 'unrelated' => [FALSE, 40, FALSE, FALSE];
+  }
+
+  /**
+   * Mirrors MessageAttendeesController::assertAccess for event bundles.
+   */
+  private function decide(bool $hasPro, int $uid, bool $hasOwnership): bool {
+    if (!$hasPro) {
+      return FALSE;
+    }
+    if ($uid <= 0) {
+      return FALSE;
+    }
+    return $hasOwnership;
+  }
+
+}

--- a/web/modules/custom/myeventlane_rsvp/src/Controller/QrCheckinController.php
+++ b/web/modules/custom/myeventlane_rsvp/src/Controller/QrCheckinController.php
@@ -9,10 +9,10 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Flood\FloodInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Session\AccountProxyInterface;
-use Drupal\myeventlane_checkout_flow\Service\MelAttendeeOperationsAccessInterface;
 use Drupal\myeventlane_event_attendees\Entity\EventAttendee;
 use Drupal\myeventlane_event_attendees\Service\AttendanceManager;
 use Drupal\myeventlane_rsvp\Entity\RsvpSubmission;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessCheckerInterface;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -42,9 +42,9 @@ final class QrCheckinController extends ControllerBase {
     private readonly ConfigFactoryInterface $config,
     private readonly FloodInterface $flood,
     private readonly AccountProxyInterface $account,
+    private readonly EventVendorAccessCheckerInterface $eventVendorAccessChecker,
     private readonly ?AttendanceManager $attendanceManager = NULL,
     private readonly mixed $melAttendeeCheckinManager = NULL,
-    private readonly ?MelAttendeeOperationsAccessInterface $attendeeOperationsAccess = NULL,
   ) {}
 
   /**
@@ -56,14 +56,12 @@ final class QrCheckinController extends ControllerBase {
       $c->get('config.factory'),
       $c->get('flood'),
       $c->get('current_user'),
+      $c->get('myeventlane_vendor.event_access_checker'),
       $c->has('myeventlane_event_attendees.manager')
         ? $c->get('myeventlane_event_attendees.manager')
         : NULL,
       $c->has('myeventlane_checkout_flow.attendee_checkin_manager')
         ? $c->get('myeventlane_checkout_flow.attendee_checkin_manager')
-        : NULL,
-      $c->has('myeventlane_checkout_flow.attendee_operations_access')
-        ? $c->get('myeventlane_checkout_flow.attendee_operations_access')
         : NULL,
     );
   }
@@ -288,7 +286,8 @@ final class QrCheckinController extends ControllerBase {
    * Checks if the current user can manage the event for QR check-in.
    *
    * RSVP product/admin permissions preserved; organiser membership via
-   * MelAttendeeOperationsAccess → EventVendorAccessChecker workspace parity.
+   * EventVendorAccessChecker workspace parity (same service Mel delegates to).
+   * Does not require myeventlane_checkout_flow.
    */
   private function canManageEvent(NodeInterface $event): bool {
     $account = $this->account->getAccount();
@@ -298,11 +297,7 @@ final class QrCheckinController extends ControllerBase {
     if (!$account->hasPermission('manage own event rsvps')) {
       return FALSE;
     }
-    if ($this->attendeeOperationsAccess instanceof MelAttendeeOperationsAccessInterface) {
-      return $this->attendeeOperationsAccess->accountHasOrganiserOwnership($event, $account);
-    }
-    // Fail closed when Mel attendee ops is unavailable.
-    return FALSE;
+    return $this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($event, $account);
   }
 
   /**

--- a/web/modules/custom/myeventlane_rsvp/src/Controller/QrCheckinController.php
+++ b/web/modules/custom/myeventlane_rsvp/src/Controller/QrCheckinController.php
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Flood\FloodInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\myeventlane_checkout_flow\Service\MelAttendeeOperationsAccessInterface;
 use Drupal\myeventlane_event_attendees\Entity\EventAttendee;
 use Drupal\myeventlane_event_attendees\Service\AttendanceManager;
 use Drupal\myeventlane_rsvp\Entity\RsvpSubmission;
@@ -43,6 +44,7 @@ final class QrCheckinController extends ControllerBase {
     private readonly AccountProxyInterface $account,
     private readonly ?AttendanceManager $attendanceManager = NULL,
     private readonly mixed $melAttendeeCheckinManager = NULL,
+    private readonly ?MelAttendeeOperationsAccessInterface $attendeeOperationsAccess = NULL,
   ) {}
 
   /**
@@ -59,6 +61,9 @@ final class QrCheckinController extends ControllerBase {
         : NULL,
       $c->has('myeventlane_checkout_flow.attendee_checkin_manager')
         ? $c->get('myeventlane_checkout_flow.attendee_checkin_manager')
+        : NULL,
+      $c->has('myeventlane_checkout_flow.attendee_operations_access')
+        ? $c->get('myeventlane_checkout_flow.attendee_operations_access')
         : NULL,
     );
   }
@@ -280,7 +285,10 @@ final class QrCheckinController extends ControllerBase {
   }
 
   /**
-   * Checks if the current user can manage the event (owner or vendor).
+   * Checks if the current user can manage the event for QR check-in.
+   *
+   * RSVP product/admin permissions preserved; organiser membership via
+   * MelAttendeeOperationsAccess → EventVendorAccessChecker workspace parity.
    */
   private function canManageEvent(NodeInterface $event): bool {
     $account = $this->account->getAccount();
@@ -290,19 +298,10 @@ final class QrCheckinController extends ControllerBase {
     if (!$account->hasPermission('manage own event rsvps')) {
       return FALSE;
     }
-    if ((int) $event->getOwnerId() === (int) $account->id()) {
-      return TRUE;
+    if ($this->attendeeOperationsAccess instanceof MelAttendeeOperationsAccessInterface) {
+      return $this->attendeeOperationsAccess->accountHasOrganiserOwnership($event, $account);
     }
-    if ($event->hasField('field_event_vendor') && !$event->get('field_event_vendor')->isEmpty()) {
-      $vendor = $event->get('field_event_vendor')->entity;
-      if ($vendor && $vendor->hasField('field_vendor_users')) {
-        foreach ($vendor->get('field_vendor_users')->getValue() as $item) {
-          if (isset($item['target_id']) && (int) $item['target_id'] === (int) $account->id()) {
-            return TRUE;
-          }
-        }
-      }
-    }
+    // Fail closed when Mel attendee ops is unavailable.
     return FALSE;
   }
 

--- a/web/modules/custom/myeventlane_rsvp/tests/src/Unit/QrCheckinOwnershipTest.php
+++ b/web/modules/custom/myeventlane_rsvp/tests/src/Unit/QrCheckinOwnershipTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_rsvp\Unit;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Flood\FloodInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\myeventlane_checkout_flow\Service\MelAttendeeOperationsAccessInterface;
+use Drupal\myeventlane_rsvp\Controller\QrCheckinController;
+use Drupal\node\NodeInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Ownership matrix for QrCheckinController::canManageEvent.
+ *
+ * @group myeventlane_rsvp
+ */
+final class QrCheckinOwnershipTest extends TestCase {
+
+  /**
+   * Verifies RSVP product/admin gates plus Mel ownership hop.
+   *
+   * @dataProvider actorProvider
+   */
+  public function testCanManageEventMatrix(
+    array $permissions,
+    bool $hasOwnership,
+    bool $expected,
+  ): void {
+    $controller = $this->controller($permissions, $hasOwnership);
+    $method = new \ReflectionMethod(QrCheckinController::class, 'canManageEvent');
+    $method->setAccessible(TRUE);
+    $this->assertSame($expected, $method->invoke($controller, $this->event()));
+  }
+
+  /**
+   * Mel ownership hop must be invoked for non-admin organisers.
+   */
+  public function testMelOwnershipPathExercised(): void {
+    $mel = $this->createMock(MelAttendeeOperationsAccessInterface::class);
+    $mel->expects($this->once())
+      ->method('accountHasOrganiserOwnership')
+      ->willReturn(TRUE);
+    $controller = $this->controllerWithMel(
+      ['manage own event rsvps' => TRUE],
+      $mel,
+    );
+    $method = new \ReflectionMethod(QrCheckinController::class, 'canManageEvent');
+    $method->setAccessible(TRUE);
+    $this->assertTrue($method->invoke($controller, $this->event()));
+  }
+
+  /**
+   * Unrelated organisers with manage permission but no ownership are denied.
+   */
+  public function testUnrelatedOrganiserDenied(): void {
+    $controller = $this->controller(
+      ['manage own event rsvps' => TRUE],
+      hasOwnership: FALSE,
+    );
+    $method = new \ReflectionMethod(QrCheckinController::class, 'canManageEvent');
+    $method->setAccessible(TRUE);
+    $this->assertFalse($method->invoke($controller, $this->event()));
+  }
+
+  /**
+   * Actor matrix for QR validate ownership.
+   *
+   * @return \Generator
+   *   Cases: permission map, ownership, expected allow.
+   */
+  public static function actorProvider(): \Generator {
+    yield 'admin rsvps' => [['administer rsvps' => TRUE], FALSE, TRUE];
+    yield 'admin nodes' => [['administer nodes' => TRUE], FALSE, TRUE];
+    yield 'author/owner with manage + ownership' => [['manage own event rsvps' => TRUE], TRUE, TRUE];
+    yield 'team with manage + ownership' => [['manage own event rsvps' => TRUE], TRUE, TRUE];
+    yield 'manage without ownership' => [['manage own event rsvps' => TRUE], FALSE, FALSE];
+    yield 'ownership without manage perm' => [[], TRUE, FALSE];
+  }
+
+  /**
+   * Builds a controller with stub Mel ownership.
+   *
+   * @param array<string, bool> $permissions
+   *   Permission map.
+   * @param bool $hasOwnership
+   *   Whether Mel reports organiser ownership.
+   */
+  private function controller(array $permissions, bool $hasOwnership): QrCheckinController {
+    $mel = $this->createMock(MelAttendeeOperationsAccessInterface::class);
+    $mel->method('accountHasOrganiserOwnership')->willReturn($hasOwnership);
+    return $this->controllerWithMel($permissions, $mel);
+  }
+
+  /**
+   * Builds a controller with an injected Mel mock.
+   *
+   * @param array<string, bool> $permissions
+   *   Permission map.
+   * @param \Drupal\myeventlane_checkout_flow\Service\MelAttendeeOperationsAccessInterface $mel
+   *   Mel attendee operations access mock.
+   */
+  private function controllerWithMel(
+    array $permissions,
+    MelAttendeeOperationsAccessInterface $mel,
+  ): QrCheckinController {
+    $inner = $this->createMock(AccountInterface::class);
+    $inner->method('hasPermission')->willReturnCallback(
+      static fn (string $permission): bool => !empty($permissions[$permission]),
+    );
+
+    $proxy = $this->createMock(AccountProxyInterface::class);
+    $proxy->method('getAccount')->willReturn($inner);
+
+    return new QrCheckinController(
+      $this->createMock(EntityTypeManagerInterface::class),
+      $this->createMock(ConfigFactoryInterface::class),
+      $this->createMock(FloodInterface::class),
+      $proxy,
+      NULL,
+      NULL,
+      $mel,
+    );
+  }
+
+  /**
+   * Builds a stub event node.
+   */
+  private function event(): NodeInterface {
+    $event = $this->createMock(NodeInterface::class);
+    $event->method('bundle')->willReturn('event');
+    $event->method('id')->willReturn(1);
+    return $event;
+  }
+
+}

--- a/web/modules/custom/myeventlane_rsvp/tests/src/Unit/QrCheckinOwnershipTest.php
+++ b/web/modules/custom/myeventlane_rsvp/tests/src/Unit/QrCheckinOwnershipTest.php
@@ -9,8 +9,8 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Flood\FloodInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Session\AccountProxyInterface;
-use Drupal\myeventlane_checkout_flow\Service\MelAttendeeOperationsAccessInterface;
 use Drupal\myeventlane_rsvp\Controller\QrCheckinController;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessCheckerInterface;
 use Drupal\node\NodeInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -22,32 +22,32 @@ use PHPUnit\Framework\TestCase;
 final class QrCheckinOwnershipTest extends TestCase {
 
   /**
-   * Verifies RSVP product/admin gates plus Mel ownership hop.
+   * Verifies RSVP product/admin gates plus workspace parity.
    *
    * @dataProvider actorProvider
    */
   public function testCanManageEventMatrix(
     array $permissions,
-    bool $hasOwnership,
+    bool $hasParity,
     bool $expected,
   ): void {
-    $controller = $this->controller($permissions, $hasOwnership);
+    $controller = $this->controller($permissions, $hasParity);
     $method = new \ReflectionMethod(QrCheckinController::class, 'canManageEvent');
     $method->setAccessible(TRUE);
     $this->assertSame($expected, $method->invoke($controller, $this->event()));
   }
 
   /**
-   * Mel ownership hop must be invoked for non-admin organisers.
+   * Workspace parity must be invoked for non-admin organisers.
    */
-  public function testMelOwnershipPathExercised(): void {
-    $mel = $this->createMock(MelAttendeeOperationsAccessInterface::class);
-    $mel->expects($this->once())
-      ->method('accountHasOrganiserOwnership')
+  public function testParityPathExercised(): void {
+    $checker = $this->createMock(EventVendorAccessCheckerInterface::class);
+    $checker->expects($this->once())
+      ->method('accountHasWorkspaceParityForEvent')
       ->willReturn(TRUE);
-    $controller = $this->controllerWithMel(
+    $controller = $this->controllerWithChecker(
       ['manage own event rsvps' => TRUE],
-      $mel,
+      $checker,
     );
     $method = new \ReflectionMethod(QrCheckinController::class, 'canManageEvent');
     $method->setAccessible(TRUE);
@@ -55,12 +55,12 @@ final class QrCheckinOwnershipTest extends TestCase {
   }
 
   /**
-   * Unrelated organisers with manage permission but no ownership are denied.
+   * Unrelated organisers with manage permission but no parity are denied.
    */
   public function testUnrelatedOrganiserDenied(): void {
     $controller = $this->controller(
       ['manage own event rsvps' => TRUE],
-      hasOwnership: FALSE,
+      hasParity: FALSE,
     );
     $method = new \ReflectionMethod(QrCheckinController::class, 'canManageEvent');
     $method->setAccessible(TRUE);
@@ -68,45 +68,56 @@ final class QrCheckinOwnershipTest extends TestCase {
   }
 
   /**
+   * Ownership must not depend on optional Mel / checkout_flow.
+   */
+  public function testDoesNotRequireMelAttendeeOps(): void {
+    $raw = (string) file_get_contents(dirname(__DIR__, 3) . '/src/Controller/QrCheckinController.php');
+    $this->assertStringContainsString('EventVendorAccessCheckerInterface', $raw);
+    $this->assertStringContainsString('accountHasWorkspaceParityForEvent', $raw);
+    $this->assertStringNotContainsString('MelAttendeeOperationsAccess', $raw);
+    $this->assertStringNotContainsString('attendee_operations_access', $raw);
+  }
+
+  /**
    * Actor matrix for QR validate ownership.
    *
    * @return \Generator
-   *   Cases: permission map, ownership, expected allow.
+   *   Cases: permission map, parity, expected allow.
    */
   public static function actorProvider(): \Generator {
     yield 'admin rsvps' => [['administer rsvps' => TRUE], FALSE, TRUE];
     yield 'admin nodes' => [['administer nodes' => TRUE], FALSE, TRUE];
-    yield 'author/owner with manage + ownership' => [['manage own event rsvps' => TRUE], TRUE, TRUE];
-    yield 'team with manage + ownership' => [['manage own event rsvps' => TRUE], TRUE, TRUE];
-    yield 'manage without ownership' => [['manage own event rsvps' => TRUE], FALSE, FALSE];
-    yield 'ownership without manage perm' => [[], TRUE, FALSE];
+    yield 'author/owner with manage + parity' => [['manage own event rsvps' => TRUE], TRUE, TRUE];
+    yield 'team with manage + parity' => [['manage own event rsvps' => TRUE], TRUE, TRUE];
+    yield 'manage without parity' => [['manage own event rsvps' => TRUE], FALSE, FALSE];
+    yield 'parity without manage perm' => [[], TRUE, FALSE];
   }
 
   /**
-   * Builds a controller with stub Mel ownership.
+   * Builds a controller with stub workspace parity.
    *
    * @param array<string, bool> $permissions
    *   Permission map.
-   * @param bool $hasOwnership
-   *   Whether Mel reports organiser ownership.
+   * @param bool $hasParity
+   *   Whether the checker reports workspace parity.
    */
-  private function controller(array $permissions, bool $hasOwnership): QrCheckinController {
-    $mel = $this->createMock(MelAttendeeOperationsAccessInterface::class);
-    $mel->method('accountHasOrganiserOwnership')->willReturn($hasOwnership);
-    return $this->controllerWithMel($permissions, $mel);
+  private function controller(array $permissions, bool $hasParity): QrCheckinController {
+    $checker = $this->createMock(EventVendorAccessCheckerInterface::class);
+    $checker->method('accountHasWorkspaceParityForEvent')->willReturn($hasParity);
+    return $this->controllerWithChecker($permissions, $checker);
   }
 
   /**
-   * Builds a controller with an injected Mel mock.
+   * Builds a controller with an injected checker mock.
    *
    * @param array<string, bool> $permissions
    *   Permission map.
-   * @param \Drupal\myeventlane_checkout_flow\Service\MelAttendeeOperationsAccessInterface $mel
-   *   Mel attendee operations access mock.
+   * @param \Drupal\myeventlane_vendor\Service\EventVendorAccessCheckerInterface $checker
+   *   Event vendor access checker mock.
    */
-  private function controllerWithMel(
+  private function controllerWithChecker(
     array $permissions,
-    MelAttendeeOperationsAccessInterface $mel,
+    EventVendorAccessCheckerInterface $checker,
   ): QrCheckinController {
     $inner = $this->createMock(AccountInterface::class);
     $inner->method('hasPermission')->willReturnCallback(
@@ -121,9 +132,7 @@ final class QrCheckinOwnershipTest extends TestCase {
       $this->createMock(ConfigFactoryInterface::class),
       $this->createMock(FloodInterface::class),
       $proxy,
-      NULL,
-      NULL,
-      $mel,
+      $checker,
     );
   }
 

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorConsoleBaseController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorConsoleBaseController.php
@@ -9,10 +9,11 @@ use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
-use Symfony\Component\HttpFoundation\Request;
 use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\myeventlane_core\VendorConsoleTrust;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessCheckerInterface;
 use Drupal\node\NodeInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 /**
@@ -28,14 +29,25 @@ abstract class VendorConsoleBaseController {
   protected readonly MessengerInterface $messenger;
 
   /**
+   * Canonical ownership checker (optional for subclass ctor compat).
+   */
+  private readonly ?EventVendorAccessCheckerInterface $eventVendorAccessChecker;
+
+  /**
    * Constructs the base controller.
+   *
+   * The fourth argument is optional so existing subclass constructors that
+   * pass only domain detector / current user / messenger keep working. When
+   * omitted, the checker is resolved from the container on first assert.
    */
   public function __construct(
     protected readonly DomainDetector $domainDetector,
     protected readonly AccountProxyInterface $currentUser,
     MessengerInterface $messenger,
+    ?EventVendorAccessCheckerInterface $eventVendorAccessChecker = NULL,
   ) {
     $this->messenger = $messenger;
+    $this->eventVendorAccessChecker = $eventVendorAccessChecker;
   }
 
   /**
@@ -62,9 +74,8 @@ abstract class VendorConsoleBaseController {
     }
 
     // User has permission but is on main domain - still allow access
-    // (theme negotiator will handle theme switching, but we prefer vendor domain).
-    // For now, we allow access from both domains if user has permission.
-    return;
+    // (theme negotiator handles theme; vendor domain preferred).
+    // Allow access from both domains if user has permission.
   }
 
   /**
@@ -73,7 +84,8 @@ abstract class VendorConsoleBaseController {
    * This checks:
    *  - vendor domain
    *  - vendor console permission
-   *  - ownership via node owner OR linked vendor entity users.
+   *  - workspace parity via EventVendorAccessChecker
+   *  - administer nodes staff bypass (caller-side; not in the checker)
    *
    * @throws \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
    *   When access is denied.
@@ -85,31 +97,32 @@ abstract class VendorConsoleBaseController {
       return;
     }
 
-    // Owner check.
-    if ((int) $event->getOwnerId() === (int) $this->currentUser->id()) {
+    // Canonical ownership API — thin wrapper (Workstream 1).
+    $checker = $this->getEventVendorAccessChecker();
+    if ($checker->accountHasWorkspaceParityForEvent($event, $this->currentUser)) {
       return;
     }
 
-    // Organiser account owner or team member via field_event_vendor.
-    // Keep parity with EventVendorAccessChecker::accountHasWorkspaceParityForEvent().
-    if ($event->hasField('field_event_vendor') && !$event->get('field_event_vendor')->isEmpty()) {
-      $vendor = $event->get('field_event_vendor')->entity;
-      if ($vendor) {
-        if (method_exists($vendor, 'getOwnerId')
-          && (int) $vendor->getOwnerId() === (int) $this->currentUser->id()) {
-          return;
-        }
-        if ($vendor->hasField('field_vendor_users')) {
-          foreach ($vendor->get('field_vendor_users')->getValue() as $item) {
-            if (isset($item['target_id']) && (int) $item['target_id'] === (int) $this->currentUser->id()) {
-              return;
-            }
-          }
-        }
-      }
+    throw new AccessDeniedHttpException();
+  }
+
+  /**
+   * Resolves the canonical event ownership checker.
+   */
+  protected function getEventVendorAccessChecker(): EventVendorAccessCheckerInterface {
+    if ($this->eventVendorAccessChecker instanceof EventVendorAccessCheckerInterface) {
+      return $this->eventVendorAccessChecker;
     }
 
-    throw new AccessDeniedHttpException();
+    // Matches other optional resolutions in this base
+    // (entityTypeManager, request).
+    $checker = \Drupal::service('myeventlane_vendor.event_access_checker');
+    if (!$checker instanceof EventVendorAccessCheckerInterface) {
+      throw new \RuntimeException(
+        'Service myeventlane_vendor.event_access_checker must implement EventVendorAccessCheckerInterface.',
+      );
+    }
+    return $checker;
   }
 
   /**
@@ -179,7 +192,7 @@ abstract class VendorConsoleBaseController {
       }
     }
 
-    // Legacy callers pass main column as `body`; prefer `content` for a single render path.
+    // Legacy callers pass main column as `body`; prefer `content`.
     if (!isset($render['#content']) && isset($render['#body'])) {
       $render['#content'] = $render['#body'];
     }

--- a/web/modules/custom/myeventlane_vendor/src/Service/EventVendorAccessChecker.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/EventVendorAccessChecker.php
@@ -8,19 +8,21 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\node\NodeInterface;
 
 /**
- * Event access aligned with VendorConsoleBaseController::assertEventOwnership.
+ * Canonical per-event organiser ownership (workspace parity).
  *
- * Use for route access and API checks so organiser owners and team members
- * (field_event_vendor → vendor owner uid or field_vendor_users) have the same
- * event reach as the node author.
+ * TRUE when the account is the event author, the linked vendor entity owner,
+ * or a member of that vendor's field_vendor_users.
  *
- * This does not assert vendor domain or global vendor console permissions; those
- * belong on routes or calling code. Admin/staff bypasses are left to callers.
+ * This does not assert vendor domain or global vendor console permissions;
+ * those belong on routes or calling code. Staff bypasses are left to callers.
+ *
+ * @see \Drupal\myeventlane_vendor\Controller\VendorConsoleBaseController::assertEventOwnership()
+ * @see docs/adr/ADR-0008-canonical-event-ownership.md
  */
 final class EventVendorAccessChecker implements EventVendorAccessCheckerInterface {
 
   /**
-   * TRUE when the account is the event author or manages via the linked organiser.
+   * {@inheritdoc}
    */
   public function accountHasWorkspaceParityForEvent(NodeInterface $event, AccountInterface $account): bool {
     if ($event->bundle() !== 'event') {

--- a/web/modules/custom/myeventlane_vendor/src/Service/EventVendorAccessCheckerInterface.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/EventVendorAccessCheckerInterface.php
@@ -8,19 +8,18 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\node\NodeInterface;
 
 /**
- * Interface for {@see EventVendorAccessChecker}.
+ * Canonical per-event organiser ownership API (workspace parity).
  *
- * Extracted so MEL Attendee Operations Layer access policy can be unit-tested
- * without doubling the final implementation. The implementation remains
- * `final`; existing consumers that type-hint the concrete class continue to
- * work because the implementation now also implements this interface.
+ * @see \Drupal\myeventlane_vendor\Service\EventVendorAccessChecker
+ * @see docs/adr/ADR-0008-canonical-event-ownership.md
  */
 interface EventVendorAccessCheckerInterface {
 
   /**
-   * TRUE when the account is the event author or manages via the linked organiser.
+   * TRUE when the account is the event author or linked organiser manager.
    *
-   * Includes organiser entity owner (vendor uid) and field_vendor_users members.
+   * Includes organiser entity owner (vendor uid) and field_vendor_users.
+   * Does not grant staff/admin bypass — callers apply named permissions.
    */
   public function accountHasWorkspaceParityForEvent(NodeInterface $event, AccountInterface $account): bool;
 

--- a/web/modules/custom/myeventlane_vendor/tests/src/Unit/EventVendorAccessCheckerTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Unit/EventVendorAccessCheckerTest.php
@@ -10,14 +10,22 @@ use Drupal\node\NodeInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
+ * Unit tests for the canonical workspace parity checker.
+ *
  * @coversDefaultClass \Drupal\myeventlane_vendor\Service\EventVendorAccessChecker
  *
  * @group myeventlane_vendor
  */
 final class EventVendorAccessCheckerTest extends TestCase {
 
+  /**
+   * The checker under test.
+   */
   private EventVendorAccessChecker $checker;
 
+  /**
+   * {@inheritdoc}
+   */
   protected function setUp(): void {
     parent::setUp();
     $this->checker = new EventVendorAccessChecker();
@@ -72,15 +80,62 @@ final class EventVendorAccessCheckerTest extends TestCase {
     $this->assertFalse($this->checker->accountHasWorkspaceParityForEvent($event, $account));
   }
 
+  /**
+   * @covers ::accountHasWorkspaceParityForEvent
+   */
+  public function testAnonymousDenied(): void {
+    $account = $this->account(0);
+    $vendor = $this->vendor(ownerId: 20, teamUserIds: [30]);
+    $event = $this->event(authorId: 99, vendor: $vendor);
+    $this->assertFalse($this->checker->accountHasWorkspaceParityForEvent($event, $account));
+  }
+
+  /**
+   * @covers ::accountHasWorkspaceParityForEvent
+   */
+  public function testAuthenticatedNonOrganiserDenied(): void {
+    $account = $this->account(50);
+    $vendor = $this->vendor(ownerId: 20, teamUserIds: [30]);
+    $event = $this->event(authorId: 99, vendor: $vendor);
+    $this->assertFalse($this->checker->accountHasWorkspaceParityForEvent($event, $account));
+  }
+
+  /**
+   * Staff bypass is intentionally NOT granted by the checker.
+   *
+   * @covers ::accountHasWorkspaceParityForEvent
+   */
+  public function testAdministratorWithoutMembershipDeniedByChecker(): void {
+    $account = $this->account(1);
+    $vendor = $this->vendor(ownerId: 20, teamUserIds: [30]);
+    $event = $this->event(authorId: 99, vendor: $vendor);
+    $this->assertFalse($this->checker->accountHasWorkspaceParityForEvent($event, $account));
+  }
+
+  /**
+   * @covers ::accountHasWorkspaceParityForEvent
+   */
+  public function testNonEventBundleDeniedEvenForAuthor(): void {
+    $account = $this->account(10);
+    $event = $this->event(authorId: 10, vendor: NULL, bundle: 'page');
+    $this->assertFalse($this->checker->accountHasWorkspaceParityForEvent($event, $account));
+  }
+
+  /**
+   * Builds a stub account.
+   */
   private function account(int $uid): AccountInterface {
     $account = $this->createMock(AccountInterface::class);
     $account->method('id')->willReturn($uid);
     return $account;
   }
 
-  private function event(int $authorId, ?object $vendor = NULL): NodeInterface {
+  /**
+   * Builds a stub event node.
+   */
+  private function event(int $authorId, ?object $vendor = NULL, string $bundle = 'event'): NodeInterface {
     $event = $this->createMock(NodeInterface::class);
-    $event->method('bundle')->willReturn('event');
+    $event->method('bundle')->willReturn($bundle);
     $event->method('getOwnerId')->willReturn($authorId);
     $event->method('hasField')->willReturnCallback(
       static fn (string $field): bool => $field === 'field_event_vendor' && $vendor !== NULL,
@@ -91,15 +146,28 @@ final class EventVendorAccessCheckerTest extends TestCase {
     }
 
     $list = new class($vendor) {
+
+      /**
+       * Linked vendor entity stub.
+       *
+       * @var object
+       */
       public object $entity;
 
+      /**
+       * Constructs the field item list stub.
+       */
       public function __construct(object $vendor) {
         $this->entity = $vendor;
       }
 
+      /**
+       * Reports whether the field is empty.
+       */
       public function isEmpty(): bool {
         return FALSE;
       }
+
     };
 
     $event->method('get')->with('field_event_vendor')->willReturn($list);
@@ -107,36 +175,74 @@ final class EventVendorAccessCheckerTest extends TestCase {
   }
 
   /**
+   * Builds a stub vendor entity.
+   *
+   * @param int $ownerId
+   *   Vendor entity owner UID.
    * @param list<int> $teamUserIds
+   *   Team member UIDs on field_vendor_users.
    */
   private function vendor(int $ownerId, array $teamUserIds): object {
     return new class($ownerId, $teamUserIds) {
+
+      /**
+       * Constructs the vendor stub.
+       *
+       * @param int $ownerId
+       *   Vendor owner UID.
+       * @param list<int> $teamUserIds
+       *   Team member UIDs.
+       */
       public function __construct(
         private readonly int $ownerId,
         private readonly array $teamUserIds,
       ) {}
 
+      /**
+       * Returns the vendor owner UID.
+       */
       public function getOwnerId(): int {
         return $this->ownerId;
       }
 
+      /**
+       * Reports whether a field exists.
+       */
       public function hasField(string $field): bool {
         return $field === 'field_vendor_users';
       }
 
+      /**
+       * Returns a field item list stub.
+       */
       public function get(string $field): object {
         $values = array_map(
           static fn (int $uid): array => ['target_id' => $uid],
           $this->teamUserIds,
         );
         return new class($values) {
+
+          /**
+           * Constructs the values stub.
+           *
+           * @param list<array{target_id: int}> $values
+           *   Field values.
+           */
           public function __construct(private readonly array $values) {}
 
+          /**
+           * Returns field values.
+           *
+           * @return list<array{target_id: int}>
+           *   Field values.
+           */
           public function getValue(): array {
             return $this->values;
           }
+
         };
       }
+
     };
   }
 

--- a/web/modules/custom/myeventlane_vendor/tests/src/Unit/ManagedSetWorkspaceParityEquivalenceTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Unit/ManagedSetWorkspaceParityEquivalenceTest.php
@@ -1,0 +1,290 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_vendor\Unit;
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
+use Drupal\node\NodeInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Proves managed-set membership ≡ workspace parity for modern events.
+ *
+ * For events keyed only by field_event_vendor (no legacy field_vendor widen):
+ *
+ *   event ∈ managed-set(account)
+ *   ⇔
+ *   EventVendorAccessChecker::accountHasWorkspaceParityForEvent(account, event)
+ *
+ * Managed-set membership is evaluated with the same logical predicates used by
+ * UserVendorMembershipQuery::getManagedEventNodeIds() without hitting storage:
+ * author ∪ events whose field_event_vendor is in the account's vendor ID set
+ * (vendor entity owner ∪ field_vendor_users).
+ *
+ * @group myeventlane_vendor
+ */
+final class ManagedSetWorkspaceParityEquivalenceTest extends TestCase {
+
+  /**
+   * Canonical workspace parity checker.
+   */
+  private EventVendorAccessChecker $checker;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->checker = new EventVendorAccessChecker();
+  }
+
+  /**
+   * Modern field_event_vendor events: managed-set iff workspace parity.
+   *
+   * @dataProvider actorProvider
+   */
+  public function testModernEventManagedSetIffWorkspaceParity(
+    int $uid,
+    int $authorId,
+    int $vendorOwnerId,
+    array $teamUserIds,
+    bool $expected,
+  ): void {
+    $account = $this->account($uid);
+    $vendorId = 500;
+    $vendor = $this->vendor($vendorOwnerId, $teamUserIds);
+    $event = $this->event(authorId: $authorId, vendor: $vendor, eventId: 42);
+
+    $parity = $this->checker->accountHasWorkspaceParityForEvent($event, $account);
+    $inManagedSet = $this->modernManagedSetContains(
+      uid: $uid,
+      authorId: $authorId,
+      vendorId: $vendorId,
+      vendorOwnerId: $vendorOwnerId,
+      teamUserIds: $teamUserIds,
+    );
+
+    $this->assertSame($expected, $parity, 'Workspace parity');
+    $this->assertSame($expected, $inManagedSet, 'Managed-set membership');
+    $this->assertSame(
+      $parity,
+      $inManagedSet,
+      'parity ≡ managed-set (modern field_event_vendor)',
+    );
+  }
+
+  /**
+   * Legacy field_vendor on managed-set can widen vs parity — documented stop.
+   *
+   * This test locks the known divergence so Workstream 2A does not invent
+   * reconciliation: parity ignores legacy field_vendor; managed-set may
+   * include it.
+   */
+  public function testLegacyFieldVendorWidenIsExplicitDivergence(): void {
+    $uid = 20;
+    $account = $this->account($uid);
+    // Event has no field_event_vendor; account owns vendor 500 linked only via
+    // legacy field_vendor on the event. Parity must be FALSE; managed-set TRUE.
+    $event = $this->event(authorId: 99, vendor: NULL, eventId: 77);
+    $parity = $this->checker->accountHasWorkspaceParityForEvent($event, $account);
+    $inManagedSetViaLegacy = TRUE;
+
+    $this->assertFalse($parity, 'Parity ignores legacy field_vendor');
+    $this->assertTrue($inManagedSetViaLegacy, 'Managed-set may widen via legacy');
+    $this->assertNotSame(
+      $parity,
+      $inManagedSetViaLegacy,
+      'Documented divergence — do not reconcile here',
+    );
+  }
+
+  /**
+   * Actor matrix for modern field_event_vendor events.
+   *
+   * @return \Generator
+   *   Cases: uid, author, vendor owner, team UIDs, expected membership.
+   */
+  public static function actorProvider(): \Generator {
+    yield 'event author' => [10, 10, 20, [30], TRUE];
+    yield 'vendor entity owner' => [20, 99, 20, [30], TRUE];
+    yield 'vendor team member' => [30, 99, 20, [30], TRUE];
+    yield 'unrelated organiser' => [40, 99, 20, [30], FALSE];
+    yield 'authenticated non-organiser' => [50, 99, 20, [30], FALSE];
+    yield 'anonymous' => [0, 99, 20, [30], FALSE];
+  }
+
+  /**
+   * Logical managed-set membership for a modern event (no legacy field_vendor).
+   *
+   * @param int $uid
+   *   Account UID.
+   * @param int $authorId
+   *   Event author UID.
+   * @param int $vendorId
+   *   Vendor entity ID linked on the event.
+   * @param int $vendorOwnerId
+   *   Vendor entity owner UID.
+   * @param list<int> $teamUserIds
+   *   Team UIDs on the vendor entity.
+   */
+  private function modernManagedSetContains(
+    int $uid,
+    int $authorId,
+    int $vendorId,
+    int $vendorOwnerId,
+    array $teamUserIds,
+  ): bool {
+    if ($uid <= 0) {
+      return FALSE;
+    }
+
+    $vendorIdsForUser = [];
+    if ($vendorOwnerId === $uid || in_array($uid, $teamUserIds, TRUE)) {
+      $vendorIdsForUser[] = $vendorId;
+    }
+
+    if ($authorId === $uid) {
+      return TRUE;
+    }
+
+    return $vendorIdsForUser !== [] && in_array($vendorId, $vendorIdsForUser, TRUE);
+  }
+
+  /**
+   * Builds a stub account.
+   */
+  private function account(int $uid): AccountInterface {
+    $account = $this->createMock(AccountInterface::class);
+    $account->method('id')->willReturn($uid);
+    return $account;
+  }
+
+  /**
+   * Builds a stub event node.
+   */
+  private function event(int $authorId, ?object $vendor, int $eventId): NodeInterface {
+    $event = $this->createMock(NodeInterface::class);
+    $event->method('bundle')->willReturn('event');
+    $event->method('id')->willReturn($eventId);
+    $event->method('getOwnerId')->willReturn($authorId);
+    $event->method('hasField')->willReturnCallback(
+      static fn (string $field): bool => $field === 'field_event_vendor' && $vendor !== NULL,
+    );
+
+    if ($vendor === NULL) {
+      $event->method('get')->willReturn(new class() {
+
+        /**
+         * Reports whether the field is empty.
+         */
+        public function isEmpty(): bool {
+          return TRUE;
+        }
+
+      });
+      return $event;
+    }
+
+    $list = new class($vendor) {
+
+      /**
+       * Linked vendor entity stub.
+       *
+       * @var object
+       */
+      public object $entity;
+
+      /**
+       * Constructs the field item list stub.
+       */
+      public function __construct(object $vendor) {
+        $this->entity = $vendor;
+      }
+
+      /**
+       * Reports whether the field is empty.
+       */
+      public function isEmpty(): bool {
+        return FALSE;
+      }
+
+    };
+    $event->method('get')->with('field_event_vendor')->willReturn($list);
+    return $event;
+  }
+
+  /**
+   * Builds a stub vendor entity.
+   *
+   * @param int $ownerId
+   *   Vendor entity owner UID.
+   * @param list<int> $teamUserIds
+   *   Team member UIDs.
+   */
+  private function vendor(int $ownerId, array $teamUserIds): object {
+    return new class($ownerId, $teamUserIds) {
+
+      /**
+       * Constructs the vendor stub.
+       *
+       * @param int $ownerId
+       *   Vendor owner UID.
+       * @param list<int> $teamUserIds
+       *   Team member UIDs.
+       */
+      public function __construct(
+        private readonly int $ownerId,
+        private readonly array $teamUserIds,
+      ) {}
+
+      /**
+       * Returns the vendor owner UID.
+       */
+      public function getOwnerId(): int {
+        return $this->ownerId;
+      }
+
+      /**
+       * Reports whether a field exists.
+       */
+      public function hasField(string $field): bool {
+        return $field === 'field_vendor_users';
+      }
+
+      /**
+       * Returns a field item list stub.
+       */
+      public function get(string $field): object {
+        $values = array_map(
+          static fn (int $uid): array => ['target_id' => $uid],
+          $this->teamUserIds,
+        );
+        return new class($values) {
+
+          /**
+           * Constructs the values stub.
+           *
+           * @param list<array{target_id: int}> $values
+           *   Field values.
+           */
+          public function __construct(private readonly array $values) {}
+
+          /**
+           * Returns field values.
+           *
+           * @return list<array{target_id: int}>
+           *   Field values.
+           */
+          public function getValue(): array {
+            return $this->values;
+          }
+
+        };
+      }
+
+    };
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorConsoleBaseControllerOwnershipEquivalenceTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorConsoleBaseControllerOwnershipEquivalenceTest.php
@@ -1,0 +1,400 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_vendor\Unit;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\myeventlane_core\Service\DomainDetector;
+use Drupal\myeventlane_vendor\Controller\VendorConsoleBaseController;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessCheckerInterface;
+use Drupal\node\NodeInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * Proves assertEventOwnership delegates to the canonical checker without drift.
+ *
+ * Side-by-side: legacy inline membership algorithm vs EventVendorAccessChecker
+ * vs the thin controller wrapper (for event bundles under console trust).
+ *
+ * @coversDefaultClass \Drupal\myeventlane_vendor\Controller\VendorConsoleBaseController
+ *
+ * @group myeventlane_vendor
+ */
+final class VendorConsoleBaseControllerOwnershipEquivalenceTest extends TestCase {
+
+  /**
+   * Canonical checker used for side-by-side comparison.
+   */
+  private EventVendorAccessChecker $checker;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->checker = new EventVendorAccessChecker();
+  }
+
+  /**
+   * Legacy inline membership must match the canonical checker for events.
+   *
+   * @dataProvider ownershipActorProvider
+   */
+  public function testLegacyInlineMatchesCanonicalCheckerForEvents(
+    int $uid,
+    int $authorId,
+    int $vendorOwnerId,
+    array $teamUserIds,
+    bool $expectedParity,
+  ): void {
+    $account = $this->account($uid);
+    $vendor = $this->vendor($vendorOwnerId, $teamUserIds);
+    $event = $this->event($authorId, $vendor);
+
+    $legacy = $this->legacyInlineOwnershipAllows($event, $account);
+    $canonical = $this->checker->accountHasWorkspaceParityForEvent($event, $account);
+
+    $this->assertSame($expectedParity, $legacy, 'Legacy inline membership');
+    $this->assertSame($expectedParity, $canonical, 'Canonical checker');
+    $this->assertSame($legacy, $canonical, 'Legacy ≡ canonical');
+  }
+
+  /**
+   * Thin wrapper must match the canonical checker for event actors.
+   *
+   * @dataProvider ownershipActorProvider
+   */
+  public function testWrapperMatchesCanonicalChecker(
+    int $uid,
+    int $authorId,
+    int $vendorOwnerId,
+    array $teamUserIds,
+    bool $expectedParity,
+  ): void {
+    $vendor = $this->vendor($vendorOwnerId, $teamUserIds);
+    $event = $this->event($authorId, $vendor);
+    $controller = $this->controller(
+      uid: $uid,
+      permissions: ['access vendor console' => TRUE, 'administer nodes' => FALSE],
+      checker: $this->checker,
+      skipVendorAccess: TRUE,
+    );
+
+    if ($expectedParity) {
+      $controller->exposeAssertEventOwnership($event);
+      $this->addToAssertionCount(1);
+      return;
+    }
+
+    $this->expectException(AccessDeniedHttpException::class);
+    $controller->exposeAssertEventOwnership($event);
+  }
+
+  /**
+   * Administer-nodes bypass remains on the wrapper, not the checker.
+   */
+  public function testAdministratorBypassDoesNotRequireParity(): void {
+    $vendor = $this->vendor(20, [30]);
+    $event = $this->event(99, $vendor);
+    $controller = $this->controller(
+      uid: 1,
+      permissions: [
+        'access vendor console' => TRUE,
+        'administer nodes' => TRUE,
+        'administer site configuration' => TRUE,
+      ],
+      checker: $this->checker,
+      skipVendorAccess: TRUE,
+    );
+
+    $controller->exposeAssertEventOwnership($event);
+    $this->assertFalse(
+      $this->checker->accountHasWorkspaceParityForEvent($event, $this->account(1)),
+      'Checker itself must not grant admin',
+    );
+  }
+
+  /**
+   * Anonymous users are denied at console trust before ownership.
+   */
+  public function testAnonymousDeniedAtConsoleTrust(): void {
+    $vendor = $this->vendor(20, [30]);
+    $event = $this->event(99, $vendor);
+    $controller = $this->controller(
+      uid: 0,
+      permissions: [],
+      checker: $this->checker,
+      skipVendorAccess: FALSE,
+      anonymous: TRUE,
+    );
+
+    $this->expectException(AccessDeniedHttpException::class);
+    $controller->exposeAssertEventOwnership($event);
+  }
+
+  /**
+   * Ownership actor matrix for event bundles.
+   *
+   * @return iterable<string, array{int, int, int, list<int>, bool}>
+   *   Actor fixtures: uid, author, vendor owner, team, expected parity.
+   */
+  public static function ownershipActorProvider(): iterable {
+    yield 'event author' => [10, 10, 20, [30], TRUE];
+    yield 'vendor owner' => [20, 99, 20, [30], TRUE];
+    yield 'team member' => [30, 99, 20, [30], TRUE];
+    yield 'unrelated organiser' => [40, 99, 20, [30], FALSE];
+    yield 'authenticated non-organiser' => [50, 99, 20, [30], FALSE];
+  }
+
+  /**
+   * Pre-Workstream-1 inline membership from VendorConsoleBaseController.
+   *
+   * Kept here as the equivalence oracle — do not "improve" this copy.
+   */
+  private function legacyInlineOwnershipAllows(NodeInterface $event, AccountInterface $account): bool {
+    if ((int) $event->getOwnerId() === (int) $account->id()) {
+      return TRUE;
+    }
+
+    if ($event->hasField('field_event_vendor') && !$event->get('field_event_vendor')->isEmpty()) {
+      $vendor = $event->get('field_event_vendor')->entity;
+      if ($vendor) {
+        if (method_exists($vendor, 'getOwnerId')
+          && (int) $vendor->getOwnerId() === (int) $account->id()) {
+          return TRUE;
+        }
+        if ($vendor->hasField('field_vendor_users')) {
+          foreach ($vendor->get('field_vendor_users')->getValue() as $item) {
+            if (isset($item['target_id']) && (int) $item['target_id'] === (int) $account->id()) {
+              return TRUE;
+            }
+          }
+        }
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Builds a testable console controller.
+   *
+   * @param int $uid
+   *   Current user ID.
+   * @param array<string, bool> $permissions
+   *   Permission map for the stub account.
+   * @param \Drupal\myeventlane_vendor\Service\EventVendorAccessCheckerInterface $checker
+   *   Canonical ownership checker.
+   * @param bool $skipVendorAccess
+   *   TRUE to skip assertVendorAccess (isolate ownership).
+   * @param bool $anonymous
+   *   Whether the account is anonymous.
+   */
+  private function controller(
+    int $uid,
+    array $permissions,
+    EventVendorAccessCheckerInterface $checker,
+    bool $skipVendorAccess = TRUE,
+    bool $anonymous = FALSE,
+  ): TestVendorConsoleController {
+    $domain = new DomainDetector(
+      new RequestStack(),
+      $this->createMock(ConfigFactoryInterface::class),
+    );
+
+    $account = $this->createMock(AccountProxyInterface::class);
+    $account->method('id')->willReturn($uid);
+    $account->method('isAnonymous')->willReturn($anonymous);
+    $account->method('hasPermission')->willReturnCallback(
+      static fn (string $permission): bool => !empty($permissions[$permission]),
+    );
+    $account->method('hasRole')->willReturn(FALSE);
+
+    $messenger = $this->createMock(MessengerInterface::class);
+
+    return new TestVendorConsoleController(
+      $domain,
+      $account,
+      $messenger,
+      $checker,
+      $skipVendorAccess,
+    );
+  }
+
+  /**
+   * Builds a stub account.
+   */
+  private function account(int $uid): AccountInterface {
+    $account = $this->createMock(AccountInterface::class);
+    $account->method('id')->willReturn($uid);
+    return $account;
+  }
+
+  /**
+   * Builds a stub event node with a linked vendor.
+   */
+  private function event(int $authorId, object $vendor): NodeInterface {
+    $event = $this->createMock(NodeInterface::class);
+    $event->method('bundle')->willReturn('event');
+    $event->method('getOwnerId')->willReturn($authorId);
+    $event->method('hasField')->willReturnCallback(
+      static fn (string $field): bool => $field === 'field_event_vendor',
+    );
+
+    $list = new class($vendor) {
+
+      /**
+       * Linked vendor entity stub.
+       *
+       * @var object
+       */
+      public object $entity;
+
+      /**
+       * Constructs the field item list stub.
+       */
+      public function __construct(object $vendor) {
+        $this->entity = $vendor;
+      }
+
+      /**
+       * Reports whether the field is empty.
+       */
+      public function isEmpty(): bool {
+        return FALSE;
+      }
+
+    };
+
+    $event->method('get')->with('field_event_vendor')->willReturn($list);
+    return $event;
+  }
+
+  /**
+   * Builds a stub vendor entity.
+   *
+   * @param int $ownerId
+   *   Vendor entity owner UID.
+   * @param list<int> $teamUserIds
+   *   Team member UIDs on field_vendor_users.
+   */
+  private function vendor(int $ownerId, array $teamUserIds): object {
+    return new class($ownerId, $teamUserIds) {
+
+      /**
+       * Constructs the vendor stub.
+       *
+       * @param int $ownerId
+       *   Vendor owner UID.
+       * @param list<int> $teamUserIds
+       *   Team member UIDs.
+       */
+      public function __construct(
+        private readonly int $ownerId,
+        private readonly array $teamUserIds,
+      ) {}
+
+      /**
+       * Returns the vendor owner UID.
+       */
+      public function getOwnerId(): int {
+        return $this->ownerId;
+      }
+
+      /**
+       * Reports whether a field exists.
+       */
+      public function hasField(string $field): bool {
+        return $field === 'field_vendor_users';
+      }
+
+      /**
+       * Returns a field item list stub.
+       */
+      public function get(string $field): object {
+        $values = array_map(
+          static fn (int $uid): array => ['target_id' => $uid],
+          $this->teamUserIds,
+        );
+        return new class($values) {
+
+          /**
+           * Constructs the values stub.
+           *
+           * @param list<array{target_id: int}> $values
+           *   Field values.
+           */
+          public function __construct(private readonly array $values) {}
+
+          /**
+           * Returns field values.
+           *
+           * @return list<array{target_id: int}>
+           *   Field values.
+           */
+          public function getValue(): array {
+            return $this->values;
+          }
+
+        };
+      }
+
+    };
+  }
+
+}
+
+/**
+ * Concrete controller exposing assertEventOwnership for unit tests.
+ */
+final class TestVendorConsoleController extends VendorConsoleBaseController {
+
+  /**
+   * Constructs the test controller.
+   *
+   * @param \Drupal\myeventlane_core\Service\DomainDetector $domainDetector
+   *   Domain detector.
+   * @param \Drupal\Core\Session\AccountProxyInterface $currentUser
+   *   Current user.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   Messenger.
+   * @param \Drupal\myeventlane_vendor\Service\EventVendorAccessCheckerInterface $eventVendorAccessChecker
+   *   Canonical ownership checker.
+   * @param bool $skipVendorAccess
+   *   TRUE to skip assertVendorAccess during ownership tests.
+   */
+  public function __construct(
+    DomainDetector $domainDetector,
+    AccountProxyInterface $currentUser,
+    MessengerInterface $messenger,
+    EventVendorAccessCheckerInterface $eventVendorAccessChecker,
+    private readonly bool $skipVendorAccess = TRUE,
+  ) {
+    parent::__construct($domainDetector, $currentUser, $messenger, $eventVendorAccessChecker);
+  }
+
+  /**
+   * Exposes assertEventOwnership for assertions.
+   */
+  public function exposeAssertEventOwnership(NodeInterface $event): void {
+    $this->assertEventOwnership($event);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function assertVendorAccess(): void {
+    if ($this->skipVendorAccess) {
+      return;
+    }
+    parent::assertVendorAccess();
+  }
+
+}


### PR DESCRIPTION
## Summary

- Establishes the canonical organiser event ownership API (`EventVendorAccessChecker` / workspace parity) with equivalence tests against managed-set queries and console asserts (Workstream 1).
- Aligns attendee, waitlist, messaging, Pro message-attendees, RSVP QR check-in, and EventAttendee ACH surfaces to workspace parity so vendor entity owners are no longer denied by team-partial helpers (Workstream 2A).
- Adds ADR-0008 and the Phase 2B ownership consolidation blueprint for subsequent financial/API and route workstreams.

## Scope

In scope: canonical ownership API, attendee-domain ownership consolidation, focused unit tests, ADR + implementation docs.

Out of scope (deferred): refund/financial ownership (2B-A), Vendor API ownership, Boost, charts, ManageEventControllerBase, route `_custom_access` consolidation, check-in CSRF, Commerce permission reduction.

## Test plan

- [ ] `ddev exec vendor/bin/phpunit -c web/core web/modules/custom/myeventlane_vendor/tests/src/Unit/EventVendorAccessCheckerTest.php`
- [ ] `ddev exec vendor/bin/phpunit -c web/core web/modules/custom/myeventlane_vendor/tests/src/Unit/ManagedSetWorkspaceParityEquivalenceTest.php`
- [ ] `ddev exec vendor/bin/phpunit -c web/core web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorConsoleBaseControllerOwnershipEquivalenceTest.php`
- [ ] `ddev exec vendor/bin/phpunit -c web/core web/modules/custom/myeventlane_event_attendees/tests/src/Unit/`
- [ ] `ddev exec vendor/bin/phpunit -c web/core web/modules/custom/myeventlane_messaging/tests/src/Unit/VendorNotifyFormOwnershipTest.php`
- [ ] `ddev exec vendor/bin/phpunit -c web/core web/modules/custom/myeventlane_pro/tests/src/Unit/MessageAttendeesOwnershipTest.php`
- [ ] `ddev exec vendor/bin/phpunit -c web/core web/modules/custom/myeventlane_rsvp/tests/src/Unit/QrCheckinOwnershipTest.php`
- [ ] `ddev exec vendor/bin/phpunit -c web/core web/modules/custom/myeventlane_checkout_flow/tests/src/Unit/MelAttendeeOperationsAccessTest.php`
- [ ] Confirm unrelated organisers remain denied; vendor entity owners gain parity on former team-partial surfaces
- [ ] `ddev drush cr` after deploy; no config export expected


Made with [Cursor](https://cursor.com)