### PR TITLE
Feature/mel financial api ownership

### DIFF
--- a/docs/adr/ADR-0008-canonical-event-ownership.md
+++ b/docs/adr/ADR-0008-canonical-event-ownership.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Accepted.** Workstream 1 (canonical API) and Workstream 2A (attendee ownership) implemented on `feature/mel-canonical-ownership-api`.
+**Accepted.** Workstream 1 (canonical API), Workstream 2A (attendee ownership), and Workstream 2B-A (financial + Vendor API ownership) implemented.
 
 ## Date
 
@@ -59,6 +59,18 @@ These two MUST remain semantically aligned for modern events keyed by `field_eve
 5. `VendorConsoleAccess` remains the organiser console trust/onboarding gate. It is **not** event ownership.
 6. Staff bypasses stay on callers via named permissions (`administer nodes`, `administer event attendees`, `administer commerce_order`, domain admin perms). The parity checker itself does not grant admin.
 7. Soft redirects and UI hiding are never access control.
+
+### Ownership responsibilities
+
+| Responsibility | Canonical service |
+|---|---|
+| Workspace ownership | `EventVendorAccessChecker` |
+| Managed event lists | `UserVendorMembershipQuery` |
+| Attendee operations | `MelAttendeeOperationsAccess` |
+| Financial integrity | `RefundAccessResolver` composed with canonical parity |
+| Console trust | `VendorConsoleAccess` |
+| API authentication | Existing `ApiAuthenticationService` (vendor-scoped API keys) |
+| API event ownership | `EventVendorAccessChecker` after identity resolution (vendor owner account + vendor link bind) |
 
 ## Alternatives
 

--- a/docs/implementation/phase2b-ownership-consolidation.md
+++ b/docs/implementation/phase2b-ownership-consolidation.md
@@ -1,9 +1,9 @@
 # Phase 2B — Ownership Architecture Consolidation
 
 **Date:** 2026-07-21  
-**Status:** Workstream 2A implemented (attendee ownership consolidation)  
-**Branch evidence:** `feature/mel-canonical-ownership-api`  
-**Prerequisite:** Phase 2A.2 security hotfix (RSVP isolation, export hardening, check-in bind); Workstream 1 canonical API  
+**Status:** Workstream 2B-A implemented (financial + Vendor API ownership)  
+**Branch evidence:** `feature/mel-financial-api-ownership` (cut from `origin/main` after PR #699)  
+**Prerequisite:** Phase 2A.2; Workstream 1 canonical API; Workstream 2A attendee ownership  
 **Companion plan (shorter):** `docs/implementation/phase2b-ownership-consolidation-plan.md`  
 **ADR:** `docs/adr/ADR-0008-canonical-event-ownership.md`
 
@@ -521,9 +521,10 @@ ddev exec vendor/bin/phpunit -c web/core \
 - [x] Workstream 1: thin `assertEventOwnership` → `EventVendorAccessChecker`; equivalence tests  
 - [x] Workstream 2A: attendee / waitlist / messaging / QR / ACH ownership → Mel → checker (or checker where Mel is cycle-blocked)  
 - [x] Parity ≡ managed-set proven for modern `field_event_vendor` events; legacy `field_vendor` widen documented (no reconciliation invented)  
-- [ ] Call-site inventory closed for non-attendee surfaces (Workstream 2B)  
+- [x] Refund parity AND store aligned (Workstream 2B-A)  
+- [x] Vendor API ownership via checker after vendor identity resolution (Workstream 2B-A)  
+- [ ] Call-site inventory closed for remaining non-attendee surfaces (Workstream 2B-B: Boost, charts, ManageEventControllerBase)  
 - [ ] Check-in routes ownership at route layer; Phase 2A.2 bind retained  
-- [ ] Refund parity AND store aligned (Workstream 2B)  
 - [ ] Order detail IDOR tests green  
 - [ ] CSRF follow-up fixed or still explicitly deferred  
 
@@ -591,9 +592,9 @@ Attendee-facing organiser workflows only. Excluded: refunds, Boost, charts, anal
 - `ManagedSetWorkspaceParityEquivalenceTest`
 - Extended: `MelAttendeeOperationsAccessTest`, `AttendeeExportAccessTest`
 
-### Remaining Workstream 2B
+### Remaining Workstream 2B-B
 
-- Boost vendor workspace path, ChartData access, RefundAccessResolver AND parity, Vendor API team parity
+- Boost vendor workspace path, ChartData access
 - `ManageEventControllerBase::access()` composition without dropping `edit own event content`
 - Optional: move Mel into `event_attendees` to eliminate cycle soft-path
 
@@ -602,6 +603,75 @@ Attendee-facing organiser workflows only. Excluded: refunds, Boost, charts, anal
 - Route `_custom_access` for check-in + console event tabs
 - Order detail IDOR bind
 - CSRF follow-up for legacy check-in (or keep deferred)
+
+---
+
+## Workstream 2B-A — Financial and Vendor API ownership (2026-07-21)
+
+### Scope
+
+Refund / financial organiser access and Vendor API event ownership only.
+
+Excluded: Boost, charts, ManageEventControllerBase, route consolidation, check-in CSRF, dashboard changes, Commerce permission stripping, Stripe/gateway logic, API authentication redesign.
+
+### Refund ownership
+
+| Class / route | Previous rule | New rule | Behaviour change |
+|---|---|---|---|
+| `RefundAccessResolver::vendorCanManageEvent` | Author **OR** store owner (+ `administer commerce_order`) | `administer commerce_order` **OR** (workspace parity **AND** valid account store↔event) | Store-only bypass closed; team with parity+store gains manage; author without store denied |
+| `RefundAccessResolver::vendorCanRefundOrderForEvent` | Manage + event items + refundable state | Manage (above) + event items + order store↔event (non-admin) + refundable state + `manage_refunds` | Foreign order store fails closed for organisers |
+| `VendorRefundRequestAccessCheck` | Manage event + tickets mode | + bind `refund_request.event_id` to route `{node}` | Mismatched request denied at route access |
+| Approve/reject forms | Soft markup on mismatch / AccessDenied with message | Hard `AccessDeniedHttpException` (no existence leak) | Soft mismatch pages removed |
+| Cancel / VendorRefundForm / Retry | Via resolver | Inherit new resolver rules | Same as manage/refund above |
+
+Admin bypass: `administer commerce_order` retained for manage; refund still requires event items + refundable state; organiser order-store bind is not required for that staff permission.
+
+### Vendor API ownership
+
+| Item | Decision |
+|---|---|
+| API identity model | Vendor-scoped API keys via `ApiAuthenticationService` → `Vendor` entity |
+| Acting Drupal account | Vendor entity **owner** only |
+| Team members | **Not** separately representable via vendor-wide keys (residual product decision: user-scoped keys would be required) |
+| Event ownership | When `field_event_vendor` is set it **must** match authenticated vendor; then `EventVendorAccessChecker` for owner account |
+| Entity bind | Attendee/event mismatch already 403 in check-in; export/event gated by `vendorOwnsEvent` |
+| Error responses | Generic FORBIDDEN / UNAUTHORIZED; no customer PII |
+
+### Behaviour matrix (refund — non-admin expected)
+
+| Actor | Correct event/store | Foreign event | Foreign store | Mismatched request |
+|---|---|---|---|---|
+| Event author | PASS (with store + perm) | FAIL | FAIL | FAIL |
+| Vendor owner | PASS | FAIL | FAIL | FAIL |
+| Team member | PASS | FAIL | FAIL | FAIL |
+| Unrelated organiser | FAIL | FAIL | FAIL | FAIL |
+| Admin/staff | PASS (documented bypass) | PASS* | PASS* | FAIL at binder |
+
+\*Admin manage bypass; refund still needs event items + refundable state.
+
+### Behaviour matrix (Vendor API)
+
+| API identity | Own event | Team event (same vendor link) | Foreign event | Malformed bind |
+|---|---|---|---|---|
+| Vendor owner key | PASS | PASS (acts as owner; link matches) | FAIL | FAIL |
+| Team member key | N/A (no user-scoped key) | N/A | N/A | N/A |
+| Foreign vendor key | FAIL | FAIL | FAIL | FAIL |
+| Invalid credential | 401 | 401 | 401 | 401 |
+
+### Tests
+
+- `RefundAccessResolverOwnershipTest` (12)
+- `VendorRefundRequestAccessCheckBindingTest` (4)
+- `VendorApiOwnershipTest` (7)
+
+### Residual decisions
+
+- User-scoped Vendor API credentials (if team members need distinct API identity)
+- Mixed-order multi-event refund policy unchanged (still requires per-event items; no new multi-event allow)
+
+### Remaining after 2B-A
+
+See **Remaining Workstream 2B-B** and **Remaining Workstream 3**.
 
 ---
 

--- a/web/modules/custom/myeventlane_api/src/Controller/VendorApiBaseController.php
+++ b/web/modules/custom/myeventlane_api/src/Controller/VendorApiBaseController.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_api\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\myeventlane_api\Service\ApiAuthenticationService;
 use Drupal\myeventlane_api\Service\ApiResponseFormatter;
 use Drupal\myeventlane_api\Service\RateLimiterService;
 use Drupal\myeventlane_vendor\Entity\Vendor;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessCheckerInterface;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -16,6 +19,15 @@ use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Base controller for vendor API endpoints.
+ *
+ * API keys are vendor-scoped (not user-specific). After authentication the
+ * acting Drupal account is the vendor entity owner. Event access requires:
+ * - authenticated vendor identity
+ * - when the event is linked via field_event_vendor, that link must match the
+ *   authenticated vendor (vendor-scoped bind)
+ * - workspace parity for the vendor owner account.
+ *
+ * Team members are not separately representable via vendor-wide API keys.
  */
 abstract class VendorApiBaseController extends ControllerBase {
 
@@ -26,7 +38,11 @@ abstract class VendorApiBaseController extends ControllerBase {
     protected readonly ApiAuthenticationService $authenticationService,
     protected readonly ApiResponseFormatter $responseFormatter,
     protected readonly RateLimiterService $rateLimiter,
-  ) {}
+    protected readonly EventVendorAccessCheckerInterface $eventVendorAccessChecker,
+    EntityTypeManagerInterface $entityTypeManager,
+  ) {
+    $this->entityTypeManager = $entityTypeManager;
+  }
 
   /**
    * {@inheritdoc}
@@ -36,6 +52,8 @@ abstract class VendorApiBaseController extends ControllerBase {
       $container->get('myeventlane_api.authentication'),
       $container->get('myeventlane_api.response_formatter'),
       $container->get('myeventlane_api.rate_limiter'),
+      $container->get('myeventlane_vendor.event_access_checker'),
+      $container->get('entity_type.manager'),
     );
   }
 
@@ -114,31 +132,47 @@ abstract class VendorApiBaseController extends ControllerBase {
   }
 
   /**
-   * Checks if a vendor owns an event.
+   * Checks if an authenticated vendor may access an event.
    *
    * @param \Drupal\myeventlane_vendor\Entity\Vendor $vendor
-   *   The vendor entity.
+   *   The vendor entity resolved from the API key.
    * @param \Drupal\node\NodeInterface $event
    *   The event node.
    *
    * @return bool
-   *   TRUE if the vendor owns the event.
+   *   TRUE if the vendor may access the event.
    */
   protected function vendorOwnsEvent(Vendor $vendor, NodeInterface $event): bool {
-    // Check if event is linked to vendor.
+    if ($event->bundle() !== 'event') {
+      return FALSE;
+    }
+
+    // Vendor-scoped key: when an event vendor link exists it must match.
     if ($event->hasField('field_event_vendor') && !$event->get('field_event_vendor')->isEmpty()) {
       $event_vendor = $event->get('field_event_vendor')->entity;
-      if ($event_vendor && $event_vendor->id() === $vendor->id()) {
-        return TRUE;
+      if (!$event_vendor || (int) $event_vendor->id() !== (int) $vendor->id()) {
+        return FALSE;
       }
     }
 
-    // Also check if vendor owner matches event owner.
-    if ($vendor->getOwnerId() && (int) $event->getOwnerId() === (int) $vendor->getOwnerId()) {
-      return TRUE;
+    $owner = $this->resolveVendorActingAccount($vendor);
+    if (!$owner instanceof AccountInterface) {
+      return FALSE;
     }
 
-    return FALSE;
+    return $this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($event, $owner);
+  }
+
+  /**
+   * Resolves the Drupal account the vendor-wide API key acts as (vendor owner).
+   */
+  protected function resolveVendorActingAccount(Vendor $vendor): ?AccountInterface {
+    $owner_id = (int) $vendor->getOwnerId();
+    if ($owner_id <= 0) {
+      return NULL;
+    }
+    $owner = $this->entityTypeManager()->getStorage('user')->load($owner_id);
+    return $owner instanceof AccountInterface ? $owner : NULL;
   }
 
 }

--- a/web/modules/custom/myeventlane_api/src/Controller/VendorAttendeeApiController.php
+++ b/web/modules/custom/myeventlane_api/src/Controller/VendorAttendeeApiController.php
@@ -11,6 +11,7 @@ use Drupal\myeventlane_api\Service\ApiResponseFormatter;
 use Drupal\myeventlane_api\Service\RateLimiterService;
 use Drupal\myeventlane_event_attendees\Entity\EventAttendee;
 use Drupal\myeventlane_event_attendees\Service\AttendanceManagerInterface;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessCheckerInterface;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -28,12 +29,18 @@ final class VendorAttendeeApiController extends VendorApiBaseController {
     ApiAuthenticationService $authenticationService,
     ApiResponseFormatter $responseFormatter,
     RateLimiterService $rateLimiter,
+    EventVendorAccessCheckerInterface $eventVendorAccessChecker,
     EntityTypeManagerInterface $entityTypeManager,
     private readonly AttendanceManagerInterface $attendanceManager,
     private readonly mixed $melAttendeeCheckinManager,
   ) {
-    parent::__construct($authenticationService, $responseFormatter, $rateLimiter);
-    $this->entityTypeManager = $entityTypeManager;
+    parent::__construct(
+      $authenticationService,
+      $responseFormatter,
+      $rateLimiter,
+      $eventVendorAccessChecker,
+      $entityTypeManager,
+    );
   }
 
   /**
@@ -44,6 +51,7 @@ final class VendorAttendeeApiController extends VendorApiBaseController {
       $container->get('myeventlane_api.authentication'),
       $container->get('myeventlane_api.response_formatter'),
       $container->get('myeventlane_api.rate_limiter'),
+      $container->get('myeventlane_vendor.event_access_checker'),
       $container->get('entity_type.manager'),
       $container->get('myeventlane_event_attendees.manager'),
       $container->has('myeventlane_checkout_flow.attendee_checkin_manager')

--- a/web/modules/custom/myeventlane_api/src/Controller/VendorEventApiController.php
+++ b/web/modules/custom/myeventlane_api/src/Controller/VendorEventApiController.php
@@ -9,6 +9,7 @@ use Drupal\myeventlane_api\Service\ApiAuthenticationService;
 use Drupal\myeventlane_api\Service\ApiResponseFormatter;
 use Drupal\myeventlane_api\Service\EventSerializer;
 use Drupal\myeventlane_api\Service\RateLimiterService;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessCheckerInterface;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -26,11 +27,17 @@ final class VendorEventApiController extends VendorApiBaseController {
     ApiAuthenticationService $authenticationService,
     ApiResponseFormatter $responseFormatter,
     RateLimiterService $rateLimiter,
+    EventVendorAccessCheckerInterface $eventVendorAccessChecker,
     EntityTypeManagerInterface $entityTypeManager,
     private readonly EventSerializer $eventSerializer,
   ) {
-    parent::__construct($authenticationService, $responseFormatter, $rateLimiter);
-    $this->entityTypeManager = $entityTypeManager;
+    parent::__construct(
+      $authenticationService,
+      $responseFormatter,
+      $rateLimiter,
+      $eventVendorAccessChecker,
+      $entityTypeManager,
+    );
   }
 
   /**
@@ -41,6 +48,7 @@ final class VendorEventApiController extends VendorApiBaseController {
       $container->get('myeventlane_api.authentication'),
       $container->get('myeventlane_api.response_formatter'),
       $container->get('myeventlane_api.rate_limiter'),
+      $container->get('myeventlane_vendor.event_access_checker'),
       $container->get('entity_type.manager'),
       $container->get('myeventlane_api.event_serializer'),
     );

--- a/web/modules/custom/myeventlane_api/src/Controller/VendorExportApiController.php
+++ b/web/modules/custom/myeventlane_api/src/Controller/VendorExportApiController.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\myeventlane_api\Service\ApiAuthenticationService;
 use Drupal\myeventlane_api\Service\ApiResponseFormatter;
 use Drupal\myeventlane_api\Service\RateLimiterService;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessCheckerInterface;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -25,10 +26,16 @@ final class VendorExportApiController extends VendorApiBaseController {
     ApiAuthenticationService $authenticationService,
     ApiResponseFormatter $responseFormatter,
     RateLimiterService $rateLimiter,
+    EventVendorAccessCheckerInterface $eventVendorAccessChecker,
     EntityTypeManagerInterface $entityTypeManager,
   ) {
-    parent::__construct($authenticationService, $responseFormatter, $rateLimiter);
-    $this->entityTypeManager = $entityTypeManager;
+    parent::__construct(
+      $authenticationService,
+      $responseFormatter,
+      $rateLimiter,
+      $eventVendorAccessChecker,
+      $entityTypeManager,
+    );
   }
 
   /**
@@ -39,6 +46,7 @@ final class VendorExportApiController extends VendorApiBaseController {
       $container->get('myeventlane_api.authentication'),
       $container->get('myeventlane_api.response_formatter'),
       $container->get('myeventlane_api.rate_limiter'),
+      $container->get('myeventlane_vendor.event_access_checker'),
       $container->get('entity_type.manager'),
     );
   }

--- a/web/modules/custom/myeventlane_api/tests/src/Unit/VendorApiOwnershipTest.php
+++ b/web/modules/custom/myeventlane_api/tests/src/Unit/VendorApiOwnershipTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_api\Unit;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\myeventlane_api\Controller\VendorApiBaseController;
+use Drupal\myeventlane_api\Service\ApiAuthenticationService;
+use Drupal\myeventlane_api\Service\ApiResponseFormatter;
+use Drupal\myeventlane_api\Service\RateLimiterService;
+use Drupal\myeventlane_vendor\Entity\Vendor;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessCheckerInterface;
+use Drupal\node\NodeInterface;
+use Drupal\user\UserInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Vendor API event ownership.
+ *
+ * @coversDefaultClass \Drupal\myeventlane_api\Controller\VendorApiBaseController
+ *
+ * @group myeventlane_api
+ */
+final class VendorApiOwnershipTest extends TestCase {
+
+  /**
+   * Linked vendor with owner parity is allowed.
+   */
+  public function testLinkedVendorWithOwnerParityAllowed(): void {
+    $controller = $this->controller(hasParity: TRUE);
+    $vendor = $this->vendor(1, 10);
+    $event = $this->event(authorId: 99, linkedVendorId: 1);
+    $this->assertTrue($this->invokeOwns($controller, $vendor, $event));
+  }
+
+  /**
+   * Foreign vendor identity is denied even if owner somehow has parity.
+   */
+  public function testForeignVendorLinkDenied(): void {
+    $controller = $this->controller(hasParity: TRUE);
+    $vendor = $this->vendor(1, 10);
+    $event = $this->event(authorId: 10, linkedVendorId: 2);
+    $this->assertFalse($this->invokeOwns($controller, $vendor, $event));
+  }
+
+  /**
+   * Unlinked event authored by vendor owner is allowed via parity.
+   */
+  public function testUnlinkedAuthorOwnedEventAllowed(): void {
+    $controller = $this->controller(hasParity: TRUE);
+    $vendor = $this->vendor(1, 10);
+    $event = $this->event(authorId: 10, linkedVendorId: NULL);
+    $this->assertTrue($this->invokeOwns($controller, $vendor, $event));
+  }
+
+  /**
+   * Foreign vendor without parity is denied.
+   */
+  public function testForeignVendorWithoutParityDenied(): void {
+    $controller = $this->controller(hasParity: FALSE);
+    $vendor = $this->vendor(2, 40);
+    $event = $this->event(authorId: 99, linkedVendorId: 1);
+    $this->assertFalse($this->invokeOwns($controller, $vendor, $event));
+  }
+
+  /**
+   * Vendor without resolvable owner account is denied.
+   */
+  public function testVendorWithoutOwnerDenied(): void {
+    $controller = $this->controller(hasParity: TRUE, ownerLoadable: FALSE);
+    $vendor = $this->vendor(1, 0);
+    $event = $this->event(authorId: 10, linkedVendorId: 1);
+    $this->assertFalse($this->invokeOwns($controller, $vendor, $event));
+  }
+
+  /**
+   * Team members are not granted access merely via vendor entity ID on the key.
+   *
+   * Vendor-wide keys act as the vendor owner account only.
+   */
+  public function testTeamNotRepresentedByVendorWideKey(): void {
+    $raw = (string) file_get_contents(dirname(__DIR__, 3) . '/src/Controller/VendorApiBaseController.php');
+    $this->assertStringContainsString('vendor-wide API keys', $raw);
+    $this->assertStringContainsString('resolveVendorActingAccount', $raw);
+    $this->assertStringContainsString('accountHasWorkspaceParityForEvent', $raw);
+    $this->assertStringNotContainsString('field_vendor_users', $raw);
+  }
+
+  /**
+   * Forbidden API messages must not include customer PII markers.
+   */
+  public function testForbiddenMessageHasNoPiiMarkers(): void {
+    $formatter = new ApiResponseFormatter();
+    $response = $formatter->error('FORBIDDEN', 'You do not have access to this event.', 403);
+    $content = $response->getContent() ?: '';
+    $this->assertStringNotContainsString('@', $content);
+    $this->assertStringNotContainsString('customer', strtolower($content));
+    $this->assertStringNotContainsString('email', strtolower($content));
+    $this->assertStringNotContainsString('order', strtolower($content));
+  }
+
+  /**
+   * Invokes protected vendorOwnsEvent via reflection.
+   */
+  private function invokeOwns(VendorApiBaseController $controller, Vendor $vendor, NodeInterface $event): bool {
+    $method = new \ReflectionMethod(VendorApiBaseController::class, 'vendorOwnsEvent');
+    $method->setAccessible(TRUE);
+    return (bool) $method->invoke($controller, $vendor, $event);
+  }
+
+  /**
+   * Builds a Vendor API base controller with stubbed ownership deps.
+   *
+   * @param bool $hasParity
+   *   Whether the checker reports workspace parity.
+   * @param bool $ownerLoadable
+   *   Whether the vendor owner user can be loaded.
+   */
+  private function controller(bool $hasParity, bool $ownerLoadable = TRUE): VendorApiBaseController {
+    $checker = $this->createMock(EventVendorAccessCheckerInterface::class);
+    $checker->method('accountHasWorkspaceParityForEvent')->willReturn($hasParity);
+
+    $user = $this->createMock(UserInterface::class);
+    $user->method('id')->willReturn(10);
+
+    $storage = $this->createMock(EntityStorageInterface::class);
+    $storage->method('load')->willReturnCallback(
+      static function ($id) use ($ownerLoadable, $user) {
+        if (!$ownerLoadable || (int) $id <= 0) {
+          return NULL;
+        }
+        return $user;
+      }
+    );
+
+    $etm = $this->createMock(EntityTypeManagerInterface::class);
+    $etm->method('getStorage')->with('user')->willReturn($storage);
+
+    $db = $this->createMock(Connection::class);
+    $time = $this->createMock(TimeInterface::class);
+
+    return new class(
+      new ApiAuthenticationService($etm),
+      new ApiResponseFormatter(),
+      new RateLimiterService($db, $time),
+      $checker,
+      $etm,
+    ) extends VendorApiBaseController {};
+  }
+
+  /**
+   * Builds a stub vendor entity.
+   *
+   * @param int $id
+   *   Vendor entity ID.
+   * @param int $ownerId
+   *   Vendor owner UID.
+   */
+  private function vendor(int $id, int $ownerId): Vendor {
+    $vendor = $this->createMock(Vendor::class);
+    $vendor->method('id')->willReturn($id);
+    $vendor->method('getOwnerId')->willReturn($ownerId);
+    return $vendor;
+  }
+
+  /**
+   * Builds a stub event node.
+   *
+   * @param int $authorId
+   *   Event author UID.
+   * @param int|null $linkedVendorId
+   *   Linked vendor ID, or NULL when unlinked.
+   */
+  private function event(int $authorId, ?int $linkedVendorId): NodeInterface {
+    $event = $this->createMock(NodeInterface::class);
+    $event->method('bundle')->willReturn('event');
+    $event->method('id')->willReturn(100);
+    $event->method('getOwnerId')->willReturn($authorId);
+    $event->method('hasField')->willReturnCallback(
+      static fn(string $name): bool => $name === 'field_event_vendor'
+    );
+
+    if ($linkedVendorId === NULL) {
+      $list = new class() {
+
+        /**
+         * Reports whether the field is empty.
+         */
+        public function isEmpty(): bool {
+          return TRUE;
+        }
+
+      };
+    }
+    else {
+      $linked = $this->createMock(Vendor::class);
+      $linked->method('id')->willReturn($linkedVendorId);
+      $list = new class($linked) {
+
+        /**
+         * Linked vendor entity stub.
+         *
+         * @var object
+         */
+        public object $entity;
+
+        /**
+         * Constructs the field item list stub.
+         */
+        public function __construct(object $vendor) {
+          $this->entity = $vendor;
+        }
+
+        /**
+         * Reports whether the field is empty.
+         */
+        public function isEmpty(): bool {
+          return FALSE;
+        }
+
+      };
+    }
+    $event->method('get')->with('field_event_vendor')->willReturn($list);
+    return $event;
+  }
+
+}

--- a/web/modules/custom/myeventlane_refunds/myeventlane_refunds.services.yml
+++ b/web/modules/custom/myeventlane_refunds/myeventlane_refunds.services.yml
@@ -27,6 +27,7 @@ services:
     arguments:
       - '@myeventlane_refunds.access_resolver'
       - '@myeventlane_event.event_mode_manager'
+      - '@myeventlane_refunds.refund_request_storage'
 
   myeventlane_refunds.retry_access:
     class: Drupal\myeventlane_refunds\Access\RetryRefundAccessCheck
@@ -35,12 +36,16 @@ services:
       - '@entity_type.manager'
       - '@myeventlane_refunds.access_resolver'
 
+  myeventlane_refunds.store_ownership_bridge:
+    class: Drupal\myeventlane_refunds\Service\VendorOwnershipStoreBridge
+    arguments: ['@myeventlane_checkout_flow.vendor_ownership_resolver']
+
   myeventlane_refunds.access_resolver:
     class: Drupal\myeventlane_refunds\Service\RefundAccessResolver
     arguments:
-      - '@myeventlane_checkout_flow.vendor_ownership_resolver'
-      - '@entity_type.manager'
+      - '@myeventlane_refunds.store_ownership_bridge'
       - '@myeventlane_refunds.order_inspector'
+      - '@myeventlane_vendor.event_access_checker'
 
   myeventlane_refunds.processor:
     class: Drupal\myeventlane_refunds\Service\RefundProcessor

--- a/web/modules/custom/myeventlane_refunds/src/Access/RefundRequestRouteBinder.php
+++ b/web/modules/custom/myeventlane_refunds/src/Access/RefundRequestRouteBinder.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_refunds\Access;
+
+/**
+ * Pure route binding helpers for refund requests.
+ */
+final class RefundRequestRouteBinder {
+
+  /**
+   * Whether a loaded refund request belongs to the route event.
+   *
+   * @param array<string, mixed>|null $request
+   *   Loaded refund request row, or NULL when missing.
+   * @param int $eventId
+   *   Route event node ID.
+   *
+   * @return bool
+   *   TRUE when the request is present and event_id matches.
+   */
+  public static function requestBelongsToEvent(?array $request, int $eventId): bool {
+    if (!is_array($request) || $eventId <= 0) {
+      return FALSE;
+    }
+    return (int) ($request['event_id'] ?? 0) === $eventId;
+  }
+
+}

--- a/web/modules/custom/myeventlane_refunds/src/Access/VendorRefundRequestAccessCheck.php
+++ b/web/modules/custom/myeventlane_refunds/src/Access/VendorRefundRequestAccessCheck.php
@@ -10,6 +10,7 @@ use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\myeventlane_event\Service\EventModeManager;
 use Drupal\myeventlane_refunds\Service\RefundAccessResolver;
+use Drupal\myeventlane_refunds\Service\RefundRequestStorage;
 use Drupal\node\NodeInterface;
 
 /**
@@ -17,7 +18,8 @@ use Drupal\node\NodeInterface;
  *
  * Enforces:
  * - Event parameter present and bundle = event
- * - Vendor can manage event (owner + vendor team)
+ * - Vendor can manage event (workspace parity AND valid store)
+ * - When a refund_request route param is present, it must belong to the route event
  * - Event has paid tickets enabled (refund requests apply only to ticketed events)
  */
 final class VendorRefundRequestAccessCheck {
@@ -25,6 +27,7 @@ final class VendorRefundRequestAccessCheck {
   public function __construct(
     private readonly RefundAccessResolver $accessResolver,
     private readonly EventModeManager $eventModeManager,
+    private readonly RefundRequestStorage $refundRequestStorage,
   ) {}
 
   /**
@@ -39,6 +42,23 @@ final class VendorRefundRequestAccessCheck {
     $eventAccess = $this->accessResolver->accessManageEvent($node, $account);
     if (!$eventAccess->isAllowed()) {
       return $eventAccess;
+    }
+
+    $refundRequestParam = $route_match->getParameter('refund_request');
+    if ($refundRequestParam !== NULL && $refundRequestParam !== '') {
+      $reqId = (int) $refundRequestParam;
+      if ($reqId <= 0) {
+        return AccessResult::forbidden('Refund request not found.')
+          ->cachePerUser()
+          ->addCacheableDependency($node);
+      }
+      $req = $this->refundRequestStorage->load($reqId);
+      if (!RefundRequestRouteBinder::requestBelongsToEvent($req, (int) $node->id())) {
+        // Fail closed without revealing whether a foreign request exists.
+        return AccessResult::forbidden('Refund request not found.')
+          ->cachePerUser()
+          ->addCacheableDependency($node);
+      }
     }
 
     if (!$this->eventModeManager->isTicketsEnabled($node)) {

--- a/web/modules/custom/myeventlane_refunds/src/Form/VendorRefundRequestApproveForm.php
+++ b/web/modules/custom/myeventlane_refunds/src/Form/VendorRefundRequestApproveForm.php
@@ -99,16 +99,13 @@ final class VendorRefundRequestApproveForm extends FormBase {
 
     $event = $this->getEventFromRequest($req);
     $order = $this->loadOrder((int) $req['order_id']);
+    // Route-event / refund-request / order binding failures: hard deny.
     if (!$event instanceof NodeInterface || !$order instanceof OrderInterface) {
-      $form['error'] = [
-        '#type' => 'markup',
-        '#markup' => '<p>' . $this->t('Refund details could not be loaded. Please refresh and try again.') . '</p>',
-      ];
-      return $form;
+      throw new AccessDeniedHttpException();
     }
 
     if (!$this->accessResolver->vendorCanManageEvent($event, $this->currentUser())) {
-      throw new AccessDeniedHttpException('You cannot approve refunds for this event.');
+      throw new AccessDeniedHttpException();
     }
 
     $form_state->set('refund_request', $req);

--- a/web/modules/custom/myeventlane_refunds/src/Form/VendorRefundRequestRejectForm.php
+++ b/web/modules/custom/myeventlane_refunds/src/Form/VendorRefundRequestRejectForm.php
@@ -74,16 +74,13 @@ final class VendorRefundRequestRejectForm extends FormBase {
 
     $event = $this->entityTypeManager->getStorage('node')->load($req['event_id']);
     $nodeId = $node instanceof NodeInterface ? $node->id() : (is_numeric($node) ? $node : NULL);
+    // Route-event / refund-request mismatch: hard deny (no soft page leak).
     if (!$event instanceof NodeInterface || $nodeId === NULL || (int) $event->id() !== (int) $nodeId) {
-      $form['error'] = [
-        '#type' => 'markup',
-        '#markup' => '<p>' . $this->t('Event mismatch.') . '</p>',
-      ];
-      return $form;
+      throw new AccessDeniedHttpException();
     }
 
     if (!$this->accessResolver->vendorCanManageEvent($event, $this->currentUser())) {
-      throw new AccessDeniedHttpException('You cannot reject refunds for this event.');
+      throw new AccessDeniedHttpException();
     }
 
     $form['#node'] = $node;

--- a/web/modules/custom/myeventlane_refunds/src/Service/RefundAccessResolver.php
+++ b/web/modules/custom/myeventlane_refunds/src/Service/RefundAccessResolver.php
@@ -5,35 +5,45 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_refunds\Service;
 
 use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\Core\Access\AccessResult;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\myeventlane_checkout_flow\Service\VendorOwnershipResolver;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessCheckerInterface;
 use Drupal\node\NodeInterface;
 
 /**
  * Resolves access control for refund operations.
+ *
+ * Organiser financial access requires:
+ * - operation-specific permission (caller / vendorCanRefundOrderForEvent)
+ * - workspace parity (EventVendorAccessChecker)
+ * - valid store ↔ event relationship (StoreEventOwnershipInterface)
+ * - for refunds: order contains items for the event, order store is valid, refundable state.
+ *
+ * Store ownership alone must not bypass workspace parity.
+ *
+ * @see docs/adr/ADR-0008-canonical-event-ownership.md
  */
 final class RefundAccessResolver {
 
   /**
    * Constructs RefundAccessResolver.
    *
-   * @param \Drupal\myeventlane_checkout_flow\Service\VendorOwnershipResolver $vendorOwnershipResolver
-   *   The vendor ownership resolver.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
-   *   The entity type manager.
-   * @param \Drupal\myeventlane_refunds\Service\RefundOrderInspector $orderInspector
-   *   The order inspector.
+   * @param \Drupal\myeventlane_refunds\Service\StoreEventOwnershipInterface $storeEventOwnership
+   *   Store ↔ event ownership gateway.
+   * @param \Drupal\myeventlane_refunds\Service\RefundOrderItemsInterface $orderInspector
+   *   Order item extraction for event binding.
+   * @param \Drupal\myeventlane_vendor\Service\EventVendorAccessCheckerInterface $eventVendorAccessChecker
+   *   Canonical workspace parity checker.
    */
   public function __construct(
-    private readonly VendorOwnershipResolver $vendorOwnershipResolver,
-    private readonly EntityTypeManagerInterface $entityTypeManager,
-    private readonly RefundOrderInspector $orderInspector,
+    private readonly StoreEventOwnershipInterface $storeEventOwnership,
+    private readonly RefundOrderItemsInterface $orderInspector,
+    private readonly EventVendorAccessCheckerInterface $eventVendorAccessChecker,
   ) {}
 
   /**
-   * Checks if a vendor can manage an event.
+   * Checks if a vendor can manage an event for financial surfaces.
    *
    * @param \Drupal\node\NodeInterface $event
    *   The event node.
@@ -44,23 +54,20 @@ final class RefundAccessResolver {
    *   TRUE if the vendor can manage the event, FALSE otherwise.
    */
   public function vendorCanManageEvent(NodeInterface $event, AccountInterface $account): bool {
-    // Admin override.
+    // Documented staff bypass — unchanged.
     if ($account->hasPermission('administer commerce_order')) {
       return TRUE;
     }
 
-    // Check if user owns the event.
-    if ((int) $event->getOwnerId() === (int) $account->id()) {
-      return TRUE;
+    if ($event->bundle() !== 'event') {
+      return FALSE;
     }
 
-    // Check via vendor store ownership.
-    $store = $this->vendorOwnershipResolver->getStoreForUser($account);
-    if ($store) {
-      return $this->vendorOwnershipResolver->vendorOwnsEvent($store, $event);
+    if (!$this->eventVendorAccessChecker->accountHasWorkspaceParityForEvent($event, $account)) {
+      return FALSE;
     }
 
-    return FALSE;
+    return $this->accountHasValidStoreRelationshipForEvent($event, $account);
   }
 
   /**
@@ -81,7 +88,7 @@ final class RefundAccessResolver {
       return FALSE;
     }
 
-    // Must be able to manage the event.
+    // Must be able to manage the event (parity AND store).
     if (!$this->vendorCanManageEvent($event, $account)) {
       return FALSE;
     }
@@ -89,6 +96,14 @@ final class RefundAccessResolver {
     // Order must contain ticket items for this event.
     $eventItems = $this->orderInspector->extractItemsForEvent($order, (int) $event->id());
     if (empty($eventItems)) {
+      return FALSE;
+    }
+
+    // Order store must belong to the same financial context as the event.
+    // Staff with administer commerce_order retain the pre-existing bypass of
+    // organiser store binding (they still need event items + refundable state).
+    if (!$account->hasPermission('administer commerce_order')
+      && !$this->orderHasValidStoreRelationshipForEvent($order, $event)) {
       return FALSE;
     }
 
@@ -145,6 +160,32 @@ final class RefundAccessResolver {
       ->cachePerUser()
       ->addCacheableDependency($order)
       ->addCacheableDependency($event);
+  }
+
+  /**
+   * Proves the account's resolvable store is valid for the event.
+   */
+  private function accountHasValidStoreRelationshipForEvent(NodeInterface $event, AccountInterface $account): bool {
+    $store = $this->storeEventOwnership->getStoreForUser($account);
+    if (!$store instanceof StoreInterface) {
+      return FALSE;
+    }
+
+    return $this->storeEventOwnership->vendorOwnsEvent($store, $event);
+  }
+
+  /**
+   * Proves the order's store (when present) is valid for the event.
+   *
+   * Missing store fails closed for refund mutations.
+   */
+  private function orderHasValidStoreRelationshipForEvent(OrderInterface $order, NodeInterface $event): bool {
+    $store = $order->getStore();
+    if (!$store instanceof StoreInterface) {
+      return FALSE;
+    }
+
+    return $this->storeEventOwnership->vendorOwnsEvent($store, $event);
   }
 
 }

--- a/web/modules/custom/myeventlane_refunds/src/Service/RefundOrderInspector.php
+++ b/web/modules/custom/myeventlane_refunds/src/Service/RefundOrderInspector.php
@@ -15,7 +15,7 @@ use Drupal\node\NodeInterface;
 /**
  * Inspects orders to determine refund eligibility and calculate amounts.
  */
-final class RefundOrderInspector {
+final class RefundOrderInspector implements RefundOrderItemsInterface {
 
   /**
    * Donation order item bundles.

--- a/web/modules/custom/myeventlane_refunds/src/Service/RefundOrderItemsInterface.php
+++ b/web/modules/custom/myeventlane_refunds/src/Service/RefundOrderItemsInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_refunds\Service;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+
+/**
+ * Order item extraction needed by refund access.
+ */
+interface RefundOrderItemsInterface {
+
+  /**
+   * Extracts order items that belong to the given event.
+   *
+   * @return list<\Drupal\commerce_order\Entity\OrderItemInterface>
+   *   Matching items.
+   */
+  public function extractItemsForEvent(OrderInterface $order, int $event_nid): array;
+
+}

--- a/web/modules/custom/myeventlane_refunds/src/Service/StoreEventOwnershipInterface.php
+++ b/web/modules/custom/myeventlane_refunds/src/Service/StoreEventOwnershipInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_refunds\Service;
+
+use Drupal\commerce_store\Entity\StoreInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Store ↔ event ownership questions needed by refund access.
+ */
+interface StoreEventOwnershipInterface {
+
+  /**
+   * Resolves the Commerce store for an account.
+   */
+  public function getStoreForUser(AccountInterface $account): ?StoreInterface;
+
+  /**
+   * Whether the store is valid for the event in the MEL vendor/store model.
+   */
+  public function vendorOwnsEvent(StoreInterface $store, NodeInterface $event): bool;
+
+}

--- a/web/modules/custom/myeventlane_refunds/src/Service/VendorOwnershipStoreBridge.php
+++ b/web/modules/custom/myeventlane_refunds/src/Service/VendorOwnershipStoreBridge.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_refunds\Service;
+
+use Drupal\commerce_store\Entity\StoreInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\myeventlane_checkout_flow\Service\VendorOwnershipResolver;
+use Drupal\node\NodeInterface;
+
+/**
+ * Adapts VendorOwnershipResolver for refund financial context checks.
+ */
+final class VendorOwnershipStoreBridge implements StoreEventOwnershipInterface {
+
+  /**
+   * Constructs the bridge.
+   */
+  public function __construct(
+    private readonly VendorOwnershipResolver $vendorOwnershipResolver,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getStoreForUser(AccountInterface $account): ?StoreInterface {
+    return $this->vendorOwnershipResolver->getStoreForUser($account);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function vendorOwnsEvent(StoreInterface $store, NodeInterface $event): bool {
+    return $this->vendorOwnershipResolver->vendorOwnsEvent($store, $event);
+  }
+
+}

--- a/web/modules/custom/myeventlane_refunds/tests/src/Unit/RefundAccessResolverOwnershipTest.php
+++ b/web/modules/custom/myeventlane_refunds/tests/src/Unit/RefundAccessResolverOwnershipTest.php
@@ -1,0 +1,364 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_refunds\Unit;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_store\Entity\StoreInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\myeventlane_refunds\Service\RefundAccessResolver;
+use Drupal\myeventlane_refunds\Service\RefundOrderItemsInterface;
+use Drupal\myeventlane_refunds\Service\StoreEventOwnershipInterface;
+use Drupal\myeventlane_vendor\Service\EventVendorAccessCheckerInterface;
+use Drupal\node\NodeInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for refund financial ownership (parity AND store).
+ *
+ * @coversDefaultClass \Drupal\myeventlane_refunds\Service\RefundAccessResolver
+ *
+ * @group myeventlane_refunds
+ */
+final class RefundAccessResolverOwnershipTest extends TestCase {
+
+  /**
+   * Event author with parity, manage permission, and valid store/order is allowed.
+   */
+  public function testAuthorWithParityAndValidStoreAllowedToRefund(): void {
+    $resolver = $this->resolver(
+      hasParity: TRUE,
+      storeOwnsEvent: TRUE,
+      accountStore: $this->store(1),
+      orderItemsForEvent: [$this->createMock(OrderItemInterface::class)],
+      orderStoreOwnsEvent: TRUE,
+    );
+    $account = $this->account(10, ['manage_refunds' => TRUE]);
+    $this->assertTrue($resolver->vendorCanRefundOrderForEvent($this->order('completed'), $this->event(), $account));
+  }
+
+  /**
+   * Vendor entity owner with parity and valid store is allowed.
+   */
+  public function testVendorOwnerWithParityAndValidStoreAllowed(): void {
+    $resolver = $this->resolver(
+      hasParity: TRUE,
+      storeOwnsEvent: TRUE,
+      accountStore: $this->store(1),
+      orderItemsForEvent: [$this->createMock(OrderItemInterface::class)],
+      orderStoreOwnsEvent: TRUE,
+    );
+    $account = $this->account(20, ['manage_refunds' => TRUE]);
+    $this->assertTrue($resolver->vendorCanManageEvent($this->event(), $account));
+    $this->assertTrue($resolver->vendorCanRefundOrderForEvent($this->order('completed'), $this->event(), $account));
+  }
+
+  /**
+   * Legitimate team member with parity and valid store is allowed.
+   */
+  public function testTeamMemberWithParityAndValidStoreAllowed(): void {
+    $resolver = $this->resolver(
+      hasParity: TRUE,
+      storeOwnsEvent: TRUE,
+      accountStore: $this->store(1),
+      orderItemsForEvent: [$this->createMock(OrderItemInterface::class)],
+      orderStoreOwnsEvent: TRUE,
+    );
+    $account = $this->account(30, ['manage_refunds' => TRUE]);
+    $this->assertTrue($resolver->vendorCanRefundOrderForEvent($this->order('completed'), $this->event(), $account));
+  }
+
+  /**
+   * Unrelated organiser is denied.
+   */
+  public function testUnrelatedOrganiserDenied(): void {
+    $resolver = $this->resolver(
+      hasParity: FALSE,
+      storeOwnsEvent: TRUE,
+      accountStore: $this->store(2),
+      orderItemsForEvent: [$this->createMock(OrderItemInterface::class)],
+      orderStoreOwnsEvent: TRUE,
+    );
+    $account = $this->account(40, ['manage_refunds' => TRUE]);
+    $this->assertFalse($resolver->vendorCanManageEvent($this->event(), $account));
+    $this->assertFalse($resolver->vendorCanRefundOrderForEvent($this->order('completed'), $this->event(), $account));
+  }
+
+  /**
+   * Store owner without workspace parity is denied.
+   */
+  public function testStoreOwnerWithoutParityDenied(): void {
+    $resolver = $this->resolver(
+      hasParity: FALSE,
+      storeOwnsEvent: TRUE,
+      accountStore: $this->store(1),
+      orderItemsForEvent: [$this->createMock(OrderItemInterface::class)],
+      orderStoreOwnsEvent: TRUE,
+    );
+    $account = $this->account(50, ['manage_refunds' => TRUE]);
+    $this->assertFalse($resolver->vendorCanManageEvent($this->event(), $account));
+    $this->assertFalse($resolver->vendorCanRefundOrderForEvent($this->order('completed'), $this->event(), $account));
+  }
+
+  /**
+   * Workspace parity with a foreign store relationship is denied.
+   */
+  public function testParityWithForeignStoreDenied(): void {
+    $resolver = $this->resolver(
+      hasParity: TRUE,
+      storeOwnsEvent: FALSE,
+      accountStore: $this->store(99),
+      orderItemsForEvent: [$this->createMock(OrderItemInterface::class)],
+      orderStoreOwnsEvent: TRUE,
+    );
+    $account = $this->account(10, ['manage_refunds' => TRUE]);
+    $this->assertFalse($resolver->vendorCanManageEvent($this->event(), $account));
+    $this->assertFalse($resolver->vendorCanRefundOrderForEvent($this->order('completed'), $this->event(), $account));
+  }
+
+  /**
+   * Parity without a resolvable store is denied.
+   */
+  public function testParityWithoutStoreDenied(): void {
+    $resolver = $this->resolver(
+      hasParity: TRUE,
+      storeOwnsEvent: FALSE,
+      accountStore: NULL,
+      orderItemsForEvent: [$this->createMock(OrderItemInterface::class)],
+      orderStoreOwnsEvent: TRUE,
+    );
+    $account = $this->account(10, ['manage_refunds' => TRUE]);
+    $this->assertFalse($resolver->vendorCanManageEvent($this->event(), $account));
+  }
+
+  /**
+   * Order with no items for the event is denied.
+   */
+  public function testOrderWithoutEventItemsDenied(): void {
+    $resolver = $this->resolver(
+      hasParity: TRUE,
+      storeOwnsEvent: TRUE,
+      accountStore: $this->store(1),
+      orderItemsForEvent: [],
+      orderStoreOwnsEvent: TRUE,
+    );
+    $account = $this->account(10, ['manage_refunds' => TRUE]);
+    $this->assertFalse($resolver->vendorCanRefundOrderForEvent($this->order('completed'), $this->event(), $account));
+  }
+
+  /**
+   * Order whose store does not own the event is denied.
+   */
+  public function testOrderForeignStoreDenied(): void {
+    $accountStore = $this->store(1);
+    $orderStore = $this->store(2);
+
+    $storeOwnership = $this->createMock(StoreEventOwnershipInterface::class);
+    $storeOwnership->method('getStoreForUser')->willReturn($accountStore);
+    $storeOwnership->method('vendorOwnsEvent')->willReturnCallback(
+      static function (StoreInterface $store) use ($accountStore): bool {
+        return (int) $store->id() === (int) $accountStore->id();
+      }
+    );
+
+    $inspector = $this->createMock(RefundOrderItemsInterface::class);
+    $inspector->method('extractItemsForEvent')->willReturn([
+      $this->createMock(OrderItemInterface::class),
+    ]);
+
+    $checker = $this->createMock(EventVendorAccessCheckerInterface::class);
+    $checker->method('accountHasWorkspaceParityForEvent')->willReturn(TRUE);
+
+    $resolver = new RefundAccessResolver($storeOwnership, $inspector, $checker);
+
+    $state = new class() {
+
+      /**
+       * Returns the state ID.
+       */
+      public function getId(): string {
+        return 'completed';
+      }
+
+    };
+    $order = $this->createMock(OrderInterface::class);
+    $order->method('getState')->willReturn($state);
+    $order->method('getStore')->willReturn($orderStore);
+
+    $account = $this->account(10, ['manage_refunds' => TRUE]);
+    $this->assertFalse($resolver->vendorCanRefundOrderForEvent($order, $this->event(), $account));
+  }
+
+  /**
+   * Missing order store fails closed.
+   */
+  public function testMissingOrderStoreDenied(): void {
+    $storeOwnership = $this->createMock(StoreEventOwnershipInterface::class);
+    $storeOwnership->method('getStoreForUser')->willReturn($this->store(1));
+    $storeOwnership->method('vendorOwnsEvent')->willReturn(TRUE);
+
+    $inspector = $this->createMock(RefundOrderItemsInterface::class);
+    $inspector->method('extractItemsForEvent')->willReturn([
+      $this->createMock(OrderItemInterface::class),
+    ]);
+
+    $checker = $this->createMock(EventVendorAccessCheckerInterface::class);
+    $checker->method('accountHasWorkspaceParityForEvent')->willReturn(TRUE);
+
+    $resolver = new RefundAccessResolver($storeOwnership, $inspector, $checker);
+    $order = $this->order('completed', hasStore: FALSE);
+    $account = $this->account(10, ['manage_refunds' => TRUE]);
+    $this->assertFalse($resolver->vendorCanRefundOrderForEvent($order, $this->event(), $account));
+  }
+
+  /**
+   * Admin bypass remains for manage and refund.
+   */
+  public function testAdminBypassRetained(): void {
+    $resolver = $this->resolver(
+      hasParity: FALSE,
+      storeOwnsEvent: FALSE,
+      accountStore: NULL,
+      orderItemsForEvent: [$this->createMock(OrderItemInterface::class)],
+      orderStoreOwnsEvent: TRUE,
+    );
+    $account = $this->account(1, ['administer commerce_order' => TRUE]);
+    $this->assertTrue($resolver->vendorCanManageEvent($this->event(), $account));
+    $this->assertTrue($resolver->vendorCanRefundOrderForEvent($this->order('completed'), $this->event(), $account));
+  }
+
+  /**
+   * Manage permission alone without manage_refunds cannot refund.
+   */
+  public function testManageWithoutRefundPermissionDenied(): void {
+    $resolver = $this->resolver(
+      hasParity: TRUE,
+      storeOwnsEvent: TRUE,
+      accountStore: $this->store(1),
+      orderItemsForEvent: [$this->createMock(OrderItemInterface::class)],
+      orderStoreOwnsEvent: TRUE,
+    );
+    $account = $this->account(10, []);
+    $this->assertTrue($resolver->vendorCanManageEvent($this->event(), $account));
+    $this->assertFalse($resolver->vendorCanRefundOrderForEvent($this->order('completed'), $this->event(), $account));
+  }
+
+  /**
+   * Builds a resolver with stubbed dependencies.
+   *
+   * @param bool $hasParity
+   *   Whether workspace parity holds.
+   * @param bool $storeOwnsEvent
+   *   Whether the account store owns the event.
+   * @param \Drupal\commerce_store\Entity\StoreInterface|null $accountStore
+   *   Account-resolvable store, or NULL.
+   * @param list<object> $orderItemsForEvent
+   *   Items returned for the event.
+   * @param bool $orderStoreOwnsEvent
+   *   Whether non-account stores own the event.
+   */
+  private function resolver(
+    bool $hasParity,
+    bool $storeOwnsEvent,
+    ?StoreInterface $accountStore,
+    array $orderItemsForEvent,
+    bool $orderStoreOwnsEvent,
+  ): RefundAccessResolver {
+    $storeOwnership = $this->createMock(StoreEventOwnershipInterface::class);
+    $storeOwnership->method('getStoreForUser')->willReturn($accountStore);
+    $storeOwnership->method('vendorOwnsEvent')->willReturnCallback(
+      static function (StoreInterface $store, NodeInterface $event) use ($accountStore, $storeOwnsEvent, $orderStoreOwnsEvent): bool {
+        if ($accountStore && (int) $store->id() === (int) $accountStore->id()) {
+          return $storeOwnsEvent;
+        }
+        return $orderStoreOwnsEvent;
+      }
+    );
+
+    $inspector = $this->createMock(RefundOrderItemsInterface::class);
+    $inspector->method('extractItemsForEvent')->willReturn($orderItemsForEvent);
+
+    $checker = $this->createMock(EventVendorAccessCheckerInterface::class);
+    $checker->method('accountHasWorkspaceParityForEvent')->willReturn($hasParity);
+
+    return new RefundAccessResolver($storeOwnership, $inspector, $checker);
+  }
+
+  /**
+   * Builds a stub account.
+   *
+   * @param int $id
+   *   Account UID.
+   * @param array<string, bool> $permissions
+   *   Permission map.
+   */
+  private function account(int $id, array $permissions): AccountInterface {
+    $account = $this->createMock(AccountInterface::class);
+    $account->method('id')->willReturn($id);
+    $account->method('hasPermission')->willReturnCallback(
+      static fn(string $perm): bool => !empty($permissions[$perm])
+    );
+    return $account;
+  }
+
+  /**
+   * Builds a stub event node.
+   */
+  private function event(): NodeInterface {
+    $event = $this->createMock(NodeInterface::class);
+    $event->method('bundle')->willReturn('event');
+    $event->method('id')->willReturn(100);
+    return $event;
+  }
+
+  /**
+   * Builds a stub store.
+   *
+   * @param int $id
+   *   Store ID.
+   */
+  private function store(int $id): StoreInterface {
+    $store = $this->createMock(StoreInterface::class);
+    $store->method('id')->willReturn($id);
+    return $store;
+  }
+
+  /**
+   * Builds a stub order.
+   *
+   * @param string $stateId
+   *   Order workflow state ID.
+   * @param bool $hasStore
+   *   Whether the order has a store.
+   */
+  private function order(string $stateId, bool $hasStore = TRUE): OrderInterface {
+    $state = new class($stateId) {
+
+      /**
+       * Constructs the state stub.
+       */
+      public function __construct(private readonly string $id) {}
+
+      /**
+       * Returns the state ID.
+       */
+      public function getId(): string {
+        return $this->id;
+      }
+
+    };
+
+    $order = $this->createMock(OrderInterface::class);
+    $order->method('getState')->willReturn($state);
+    if ($hasStore) {
+      $order->method('getStore')->willReturn($this->store(1));
+    }
+    else {
+      $order->method('getStore')->willReturn(NULL);
+    }
+    return $order;
+  }
+
+}

--- a/web/modules/custom/myeventlane_refunds/tests/src/Unit/VendorRefundRequestAccessCheckBindingTest.php
+++ b/web/modules/custom/myeventlane_refunds/tests/src/Unit/VendorRefundRequestAccessCheckBindingTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_refunds\Unit;
+
+use Drupal\myeventlane_refunds\Access\RefundRequestRouteBinder;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for refund-request route-event binding.
+ *
+ * @coversDefaultClass \Drupal\myeventlane_refunds\Access\RefundRequestRouteBinder
+ *
+ * @group myeventlane_refunds
+ */
+final class VendorRefundRequestAccessCheckBindingTest extends TestCase {
+
+  /**
+   * Matching refund request and event is allowed.
+   */
+  public function testMatchingRefundRequestAllowed(): void {
+    $this->assertTrue(RefundRequestRouteBinder::requestBelongsToEvent(
+      ['id' => 7, 'event_id' => 100],
+      100,
+    ));
+  }
+
+  /**
+   * Route-event / refund-request mismatch is denied.
+   */
+  public function testMismatchedRefundRequestDenied(): void {
+    $this->assertFalse(RefundRequestRouteBinder::requestBelongsToEvent(
+      ['id' => 7, 'event_id' => 999],
+      100,
+    ));
+  }
+
+  /**
+   * Missing refund request fails closed.
+   */
+  public function testMissingRefundRequestDenied(): void {
+    $this->assertFalse(RefundRequestRouteBinder::requestBelongsToEvent(NULL, 100));
+  }
+
+  /**
+   * Invalid event id fails closed.
+   */
+  public function testInvalidEventIdDenied(): void {
+    $this->assertFalse(RefundRequestRouteBinder::requestBelongsToEvent(
+      ['id' => 7, 'event_id' => 100],
+      0,
+    ));
+  }
+
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes who can manage and execute refunds and which events Vendor API keys can touch—security- and money-sensitive behavior with intentional narrowing (e.g. store-only bypass, authors without store) and new IDOR bindings.
> 
> **Overview**
> Implements **Phase 2B-A**: organiser **refund/financial** access and **Vendor API** event scope now follow ADR-0008 instead of ad‑hoc author/store or vendor-link rules.
> 
> **Refunds:** `RefundAccessResolver` no longer grants manage/refund from **author OR store alone**. Non-admin organisers need **`EventVendorAccessChecker` workspace parity** plus a **valid account store↔event** relationship (via a new `VendorOwnershipStoreBridge`); refunds also require the **order’s store** to match the event for non-admins. `VendorRefundRequestAccessCheck` binds route `refund_request` to the route event; approve/reject forms **hard-deny** on mismatch instead of soft error markup. Docs and exit criteria mark Workstream 2B-A done.
> 
> **Vendor API:** `VendorApiBaseController::vendorOwnsEvent` injects the canonical checker: vendor-wide keys act as the **vendor owner** account, enforce **`field_event_vendor`** match when set, then parity. Subcontrollers wire the new dependency.
> 
> **Tests:** `RefundAccessResolverOwnershipTest`, `VendorRefundRequestAccessCheckBindingTest`, `VendorApiOwnershipTest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87d0133a5f9a1a18d76b0b7b37eb19768f4bbbe0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->