### PR TITLE
feat: VX2 Sprint 2 — One Event Workspace

### DIFF
--- a/docs/vendor-experience-convergence-implementation-plan.md
+++ b/docs/vendor-experience-convergence-implementation-plan.md
@@ -8,7 +8,7 @@ This plan tells engineering **what to build in what order**. It does not prescri
 
 ### Sprint 1 (2026-07-22) — VX2-00 shipped slice
 
-**Branch:** `feature/vx2-trust-language-navigation`
+**Branch:** `feature/vx2-trust-language-navigation` (merged PR #701)
 
 **Implemented**
 
@@ -22,24 +22,42 @@ This plan tells engineering **what to build in what order**. It does not prescri
 | — | Placeholder manage routes redirect (promote/comms/payments/advanced) |
 | — | Onboarding reduced shell: Dashboard · Events · Support |
 
+### Sprint 2 (2026-07-22) — VX2-03 One Event Workspace
+
+**Branch:** `feature/vx2-event-workspace`
+
+**Implemented**
+
+| ID | Item |
+| --- | --- |
+| C-09 | One Event Workspace nav chrome (Overview → Settings Convergence map) |
+| — | Shell rebrand: Event Workspace (not Studio/Manager product names) |
+| — | Overview organiser home (next action, readiness, sales, Stripe, marketing, analytics) |
+| — | Human readiness checklist + explanatory strip |
+| — | Marketing + Publishing workspace sections |
+| — | Schedule / Venue / Images / Messages aliases + section plugins |
+| — | Empty states + subtle publish celebration |
+| — | Manager tabs / preprocess aligned to Workspace routes |
+
 **Deferred (later epics)**
 
 | ID | Item | Epic |
 | --- | --- | --- |
 | C-01 / C-02 | Check-in / ticket permission drift | VX2-00 follow-up / VX2-05 |
 | C-04 | Broader singular path 301 sweep | VX2-00 follow-up |
-| C-09 | One Event Workspace nav chrome | VX2-03 |
 | C-15 | Payments hub page | VX2-07 |
 | C-16 / C-17 | Messages send unification / Orders hub | VX2-06 / later |
 | C-12 | Check-in stacks → Door Mode | VX2-05 |
+| — | Schedule/Venue dedicated field forms (currently shared information form) | VX2-03 follow-up |
+| C-14 | Tickets app (advanced collapsed UX depth) | VX2-04 |
 
-**Screens / surfaces touched**
+**Screens / surfaces touched (Sprint 2)**
 
-- Organiser shell sidebar + header Create CTA + account menu  
-- Event Studio section groups and ticket/capability microcopy  
-- Event Manager/workspace labels, attendees, analytics, dashboard Twig  
-- Help titles; field label Ticket → Ticket (config)  
-- Manage-event placeholder controller (redirect)
+- Event Workspace sidebar + topbar + readiness strip + Overview template  
+- Event Studio section plugins / routes (Convergence IA; advanced hidden)  
+- `EventWorkspaceOverviewBuilder`, readiness, empty states, publish handoff  
+- Vendor event tabs + console preprocess tabs  
+- Convergence docs (this pack)
 
 ---
 
@@ -169,6 +187,10 @@ VX2-00 redirects; nav IA from Convergence navigation doc.
 ### Exit criteria
 
 Organiser never chooses between “Studio” and “Manager” for the same job.
+
+### Sprint 2 shipped note (2026-07-22)
+
+Organiser chrome is **Event Workspace** with Convergence secondary nav. Studio remains the implementation shell (not redesigned/replaced). Staff may still open mission-control Overview. Schedule/Venue share the information form until a dedicated field split ships.
 
 ---
 

--- a/docs/vendor-experience-convergence-roadmap.md
+++ b/docs/vendor-experience-convergence-roadmap.md
@@ -2,7 +2,7 @@
 
 **Status:** Prioritised product roadmap  
 **Date:** 2026-07-22  
-**Runtime:** VX2-00 Sprint 1 in progress / shipped on `feature/vx2-trust-language-navigation`  
+**Runtime:** VX2 Sprint 2 on `feature/vx2-event-workspace`; Sprint 1 merged (PR #701)  
 **Related:** [`vendor-experience-convergence.md`](vendor-experience-convergence.md), [`vendor-experience-convergence-priority-matrix.md`](vendor-experience-convergence-priority-matrix.md), [`vendor-experience-convergence-implementation-plan.md`](vendor-experience-convergence-implementation-plan.md)
 
 ---

--- a/docs/vendor-experience-convergence-screen-specifications.md
+++ b/docs/vendor-experience-convergence-screen-specifications.md
@@ -144,6 +144,7 @@ Format: Purpose · Primary action · Content · States · Notes
 | **Primary action** | Continue setup **or** Share / Door Mode |
 | **Content** | Readiness; KPIs; attention; quick links to Tickets / Attendees / Messages |
 | **Notes** | Single home — replaces dual Manager/Studio overview |
+| **Sprint 2** | Live in Event Workspace Overview (`EventWorkspaceOverviewBuilder`) — status, human readiness, today’s tasks, sales, Stripe, marketing, analytics snapshot, next action |
 
 ### B2. Details
 

--- a/docs/vendor-experience-convergence.md
+++ b/docs/vendor-experience-convergence.md
@@ -3,7 +3,7 @@
 **Product Blueprint & Migration Plan**  
 **Status:** Complete — ready to drive the next generation of MyEventLane development  
 **Date:** 2026-07-22  
-**Runtime:** VX2 Sprint 1 (VX2-00 Trust, Language & Navigation) shipped on branch `feature/vx2-trust-language-navigation` (2026-07-22)  
+**Runtime:** VX2 Sprint 2 (One Event Workspace / VX2-03) on branch `feature/vx2-event-workspace` (2026-07-22); Sprint 1 merged via PR #701  
 **Method:** Repository review + synthesis of VX2 product docs and prior audits  
 **Language standard:** Organiser (human) · `vendor` (machine / URLs)
 
@@ -78,7 +78,7 @@ Permanent principles remain in [`vendor-experience-v2-design-principles.md`](ven
 2. Event Studio remains the builder / publish authority; Event Manager and Studio converge into **one Event Workspace**.
 3. `mel_ticket_type` remains the ticket abstraction; Commerce stays hidden.
 4. Workspace ownership (ADR-0008) remains the access contract.
-5. ~~This pack does **not** change runtime behaviour.~~ **Update (Sprint 1):** organiser-visible language, shell navigation, Create Event gateway alignment, and placeholder redirects are live in code.
+5. ~~This pack does **not** change runtime behaviour.~~ **Update (Sprint 1):** organiser-visible language, shell navigation, Create Event gateway alignment, and placeholder redirects are live in code. **Update (Sprint 2):** One Event Workspace shell/nav, Overview home, human readiness, Marketing/Publishing sections, and Manager tab convergence are live in code.
 6. Prior VX2 findings are treated as authoritative unless contradicted by the 2026-07-22 inventory.
 
 ---
@@ -409,8 +409,21 @@ Full definitions: [`vendor-experience-convergence-success-metrics.md`](vendor-ex
 | Create Event → gateway / draft-choice | **Done** — shell CTA + account menu |
 | Placeholder manage routes | **Done** — redirect (not “coming soon”) |
 | Payments / Orders hubs | **Deferred** — labels point at existing payouts / event-scoped orders |
-| Full Event Workspace merge | **Deferred** — VX2-03 |
 | Door Mode check-in merge | **Deferred** — VX2-05 (removed from shell only) |
+
+## Sprint 2 runtime status (VX2-03 One Event Workspace)
+
+| Area | Status |
+| --- | --- |
+| One Workspace shell language | **Done** — Event Workspace topbar/sidebar; Events breadcrumb; View page + Publish |
+| Convergence secondary nav | **Done** — Overview → Details → Schedule → Venue → Images → Tickets → Attendees → Messages → Marketing → Orders → Analytics → Publishing → Settings |
+| Advanced sections off primary nav | **Done** — Content, Guest questions, Capacity, Merch & add-ons, Collection hidden |
+| Overview as organiser home | **Done** — readiness, next action, sales, Stripe, marketing, analytics snapshot |
+| Human publishing readiness | **Done** — checklist nouns + “You’re almost there…” explanations |
+| Empty states / celebration | **Done** — AU warm empty copy; publish celebration without emoji gimmick |
+| Manager dual chrome | **Converged** — tabs/preprocess point at Workspace routes; staff mission-control retained |
+| Dedicated Schedule/Venue field forms | **Partial** — nav sections share Event information form (field split deferred) |
+| Full Attendees / Door / Tickets depth | **Deferred** — VX2-04 / VX2-05 |
 
 ---
 
@@ -420,4 +433,4 @@ Full definitions: [`vendor-experience-convergence-success-metrics.md`](vendor-ex
 
 **Biggest revenue opportunities:** Faster first publish; higher Stripe completion; free Analytics pulse that earns Pro; clearer Boost / Marketing; fewer support dead ends that abandon paid flows.
 
-**Vendor Experience Convergence blueprint is complete.** Sprint 1 delivers Trust, Language & Navigation; remaining epics follow the roadmap.
+**Vendor Experience Convergence blueprint is complete.** Sprint 1 delivered Trust, Language & Navigation; Sprint 2 delivered One Event Workspace; remaining epics follow the roadmap.

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -2802,6 +2802,17 @@
   color: #5b21b6;
 }
 
+.mel-event-studio-empty-state__actions {
+  margin-block-start: 16px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.mel-event-studio-empty-state__actions .mel-btn {
+  min-height: 44px;
+}
+
 .mel-event-studio-publish-feedback {
   padding: 16px 18px;
   border: 1px solid rgba(244, 63, 94, 0.28);

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -5482,3 +5482,139 @@
   font-size: 0.875rem;
   margin-block-end: 12px;
 }
+/* -------------------------------------------------------------------------- */
+/* VX2 Event Workspace overview + human readiness                              */
+/* -------------------------------------------------------------------------- */
+
+.mel-event-workspace-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  max-width: 56rem;
+}
+
+.mel-event-workspace-overview__lede,
+.mel-event-workspace-overview__readiness-explain,
+.mel-event-workspace-overview__next-message {
+  margin: 0;
+  color: var(--mel-text-muted, #4a5568);
+}
+
+.mel-event-workspace-overview__celebrate {
+  padding: 1rem 1.25rem;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(110, 195, 160, 0.18), rgba(255, 255, 255, 0.9));
+  border: 1px solid rgba(110, 195, 160, 0.35);
+}
+
+.mel-event-workspace-overview__celebrate-title {
+  margin: 0 0 0.25rem;
+  font-weight: 600;
+}
+
+.mel-event-workspace-overview__celebrate-message {
+  margin: 0;
+}
+
+.mel-event-workspace-overview__next {
+  padding: 1.25rem;
+  border-radius: 12px;
+  background: var(--mel-surface, #fff);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.mel-event-workspace-overview__next-title {
+  margin: 0.25rem 0 0.5rem;
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.mel-event-workspace-overview__checklist,
+.mel-event-studio-readiness-strip__checklist {
+  list-style: none;
+  margin: 0.75rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.mel-event-workspace-overview__check,
+.mel-event-studio-readiness-strip__check {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  min-height: 44px;
+  padding: 0.35rem 0;
+}
+
+.mel-event-workspace-overview__grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 720px) {
+  .mel-event-workspace-overview__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.mel-event-workspace-overview__card {
+  padding: 1rem 1.25rem;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: var(--mel-surface, #fff);
+}
+
+.mel-event-workspace-overview__card-title,
+.mel-event-workspace-overview__section-title {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+}
+
+.mel-event-workspace-overview__metrics {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.mel-event-workspace-overview__quick-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.25rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.mel-event-workspace-overview__quick-list a {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.mel-event-studio-topbar__breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+  margin: 0 0 0.35rem;
+  font-size: 0.875rem;
+}
+
+.mel-event-studio-topbar__breadcrumb-link {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.mel-event-studio-readiness-strip__explain {
+  margin: 0.35rem 0 0;
+  font-size: 0.9rem;
+}
+
+.mel-event-studio-sidebar__heading:empty {
+  display: none;
+}

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -5547,6 +5547,15 @@
   padding: 0.35rem 0;
 }
 
+.mel-event-workspace-overview__check--warning,
+.mel-event-workspace-overview__check--idea {
+  color: var(--mel-text-muted, #4a5568);
+}
+
+.mel-event-workspace-overview__check--attention {
+  color: var(--mel-text, #1a202c);
+}
+
 .mel-event-workspace-overview__grid {
   display: grid;
   gap: 1rem;

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -5560,7 +5560,8 @@
 
 .mel-event-workspace-overview__check--warning,
 .mel-event-workspace-overview__check--idea,
-.mel-event-studio-readiness-strip__check--warning {
+.mel-event-studio-readiness-strip__check--warning,
+.mel-event-studio-readiness-strip__check--idea {
   color: var(--mel-text-muted, #4a5568);
 }
 

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -5548,11 +5548,13 @@
 }
 
 .mel-event-workspace-overview__check--warning,
-.mel-event-workspace-overview__check--idea {
+.mel-event-workspace-overview__check--idea,
+.mel-event-studio-readiness-strip__check--warning {
   color: var(--mel-text-muted, #4a5568);
 }
 
-.mel-event-workspace-overview__check--attention {
+.mel-event-workspace-overview__check--attention,
+.mel-event-studio-readiness-strip__check--attention {
   color: var(--mel-text, #1a202c);
 }
 

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
@@ -308,7 +308,7 @@
         + (tone ? ` mel-event-studio-readiness-strip__check--${tone}` : '');
       const mark = document.createElement('span');
       mark.setAttribute('aria-hidden', 'true');
-      mark.textContent = complete ? '✔' : (tone === 'warning' ? '◇' : '○');
+      mark.textContent = complete ? '✔' : ((tone === 'warning' || tone === 'idea') ? '◇' : '○');
       const sr = document.createElement('span');
       sr.className = 'visually-hidden';
       if (complete) {
@@ -316,6 +316,9 @@
       }
       else if (tone === 'warning') {
         sr.textContent = Drupal.t('Suggested review');
+      }
+      else if (tone === 'idea') {
+        sr.textContent = Drupal.t('Idea');
       }
       else {
         sr.textContent = Drupal.t('Outstanding');

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
@@ -382,9 +382,10 @@
       updateReadinessChecklist(strip, readiness.checklist);
     }
 
-    setText(strip, '[data-mel-readiness-errors-count]', Drupal.formatPlural((readiness.errors || []).length, '1 blocker', '@count blocker(s)'));
-    setText(strip, '[data-mel-readiness-warnings-count]', Drupal.formatPlural((readiness.warnings || []).length, '1 warning', '@count warning(s)'));
-    setText(strip, '[data-mel-readiness-recommendations-count]', Drupal.formatPlural((readiness.recommendations || []).length, '1 idea', '@count idea(s)'));
+    // Match server-rendered strip counts (mel-event-studio-workspace.html.twig).
+    setText(strip, '[data-mel-readiness-errors-count]', Drupal.t('@count to finish', { '@count': (readiness.errors || []).length }));
+    setText(strip, '[data-mel-readiness-warnings-count]', Drupal.t('@count to review', { '@count': (readiness.warnings || []).length }));
+    setText(strip, '[data-mel-readiness-recommendations-count]', Drupal.t('@count idea(s)', { '@count': (readiness.recommendations || []).length }));
     setText(strip, '[data-mel-readiness-completed-count]', Drupal.t('@count complete', { '@count': (readiness.completed || []).length }));
   }
 

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
@@ -211,8 +211,10 @@
       '<div class="mel-event-studio-readiness-strip__summary">',
       '<strong data-mel-readiness-title></strong>',
       '<span data-mel-readiness-state></span>',
+      '<p class="mel-event-studio-readiness-strip__explain" data-mel-readiness-explain hidden></p>',
       '</div>',
-      '<div class="mel-event-studio-readiness-strip__counts">',
+      '<ul class="mel-event-studio-readiness-strip__checklist" data-mel-readiness-checklist hidden></ul>',
+      '<div class="mel-event-studio-readiness-strip__counts" data-mel-readiness-counts>',
       '<span data-mel-readiness-errors-count></span>',
       '<span data-mel-readiness-warnings-count></span>',
       '<span data-mel-readiness-recommendations-count></span>',
@@ -227,6 +229,92 @@
       shell.prepend(strip);
     }
     return strip;
+  }
+
+  function ensureReadinessExplain(strip) {
+    let explain = strip.querySelector('[data-mel-readiness-explain]');
+    if (explain) {
+      return explain;
+    }
+    const summary = strip.querySelector('.mel-event-studio-readiness-strip__summary');
+    if (!summary) {
+      return null;
+    }
+    explain = document.createElement('p');
+    explain.className = 'mel-event-studio-readiness-strip__explain';
+    explain.setAttribute('data-mel-readiness-explain', '');
+    summary.appendChild(explain);
+    return explain;
+  }
+
+  function ensureReadinessChecklist(strip) {
+    let list = strip.querySelector('[data-mel-readiness-checklist]');
+    if (list) {
+      return list;
+    }
+    list = document.createElement('ul');
+    list.className = 'mel-event-studio-readiness-strip__checklist';
+    list.setAttribute('data-mel-readiness-checklist', '');
+    const counts = strip.querySelector('[data-mel-readiness-counts], .mel-event-studio-readiness-strip__counts');
+    if (counts) {
+      counts.insertAdjacentElement('beforebegin', list);
+    }
+    else {
+      strip.appendChild(list);
+    }
+    return list;
+  }
+
+  function ensureReadinessCounts(strip) {
+    let counts = strip.querySelector('[data-mel-readiness-counts], .mel-event-studio-readiness-strip__counts');
+    if (counts) {
+      return counts;
+    }
+    counts = document.createElement('div');
+    counts.className = 'mel-event-studio-readiness-strip__counts';
+    counts.setAttribute('data-mel-readiness-counts', '');
+    counts.innerHTML = [
+      '<span data-mel-readiness-errors-count></span>',
+      '<span data-mel-readiness-warnings-count></span>',
+      '<span data-mel-readiness-recommendations-count></span>',
+      '<span data-mel-readiness-completed-count></span>',
+    ].join('');
+    strip.appendChild(counts);
+    return counts;
+  }
+
+  function updateReadinessChecklist(strip, checklist) {
+    const list = ensureReadinessChecklist(strip);
+    const counts = ensureReadinessCounts(strip);
+    const items = Array.isArray(checklist) ? checklist : [];
+    if (items.length === 0) {
+      list.hidden = true;
+      list.replaceChildren();
+      counts.hidden = false;
+      return;
+    }
+    counts.hidden = true;
+    list.hidden = false;
+    list.replaceChildren();
+    items.forEach((item) => {
+      if (!item || typeof item.label !== 'string') {
+        return;
+      }
+      const complete = !!item.complete;
+      const li = document.createElement('li');
+      li.className = 'mel-event-studio-readiness-strip__check' + (complete ? ' is-complete' : '');
+      const mark = document.createElement('span');
+      mark.setAttribute('aria-hidden', 'true');
+      mark.textContent = complete ? '✔' : '○';
+      const sr = document.createElement('span');
+      sr.className = 'visually-hidden';
+      sr.textContent = complete ? Drupal.t('Complete') : Drupal.t('Outstanding');
+      const label = document.createTextNode(' ' + item.label);
+      li.appendChild(mark);
+      li.appendChild(sr);
+      li.appendChild(label);
+      list.appendChild(li);
+    });
   }
 
   function ensureHomepageReadinessWrapper(shell) {
@@ -269,6 +357,20 @@
         : Drupal.t('Needs attention'));
     setText(strip, '[data-mel-readiness-title]', title);
     setText(strip, '[data-mel-readiness-state]', readiness.state || '');
+
+    const explain = ensureReadinessExplain(strip);
+    if (explain) {
+      const explanation = typeof readiness.strip_explanation === 'string'
+        ? readiness.strip_explanation
+        : '';
+      explain.textContent = explanation;
+      explain.hidden = explanation === '';
+    }
+
+    if (readiness.checklist !== undefined) {
+      updateReadinessChecklist(strip, readiness.checklist);
+    }
+
     setText(strip, '[data-mel-readiness-errors-count]', Drupal.formatPlural((readiness.errors || []).length, '1 blocker', '@count blocker(s)'));
     setText(strip, '[data-mel-readiness-warnings-count]', Drupal.formatPlural((readiness.warnings || []).length, '1 warning', '@count warning(s)'));
     setText(strip, '[data-mel-readiness-recommendations-count]', Drupal.formatPlural((readiness.recommendations || []).length, '1 idea', '@count idea(s)'));

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
@@ -301,14 +301,25 @@
         return;
       }
       const complete = !!item.complete;
+      const tone = typeof item.tone === 'string' ? item.tone : '';
       const li = document.createElement('li');
-      li.className = 'mel-event-studio-readiness-strip__check' + (complete ? ' is-complete' : '');
+      li.className = 'mel-event-studio-readiness-strip__check'
+        + (complete ? ' is-complete' : '')
+        + (tone ? ` mel-event-studio-readiness-strip__check--${tone}` : '');
       const mark = document.createElement('span');
       mark.setAttribute('aria-hidden', 'true');
-      mark.textContent = complete ? '✔' : '○';
+      mark.textContent = complete ? '✔' : (tone === 'warning' ? '◇' : '○');
       const sr = document.createElement('span');
       sr.className = 'visually-hidden';
-      sr.textContent = complete ? Drupal.t('Complete') : Drupal.t('Outstanding');
+      if (complete) {
+        sr.textContent = Drupal.t('Complete');
+      }
+      else if (tone === 'warning') {
+        sr.textContent = Drupal.t('Suggested review');
+      }
+      else {
+        sr.textContent = Drupal.t('Outstanding');
+      }
       const label = document.createTextNode(' ' + item.label);
       li.appendChild(mark);
       li.appendChild(sr);

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
@@ -105,6 +105,7 @@ function myeventlane_event_studio_theme($existing, $type, $theme, $path) {
         'guidance' => [],
         'icon' => 'spark',
         'state' => 'default',
+        'actions' => [],
       ],
       'template' => 'mel-event-studio-empty-state',
     ],

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
@@ -53,7 +53,11 @@ function myeventlane_event_studio_theme($existing, $type, $theme, $path) {
         'analytics' => [],
         'next_action' => [],
         'quick_links' => [],
-        'celebration' => NULL,
+        'celebration' => [
+          'show' => FALSE,
+          'title' => '',
+          'message' => '',
+        ],
       ],
       'template' => 'mel-event-studio-overview',
     ],

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
@@ -40,6 +40,23 @@ function myeventlane_event_studio_theme($existing, $type, $theme, $path) {
       ],
       'template' => 'mel-event-studio-wizard-nav',
     ],
+    'mel_event_studio_overview' => [
+      'variables' => [
+        'status' => [],
+        'readiness' => [],
+        'todays_tasks' => [],
+        'sales' => [],
+        'ticket_summary' => '',
+        'attendee_summary' => '',
+        'stripe' => [],
+        'marketing' => [],
+        'analytics' => [],
+        'next_action' => [],
+        'quick_links' => [],
+        'celebration' => NULL,
+      ],
+      'template' => 'mel-event-studio-overview',
+    ],
     'mel_event_studio_workspace' => [
       'variables' => [
         'node' => NULL,

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.routing.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.routing.yml
@@ -48,8 +48,66 @@ myeventlane_event_studio.workspace_information:
       node:
         type: entity:node
 
+# VX2 alias: Details (canonical path remains /studio/information).
+myeventlane_event_studio.workspace_details:
+  path: '/vendor/events/{node}/studio/details'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
+    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
+    section: 'information'
+  requirements:
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.workspace_schedule:
+  path: '/vendor/events/{node}/studio/schedule'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
+    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
+    section: 'schedule'
+  requirements:
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.workspace_venue:
+  path: '/vendor/events/{node}/studio/venue'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
+    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
+    section: 'venue'
+  requirements:
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
 myeventlane_event_studio.workspace_branding:
   path: '/vendor/events/{node}/studio/branding'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
+    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
+    section: 'branding'
+  requirements:
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+# VX2 alias: Images.
+myeventlane_event_studio.workspace_images:
+  path: '/vendor/events/{node}/studio/images'
   defaults:
     _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
     _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
@@ -174,6 +232,49 @@ myeventlane_event_studio.workspace_messaging:
     _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
     _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
     section: 'messaging'
+  requirements:
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+# VX2 alias: Messages.
+myeventlane_event_studio.workspace_messages:
+  path: '/vendor/events/{node}/studio/messages'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
+    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
+    section: 'messaging'
+  requirements:
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.workspace_marketing:
+  path: '/vendor/events/{node}/studio/marketing'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
+    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
+    section: 'marketing'
+  requirements:
+    _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
+    node: \d+
+  options:
+    parameters:
+      node:
+        type: entity:node
+
+myeventlane_event_studio.workspace_publishing:
+  path: '/vendor/events/{node}/studio/publishing'
+  defaults:
+    _controller: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspace'
+    _title_callback: '\Drupal\myeventlane_event_studio\Controller\EventStudioController::workspaceTitle'
+    section: 'publishing'
   requirements:
     _custom_access: '\Drupal\myeventlane_event_studio\Access\EventStudioAccess::access'
     node: \d+

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -100,6 +100,15 @@ services:
       - '@logger.channel.myeventlane_event_studio'
       - '@string_translation'
 
+  myeventlane_event_studio.overview_builder:
+    class: Drupal\myeventlane_event_studio\Service\EventWorkspaceOverviewBuilder
+    arguments:
+      - '@myeventlane_vendor.event_workspace_view_model_builder'
+      - '@myeventlane_vendor.paid_publish_stripe_gate'
+      - '@myeventlane_event_studio.readiness'
+      - '@logger.channel.myeventlane_event_studio'
+      - '@string_translation'
+
   myeventlane_event_studio.section_renderer:
     class: Drupal\myeventlane_event_studio\Service\EventStudioSectionRenderer
     arguments:
@@ -114,6 +123,8 @@ services:
       - '@?myeventlane_metrics.service'
       - '@myeventlane_event_studio.event_ticket_preview_builder'
       - '@?myeventlane_tickets.access_code_management_builder'
+      - '@myeventlane_event_studio.overview_builder'
+      - '@myeventlane_core.domain_detector'
 
   myeventlane_event_studio.highlight_helper:
     class: Drupal\myeventlane_event_studio\Service\EventHighlightHelper

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -105,7 +105,7 @@ services:
     arguments:
       - '@myeventlane_vendor.event_workspace_view_model_builder'
       - '@myeventlane_vendor.paid_publish_stripe_gate'
-      - '@myeventlane_event_studio.readiness'
+      - '@myeventlane_event_studio.readiness_facade'
       - '@logger.channel.myeventlane_event_studio'
       - '@string_translation'
 

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
@@ -380,7 +380,7 @@ final class EventStudioController extends ControllerBase {
     if ($node->bundle() !== 'event') {
       throw new NotFoundHttpException();
     }
-    return (string) $this->t('@title Studio', ['@title' => $node->label()]);
+    return (string) $this->t('@title — Event Workspace', ['@title' => $node->label()]);
   }
 
   public function editTitle(NodeInterface $node): string {
@@ -403,7 +403,7 @@ final class EventStudioController extends ControllerBase {
     return [
       'title' => $node->label(),
       'location' => $this->workspacePresentation->buildTopbarLocation($node),
-      'status' => $node->isPublished() ? $this->t('Published') : $this->t('Draft'),
+      'status' => $node->isPublished() ? $this->t('Live') : $this->t('Draft'),
       'state' => $state,
       'show_last_saved' => FALSE,
       'restore_draft' => $this->autosaveService->hasDraft($node, $section),
@@ -421,6 +421,7 @@ final class EventStudioController extends ControllerBase {
       'manage_event_url' => $isStaff
         ? Url::fromRoute('myeventlane_vendor.console.event_workspace', ['event' => $node->id()])->toString()
         : '',
+      'events_url' => Url::fromRoute('myeventlane_vendor.console.events')->toString(),
       'changed' => $node->getChangedTime(),
       'revision_id' => (int) $node->getRevisionId(),
     ];

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPublishController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPublishController.php
@@ -278,7 +278,8 @@ final class EventStudioPublishController {
       'messages' => $messages,
       'published' => $node->isPublished(),
       'topbar' => [
-        'status' => $node->isPublished() ? (string) $this->t('Published') : (string) $this->t('Draft'),
+        // Match EventStudioController::buildTopbar Sprint 2 organiser copy.
+        'status' => $node->isPublished() ? (string) $this->t('Live') : (string) $this->t('Draft'),
         'state' => ($node->isPublished() && $publish_result->ready)
           ? ''
           : $this->workspacePresentation->operationalState($publish_result),

--- a/web/modules/custom/myeventlane_event_studio/src/EventStudioPreprocess.php
+++ b/web/modules/custom/myeventlane_event_studio/src/EventStudioPreprocess.php
@@ -239,7 +239,7 @@ final class EventStudioPreprocess {
     }
 
     return [
-      'title' => (string) $this->t('🎉 Your event is now live'),
+      'title' => (string) $this->t('Your event is now live'),
       'message' => (string) $this->t('Published successfully'),
       'boost_url' => $boost_url,
       'view_url' => $canonical_absolute,

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventInformationForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventInformationForm.php
@@ -41,7 +41,7 @@ final class EventInformationForm extends EventStudioBaseForm {
   }
 
   protected function getNextRouteName(): string {
-    return 'myeventlane_event_studio.workspace_information';
+    return $this->resolveStayRouteName();
   }
 
   protected function getPreviousRouteName(): ?string {
@@ -62,7 +62,22 @@ final class EventInformationForm extends EventStudioBaseForm {
     $this->messenger()->addStatus($has_location
       ? $this->t('Event information and venue saved.')
       : $this->t('Event information saved.'));
-    $form_state->setRedirect('myeventlane_event_studio.workspace_information', ['node' => $saved->id()]);
+    // Schedule / Venue / Details share this form — stay on the nav section
+    // the organiser opened instead of always bouncing to Details.
+    $form_state->setRedirect($this->resolveStayRouteName(), ['node' => $saved->id()]);
+  }
+
+  /**
+   * Returns the workspace route for the current Schedule/Venue/Details alias.
+   */
+  private function resolveStayRouteName(): string {
+    $route = (string) ($this->getRouteMatch()->getRouteName() ?? '');
+    return match ($route) {
+      'myeventlane_event_studio.workspace_schedule' => 'myeventlane_event_studio.workspace_schedule',
+      'myeventlane_event_studio.workspace_venue' => 'myeventlane_event_studio.workspace_venue',
+      'myeventlane_event_studio.workspace_details' => 'myeventlane_event_studio.workspace_details',
+      default => 'myeventlane_event_studio.workspace_information',
+    };
   }
 
   protected function buildWizardStepContent(array &$form, FormStateInterface $form_state, NodeInterface $node, array $melDefaults): void {

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/AnalyticsSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/AnalyticsSection.php
@@ -12,16 +12,16 @@ use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
 #[EventStudioSection(
   id: 'analytics',
   title: 'Analytics',
-  group: 'Operations',
+  group: 'Workspace',
   routeName: 'myeventlane_event_studio.workspace_analytics',
   section_state: 'readonly',
-  weight: 230,
+  weight: 100,
   icon: 'analytics',
   renderTarget: 'readonly_summary',
   writable: FALSE,
   readiness_participant: FALSE,
   empty_state_type: 'readonly_empty',
-  mobile_priority: 110,
+  mobile_priority: 90,
   operationalArea: 'analytics',
 )]
 final class AnalyticsSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/AttendeesSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/AttendeesSection.php
@@ -12,16 +12,16 @@ use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
 #[EventStudioSection(
   id: 'attendees',
   title: 'Attendees',
-  group: 'Operations',
+  group: 'Workspace',
   routeName: 'myeventlane_event_studio.workspace_attendees',
   section_state: 'readonly',
-  weight: 200,
+  weight: 60,
   icon: 'attendees',
   renderTarget: 'readonly_summary',
   writable: FALSE,
   readiness_participant: FALSE,
   empty_state_type: 'readonly_empty',
-  mobile_priority: 90,
+  mobile_priority: 50,
   operationalArea: 'operations',
 )]
 final class AttendeesSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/BrandingSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/BrandingSection.php
@@ -7,16 +7,17 @@ namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
 use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
 
 /**
- * Branding section metadata.
+ * Images section metadata (hero / cover photo).
  */
 #[EventStudioSection(
   id: 'branding',
-  title: 'Branding',
-  group: 'Event',
+  title: 'Images',
+  group: 'Workspace',
   routeName: 'myeventlane_event_studio.workspace_branding',
   section_state: 'active',
-  weight: 20,
+  weight: 40,
   icon: 'branding',
+  routeFragment: 'images',
   renderTarget: 'form:Drupal\myeventlane_event_studio\Form\EventBrandingForm',
   writable: TRUE,
   readiness_participant: TRUE,

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/CapacitySection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/CapacitySection.php
@@ -7,15 +7,15 @@ namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
 use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
 
 /**
- * Capacity section metadata.
+ * Capacity — advanced ticket tooling (not primary Workspace nav).
  */
 #[EventStudioSection(
   id: 'capacity',
   title: 'Capacity',
-  group: 'Tickets & sales',
+  group: 'Workspace',
   routeName: 'myeventlane_event_studio.workspace_capacity',
   section_state: 'active',
-  weight: 120,
+  weight: 56,
   icon: 'capacity',
   renderTarget: 'capacity_summary',
   writable: FALSE,
@@ -23,5 +23,6 @@ use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
   empty_state_type: 'none',
   mobile_priority: 80,
   operationalArea: 'ticket',
+  navigationVisible: FALSE,
 )]
 final class CapacitySection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/ContentSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/ContentSection.php
@@ -7,15 +7,15 @@ namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
 use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
 
 /**
- * Content section metadata.
+ * Content section — nested under Details (not primary Workspace nav).
  */
 #[EventStudioSection(
   id: 'content',
   title: 'Content',
-  group: 'Event',
+  group: 'Workspace',
   routeName: 'myeventlane_event_studio.workspace_content',
   section_state: 'active',
-  weight: 30,
+  weight: 35,
   icon: 'content',
   renderTarget: 'form:Drupal\myeventlane_event_studio\Form\EventContentForm',
   writable: TRUE,
@@ -23,5 +23,6 @@ use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
   empty_state_type: 'none',
   mobile_priority: 30,
   operationalArea: 'event',
+  navigationVisible: FALSE,
 )]
 final class ContentSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/EventStudioSectionBase.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/EventStudioSectionBase.php
@@ -104,6 +104,8 @@ abstract class EventStudioSectionBase extends PluginBase implements EventStudioS
    */
   public function groupWeight(): int {
     return match ((string) $this->pluginDefinition['group']) {
+      'Workspace' => 0,
+      // Legacy group labels kept for any deferred plugins not yet migrated.
       'Event' => 0,
       'Tickets & sales' => 100,
       'Operations' => 200,

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/ExtrasSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/ExtrasSection.php
@@ -7,15 +7,15 @@ namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
 use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
 
 /**
- * Unified merch and add-on product setup (Commerce-backed).
+ * Merch & add-ons — progressive disclosure under Tickets (not primary nav).
  */
 #[EventStudioSection(
   id: 'extras',
   title: 'Merch & add-ons',
-  group: 'Tickets & sales',
+  group: 'Workspace',
   routeName: 'myeventlane_event_studio.workspace_extras',
   section_state: 'active',
-  weight: 125,
+  weight: 57,
   icon: 'extras',
   renderTarget: 'form:Drupal\myeventlane_event_studio\Form\EventStudioEventExtrasForm',
   writable: TRUE,
@@ -24,5 +24,6 @@ use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
   empty_state_type: 'none',
   mobile_priority: 155,
   operationalArea: 'commerce_product',
+  navigationVisible: FALSE,
 )]
 final class ExtrasSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/FulfilmentSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/FulfilmentSection.php
@@ -7,15 +7,15 @@ namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
 use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
 
 /**
- * Fulfilment / operational capability authoring section.
+ * Collection / fulfilment — advanced ops (not primary Workspace nav).
  */
 #[EventStudioSection(
   id: 'fulfilment',
   title: 'Collection',
-  group: 'Operations',
+  group: 'Workspace',
   routeName: 'myeventlane_event_studio.workspace_fulfilment',
   section_state: 'active',
-  weight: 210,
+  weight: 130,
   icon: 'fulfilment',
   renderTarget: 'form:Drupal\myeventlane_event_studio\Form\EventStudioOperationalCapabilityForm',
   writable: TRUE,
@@ -24,5 +24,6 @@ use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
   empty_state_type: 'none',
   mobile_priority: 180,
   operationalArea: 'fulfilment',
+  navigationVisible: FALSE,
 )]
 final class FulfilmentSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/MarketingSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/MarketingSection.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
+
+use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
+
+/**
+ * Marketing section — share tools and Boost entry.
+ */
+#[EventStudioSection(
+  id: 'marketing',
+  title: 'Marketing',
+  group: 'Workspace',
+  routeName: 'myeventlane_event_studio.workspace_marketing',
+  section_state: 'active',
+  weight: 80,
+  icon: 'marketing',
+  renderTarget: 'marketing_hub',
+  writable: FALSE,
+  readiness_participant: FALSE,
+  empty_state_type: 'none',
+  mobile_priority: 70,
+  operationalArea: 'marketing',
+)]
+final class MarketingSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/MessagingSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/MessagingSection.php
@@ -7,21 +7,22 @@ namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
 use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
 
 /**
- * Messaging section metadata (formerly "promotions").
+ * Messages section metadata.
  */
 #[EventStudioSection(
   id: 'messaging',
-  title: 'Publishing & updates',
-  group: 'Event',
+  title: 'Messages',
+  group: 'Workspace',
   routeName: 'myeventlane_event_studio.workspace_messaging',
   section_state: 'active',
-  weight: 40,
+  weight: 70,
   icon: 'promotions',
+  routeFragment: 'messages',
   renderTarget: 'form:Drupal\myeventlane_event_studio\Form\MessagingForm',
   writable: TRUE,
   readiness_participant: FALSE,
   empty_state_type: 'none',
-  mobile_priority: 40,
+  mobile_priority: 60,
   operationalArea: 'event',
 )]
 final class MessagingSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/OrdersSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/OrdersSection.php
@@ -12,16 +12,16 @@ use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
 #[EventStudioSection(
   id: 'orders',
   title: 'Orders',
-  group: 'Operations',
+  group: 'Workspace',
   routeName: 'myeventlane_event_studio.workspace_orders',
   section_state: 'readonly',
-  weight: 220,
+  weight: 90,
   icon: 'orders',
   renderTarget: 'readonly_summary',
   writable: FALSE,
   readiness_participant: FALSE,
   empty_state_type: 'readonly_empty',
-  mobile_priority: 100,
+  mobile_priority: 80,
   operationalArea: 'commerce',
 )]
 final class OrdersSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/OverviewSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/OverviewSection.php
@@ -7,12 +7,12 @@ namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
 use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
 
 /**
- * Overview section metadata.
+ * Overview section metadata — organiser event home.
  */
 #[EventStudioSection(
   id: 'overview',
   title: 'Overview',
-  group: 'Event',
+  group: 'Workspace',
   routeName: 'myeventlane_event_studio.workspace',
   section_state: 'active',
   weight: 0,

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/PublishingSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/PublishingSection.php
@@ -7,21 +7,21 @@ namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
 use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
 
 /**
- * Settings section metadata.
+ * Publishing section — visibility and readiness before going live.
  */
 #[EventStudioSection(
-  id: 'settings',
-  title: 'Settings',
+  id: 'publishing',
+  title: 'Publishing',
   group: 'Workspace',
-  routeName: 'myeventlane_event_studio.workspace_settings',
+  routeName: 'myeventlane_event_studio.workspace_publishing',
   section_state: 'active',
-  weight: 120,
-  icon: 'settings',
-  renderTarget: 'settings_with_readiness',
+  weight: 110,
+  icon: 'publishing',
+  renderTarget: 'publishing_hub',
   writable: TRUE,
   readiness_participant: TRUE,
   empty_state_type: 'none',
-  mobile_priority: 100,
+  mobile_priority: 45,
   operationalArea: 'event',
 )]
-final class SettingsSection extends EventStudioSectionBase {}
+final class PublishingSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/QuestionsSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/QuestionsSection.php
@@ -7,15 +7,15 @@ namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
 use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
 
 /**
- * Checkout questions section metadata.
+ * Guest questions — advanced ticket tooling (not primary Workspace nav).
  */
 #[EventStudioSection(
   id: 'questions',
   title: 'Guest questions',
-  group: 'Tickets & sales',
+  group: 'Workspace',
   routeName: 'myeventlane_event_studio.workspace_questions',
   section_state: 'active',
-  weight: 110,
+  weight: 55,
   icon: 'questions',
   renderTarget: 'form:Drupal\myeventlane_event_studio\Form\EventCheckoutQuestionsForm',
   writable: TRUE,
@@ -23,5 +23,6 @@ use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
   empty_state_type: 'none',
   mobile_priority: 70,
   operationalArea: 'commerce',
+  navigationVisible: FALSE,
 )]
 final class QuestionsSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/ScheduleSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/ScheduleSection.php
@@ -7,22 +7,21 @@ namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
 use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
 
 /**
- * Details section metadata (event story, title, summary, category).
+ * Schedule section — date, time, and timezone (shared information form).
  */
 #[EventStudioSection(
-  id: 'information',
-  title: 'Details',
+  id: 'schedule',
+  title: 'Schedule',
   group: 'Workspace',
-  routeName: 'myeventlane_event_studio.workspace_information',
+  routeName: 'myeventlane_event_studio.workspace_schedule',
   section_state: 'active',
-  weight: 10,
-  icon: 'information',
-  routeFragment: 'details',
+  weight: 20,
+  icon: 'schedule',
   renderTarget: 'form:Drupal\myeventlane_event_studio\Form\EventInformationForm',
   writable: TRUE,
   readiness_participant: TRUE,
   empty_state_type: 'none',
-  mobile_priority: 10,
+  mobile_priority: 15,
   operationalArea: 'event',
 )]
-final class InformationSection extends EventStudioSectionBase {}
+final class ScheduleSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/TicketsSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/TicketsSection.php
@@ -7,21 +7,21 @@ namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
 use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
 
 /**
- * Ticketing section metadata.
+ * Tickets section metadata.
  */
 #[EventStudioSection(
   id: 'tickets',
   title: 'Tickets',
-  group: 'Tickets & sales',
+  group: 'Workspace',
   routeName: 'myeventlane_event_studio.workspace_tickets',
   section_state: 'active',
-  weight: 100,
+  weight: 50,
   icon: 'tickets',
   renderTarget: 'tickets_stack',
   writable: TRUE,
   readiness_participant: TRUE,
   empty_state_type: 'none',
-  mobile_priority: 60,
+  mobile_priority: 40,
   operationalArea: 'ticket',
 )]
 final class TicketsSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/VenueSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/VenueSection.php
@@ -7,22 +7,21 @@ namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
 use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
 
 /**
- * Details section metadata (event story, title, summary, category).
+ * Venue section — place, map, and access notes (shared information form).
  */
 #[EventStudioSection(
-  id: 'information',
-  title: 'Details',
+  id: 'venue',
+  title: 'Venue',
   group: 'Workspace',
-  routeName: 'myeventlane_event_studio.workspace_information',
+  routeName: 'myeventlane_event_studio.workspace_venue',
   section_state: 'active',
-  weight: 10,
-  icon: 'information',
-  routeFragment: 'details',
+  weight: 30,
+  icon: 'venue',
   renderTarget: 'form:Drupal\myeventlane_event_studio\Form\EventInformationForm',
   writable: TRUE,
   readiness_participant: TRUE,
   empty_state_type: 'none',
-  mobile_priority: 10,
+  mobile_priority: 18,
   operationalArea: 'event',
 )]
-final class InformationSection extends EventStudioSectionBase {}
+final class VenueSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventReadinessService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventReadinessService.php
@@ -75,7 +75,12 @@ final class EventReadinessService {
       $errors[] = (string) $this->t('Choose how attendees will join this event.');
     }
     else {
-      $completed[] = (string) $this->t('Tickets ready');
+      // Mode alone is not "Tickets ready" for paid/external — those need
+      // tickets/URL checks below. RSVP is ready once the mode is selected.
+      $completed[] = (string) $this->t('Booking mode selected');
+      if ($event_type === 'rsvp') {
+        $completed[] = (string) $this->t('Tickets ready');
+      }
     }
 
     if ($event_type === 'external') {
@@ -84,6 +89,7 @@ final class EventReadinessService {
       }
       else {
         $completed[] = (string) $this->t('External booking link');
+        $completed[] = (string) $this->t('Tickets ready');
       }
     }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventReadinessService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventReadinessService.php
@@ -63,11 +63,11 @@ final class EventReadinessService {
       $errors[] = (string) $this->t('Add an event title.');
     }
     else {
-      $completed[] = (string) $this->t('Event title added.');
+      $completed[] = (string) $this->t('Event title');
     }
 
     if ($this->validateDates($event, $errors)) {
-      $completed[] = (string) $this->t('Event dates complete.');
+      $completed[] = (string) $this->t('Schedule');
     }
 
     $event_type = $this->eventType($event);
@@ -75,7 +75,7 @@ final class EventReadinessService {
       $errors[] = (string) $this->t('Choose how attendees will join this event.');
     }
     else {
-      $completed[] = (string) $this->t('Booking mode selected.');
+      $completed[] = (string) $this->t('Tickets ready');
     }
 
     if ($event_type === 'external') {
@@ -83,20 +83,20 @@ final class EventReadinessService {
         $errors[] = (string) $this->t('Add the external booking URL.');
       }
       else {
-        $completed[] = (string) $this->t('External booking URL added.');
+        $completed[] = (string) $this->t('External booking link');
       }
     }
 
     if (in_array($event_type, ['paid', 'both'], TRUE)) {
       if ($this->validatePaidTickets($event, $errors, $warnings)) {
-        $completed[] = (string) $this->t('Ticketing configured.');
+        $completed[] = (string) $this->t('Tickets ready');
       }
       $stripe = $this->validateStripePublish($account, (int) $event->id(), $warnings);
       if ($stripe !== NULL) {
         $errors[] = $stripe;
       }
       else {
-        $completed[] = (string) $this->t('Payment onboarding complete.');
+        $completed[] = (string) $this->t('Payments connected');
       }
     }
 
@@ -105,18 +105,18 @@ final class EventReadinessService {
       $errors[] = $reason;
     }
     if ($denials === []) {
-      $completed[] = (string) $this->t('Vendor publish requirements complete.');
+      $completed[] = (string) $this->t('Organiser profile ready');
     }
 
     if (!$event->hasField('field_event_image') || $event->get('field_event_image')->isEmpty()) {
-      $recommendations[] = (string) $this->t('Add a banner image for stronger event conversion.');
+      $recommendations[] = (string) $this->t('Add a cover image so your event looks inviting.');
     }
     else {
-      $completed[] = (string) $this->t('Branding image added.');
+      $completed[] = (string) $this->t('Cover image');
     }
 
     if ($this->validateCapacities($event, $errors, $warnings)) {
-      $completed[] = (string) $this->t('Capacity settings valid.');
+      $completed[] = (string) $this->t('Capacity');
     }
 
     $this->addOptionalRecommendations($event, $recommendations);

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioAutosaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioAutosaveService.php
@@ -10,6 +10,9 @@ use Psr\Log\LoggerInterface;
 
 /**
  * Stores bounded Event Studio section drafts without mutating event entities.
+ *
+ * Schedule and Venue share EventInformationForm with Details, so their drafts
+ * use the canonical `information` storage key.
  */
 final class EventStudioAutosaveService {
 
@@ -24,36 +27,60 @@ final class EventStudioAutosaveService {
    * @param array<string, mixed> $mel
    */
   public function storeDraft(NodeInterface $event, string $section, array $mel, float $autosaveTimestamp, int $baseChanged, int $baseRevisionId): void {
-    $this->privateTempStoreFactory
-      ->get(self::STORE)
-      ->set($this->key($event, $section), [
-        'event_id' => (int) $event->id(),
-        'section' => $section,
-        'mel' => $mel,
-        'autosave_ts' => $autosaveTimestamp,
-        'base_changed' => $baseChanged,
-        'base_revision_id' => $baseRevisionId,
-        'stored_at' => time(),
-      ]);
+    $canonical = $this->canonicalSection($section);
+    $payload = [
+      'event_id' => (int) $event->id(),
+      'section' => $canonical,
+      'mel' => $mel,
+      'autosave_ts' => $autosaveTimestamp,
+      'base_changed' => $baseChanged,
+      'base_revision_id' => $baseRevisionId,
+      'stored_at' => time(),
+    ];
+    $this->store()->set($this->key($event, $canonical), $payload);
+    // Drop alias keys so Schedule/Venue/Details cannot diverge.
+    $this->deleteAliasKeys($event, $canonical, $canonical);
   }
 
   /**
    * @return array<string, mixed>|null
    */
   public function getDraft(NodeInterface $event, string $section): ?array {
-    $draft = $this->privateTempStoreFactory
-      ->get(self::STORE)
-      ->get($this->key($event, $section));
+    $canonical = $this->canonicalSection($section);
+    $draft = $this->readRawDraft($event, $canonical);
+
+    // Migrate pre-normalization alias keys (schedule/venue) into the canonical key.
+    if ($draft === NULL) {
+      foreach ($this->sectionAliases($canonical) as $alias) {
+        if ($alias === $canonical) {
+          continue;
+        }
+        $legacy = $this->readRawDraft($event, $alias);
+        if ($legacy === NULL) {
+          continue;
+        }
+        $legacy['section'] = $canonical;
+        $this->store()->set($this->key($event, $canonical), $legacy);
+        $this->deleteAliasKeys($event, $canonical, $canonical);
+        $draft = $legacy;
+        $this->logger->notice('Event Studio autosave draft migrated to canonical section: event_id=@nid from=@from to=@to', [
+          '@nid' => (string) $event->id(),
+          '@from' => $alias,
+          '@to' => $canonical,
+        ]);
+        break;
+      }
+    }
 
     if (!is_array($draft)) {
       return NULL;
     }
 
     if ($this->draftIsOlderThanEntity($event, $draft)) {
-      $this->clearDraft($event, $section);
+      $this->clearDraft($event, $canonical);
       $this->logger->notice('Event Studio autosave draft invalidated after newer entity save: event_id=@nid section=@section', [
         '@nid' => (string) $event->id(),
-        '@section' => $section,
+        '@section' => $canonical,
       ]);
       return NULL;
     }
@@ -66,9 +93,8 @@ final class EventStudioAutosaveService {
   }
 
   public function clearDraft(NodeInterface $event, string $section): void {
-    $this->privateTempStoreFactory
-      ->get(self::STORE)
-      ->delete($this->key($event, $section));
+    $canonical = $this->canonicalSection($section);
+    $this->deleteAliasKeys($event, $canonical, NULL);
   }
 
   public function isStaleSubmission(NodeInterface $event, int $baseChanged, int $baseRevisionId): bool {
@@ -84,6 +110,17 @@ final class EventStudioAutosaveService {
   }
 
   /**
+   * Resolves Schedule/Venue (and similar) aliases to the shared draft storage key.
+   */
+  public function canonicalSection(string $section): string {
+    $safe = preg_replace('/[^a-z0-9_:-]+/i', '_', trim($section)) ?: 'section';
+    return match ($safe) {
+      'schedule', 'venue', 'details' => 'information',
+      default => $safe,
+    };
+  }
+
+  /**
    * @param array<string, mixed> $draft
    */
   private function draftIsOlderThanEntity(NodeInterface $event, array $draft): bool {
@@ -91,6 +128,37 @@ final class EventStudioAutosaveService {
     $baseRevisionId = (int) ($draft['base_revision_id'] ?? 0);
 
     return $this->isStaleSubmission($event, $baseChanged, $baseRevisionId);
+  }
+
+  /**
+   * @return array<string, mixed>|null
+   */
+  private function readRawDraft(NodeInterface $event, string $section): ?array {
+    $draft = $this->store()->get($this->key($event, $section));
+    return is_array($draft) ? $draft : NULL;
+  }
+
+  /**
+   * @return list<string>
+   */
+  private function sectionAliases(string $canonical): array {
+    return match ($canonical) {
+      'information' => ['information', 'schedule', 'venue', 'details'],
+      default => [$canonical],
+    };
+  }
+
+  private function deleteAliasKeys(NodeInterface $event, string $canonical, ?string $keep): void {
+    foreach ($this->sectionAliases($canonical) as $alias) {
+      if ($keep !== NULL && $alias === $keep) {
+        continue;
+      }
+      $this->store()->delete($this->key($event, $alias));
+    }
+  }
+
+  private function store(): \Drupal\Core\TempStore\PrivateTempStore {
+    return $this->privateTempStoreFactory->get(self::STORE);
   }
 
   private function key(NodeInterface $event, string $section): string {

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioEmptyStateBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioEmptyStateBuilder.php
@@ -8,7 +8,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 
 /**
- * Builds consistent empty states for Event Studio operational sections.
+ * Builds consistent empty states for Event Workspace sections.
  */
 final class EventStudioEmptyStateBuilder {
 
@@ -19,7 +19,7 @@ final class EventStudioEmptyStateBuilder {
   }
 
   /**
-   * Builds an Event Studio empty-state render array.
+   * Builds an Event Workspace empty-state render array.
    *
    * @param list<string> $guidance
    *   Optional guidance items shown below the main copy.
@@ -47,11 +47,11 @@ final class EventStudioEmptyStateBuilder {
     if ($section_id === 'merchandise') {
       return $this->build(
         (string) $this->t('Merchandise'),
-        (string) $this->t('Merchandise will help organisers sell event products without leaving MEL.'),
-        (string) $this->t('Planned capability. It will appear here once product ownership, payments, fulfilment, and access rules are ready.'),
+        (string) $this->t('Sell event merch without leaving MyEventLane.'),
+        (string) $this->t('This is planned. It will appear here when product ownership, payments, and collection are ready.'),
         [
           (string) $this->t('No merchandise controls are active yet.'),
-          (string) $this->t('Future setup will reuse governed Commerce and fulfilment services.'),
+          (string) $this->t('Learn more in Support when this capability launches.'),
         ],
         'merchandise',
         'deferred',
@@ -60,11 +60,11 @@ final class EventStudioEmptyStateBuilder {
     if ($section_id === 'addons') {
       return $this->build(
         (string) $this->t('Add-ons'),
-        (string) $this->t('Add-ons will support optional upgrades such as parking, meals, or experience extras.'),
-        (string) $this->t('Reserved until add-on pricing, checkout, refunds, and attendee reporting are governed end-to-end.'),
+        (string) $this->t('Offer optional upgrades such as parking, meals, or experience extras.'),
+        (string) $this->t('Reserved until pricing, checkout, refunds, and attendee reporting are ready end-to-end.'),
         [
           (string) $this->t('No attendee-facing add-on controls are exposed yet.'),
-          (string) $this->t('Future controls must use existing Commerce checkout ownership.'),
+          (string) $this->t('Ticket sales continue as usual.'),
         ],
         'addons',
         'deferred',
@@ -72,12 +72,12 @@ final class EventStudioEmptyStateBuilder {
     }
     if ($section_id === 'fulfilment') {
       return $this->build(
-        (string) $this->t('Fulfilment'),
-        (string) $this->t('Fulfilment will coordinate product handoffs, delivery notes, and operational tasks.'),
-        (string) $this->t('Reserved until the fulfilment domain has approved access, reporting, and state contracts.'),
+        (string) $this->t('Collection'),
+        (string) $this->t('Coordinate handoffs, delivery notes, and operational tasks.'),
+        (string) $this->t('Reserved until collection tools have approved access and reporting.'),
         [
           (string) $this->t('Current ticket and RSVP operations are unaffected.'),
-          (string) $this->t('Future fulfilment tools will be event-scoped and audit-friendly.'),
+          (string) $this->t('Future collection tools stay event-scoped.'),
         ],
         'fulfilment',
         'deferred',
@@ -85,11 +85,11 @@ final class EventStudioEmptyStateBuilder {
     }
 
     return $this->build(
-      (string) $this->t('No @section workspace yet', ['@section' => $section_label]),
-      (string) $this->t('@section is reserved for a governed Studio extension. It must register a section contract before adding operational UI.', [
+      (string) $this->t('No @section yet', ['@section' => $section_label]),
+      (string) $this->t('@section is coming soon in Event Workspace.', [
         '@section' => $section_label,
       ]),
-      (string) $this->t('Keep this section empty until the owning domain service and access contract exist.'),
+      (string) $this->t('Keep using the other sections for now — we will open this when it is ready.'),
       [],
       'roadmap',
       'deferred',
@@ -104,8 +104,8 @@ final class EventStudioEmptyStateBuilder {
   public function comingSoonSection(string $section_label): array {
     return $this->build(
       $section_label,
-      (string) $this->t('This Studio capability is intentionally disabled for now.'),
-      (string) $this->t('It will become available only after the owning domain, access, and save contracts are approved.'),
+      (string) $this->t('This part of Event Workspace is not available yet.'),
+      (string) $this->t('It will appear here once the experience is ready for organisers.'),
       [],
       'roadmap',
       'coming-soon',
@@ -118,13 +118,32 @@ final class EventStudioEmptyStateBuilder {
    * @return array<string, mixed>
    */
   public function readonlyEmptySection(string $section_label, string $body = ''): array {
+    $defaults = [
+      'Attendees' => [
+        (string) $this->t('Guests will appear here after your first booking.'),
+        (string) $this->t('Share your event page to start collecting attendees.'),
+      ],
+      'Orders' => [
+        (string) $this->t('Orders will appear here after your first sale.'),
+        (string) $this->t('Create tickets and publish when you are ready to sell.'),
+      ],
+      'Analytics' => [
+        (string) $this->t('Publish your event to start tracking sales.'),
+        (string) $this->t('Once live, you will see attendance and revenue here.'),
+      ],
+    ];
+    $pair = $defaults[$section_label] ?? [
+      $body !== '' ? $body : (string) $this->t('Nothing to show for this event yet.'),
+      (string) $this->t('Check back after your first booking or publish.'),
+    ];
+
     return $this->build(
       $section_label,
-      $body !== '' ? $body : (string) $this->t('No readonly reporting data is available for this event yet.'),
-      (string) $this->t('This section does not mutate event state. Filters, pagination, and exports must be added through governed reporting services.'),
+      $pair[0],
+      $pair[1],
       [
-        (string) $this->t('Reporting stays event-scoped.'),
-        (string) $this->t('Write actions remain in their owning operational sections.'),
+        (string) $this->t('This view is event-scoped and read-only.'),
+        (string) $this->t('Use Tickets, Messages, or Publishing to make changes.'),
       ],
       'reporting',
       'readonly',
@@ -139,8 +158,8 @@ final class EventStudioEmptyStateBuilder {
   public function unavailableSection(string $section_label): array {
     return $this->build(
       $section_label,
-      (string) $this->t('This Studio section cannot render because its operational contract is incomplete.'),
-      (string) $this->t('The issue has been logged for review.'),
+      (string) $this->t('This section could not load right now.'),
+      (string) $this->t('Try refreshing the page. If it keeps happening, contact Support — we have logged the issue.'),
       [],
       'alert',
       'unavailable',

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioEmptyStateBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioEmptyStateBuilder.php
@@ -23,10 +23,12 @@ final class EventStudioEmptyStateBuilder {
    *
    * @param list<string> $guidance
    *   Optional guidance items shown below the main copy.
+   * @param array<string, mixed> $actions
+   *   Optional primary CTA render array (e.g. link) rendered inside the theme.
    *
    * @return array<string, mixed>
    */
-  public function build(string $title, string $body, string $prompt = '', array $guidance = [], string $icon = 'spark', string $state = 'default'): array {
+  public function build(string $title, string $body, string $prompt = '', array $guidance = [], string $icon = 'spark', string $state = 'default', array $actions = []): array {
     return [
       '#theme' => 'mel_event_studio_empty_state',
       '#title' => $title,
@@ -35,6 +37,7 @@ final class EventStudioEmptyStateBuilder {
       '#guidance' => $guidance,
       '#icon' => $icon,
       '#state' => $state,
+      '#actions' => $actions,
     ];
   }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
@@ -8,7 +8,9 @@ use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\Url;
 use Drupal\myeventlane_capacity\Service\EventCapacityServiceInterface;
+use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\myeventlane_event_studio\DTO\EventReadinessResult;
 use Drupal\myeventlane_event_studio\DTO\ReadonlySectionProjection;
 use Drupal\myeventlane_event_studio\Form\EventSettingsForm;
@@ -40,6 +42,8 @@ final class EventStudioSectionRenderer {
     private readonly ?EventMetricsServiceInterface $metricsService = NULL,
     private readonly ?EventTicketPreviewBuilder $eventTicketPreviewBuilder = NULL,
     private readonly ?AccessCodeManagementBuilder $accessCodeManagementBuilder = NULL,
+    private readonly ?EventWorkspaceOverviewBuilder $overviewBuilder = NULL,
+    private readonly ?DomainDetector $domainDetector = NULL,
   ) {
     $this->stringTranslation = $stringTranslation;
   }
@@ -78,6 +82,8 @@ final class EventStudioSectionRenderer {
       'tickets_stack' => $this->buildTicketsStack($event),
       'settings_with_readiness' => $this->buildSettingsSection($event),
       'capacity_summary' => $this->buildCapacitySection($event, $section),
+      'marketing_hub' => $this->buildMarketingHub($event),
+      'publishing_hub' => $this->buildPublishingHub($event),
       default => $this->buildUnknownTarget($section, $target),
     };
   }
@@ -106,26 +112,169 @@ final class EventStudioSectionRenderer {
    * @return array<string, mixed>
    */
   private function buildOverviewSection(NodeInterface $event): array {
+    if ($this->overviewBuilder instanceof EventWorkspaceOverviewBuilder) {
+      return $this->overviewBuilder->build($event, $this->currentUser);
+    }
+
+    $this->logger->error('Event Workspace overview builder unavailable for event @event.', [
+      '@event' => (string) $event->id(),
+    ]);
+    return $this->emptyStateBuilder->unavailableSection((string) $this->t('Overview'));
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildMarketingHub(NodeInterface $event): array {
+    $nid = (int) $event->id();
+    $publicPath = Url::fromRoute('entity.node.canonical', ['node' => $nid])->toString();
+    $publicUrl = $this->domainDetector instanceof DomainDetector
+      ? $this->domainDetector->publicUrl($publicPath)
+      : $publicPath;
+    $boostUrl = NULL;
+    try {
+      $boostUrl = Url::fromRoute('myeventlane_boost.vendor_event_boost', ['event' => $nid])->toString();
+    }
+    catch (\Throwable) {
+      $boostUrl = NULL;
+    }
+
+    if (!$event->isPublished()) {
+      return $this->emptyStateBuilder->build(
+        (string) $this->t('Marketing'),
+        (string) $this->t('Publish your event to start sharing and Boosting it.'),
+        (string) $this->t('Once live, you can copy your public link and run Boost from here.'),
+        [
+          (string) $this->t('Finish publishing first.'),
+          (string) $this->t('Then share your page with your community.'),
+        ],
+        'spark',
+        'default',
+      ) + [
+        'actions' => [
+          '#type' => 'link',
+          '#title' => $this->t('Go to publishing'),
+          '#url' => Url::fromRoute('myeventlane_event_studio.workspace_publishing', ['node' => $nid]),
+          '#attributes' => ['class' => ['mel-btn', 'mel-btn--primary']],
+        ],
+      ];
+    }
+
     return [
       '#type' => 'container',
-      '#attributes' => ['class' => ['mel-event-studio-overview']],
+      '#attributes' => ['class' => ['mel-event-workspace-marketing']],
       'intro' => [
         '#type' => 'html_tag',
         '#tag' => 'p',
-        '#value' => $this->t('Use the sections below to finish setup. Readiness and boost status stay above so you always know what needs attention next.'),
-        '#attributes' => ['class' => ['mel-event-studio-overview__summary']],
+        '#value' => $this->t('Drive ticket sales for this event. Share your public page or Boost visibility across MyEventLane.'),
       ],
-      'actions' => [
-        '#theme' => 'item_list',
-        '#title' => $this->t('Suggested next steps'),
-        '#items' => [
-          $this->t('Start with Event information for the public details guests see first.'),
-          $this->t('Confirm RSVP or ticket setup before sharing the page.'),
-          $this->t('Review Branding and Content when you are ready to promote the event.'),
+      'share' => [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['mel-event-workspace-marketing__share']],
+        'title' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h3',
+          '#value' => $this->t('Share your event'),
         ],
-        '#attributes' => ['class' => ['mel-event-studio-overview__list']],
+        'url' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $publicUrl,
+        ],
+        'view' => [
+          '#type' => 'link',
+          '#title' => $this->t('View page'),
+          '#url' => Url::fromRoute('entity.node.canonical', ['node' => $nid]),
+          '#attributes' => [
+            'class' => ['mel-btn', 'mel-btn--secondary'],
+            'target' => '_blank',
+            'rel' => 'noopener noreferrer',
+          ],
+        ],
       ],
+      'boost' => $boostUrl ? [
+        '#type' => 'container',
+        'title' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h3',
+          '#value' => $this->t('Boost'),
+        ],
+        'copy' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->t('Feature your event in discovery so more people find you.'),
+        ],
+        'cta' => [
+          '#type' => 'link',
+          '#title' => $this->t('Start Boost'),
+          '#url' => Url::fromRoute('myeventlane_boost.vendor_event_boost', ['event' => $nid]),
+          '#attributes' => ['class' => ['mel-btn', 'mel-btn--primary']],
+        ],
+      ] : [],
     ];
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function buildPublishingHub(NodeInterface $event): array {
+    $account = $this->currentUser;
+    $readiness = $this->eventReadiness->evaluate($event, $account);
+    $remaining = count($readiness->errors);
+    $headline = $readiness->ready
+      ? ($event->isPublished()
+        ? (string) $this->t('Your event is live')
+        : (string) $this->t('Ready to publish'))
+      : ($remaining === 1
+        ? (string) $this->t("You're almost there…")
+        : (string) $this->t('A few things left before publishing'));
+    $explanation = $readiness->ready
+      ? (string) $this->t('Everything needed to go live looks good.')
+      : ($remaining === 1 && $readiness->errors !== []
+        ? (string) $this->t('One more thing before publishing: @reason', ['@reason' => $readiness->errors[0]])
+        : (string) $this->t('Finish the checklist below. We never block without explaining why.'));
+
+    $checklist = [];
+    foreach ($readiness->completed as $item) {
+      $checklist[] = ['#markup' => '✔ ' . $this->humanChecklistLabel((string) $item)];
+    }
+    foreach ($readiness->errors as $item) {
+      $checklist[] = ['#markup' => '○ ' . (string) $item];
+    }
+
+    return [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['mel-event-workspace-publishing']],
+      'headline' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h3',
+        '#value' => $headline,
+      ],
+      'explain' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $explanation,
+      ],
+      'checklist' => [
+        '#theme' => 'item_list',
+        '#title' => $this->t('Publishing checklist'),
+        '#items' => $checklist,
+      ],
+      'settings' => $this->formBuilder->getForm(EventSettingsForm::class, $event),
+    ];
+  }
+
+  private function humanChecklistLabel(string $label): string {
+    return match ($label) {
+      'Event title added.', 'Event title' => (string) $this->t('Event title'),
+      'Event dates complete.', 'Schedule' => (string) $this->t('Schedule'),
+      'Booking mode selected.', 'Ticketing configured.', 'Tickets ready' => (string) $this->t('Tickets ready'),
+      'Payment onboarding complete.', 'Payments connected' => (string) $this->t('Payments connected'),
+      'Vendor publish requirements complete.', 'Organiser profile ready' => (string) $this->t('Organiser profile ready'),
+      'Branding image added.', 'Cover image' => (string) $this->t('Cover image'),
+      'Capacity settings valid.', 'Capacity' => (string) $this->t('Capacity'),
+      default => rtrim($label, '.'),
+    };
   }
 
   /**
@@ -144,9 +293,9 @@ final class EventStudioSectionRenderer {
       'items' => [
         '#theme' => 'item_list',
         '#items' => [
-          $this->t('Check event information and public copy first.'),
-          $this->t('Confirm RSVP or ticket setup before sharing the page.'),
-          $this->t('Use the readiness strip above when you are ready to publish.'),
+          $this->t('Start with Details so guests know what the event is about.'),
+          $this->t('Confirm tickets or RSVP before sharing the page.'),
+          $this->t('Use Publishing when you are ready to go live.'),
         ],
         '#attributes' => ['class' => ['mel-event-studio-next-steps__list']],
       ],

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
@@ -150,14 +150,13 @@ final class EventStudioSectionRenderer {
         ],
         'spark',
         'default',
-      ) + [
-        'actions' => [
+        [
           '#type' => 'link',
           '#title' => $this->t('Go to publishing'),
           '#url' => Url::fromRoute('myeventlane_event_studio.workspace_publishing', ['node' => $nid]),
           '#attributes' => ['class' => ['mel-btn', 'mel-btn--primary']],
         ],
-      ];
+      );
     }
 
     return [

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
@@ -268,7 +268,8 @@ final class EventStudioSectionRenderer {
     return match ($label) {
       'Event title added.', 'Event title' => (string) $this->t('Event title'),
       'Event dates complete.', 'Schedule' => (string) $this->t('Schedule'),
-      'Booking mode selected.', 'Ticketing configured.', 'Tickets ready' => (string) $this->t('Tickets ready'),
+      'Booking mode selected.', 'Booking mode selected' => (string) $this->t('Booking mode'),
+      'Ticketing configured.', 'Tickets ready' => (string) $this->t('Tickets ready'),
       'Payment onboarding complete.', 'Payments connected' => (string) $this->t('Payments connected'),
       'Vendor publish requirements complete.', 'Organiser profile ready' => (string) $this->t('Organiser profile ready'),
       'Branding image added.', 'Cover image' => (string) $this->t('Cover image'),

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWorkspacePresentation.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWorkspacePresentation.php
@@ -221,7 +221,8 @@ final class EventStudioWorkspacePresentation {
     return match ($label) {
       'Event title added.', 'Event title' => (string) $this->t('Event title'),
       'Event dates complete.', 'Schedule' => (string) $this->t('Schedule'),
-      'Booking mode selected.', 'Ticketing configured.', 'Tickets ready' => (string) $this->t('Tickets ready'),
+      'Booking mode selected.', 'Booking mode selected' => (string) $this->t('Booking mode'),
+      'Ticketing configured.', 'Tickets ready' => (string) $this->t('Tickets ready'),
       'Payment onboarding complete.', 'Payments connected' => (string) $this->t('Payments connected'),
       'Vendor publish requirements complete.', 'Organiser profile ready' => (string) $this->t('Organiser profile ready'),
       'Branding image added.', 'Cover image' => (string) $this->t('Cover image'),

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWorkspacePresentation.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWorkspacePresentation.php
@@ -201,12 +201,13 @@ final class EventStudioWorkspacePresentation {
   }
 
   /**
-   * Builds the strip checklist, always including every blocking error.
+   * Builds the strip checklist, always including every blocking error and warning.
    *
-   * Completed rows fill remaining slots up to eight total. Blocking errors are
-   * never truncated — publish can remain blocked by items that must stay visible.
+   * Completed rows fill remaining slots up to eight total. Blocking errors and
+   * warnings are never truncated — checklist mode replaces the count row, so
+   * warnings must remain visible alongside blockers.
    *
-   * @return list<array{label: string, complete: bool}>
+   * @return list<array{label: string, complete: bool, tone: string}>
    */
   private function buildHumanChecklist(EventReadinessResult $result): array {
     $completed = [];
@@ -214,6 +215,7 @@ final class EventStudioWorkspacePresentation {
       $completed[] = [
         'label' => $this->humanChecklistLabel((string) $label),
         'complete' => TRUE,
+        'tone' => 'success',
       ];
     }
     $errors = [];
@@ -221,11 +223,21 @@ final class EventStudioWorkspacePresentation {
       $errors[] = [
         'label' => rtrim((string) $label, '.'),
         'complete' => FALSE,
+        'tone' => 'attention',
       ];
     }
-    // Reserve space for all blockers; only soft-cap completed rows.
-    $completed_room = max(0, 8 - count($errors));
-    return array_merge(array_slice($completed, 0, $completed_room), $errors);
+    $warnings = [];
+    foreach ($result->warnings as $label) {
+      $warnings[] = [
+        'label' => rtrim((string) $label, '.'),
+        'complete' => FALSE,
+        'tone' => 'warning',
+      ];
+    }
+    // Reserve space for all blockers + warnings; only soft-cap completed rows.
+    $outstanding = array_merge($errors, $warnings);
+    $completed_room = max(0, 8 - count($outstanding));
+    return array_merge(array_slice($completed, 0, $completed_room), $outstanding);
   }
 
   private function humanChecklistLabel(string $label): string {

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWorkspacePresentation.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWorkspacePresentation.php
@@ -60,7 +60,10 @@ final class EventStudioWorkspacePresentation {
       'show_publish_strip' => $this->shouldShowPublishStrip($result, $published),
       'strip_title' => $this->readinessStripTitle($result, $published),
       'strip_explanation' => $this->readinessStripExplanation($result),
-      'checklist' => $this->buildHumanChecklist($result),
+      'checklist' => $this->buildHumanChecklist(
+        $result,
+        is_array($readiness_bundle['recommended'] ?? NULL) ? $readiness_bundle['recommended'] : [],
+      ),
     ];
   }
 
@@ -154,7 +157,10 @@ final class EventStudioWorkspacePresentation {
       'show_publish_strip' => $this->shouldShowPublishStrip($result, $published),
       'strip_title' => $this->readinessStripTitle($result, $published),
       'strip_explanation' => $this->readinessStripExplanation($result),
-      'checklist' => $this->buildHumanChecklist($result),
+      'checklist' => $this->buildHumanChecklist(
+        $result,
+        is_array($readiness_bundle['recommended'] ?? NULL) ? $readiness_bundle['recommended'] : [],
+      ),
       'show_homepage_readiness' => $this->shouldShowHomepageReadinessCard(
         (bool) ($readiness_bundle['promotion_ready'] ?? FALSE),
         $published,
@@ -201,15 +207,18 @@ final class EventStudioWorkspacePresentation {
   }
 
   /**
-   * Builds the strip checklist, always including every blocking error and warning.
+   * Builds the strip checklist, always including blockers, warnings, and ideas.
    *
-   * Completed rows fill remaining slots up to eight total. Blocking errors and
-   * warnings are never truncated — checklist mode replaces the count row, so
-   * warnings must remain visible alongside blockers.
+   * Completed rows fill remaining slots up to eight total. Blocking errors,
+   * warnings, and optional recommendations are never truncated — checklist
+   * mode replaces the count row, so idea counts must remain visible too.
+   *
+   * @param list<string> $recommendations
+   *   Idea labels from the readiness facade bundle (publish + promotion).
    *
    * @return list<array{label: string, complete: bool, tone: string}>
    */
-  private function buildHumanChecklist(EventReadinessResult $result): array {
+  private function buildHumanChecklist(EventReadinessResult $result, array $recommendations = []): array {
     $completed = [];
     foreach ($result->completed as $label) {
       $completed[] = [
@@ -234,8 +243,17 @@ final class EventStudioWorkspacePresentation {
         'tone' => 'warning',
       ];
     }
-    // Reserve space for all blockers + warnings; only soft-cap completed rows.
-    $outstanding = array_merge($errors, $warnings);
+    // Facade-merged recommendations so checklist matches count-mode ideas.
+    $ideas = [];
+    foreach ($recommendations as $label) {
+      $ideas[] = [
+        'label' => rtrim((string) $label, '.'),
+        'complete' => FALSE,
+        'tone' => 'idea',
+      ];
+    }
+    // Reserve space for all blockers + warnings + ideas; soft-cap completed.
+    $outstanding = array_merge($errors, $warnings, $ideas);
     $completed_room = max(0, 8 - count($outstanding));
     return array_merge(array_slice($completed, 0, $completed_room), $outstanding);
   }

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWorkspacePresentation.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWorkspacePresentation.php
@@ -59,6 +59,8 @@ final class EventStudioWorkspacePresentation {
       'published' => $published,
       'show_publish_strip' => $this->shouldShowPublishStrip($result, $published),
       'strip_title' => $this->readinessStripTitle($result, $published),
+      'strip_explanation' => $this->readinessStripExplanation($result),
+      'checklist' => $this->buildHumanChecklist($result),
     ];
   }
 
@@ -151,6 +153,8 @@ final class EventStudioWorkspacePresentation {
       'published' => $published,
       'show_publish_strip' => $this->shouldShowPublishStrip($result, $published),
       'strip_title' => $this->readinessStripTitle($result, $published),
+      'strip_explanation' => $this->readinessStripExplanation($result),
+      'checklist' => $this->buildHumanChecklist($result),
       'show_homepage_readiness' => $this->shouldShowHomepageReadinessCard(
         (bool) ($readiness_bundle['promotion_ready'] ?? FALSE),
         $published,
@@ -167,12 +171,64 @@ final class EventStudioWorkspacePresentation {
 
   public function readinessStripTitle(EventReadinessResult $result, bool $published): string {
     if (!$result->ready) {
-      return (string) $this->t('Needs attention');
+      if (count($result->errors) === 1) {
+        return (string) $this->t("You're almost there…");
+      }
+      return (string) $this->t('A few things left before publishing');
     }
     if ($published) {
       return (string) $this->t('Published and ready');
     }
     return (string) $this->t('Ready to publish');
+  }
+
+  public function readinessStripExplanation(EventReadinessResult $result): string {
+    if ($result->ready) {
+      return (string) $this->t('Everything needed to go live looks good.');
+    }
+    if (count($result->errors) === 1) {
+      return (string) $this->t('One more thing before publishing: @reason', [
+        '@reason' => $result->errors[0],
+      ]);
+    }
+    if ($result->errors !== []) {
+      return (string) $this->t('Finish the items below so guests can find and book your event.');
+    }
+    return (string) $this->t('Review the suggestions below to make your event page stronger.');
+  }
+
+  /**
+   * @return list<array{label: string, complete: bool}>
+   */
+  private function buildHumanChecklist(EventReadinessResult $result): array {
+    $items = [];
+    foreach ($result->completed as $label) {
+      $items[] = [
+        'label' => $this->humanChecklistLabel((string) $label),
+        'complete' => TRUE,
+      ];
+    }
+    foreach ($result->errors as $label) {
+      $items[] = [
+        'label' => rtrim((string) $label, '.'),
+        'complete' => FALSE,
+      ];
+    }
+    return array_slice($items, 0, 8);
+  }
+
+  private function humanChecklistLabel(string $label): string {
+    return match ($label) {
+      'Event title added.', 'Event title' => (string) $this->t('Event title'),
+      'Event dates complete.', 'Schedule' => (string) $this->t('Schedule'),
+      'Booking mode selected.', 'Ticketing configured.', 'Tickets ready' => (string) $this->t('Tickets ready'),
+      'Payment onboarding complete.', 'Payments connected' => (string) $this->t('Payments connected'),
+      'Vendor publish requirements complete.', 'Organiser profile ready' => (string) $this->t('Organiser profile ready'),
+      'Branding image added.', 'Cover image' => (string) $this->t('Cover image'),
+      'Capacity settings valid.', 'Capacity' => (string) $this->t('Capacity'),
+      'External booking URL added.', 'External booking link' => (string) $this->t('External booking link'),
+      default => rtrim($label, '.'),
+    };
   }
 
   public function shouldShowPublishStrip(EventReadinessResult $result, bool $published): bool {

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWorkspacePresentation.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWorkspacePresentation.php
@@ -184,6 +184,9 @@ final class EventStudioWorkspacePresentation {
 
   public function readinessStripExplanation(EventReadinessResult $result): string {
     if ($result->ready) {
+      if ($result->warnings !== []) {
+        return (string) $this->t('You can publish now. Optional suggestions are still worth a quick look.');
+      }
       return (string) $this->t('Everything needed to go live looks good.');
     }
     if (count($result->errors) === 1) {
@@ -198,23 +201,31 @@ final class EventStudioWorkspacePresentation {
   }
 
   /**
+   * Builds the strip checklist, always including every blocking error.
+   *
+   * Completed rows fill remaining slots up to eight total. Blocking errors are
+   * never truncated — publish can remain blocked by items that must stay visible.
+   *
    * @return list<array{label: string, complete: bool}>
    */
   private function buildHumanChecklist(EventReadinessResult $result): array {
-    $items = [];
+    $completed = [];
     foreach ($result->completed as $label) {
-      $items[] = [
+      $completed[] = [
         'label' => $this->humanChecklistLabel((string) $label),
         'complete' => TRUE,
       ];
     }
+    $errors = [];
     foreach ($result->errors as $label) {
-      $items[] = [
+      $errors[] = [
         'label' => rtrim((string) $label, '.'),
         'complete' => FALSE,
       ];
     }
-    return array_slice($items, 0, 8);
+    // Reserve space for all blockers; only soft-cap completed rows.
+    $completed_room = max(0, 8 - count($errors));
+    return array_merge(array_slice($completed, 0, $completed_room), $errors);
   }
 
   private function humanChecklistLabel(string $label): string {

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventWorkspaceOverviewBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventWorkspaceOverviewBuilder.php
@@ -66,7 +66,7 @@ final class EventWorkspaceOverviewBuilder {
       $readiness->recommendations,
     );
 
-    $stripe = $this->buildStripeHealth($account, $nid);
+    $stripe = $this->buildStripeHealth($account, $event, $eventMeta);
     $remaining = count($readiness->errors);
     $nextRecommended = $this->resolveNextRecommendedAction($next, $readiness, $published, $nid);
 
@@ -145,7 +145,7 @@ final class EventWorkspaceOverviewBuilder {
     $map = [
       'Event title added' => (string) $this->t('Event title'),
       'Event dates complete' => (string) $this->t('Schedule'),
-      'Booking mode selected' => (string) $this->t('Tickets ready'),
+      'Booking mode selected' => (string) $this->t('Booking mode'),
       'Ticketing configured' => (string) $this->t('Tickets ready'),
       'Payment onboarding complete' => (string) $this->t('Payments connected'),
       'Vendor publish requirements complete' => (string) $this->t('Organiser profile ready'),
@@ -193,10 +193,26 @@ final class EventWorkspaceOverviewBuilder {
   /**
    * Builds Stripe / payments health for Overview.
    *
+   * Paid-ticket Stripe checks only run for paid / hybrid events.
+   *
+   * @param array<string, mixed> $eventMeta
+   *   Workspace event metadata (may include event_type).
+   *
    * @return array{label: string, tone: string, detail: string, url: ?string}
    *   Payments status card payload.
    */
-  private function buildStripeHealth(AccountInterface $account, int $eventId): array {
+  private function buildStripeHealth(AccountInterface $account, NodeInterface $event, array $eventMeta): array {
+    $eventId = (int) $event->id();
+    $eventType = $this->resolveEventBookingType($event, $eventMeta);
+    if (!in_array($eventType, ['paid', 'both'], TRUE)) {
+      return [
+        'label' => (string) $this->t('Payments'),
+        'tone' => 'muted',
+        'detail' => (string) $this->t('Payments apply when you sell paid tickets for this event.'),
+        'url' => $this->safeUrl('myeventlane_vendor.payouts'),
+      ];
+    }
+
     try {
       $denial = $this->stripeGate->validatePaidPublishAllowed($account, $eventId);
     }
@@ -228,6 +244,23 @@ final class EventWorkspaceOverviewBuilder {
       'detail' => $denial,
       'url' => $this->safeUrl('myeventlane_vendor.payouts'),
     ];
+  }
+
+  /**
+   * Resolves booking mode for Overview payments gating.
+   *
+   * @param array<string, mixed> $eventMeta
+   *   Workspace event metadata.
+   */
+  private function resolveEventBookingType(NodeInterface $event, array $eventMeta): string {
+    $fromMeta = trim((string) ($eventMeta['event_type'] ?? ''));
+    if (in_array($fromMeta, ['paid', 'rsvp', 'both', 'external', 'unknown'], TRUE)) {
+      return $fromMeta === 'unknown' ? '' : $fromMeta;
+    }
+    if ($event->hasField('field_event_type') && !$event->get('field_event_type')->isEmpty()) {
+      return (string) $event->get('field_event_type')->value;
+    }
+    return '';
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventWorkspaceOverviewBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventWorkspaceOverviewBuilder.php
@@ -338,6 +338,10 @@ final class EventWorkspaceOverviewBuilder {
   /**
    * Resolves the primary next action for Overview.
    *
+   * Prefers Workspace readiness/publishing CTAs over generic mission-control
+   * placeholders such as "Finish and publish your event" or "Event looks ready".
+   * Concrete operational actions (unknown event type, manage bookings) still win.
+   *
    * @param array<string, mixed> $next
    *   Workspace next-action payload.
    * @param \Drupal\myeventlane_event_studio\DTO\EventReadinessResult $readiness
@@ -351,9 +355,13 @@ final class EventWorkspaceOverviewBuilder {
    *   Next-action card payload.
    */
   private function resolveNextRecommendedAction(array $next, EventReadinessResult $readiness, bool $published, int $nid): array {
-    if (!empty($next['title'])) {
+    $title = trim((string) ($next['title'] ?? ''));
+    $severity = (string) ($next['severity'] ?? '');
+
+    // Keep hard blockers and live booking activity from mission-control.
+    if ($title !== '' && ($severity === 'error' || ($published && $severity === 'info'))) {
       return [
-        'title' => (string) $next['title'],
+        'title' => $title,
         'message' => (string) ($next['message'] ?? ''),
         'action_label' => isset($next['action_label']) ? (string) $next['action_label'] : NULL,
         'url' => isset($next['url']) && $next['url'] instanceof Url
@@ -361,6 +369,7 @@ final class EventWorkspaceOverviewBuilder {
           : (isset($next['url']) ? (string) $next['url'] : NULL),
       ];
     }
+
     if (!$readiness->ready) {
       return [
         'title' => (string) $this->t('Continue setup'),

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventWorkspaceOverviewBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventWorkspaceOverviewBuilder.php
@@ -26,7 +26,7 @@ final class EventWorkspaceOverviewBuilder {
   public function __construct(
     private readonly VendorEventWorkspaceViewModelBuilder $workspaceViewModel,
     private readonly PaidPublishStripeGate $stripeGate,
-    private readonly EventReadinessService $eventReadiness,
+    private readonly EventReadinessFacade $readinessFacade,
     private readonly LoggerInterface $logger,
     TranslationInterface $stringTranslation,
   ) {
@@ -51,7 +51,10 @@ final class EventWorkspaceOverviewBuilder {
       $workspace = [];
     }
 
-    $readiness = $this->eventReadiness->evaluate($event, $account);
+    // Same facade bundle as the workspace readiness strip so idea rows match.
+    $bundle = $this->readinessFacade->evaluate($event, $account);
+    $readiness = $bundle['publish'];
+    $recommended = is_array($bundle['recommended'] ?? NULL) ? $bundle['recommended'] : [];
     $nid = (int) $event->id();
     $published = $event->isPublished();
 
@@ -63,7 +66,7 @@ final class EventWorkspaceOverviewBuilder {
       $readiness->completed,
       $readiness->errors,
       $readiness->warnings,
-      $readiness->recommendations,
+      $recommended,
     );
 
     $stripe = $this->buildStripeHealth($account, $event, $eventMeta);
@@ -421,10 +424,10 @@ final class EventWorkspaceOverviewBuilder {
   /**
    * Optional subtle celebration for early draft progress.
    *
-   * @return array{show: bool, title: string, message: string}|null
-   *   Celebration payload, or NULL when not shown.
+   * @return array{show: bool, title: string, message: string}
+   *   Celebration payload. show is FALSE when nothing should render.
    */
-  private function buildCelebrationHint(NodeInterface $event, EventReadinessResult $readiness, bool $published): ?array {
+  private function buildCelebrationHint(NodeInterface $event, EventReadinessResult $readiness, bool $published): array {
     $title = trim($event->label());
     if ($title !== '' && strcasecmp($title, 'Untitled event') !== 0 && !$published && $readiness->completed !== []) {
       if (count($readiness->completed) === 1) {
@@ -435,7 +438,11 @@ final class EventWorkspaceOverviewBuilder {
         ];
       }
     }
-    return NULL;
+    return [
+      'show' => FALSE,
+      'title' => '',
+      'message' => '',
+    ];
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventWorkspaceOverviewBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventWorkspaceOverviewBuilder.php
@@ -99,6 +99,10 @@ final class EventWorkspaceOverviewBuilder {
   /**
    * Builds a human checklist from readiness strings.
    *
+   * Blocking errors use tone "attention". Warnings are non-blocking
+   * (EventReadinessResult::ready can still be TRUE) and use tone "warning"
+   * so they are not presented as publish blockers.
+   *
    * @param list<string> $completed
    *   Completed readiness labels.
    * @param list<string> $errors
@@ -120,11 +124,18 @@ final class EventWorkspaceOverviewBuilder {
         'tone' => 'success',
       ];
     }
-    foreach (array_merge($errors, $warnings) as $label) {
+    foreach ($errors as $label) {
       $items[] = [
         'label' => $this->humaniseChecklistLabel((string) $label),
         'complete' => FALSE,
         'tone' => 'attention',
+      ];
+    }
+    foreach ($warnings as $label) {
+      $items[] = [
+        'label' => $this->humaniseChecklistLabel((string) $label),
+        'complete' => FALSE,
+        'tone' => 'warning',
       ];
     }
     foreach ($recommendations as $label) {
@@ -177,6 +188,9 @@ final class EventWorkspaceOverviewBuilder {
    */
   private function readinessExplanation(EventReadinessResult $readiness): string {
     if ($readiness->ready) {
+      if ($readiness->warnings !== []) {
+        return (string) $this->t('You can publish now. The items marked for review are optional improvements.');
+      }
       return (string) $this->t('Everything needed to go live looks good.');
     }
     if (count($readiness->errors) === 1) {

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventWorkspaceOverviewBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventWorkspaceOverviewBuilder.php
@@ -1,0 +1,430 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Service;
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\Url;
+use Drupal\myeventlane_event_studio\DTO\EventReadinessResult;
+use Drupal\myeventlane_vendor\Service\PaidPublishStripeGate;
+use Drupal\myeventlane_vendor\Service\VendorEventWorkspaceViewModelBuilder;
+use Drupal\node\NodeInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Builds the Event Workspace Overview (organiser home).
+ *
+ * Reuses Workspace mission-control signals without a second product shell.
+ */
+final class EventWorkspaceOverviewBuilder {
+
+  use StringTranslationTrait;
+
+  public function __construct(
+    private readonly VendorEventWorkspaceViewModelBuilder $workspaceViewModel,
+    private readonly PaidPublishStripeGate $stripeGate,
+    private readonly EventReadinessService $eventReadiness,
+    private readonly LoggerInterface $logger,
+    TranslationInterface $stringTranslation,
+  ) {
+    $this->stringTranslation = $stringTranslation;
+  }
+
+  /**
+   * Builds the Overview render array for one event.
+   *
+   * @return array<string, mixed>
+   *   Themeable render array.
+   */
+  public function build(NodeInterface $event, AccountInterface $account): array {
+    try {
+      $workspace = $this->workspaceViewModel->build($event, $account);
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('Event Workspace overview model failed for event @nid: @message', [
+        '@nid' => (string) $event->id(),
+        '@message' => $e->getMessage(),
+      ]);
+      $workspace = [];
+    }
+
+    $readiness = $this->eventReadiness->evaluate($event, $account);
+    $nid = (int) $event->id();
+    $published = $event->isPublished();
+
+    $next = is_array($workspace['next_action'] ?? NULL) ? $workspace['next_action'] : [];
+    $focus = is_array($workspace['todays_focus'] ?? NULL) ? $workspace['todays_focus'] : [];
+    $sales = is_array($workspace['sales_snapshot'] ?? NULL) ? $workspace['sales_snapshot'] : [];
+    $eventMeta = is_array($workspace['event'] ?? NULL) ? $workspace['event'] : [];
+    $humanChecklist = $this->buildHumanChecklist(
+      $readiness->completed,
+      $readiness->errors,
+      $readiness->warnings,
+      $readiness->recommendations,
+    );
+
+    $stripe = $this->buildStripeHealth($account, $nid);
+    $remaining = count($readiness->errors);
+    $nextRecommended = $this->resolveNextRecommendedAction($next, $readiness, $published, $nid);
+
+    return [
+      '#theme' => 'mel_event_studio_overview',
+      '#status' => [
+        'label' => (string) ($eventMeta['status_label'] ?? ($published ? $this->t('Live') : $this->t('Draft'))),
+        'key' => (string) ($eventMeta['status'] ?? ($published ? 'live' : 'draft')),
+      ],
+      '#readiness' => [
+        'ready' => $readiness->ready,
+        'score' => (int) ($workspace['readiness']['score'] ?? 0),
+        'items' => $humanChecklist,
+        'headline' => $this->readinessHeadline($readiness->ready, $published, $remaining),
+        'explanation' => $this->readinessExplanation($readiness),
+      ],
+      '#todays_tasks' => $focus,
+      '#sales' => $sales,
+      '#ticket_summary' => $this->metricFromSales($sales, 'tickets'),
+      '#attendee_summary' => $this->metricFromSales($sales, 'attendees'),
+      '#stripe' => $stripe,
+      '#marketing' => $this->buildMarketingStatus($event, $account),
+      '#analytics' => $this->buildAnalyticsSnapshot($workspace),
+      '#next_action' => $nextRecommended,
+      '#quick_links' => $this->buildQuickLinks($nid, $account),
+      '#celebration' => $this->buildCelebrationHint($event, $readiness, $published),
+    ];
+  }
+
+  /**
+   * Builds a human checklist from readiness strings.
+   *
+   * @param list<string> $completed
+   *   Completed readiness labels.
+   * @param list<string> $errors
+   *   Blocking readiness labels.
+   * @param list<string> $warnings
+   *   Warning readiness labels.
+   * @param list<string> $recommendations
+   *   Optional recommendation labels.
+   *
+   * @return list<array{label: string, complete: bool, tone: string}>
+   *   Checklist rows for Overview.
+   */
+  private function buildHumanChecklist(array $completed, array $errors, array $warnings, array $recommendations): array {
+    $items = [];
+    foreach ($completed as $label) {
+      $items[] = [
+        'label' => $this->humaniseChecklistLabel((string) $label),
+        'complete' => TRUE,
+        'tone' => 'success',
+      ];
+    }
+    foreach (array_merge($errors, $warnings) as $label) {
+      $items[] = [
+        'label' => $this->humaniseChecklistLabel((string) $label),
+        'complete' => FALSE,
+        'tone' => 'attention',
+      ];
+    }
+    foreach ($recommendations as $label) {
+      $items[] = [
+        'label' => $this->humaniseChecklistLabel((string) $label),
+        'complete' => FALSE,
+        'tone' => 'idea',
+      ];
+    }
+    return $items;
+  }
+
+  /**
+   * Maps technical readiness copy to short organiser labels.
+   */
+  private function humaniseChecklistLabel(string $label): string {
+    $trimmed = rtrim($label, '.');
+    $map = [
+      'Event title added' => (string) $this->t('Event title'),
+      'Event dates complete' => (string) $this->t('Schedule'),
+      'Booking mode selected' => (string) $this->t('Tickets ready'),
+      'Ticketing configured' => (string) $this->t('Tickets ready'),
+      'Payment onboarding complete' => (string) $this->t('Payments connected'),
+      'Vendor publish requirements complete' => (string) $this->t('Organiser profile ready'),
+      'Branding image added' => (string) $this->t('Cover image'),
+      'Capacity settings valid' => (string) $this->t('Capacity'),
+      'External booking URL added' => (string) $this->t('External booking link'),
+    ];
+    return $map[$trimmed] ?? $trimmed;
+  }
+
+  /**
+   * Builds the readiness headline for Overview.
+   */
+  private function readinessHeadline(bool $ready, bool $published, int $remaining): string {
+    if ($published && $ready) {
+      return (string) $this->t('Your event is live');
+    }
+    if ($ready) {
+      return (string) $this->t('Ready to publish');
+    }
+    if ($remaining === 1) {
+      return (string) $this->t("You're almost there…");
+    }
+    return (string) $this->t('A few things left before publishing');
+  }
+
+  /**
+   * Explains why publishing is ready or blocked.
+   */
+  private function readinessExplanation(EventReadinessResult $readiness): string {
+    if ($readiness->ready) {
+      return (string) $this->t('Everything needed to go live looks good.');
+    }
+    if (count($readiness->errors) === 1) {
+      return (string) $this->t('One more thing before publishing: @reason', [
+        '@reason' => $readiness->errors[0],
+      ]);
+    }
+    if ($readiness->errors !== []) {
+      return (string) $this->t('Finish the items below so guests can find and book your event.');
+    }
+    return (string) $this->t('Review the suggestions below to make your event page stronger.');
+  }
+
+  /**
+   * Builds Stripe / payments health for Overview.
+   *
+   * @return array{label: string, tone: string, detail: string, url: ?string}
+   *   Payments status card payload.
+   */
+  private function buildStripeHealth(AccountInterface $account, int $eventId): array {
+    try {
+      $denial = $this->stripeGate->validatePaidPublishAllowed($account, $eventId);
+    }
+    catch (\Throwable $e) {
+      $this->logger->warning('Stripe health check failed for overview event @nid: @message', [
+        '@nid' => (string) $eventId,
+        '@message' => $e->getMessage(),
+      ]);
+      return [
+        'label' => (string) $this->t('Payments'),
+        'tone' => 'attention',
+        'detail' => (string) $this->t('We could not confirm Stripe just now.'),
+        'url' => $this->safeUrl('myeventlane_vendor.payouts'),
+      ];
+    }
+
+    if ($denial === NULL) {
+      return [
+        'label' => (string) $this->t('Payments'),
+        'tone' => 'success',
+        'detail' => (string) $this->t("Stripe connected — you're ready to get paid."),
+        'url' => $this->safeUrl('myeventlane_vendor.payouts'),
+      ];
+    }
+
+    return [
+      'label' => (string) $this->t('Payments'),
+      'tone' => 'attention',
+      'detail' => $denial,
+      'url' => $this->safeUrl('myeventlane_vendor.payouts'),
+    ];
+  }
+
+  /**
+   * Builds marketing status for Overview.
+   *
+   * @return array{label: string, detail: string, url: ?string}
+   *   Marketing card payload.
+   */
+  private function buildMarketingStatus(NodeInterface $event, AccountInterface $account): array {
+    $nid = (int) $event->id();
+    $boostUrl = $this->safeUrl('myeventlane_boost.vendor_event_boost', ['event' => $nid]);
+    if (!$event->isPublished()) {
+      return [
+        'label' => (string) $this->t('Marketing'),
+        'detail' => (string) $this->t('Publish your event to share and Boost it.'),
+        'url' => $this->safeUrl('myeventlane_event_studio.workspace_publishing', ['node' => $nid]),
+      ];
+    }
+    return [
+      'label' => (string) $this->t('Marketing'),
+      'detail' => (string) $this->t('Share your page or Boost to reach more people.'),
+      'url' => $boostUrl ?? $this->safeUrl('myeventlane_event_studio.workspace_marketing', ['node' => $nid]),
+    ];
+  }
+
+  /**
+   * Builds a short analytics snapshot from workspace metrics.
+   *
+   * @param array<string, mixed> $workspace
+   *   Workspace view model.
+   *
+   * @return array{label: string, detail: string, url: ?string}
+   *   Analytics card payload.
+   */
+  private function buildAnalyticsSnapshot(array $workspace): array {
+    $metrics = is_array($workspace['metrics'] ?? NULL) ? $workspace['metrics'] : [];
+    $parts = [];
+    foreach ($metrics as $metric) {
+      if (!is_array($metric)) {
+        continue;
+      }
+      $label = trim((string) ($metric['label'] ?? ''));
+      $value = trim((string) ($metric['value'] ?? ''));
+      if ($label !== '' && $value !== '') {
+        $parts[] = $label . ': ' . $value;
+      }
+      if (count($parts) >= 2) {
+        break;
+      }
+    }
+    $nid = (int) ($workspace['event']['nid'] ?? 0);
+    return [
+      'label' => (string) $this->t('Analytics'),
+      'detail' => $parts !== []
+        ? implode(' · ', $parts)
+        : (string) $this->t('Publish your event to start tracking sales.'),
+      'url' => $nid > 0 ? $this->safeUrl('myeventlane_event_studio.workspace_analytics', ['node' => $nid]) : NULL,
+    ];
+  }
+
+  /**
+   * Resolves the primary next action for Overview.
+   *
+   * @param array<string, mixed> $next
+   *   Workspace next-action payload.
+   * @param \Drupal\myeventlane_event_studio\DTO\EventReadinessResult $readiness
+   *   Publish readiness result.
+   * @param bool $published
+   *   Whether the event is published.
+   * @param int $nid
+   *   Event node id.
+   *
+   * @return array{title: string, message: string, action_label: ?string, url: ?string}
+   *   Next-action card payload.
+   */
+  private function resolveNextRecommendedAction(array $next, EventReadinessResult $readiness, bool $published, int $nid): array {
+    if (!empty($next['title'])) {
+      return [
+        'title' => (string) $next['title'],
+        'message' => (string) ($next['message'] ?? ''),
+        'action_label' => isset($next['action_label']) ? (string) $next['action_label'] : NULL,
+        'url' => isset($next['url']) && $next['url'] instanceof Url
+          ? $next['url']->toString()
+          : (isset($next['url']) ? (string) $next['url'] : NULL),
+      ];
+    }
+    if (!$readiness->ready) {
+      return [
+        'title' => (string) $this->t('Continue setup'),
+        'message' => $readiness->errors[0] ?? (string) $this->t('Finish the readiness checklist so you can publish.'),
+        'action_label' => (string) $this->t('Review publishing'),
+        'url' => $this->safeUrl('myeventlane_event_studio.workspace_publishing', ['node' => $nid]),
+      ];
+    }
+    if (!$published) {
+      return [
+        'title' => (string) $this->t('Ready when you are'),
+        'message' => (string) $this->t('Your event looks ready. Publish when you want guests to find it.'),
+        'action_label' => (string) $this->t('Go to publishing'),
+        'url' => $this->safeUrl('myeventlane_event_studio.workspace_publishing', ['node' => $nid]),
+      ];
+    }
+    return [
+      'title' => (string) $this->t('Share your event'),
+      'message' => (string) $this->t('Your event is live. Share the page or message your attendees.'),
+      'action_label' => (string) $this->t('Open marketing'),
+      'url' => $this->safeUrl('myeventlane_event_studio.workspace_marketing', ['node' => $nid]),
+    ];
+  }
+
+  /**
+   * Builds Overview quick links.
+   *
+   * @return list<array{label: string, url: string}>
+   *   Quick-link rows.
+   */
+  private function buildQuickLinks(int $nid, AccountInterface $account): array {
+    $links = [];
+    $map = [
+      [(string) $this->t('Tickets'), 'myeventlane_event_studio.workspace_tickets', ['node' => $nid]],
+      [(string) $this->t('Attendees'), 'myeventlane_event_studio.workspace_attendees', ['node' => $nid]],
+      [(string) $this->t('Messages'), 'myeventlane_event_studio.workspace_messaging', ['node' => $nid]],
+      [(string) $this->t('Orders'), 'myeventlane_event_studio.workspace_orders', ['node' => $nid]],
+      [(string) $this->t('Analytics'), 'myeventlane_event_studio.workspace_analytics', ['node' => $nid]],
+    ];
+    foreach ($map as [$label, $route, $params]) {
+      $url = $this->safeUrl($route, $params);
+      if ($url !== NULL) {
+        $links[] = ['label' => $label, 'url' => $url];
+      }
+    }
+    return $links;
+  }
+
+  /**
+   * Optional subtle celebration for early draft progress.
+   *
+   * @return array{show: bool, title: string, message: string}|null
+   *   Celebration payload, or NULL when not shown.
+   */
+  private function buildCelebrationHint(NodeInterface $event, EventReadinessResult $readiness, bool $published): ?array {
+    $title = trim($event->label());
+    if ($title !== '' && strcasecmp($title, 'Untitled event') !== 0 && !$published && $readiness->completed !== []) {
+      if (count($readiness->completed) === 1) {
+        return [
+          'show' => TRUE,
+          'title' => (string) $this->t('Nice start'),
+          'message' => (string) $this->t("Your first draft is underway. Keep going — you're building something people will love."),
+        ];
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * Extracts a preferred metric string from the sales snapshot.
+   *
+   * @param array<string, mixed> $sales
+   *   Sales snapshot payload.
+   * @param string $prefer
+   *   Preference key: tickets or attendees.
+   *
+   * @return string
+   *   Metric value or empty string.
+   */
+  private function metricFromSales(array $sales, string $prefer): string {
+    $metrics = is_array($sales['metrics'] ?? NULL) ? $sales['metrics'] : [];
+    foreach ($metrics as $metric) {
+      if (!is_array($metric)) {
+        continue;
+      }
+      $label = strtolower((string) ($metric['label'] ?? ''));
+      if ($prefer === 'tickets' && str_contains($label, 'ticket')) {
+        return trim((string) ($metric['value'] ?? ''));
+      }
+      if ($prefer === 'attendees' && (str_contains($label, 'rsvp') || str_contains($label, 'attendee') || str_contains($label, 'check'))) {
+        return trim((string) ($metric['value'] ?? ''));
+      }
+    }
+    return '';
+  }
+
+  /**
+   * Builds a route URL string when the route exists.
+   *
+   * @param string $route
+   *   Route name.
+   * @param array<string, mixed> $params
+   *   Route parameters.
+   */
+  private function safeUrl(string $route, array $params = []): ?string {
+    try {
+      return Url::fromRoute($route, $params)->toString();
+    }
+    catch (\Throwable) {
+      return NULL;
+    }
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-empty-state.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-empty-state.html.twig
@@ -24,5 +24,11 @@
         {% endfor %}
       </ul>
     {% endif %}
+
+    {% if actions %}
+      <div class="mel-event-studio-empty-state__actions">
+        {{ actions }}
+      </div>
+    {% endif %}
   </div>
 </div>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-overview.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-overview.html.twig
@@ -10,10 +10,10 @@
     <p class="mel-event-workspace-overview__lede">{{ "Here's where you are with this event — and what to do next."|t }}</p>
   </header>
 
-  {% if celebration.show|default(false) %}
+  {% if celebration is iterable and celebration.show|default(false) %}
     <div class="mel-event-workspace-overview__celebrate" role="status">
-      <p class="mel-event-workspace-overview__celebrate-title">{{ celebration.title }}</p>
-      <p class="mel-event-workspace-overview__celebrate-message">{{ celebration.message }}</p>
+      <p class="mel-event-workspace-overview__celebrate-title">{{ celebration.title|default('') }}</p>
+      <p class="mel-event-workspace-overview__celebrate-message">{{ celebration.message|default('') }}</p>
     </div>
   {% endif %}
 

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-overview.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-overview.html.twig
@@ -37,8 +37,18 @@
       <ul class="mel-event-workspace-overview__checklist">
         {% for item in readiness.items %}
           <li class="mel-event-workspace-overview__check mel-event-workspace-overview__check--{{ item.tone|clean_class }}">
-            <span class="mel-event-workspace-overview__check-mark" aria-hidden="true">{{ item.complete ? '✔' : '○' }}</span>
-            <span class="visually-hidden">{{ item.complete ? 'Complete:'|t : 'Outstanding:'|t }}</span>
+            <span class="mel-event-workspace-overview__check-mark" aria-hidden="true">{{ item.complete ? '✔' : (item.tone == 'warning' or item.tone == 'idea' ? '◇' : '○') }}</span>
+            <span class="visually-hidden">
+              {% if item.complete %}
+                {{ 'Complete:'|t }}
+              {% elseif item.tone == 'warning' %}
+                {{ 'Suggested review:'|t }}
+              {% elseif item.tone == 'idea' %}
+                {{ 'Idea:'|t }}
+              {% else %}
+                {{ 'Required before publishing:'|t }}
+              {% endif %}
+            </span>
             {{ item.label }}
           </li>
         {% endfor %}

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-overview.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-overview.html.twig
@@ -1,0 +1,120 @@
+{#
+/**
+ * @file
+ * Event Workspace Overview — organiser home for one event.
+ */
+#}
+<section class="mel-event-workspace-overview" aria-labelledby="mel-workspace-overview-heading">
+  <header class="mel-event-workspace-overview__header">
+    <h2 id="mel-workspace-overview-heading" class="mel-event-workspace-overview__title">{{ 'Overview'|t }}</h2>
+    <p class="mel-event-workspace-overview__lede">{{ "Here's where you are with this event — and what to do next."|t }}</p>
+  </header>
+
+  {% if celebration.show|default(false) %}
+    <div class="mel-event-workspace-overview__celebrate" role="status">
+      <p class="mel-event-workspace-overview__celebrate-title">{{ celebration.title }}</p>
+      <p class="mel-event-workspace-overview__celebrate-message">{{ celebration.message }}</p>
+    </div>
+  {% endif %}
+
+  {% if next_action %}
+    <section class="mel-event-workspace-overview__next" aria-labelledby="mel-workspace-next-heading">
+      <h3 id="mel-workspace-next-heading" class="mel-event-workspace-overview__section-title">{{ 'What to do next'|t }}</h3>
+      <p class="mel-event-workspace-overview__next-title">{{ next_action.title }}</p>
+      {% if next_action.message %}
+        <p class="mel-event-workspace-overview__next-message">{{ next_action.message }}</p>
+      {% endif %}
+      {% if next_action.url and next_action.action_label %}
+        <a class="mel-btn mel-btn--primary" href="{{ next_action.url }}">{{ next_action.action_label }}</a>
+      {% endif %}
+    </section>
+  {% endif %}
+
+  <section class="mel-event-workspace-overview__readiness" aria-labelledby="mel-workspace-readiness-heading">
+    <h3 id="mel-workspace-readiness-heading" class="mel-event-workspace-overview__section-title">{{ readiness.headline }}</h3>
+    <p class="mel-event-workspace-overview__readiness-explain">{{ readiness.explanation }}</p>
+    {% if readiness.items %}
+      <ul class="mel-event-workspace-overview__checklist">
+        {% for item in readiness.items %}
+          <li class="mel-event-workspace-overview__check mel-event-workspace-overview__check--{{ item.tone|clean_class }}">
+            <span class="mel-event-workspace-overview__check-mark" aria-hidden="true">{{ item.complete ? '✔' : '○' }}</span>
+            <span class="visually-hidden">{{ item.complete ? 'Complete:'|t : 'Outstanding:'|t }}</span>
+            {{ item.label }}
+          </li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+  </section>
+
+  {% if todays_tasks.message|default('') %}
+    <section class="mel-event-workspace-overview__focus" aria-labelledby="mel-workspace-focus-heading">
+      <h3 id="mel-workspace-focus-heading" class="mel-event-workspace-overview__section-title">{{ "Today's tasks"|t }}</h3>
+      <p>{{ todays_tasks.message }}</p>
+    </section>
+  {% endif %}
+
+  <div class="mel-event-workspace-overview__grid">
+    <section class="mel-event-workspace-overview__card" aria-labelledby="mel-workspace-status-heading">
+      <h3 id="mel-workspace-status-heading" class="mel-event-workspace-overview__card-title">{{ 'Status'|t }}</h3>
+      <p>{{ status.label }}</p>
+    </section>
+
+    <section class="mel-event-workspace-overview__card" aria-labelledby="mel-workspace-sales-heading">
+      <h3 id="mel-workspace-sales-heading" class="mel-event-workspace-overview__card-title">{{ 'Recent sales'|t }}</h3>
+      {% if sales.metrics|default([]) %}
+        <ul class="mel-event-workspace-overview__metrics">
+          {% for metric in sales.metrics %}
+            <li><strong>{{ metric.value }}</strong> {{ metric.label }}</li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <p>{{ 'Sales will appear here after your first booking.'|t }}</p>
+      {% endif %}
+    </section>
+
+    <section class="mel-event-workspace-overview__card" aria-labelledby="mel-workspace-tickets-heading">
+      <h3 id="mel-workspace-tickets-heading" class="mel-event-workspace-overview__card-title">{{ 'Ticket summary'|t }}</h3>
+      <p>{{ ticket_summary|default('Add tickets so people can register.'|t) }}</p>
+    </section>
+
+    <section class="mel-event-workspace-overview__card" aria-labelledby="mel-workspace-attendees-heading">
+      <h3 id="mel-workspace-attendees-heading" class="mel-event-workspace-overview__card-title">{{ 'Attendee summary'|t }}</h3>
+      <p>{{ attendee_summary|default('Guests will appear here after your first booking.'|t) }}</p>
+    </section>
+
+    <section class="mel-event-workspace-overview__card" aria-labelledby="mel-workspace-stripe-heading">
+      <h3 id="mel-workspace-stripe-heading" class="mel-event-workspace-overview__card-title">{{ stripe.label }}</h3>
+      <p>{{ stripe.detail }}</p>
+      {% if stripe.url %}
+        <a class="mel-btn mel-btn--ghost" href="{{ stripe.url }}">{{ 'View payments'|t }}</a>
+      {% endif %}
+    </section>
+
+    <section class="mel-event-workspace-overview__card" aria-labelledby="mel-workspace-marketing-heading">
+      <h3 id="mel-workspace-marketing-heading" class="mel-event-workspace-overview__card-title">{{ marketing.label }}</h3>
+      <p>{{ marketing.detail }}</p>
+      {% if marketing.url %}
+        <a class="mel-btn mel-btn--ghost" href="{{ marketing.url }}">{{ 'Open marketing'|t }}</a>
+      {% endif %}
+    </section>
+
+    <section class="mel-event-workspace-overview__card" aria-labelledby="mel-workspace-analytics-heading">
+      <h3 id="mel-workspace-analytics-heading" class="mel-event-workspace-overview__card-title">{{ analytics.label }}</h3>
+      <p>{{ analytics.detail }}</p>
+      {% if analytics.url %}
+        <a class="mel-btn mel-btn--ghost" href="{{ analytics.url }}">{{ 'View analytics'|t }}</a>
+      {% endif %}
+    </section>
+  </div>
+
+  {% if quick_links %}
+    <nav class="mel-event-workspace-overview__quick" aria-label="{{ 'Quick links'|t }}">
+      <h3 class="mel-event-workspace-overview__section-title">{{ 'Jump to'|t }}</h3>
+      <ul class="mel-event-workspace-overview__quick-list">
+        {% for link in quick_links %}
+          <li><a href="{{ link.url }}">{{ link.label }}</a></li>
+        {% endfor %}
+      </ul>
+    </nav>
+  {% endif %}
+</section>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-sidebar.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-sidebar.html.twig
@@ -1,15 +1,17 @@
 {#
 /**
  * @file
- * Canonical Event Studio sidebar navigation.
+ * Event Workspace sidebar navigation.
  */
 #}
-<aside class="mel-event-studio-sidebar" id="mel-event-studio-sidebar" aria-label="{{ 'Event Studio sections'|t }}">
+<aside class="mel-event-studio-sidebar" id="mel-event-studio-sidebar" aria-label="{{ 'Event workspace'|t }}">
   <div class="mel-event-studio-sidebar__inner">
     {% for group, items in sections %}
-      <nav class="mel-event-studio-sidebar__group" aria-labelledby="mel-studio-nav-{{ loop.index }}">
-        <h2 class="mel-event-studio-sidebar__heading" id="mel-studio-nav-{{ loop.index }}">{{ group }}</h2>
-        <ul class="mel-event-studio-sidebar__list">
+      <nav class="mel-event-studio-sidebar__group" aria-label="{{ 'Event workspace sections'|t }}">
+        {% if group and group != 'Workspace' %}
+          <h2 class="mel-event-studio-sidebar__heading" id="mel-studio-nav-{{ loop.index }}">{{ group }}</h2>
+        {% endif %}
+        <ul class="mel-event-studio-sidebar__list"{% if group and group != 'Workspace' %} aria-labelledby="mel-studio-nav-{{ loop.index }}"{% endif %}>
           {% for item in items %}
             <li
               class="mel-event-studio-sidebar__item mel-event-studio-sidebar__item--{{ item.section_state|default('active')|clean_class }}"
@@ -26,8 +28,8 @@
                 {% if item.active %}aria-current="page"{% endif %}
               >
                 <span class="mel-event-studio-sidebar__label">{{ item.label }}</span>
-                {% if item.section_state is defined and item.section_state != 'active' %}
-                  <span class="mel-event-studio-sidebar__state">{{ item.section_state == 'readonly' ? 'Readonly'|t : (item.section_state == 'deferred' ? 'Planned'|t : 'Coming soon'|t) }}</span>
+                {% if item.section_state is defined and item.section_state != 'active' and item.section_state != 'readonly' %}
+                  <span class="mel-event-studio-sidebar__state">{{ item.section_state == 'deferred' ? 'Planned'|t : 'Coming soon'|t }}</span>
                 {% endif %}
               </a>
             </li>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-topbar.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-topbar.html.twig
@@ -1,12 +1,17 @@
 {#
 /**
  * @file
- * Canonical Event Studio top bar.
+ * Event Workspace top bar.
  */
 #}
 <header class="mel-event-studio-topbar" role="banner">
   <div class="mel-event-studio-topbar__primary">
-    <p class="mel-event-studio-topbar__eyebrow">{{ 'Event Studio'|t }}</p>
+    <nav class="mel-event-studio-topbar__breadcrumb" aria-label="{{ 'Event breadcrumb'|t }}">
+      <a class="mel-event-studio-topbar__breadcrumb-link" href="{{ topbar.events_url|default('/vendor/events') }}">{{ 'Events'|t }}</a>
+      <span class="mel-event-studio-topbar__breadcrumb-sep" aria-hidden="true">/</span>
+      <span class="mel-event-studio-topbar__breadcrumb-current">{{ topbar.title }}</span>
+    </nav>
+    <p class="mel-event-studio-topbar__eyebrow">{{ 'Event Workspace'|t }}</p>
     <h1 class="mel-event-studio-topbar__title">{{ topbar.title }}</h1>
     {% set location = topbar.location|default({}) %}
     <div class="mel-event-studio-topbar__location" data-mel-topbar-location role="status" aria-live="polite">
@@ -46,9 +51,9 @@
   </div>
   <div class="mel-event-studio-topbar__actions">
     {% if topbar.show_manage_event_link %}
-      <a class="mel-btn mel-btn--secondary mel-event-studio-topbar__manage-event" href="{{ topbar.manage_event_url }}">{{ 'Overview'|t }}</a>
+      <a class="mel-btn mel-btn--secondary mel-event-studio-topbar__manage-event" href="{{ topbar.manage_event_url }}">{{ 'Staff Overview'|t }}</a>
     {% endif %}
-    <a class="mel-btn mel-btn--ghost" href="{{ topbar.preview_url }}" target="_blank" rel="noopener noreferrer">{{ 'Preview'|t }}</a>
+    <a class="mel-btn mel-btn--ghost" href="{{ topbar.preview_url }}" target="_blank" rel="noopener noreferrer">{{ 'View page'|t }}</a>
     <button
       class="mel-btn{% if topbar.published %} mel-btn--ghost mel-event-studio-topbar__status-action{% else %} mel-btn--primary{% endif %}"
       type="button"

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
@@ -34,12 +34,14 @@
       <ul class="mel-event-studio-readiness-strip__checklist" data-mel-readiness-checklist>
         {% for item in readiness.checklist %}
           <li class="mel-event-studio-readiness-strip__check{% if item.complete %} is-complete{% endif %}{% if item.tone|default('') %} mel-event-studio-readiness-strip__check--{{ item.tone|clean_class }}{% endif %}">
-            <span aria-hidden="true">{{ item.complete ? '✔' : (item.tone|default('') == 'warning' ? '◇' : '○') }}</span>
+            <span aria-hidden="true">{{ item.complete ? '✔' : (item.tone|default('') in ['warning', 'idea'] ? '◇' : '○') }}</span>
             <span class="visually-hidden">
               {% if item.complete %}
                 {{ 'Complete'|t }}
               {% elseif item.tone|default('') == 'warning' %}
                 {{ 'Suggested review'|t }}
+              {% elseif item.tone|default('') == 'idea' %}
+                {{ 'Idea'|t }}
               {% else %}
                 {{ 'Outstanding'|t }}
               {% endif %}

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
@@ -33,9 +33,17 @@
     {% if readiness.checklist|default([]) %}
       <ul class="mel-event-studio-readiness-strip__checklist" data-mel-readiness-checklist>
         {% for item in readiness.checklist %}
-          <li class="mel-event-studio-readiness-strip__check{% if item.complete %} is-complete{% endif %}">
-            <span aria-hidden="true">{{ item.complete ? '✔' : '○' }}</span>
-            <span class="visually-hidden">{{ item.complete ? 'Complete'|t : 'Outstanding'|t }}</span>
+          <li class="mel-event-studio-readiness-strip__check{% if item.complete %} is-complete{% endif %}{% if item.tone|default('') %} mel-event-studio-readiness-strip__check--{{ item.tone|clean_class }}{% endif %}">
+            <span aria-hidden="true">{{ item.complete ? '✔' : (item.tone|default('') == 'warning' ? '◇' : '○') }}</span>
+            <span class="visually-hidden">
+              {% if item.complete %}
+                {{ 'Complete'|t }}
+              {% elseif item.tone|default('') == 'warning' %}
+                {{ 'Suggested review'|t }}
+              {% else %}
+                {{ 'Outstanding'|t }}
+              {% endif %}
+            </span>
             {{ item.label }}
           </li>
         {% endfor %}

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
@@ -41,7 +41,7 @@
         {% endfor %}
       </ul>
     {% else %}
-      <div class="mel-event-studio-readiness-strip__counts">
+      <div class="mel-event-studio-readiness-strip__counts" data-mel-readiness-counts>
         <span data-mel-readiness-errors-count>{{ readiness.errors|length }} {{ 'to finish'|t }}</span>
         <span data-mel-readiness-warnings-count>{{ readiness.warnings|length }} {{ 'to review'|t }}</span>
         <span data-mel-readiness-recommendations-count>{{ readiness.recommendations|default([])|length }} {{ 'idea(s)'|t }}</span>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
@@ -26,13 +26,28 @@
     <div class="mel-event-studio-readiness-strip__summary">
       <strong data-mel-readiness-title>{{ readiness.strip_title|default(readiness.ready ? 'Ready to publish'|t : 'Needs attention'|t) }}</strong>
       <span data-mel-readiness-state>{{ readiness.state }}</span>
+      {% if readiness.strip_explanation|default('') %}
+        <p class="mel-event-studio-readiness-strip__explain" data-mel-readiness-explain>{{ readiness.strip_explanation }}</p>
+      {% endif %}
     </div>
-    <div class="mel-event-studio-readiness-strip__counts">
-      <span data-mel-readiness-errors-count>{{ readiness.errors|length }} {{ 'blocker(s)'|t }}</span>
-      <span data-mel-readiness-warnings-count>{{ readiness.warnings|length }} {{ 'warning(s)'|t }}</span>
-      <span data-mel-readiness-recommendations-count>{{ readiness.recommendations|default([])|length }} {{ 'idea(s)'|t }}</span>
-      <span data-mel-readiness-completed-count>{{ readiness.completed|length }} {{ 'complete'|t }}</span>
-    </div>
+    {% if readiness.checklist|default([]) %}
+      <ul class="mel-event-studio-readiness-strip__checklist" data-mel-readiness-checklist>
+        {% for item in readiness.checklist %}
+          <li class="mel-event-studio-readiness-strip__check{% if item.complete %} is-complete{% endif %}">
+            <span aria-hidden="true">{{ item.complete ? '✔' : '○' }}</span>
+            <span class="visually-hidden">{{ item.complete ? 'Complete'|t : 'Outstanding'|t }}</span>
+            {{ item.label }}
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <div class="mel-event-studio-readiness-strip__counts">
+        <span data-mel-readiness-errors-count>{{ readiness.errors|length }} {{ 'to finish'|t }}</span>
+        <span data-mel-readiness-warnings-count>{{ readiness.warnings|length }} {{ 'to review'|t }}</span>
+        <span data-mel-readiness-recommendations-count>{{ readiness.recommendations|default([])|length }} {{ 'idea(s)'|t }}</span>
+        <span data-mel-readiness-completed-count>{{ readiness.completed|length }} {{ 'complete'|t }}</span>
+      </div>
+    {% endif %}
   </section>
 
   <div class="mel-event-studio-homepage-readiness"{% if not homepage_readiness %} hidden{% endif %}>

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioAutosaveCanonicalSectionTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioAutosaveCanonicalSectionTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\Core\TempStore\PrivateTempStore;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
+use Drupal\myeventlane_event_studio\Service\EventStudioAutosaveService;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\UnitTestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Autosave draft key canonicalisation for shared information form sections.
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventStudioAutosaveCanonicalSectionTest extends UnitTestCase {
+
+  public function testScheduleAndVenueShareInformationDraftKey(): void {
+    $store = $this->createMock(PrivateTempStore::class);
+    $bag = [];
+    $store->method('set')->willReturnCallback(
+      static function (string $key, mixed $value) use (&$bag): void {
+        $bag[$key] = $value;
+      },
+    );
+    $store->method('get')->willReturnCallback(
+      static function (string $key) use (&$bag): mixed {
+        return $bag[$key] ?? NULL;
+      },
+    );
+    $store->method('delete')->willReturnCallback(
+      static function (string $key) use (&$bag): void {
+        unset($bag[$key]);
+      },
+    );
+
+    $factory = $this->createMock(PrivateTempStoreFactory::class);
+    $factory->method('get')->willReturn($store);
+    $logger = $this->createMock(LoggerInterface::class);
+    $service = new EventStudioAutosaveService($factory, $logger);
+
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('id')->willReturn(42);
+    $node->method('getChangedTime')->willReturn(100);
+    $node->method('getRevisionId')->willReturn(7);
+
+    $this->assertSame('information', $service->canonicalSection('schedule'));
+    $this->assertSame('information', $service->canonicalSection('venue'));
+    $this->assertSame('information', $service->canonicalSection('details'));
+    $this->assertSame('information', $service->canonicalSection('information'));
+    $this->assertSame('tickets', $service->canonicalSection('tickets'));
+
+    $service->storeDraft($node, 'schedule', ['title' => 'From schedule'], 1.0, 100, 7);
+
+    $this->assertArrayHasKey('node.42.information', $bag);
+    $this->assertArrayNotHasKey('node.42.schedule', $bag);
+    $this->assertTrue($service->hasDraft($node, 'venue'));
+    $this->assertTrue($service->hasDraft($node, 'information'));
+    $this->assertSame('From schedule', $service->getDraft($node, 'details')['mel']['title'] ?? NULL);
+
+    $service->clearDraft($node, 'venue');
+    $this->assertFalse($service->hasDraft($node, 'schedule'));
+    $this->assertFalse($service->hasDraft($node, 'information'));
+  }
+
+  public function testLegacyAliasDraftMigratesToCanonicalKey(): void {
+    $store = $this->createMock(PrivateTempStore::class);
+    $bag = [
+      'node.9.venue' => [
+        'event_id' => 9,
+        'section' => 'venue',
+        'mel' => ['title' => 'Legacy venue draft'],
+        'autosave_ts' => 1.0,
+        'base_changed' => 50,
+        'base_revision_id' => 3,
+        'stored_at' => time(),
+      ],
+    ];
+    $store->method('set')->willReturnCallback(
+      static function (string $key, mixed $value) use (&$bag): void {
+        $bag[$key] = $value;
+      },
+    );
+    $store->method('get')->willReturnCallback(
+      static function (string $key) use (&$bag): mixed {
+        return $bag[$key] ?? NULL;
+      },
+    );
+    $store->method('delete')->willReturnCallback(
+      static function (string $key) use (&$bag): void {
+        unset($bag[$key]);
+      },
+    );
+
+    $factory = $this->createMock(PrivateTempStoreFactory::class);
+    $factory->method('get')->willReturn($store);
+    $logger = $this->createMock(LoggerInterface::class);
+    $service = new EventStudioAutosaveService($factory, $logger);
+
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('id')->willReturn(9);
+    $node->method('getChangedTime')->willReturn(50);
+    $node->method('getRevisionId')->willReturn(3);
+
+    $draft = $service->getDraft($node, 'information');
+    $this->assertNotNull($draft);
+    $this->assertSame('Legacy venue draft', $draft['mel']['title'] ?? NULL);
+    $this->assertArrayHasKey('node.9.information', $bag);
+    $this->assertArrayNotHasKey('node.9.venue', $bag);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioEmptyStateActionsTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioEmptyStateActionsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\Url;
+use Drupal\myeventlane_event_studio\Service\EventStudioEmptyStateBuilder;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_event_studio\Service\EventStudioEmptyStateBuilder
+ * @group myeventlane_event_studio
+ */
+final class EventStudioEmptyStateActionsTest extends UnitTestCase {
+
+  /**
+   * @covers ::build
+   */
+  public function testBuildPassesActionsIntoThemeVariables(): void {
+    $translation = $this->createMock(TranslationInterface::class);
+    $translation->method('translate')->willReturnCallback(
+      static fn (string $string, array $args = [], array $options = []) => $string,
+    );
+
+    $builder = new EventStudioEmptyStateBuilder($translation);
+    $actions = [
+      '#type' => 'link',
+      '#title' => 'Go to publishing',
+      '#url' => Url::fromRoute('<front>'),
+    ];
+    $build = $builder->build(
+      'Marketing',
+      'Publish first.',
+      'Then share.',
+      ['Finish publishing first.'],
+      'spark',
+      'default',
+      $actions,
+    );
+
+    $this->assertSame('mel_event_studio_empty_state', $build['#theme']);
+    $this->assertSame($actions, $build['#actions']);
+  }
+
+  public function testMarketingDraftCtaUsesThemeActionsNotSiblingKey(): void {
+    $renderer = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioSectionRenderer.php');
+    $template = file_get_contents(dirname(__DIR__, 3) . '/templates/mel-event-studio-empty-state.html.twig');
+    $module = file_get_contents(dirname(__DIR__, 3) . '/myeventlane_event_studio.module');
+    $this->assertIsString($renderer);
+    $this->assertIsString($template);
+    $this->assertIsString($module);
+
+    $this->assertStringContainsString("'#actions' => \$actions", file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioEmptyStateBuilder.php'));
+    $this->assertStringContainsString("mel-event-studio-empty-state__actions", $template);
+    $this->assertStringContainsString("'actions' => []", $module);
+    $this->assertStringContainsString('Go to publishing', $renderer);
+    $this->assertStringNotContainsString(") + [\n        'actions' => [", $renderer);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioManageEventIaTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioManageEventIaTest.php
@@ -63,6 +63,8 @@ final class EventStudioManageEventIaTest extends UnitTestCase {
     $this->assertStringContainsString('myeventlane_event_studio.workspace', $tabs);
     $this->assertStringContainsString('workspace_publishing', $tabs);
     $this->assertStringContainsString('workspace_marketing', $tabs);
+    $this->assertStringContainsString("'key' => 'refund_requests'", $tabs);
+    $this->assertStringContainsString("'key' => 'boost'", $tabs);
     $this->assertStringContainsString("title: 'Overview'", $tasks);
     $this->assertStringContainsString('myeventlane_vendor.console.event_workspace', $tasks);
   }

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioManageEventIaTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioManageEventIaTest.php
@@ -23,12 +23,18 @@ final class EventStudioManageEventIaTest extends UnitTestCase {
     $this->assertStringContainsString('myeventlane_vendor.console.event_workspace', $contents);
   }
 
-  public function testStudioOverviewDoesNotRenderTicketSalesPanel(): void {
+  public function testStudioOverviewUsesWorkspaceOverviewBuilder(): void {
     $contents = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioSectionRenderer.php');
     $this->assertIsString($contents);
+    $this->assertStringContainsString('EventWorkspaceOverviewBuilder', $contents);
+    $this->assertStringContainsString('buildOverviewSection', $contents);
     $this->assertStringNotContainsString('buildTicketSalesPanelRenderArray', $contents);
     $this->assertStringNotContainsString("build['ticket_sales']", $contents);
     $this->assertStringNotContainsString('EventStudioCommerceSalesSummaryBuilder', $contents);
+  }
+
+  public function testStudioOverviewDoesNotRenderTicketSalesPanel(): void {
+    $this->testStudioOverviewUsesWorkspaceOverviewBuilder();
   }
 
   public function testVendorEventWorkspaceRendersTicketSalesPanel(): void {
@@ -54,7 +60,9 @@ final class EventStudioManageEventIaTest extends UnitTestCase {
     $this->assertIsString($tabs);
     $this->assertIsString($tasks);
     $this->assertStringContainsString('Overview', $tabs);
-    $this->assertStringContainsString('myeventlane_vendor.console.event_workspace', $tabs);
+    $this->assertStringContainsString('myeventlane_event_studio.workspace', $tabs);
+    $this->assertStringContainsString('workspace_publishing', $tabs);
+    $this->assertStringContainsString('workspace_marketing', $tabs);
     $this->assertStringContainsString("title: 'Overview'", $tasks);
     $this->assertStringContainsString('myeventlane_vendor.console.event_workspace', $tasks);
   }

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspacePresentationContractTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspacePresentationContractTest.php
@@ -135,6 +135,9 @@ final class EventStudioWorkspacePresentationContractTest extends UnitTestCase {
     $this->assertStringContainsString('buildEventHealth($readiness_bundle', $publish);
     $this->assertStringContainsString('homepage_readiness_html', $publish);
     $this->assertStringNotContainsString('buildAjaxReadinessPayload(', $publish);
+    // Topbar badge must match Sprint 2 full-page copy after in-place publish.
+    $this->assertStringContainsString("\$this->t('Live')", $publish);
+    $this->assertStringNotContainsString("'status' => \$node->isPublished() ? (string) \$this->t('Published')", $publish);
   }
 
   public function testShellJsSyncsHomepageReadinessVisibility(): void {

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceStateMatrixTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceStateMatrixTest.php
@@ -99,8 +99,48 @@ final class EventStudioWorkspaceStateMatrixTest extends UnitTestCase {
 
     $this->assertTrue($payload['show_publish_strip']);
     $this->assertArrayHasKey('strip_title', $payload);
+    $this->assertArrayHasKey('strip_explanation', $payload);
+    $this->assertArrayHasKey('checklist', $payload);
     $this->assertSame(['Add banner image'], $payload['recommendations']);
     $this->assertArrayHasKey('show_homepage_readiness', $payload);
+  }
+
+  public function testStripChecklistNeverOmitsBlockingErrorsPastSoftCap(): void {
+    $node = $this->node(FALSE, 107);
+    $errors = [
+      'Add an event title.',
+      'Add event dates.',
+      'Select a booking mode.',
+      'Configure ticketing.',
+    ];
+    $completed = [
+      'Payment onboarding complete.',
+      'Vendor publish requirements complete.',
+      'Branding image added.',
+      'Capacity settings valid.',
+      'External booking URL added.',
+    ];
+    $bundle = [
+      'publish' => EventReadinessResult::create($errors, [], $completed),
+      'promotion' => [
+        'ready' => FALSE,
+        'status_label' => 'Needs attention before homepage promotion',
+        'short_status_label' => 'Needs attention',
+      ],
+      'recommended' => [],
+      'promotion_ready' => FALSE,
+    ];
+    $summary = $this->presentation->buildReadinessSummary($bundle, $node);
+    $incomplete = array_values(array_filter(
+      $summary['checklist'],
+      static fn(array $item): bool => empty($item['complete']),
+    ));
+
+    $this->assertCount(4, $incomplete);
+    $this->assertLessThanOrEqual(8, count($summary['checklist']));
+    foreach ($errors as $error) {
+      $this->assertContains(rtrim($error, '.'), array_column($incomplete, 'label'));
+    }
   }
 
   public function testWorkspaceTemplateIncludesEventHealthBeforePublishStrip(): void {
@@ -125,6 +165,9 @@ final class EventStudioWorkspaceStateMatrixTest extends UnitTestCase {
     $this->assertStringContainsString('result.event_health', $js);
     $this->assertStringContainsString('ensureReadinessStrip', $js);
     $this->assertStringContainsString('updateHomepageReadiness', $js);
+    $this->assertStringContainsString('updateReadinessChecklist', $js);
+    $this->assertStringContainsString('strip_explanation', $js);
+    $this->assertStringContainsString('data-mel-readiness-explain', $js);
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceStateMatrixTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceStateMatrixTest.php
@@ -50,7 +50,9 @@ final class EventStudioWorkspaceStateMatrixTest extends UnitTestCase {
     $summary = $this->presentation->buildReadinessSummary($bundle, $node);
 
     $this->assertTrue($summary['show_publish_strip']);
-    $this->assertSame('Needs attention', $summary['strip_title']);
+    $this->assertSame("You're almost there…", $summary['strip_title']);
+    $this->assertStringContainsString('One more thing before publishing', $summary['strip_explanation']);
+    $this->assertNotEmpty($summary['checklist']);
   }
 
   public function testPublishedReadyHidesPublishStripWithoutBlockers(): void {

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceStateMatrixTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceStateMatrixTest.php
@@ -108,7 +108,57 @@ final class EventStudioWorkspaceStateMatrixTest extends UnitTestCase {
     $this->assertNotEmpty($warningRows);
     $this->assertSame('Review capacity', $warningRows[0]['label']);
     $this->assertSame(['Add banner image'], $payload['recommendations']);
+    $ideaRows = array_values(array_filter(
+      $payload['checklist'],
+      static fn(array $item): bool => ($item['tone'] ?? '') === 'idea',
+    ));
+    $this->assertCount(1, $ideaRows);
+    $this->assertSame('Add banner image', $ideaRows[0]['label']);
     $this->assertArrayHasKey('show_homepage_readiness', $payload);
+  }
+
+  public function testStripChecklistIncludesRecommendationIdeas(): void {
+    $node = $this->node(FALSE, 108);
+    $bundle = [
+      'publish' => EventReadinessResult::create(
+        ['Add an event title.'],
+        [],
+        ['Payment onboarding complete.'],
+        ['Add a short event summary so attendees understand the experience quickly.'],
+      ),
+      'promotion' => [
+        'ready' => FALSE,
+        'status_label' => 'Needs attention before homepage promotion',
+        'short_status_label' => 'Needs attention',
+      ],
+      'recommended' => [
+        'Add a short event summary so attendees understand the experience quickly.',
+        'Add banner image',
+      ],
+      'promotion_ready' => FALSE,
+    ];
+    $summary = $this->presentation->buildReadinessSummary($bundle, $node);
+    $ideaRows = array_values(array_filter(
+      $summary['checklist'],
+      static fn(array $item): bool => ($item['tone'] ?? '') === 'idea',
+    ));
+    $this->assertCount(2, $ideaRows);
+    $this->assertSame(
+      [
+        'Add a short event summary so attendees understand the experience quickly',
+        'Add banner image',
+      ],
+      array_column($ideaRows, 'label'),
+    );
+  }
+
+  public function testInformationFormStaysOnScheduleOrVenueAfterSave(): void {
+    $form = file_get_contents(dirname(__DIR__, 3) . '/src/Form/EventInformationForm.php');
+    $this->assertIsString($form);
+    $this->assertStringContainsString('resolveStayRouteName', $form);
+    $this->assertStringContainsString('workspace_schedule', $form);
+    $this->assertStringContainsString('workspace_venue', $form);
+    $this->assertStringContainsString('setRedirect($this->resolveStayRouteName()', $form);
   }
 
   public function testStripChecklistNeverOmitsBlockingErrorsPastSoftCap(): void {
@@ -194,6 +244,8 @@ final class EventStudioWorkspaceStateMatrixTest extends UnitTestCase {
     $this->assertStringContainsString("@count to finish", $js);
     $this->assertStringContainsString("@count to review", $js);
     $this->assertStringNotContainsString('blocker(s)', $js);
+    $this->assertStringContainsString("tone === 'idea'", $js);
+    $this->assertStringContainsString("Drupal.t('Idea')", $js);
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceStateMatrixTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceStateMatrixTest.php
@@ -101,6 +101,12 @@ final class EventStudioWorkspaceStateMatrixTest extends UnitTestCase {
     $this->assertArrayHasKey('strip_title', $payload);
     $this->assertArrayHasKey('strip_explanation', $payload);
     $this->assertArrayHasKey('checklist', $payload);
+    $warningRows = array_values(array_filter(
+      $payload['checklist'],
+      static fn(array $item): bool => ($item['tone'] ?? '') === 'warning',
+    ));
+    $this->assertNotEmpty($warningRows);
+    $this->assertSame('Review capacity', $warningRows[0]['label']);
     $this->assertSame(['Add banner image'], $payload['recommendations']);
     $this->assertArrayHasKey('show_homepage_readiness', $payload);
   }
@@ -113,6 +119,10 @@ final class EventStudioWorkspaceStateMatrixTest extends UnitTestCase {
       'Select a booking mode.',
       'Configure ticketing.',
     ];
+    $warnings = [
+      'Cover image could be sharper.',
+      'Add a short summary.',
+    ];
     $completed = [
       'Payment onboarding complete.',
       'Vendor publish requirements complete.',
@@ -121,7 +131,7 @@ final class EventStudioWorkspaceStateMatrixTest extends UnitTestCase {
       'External booking URL added.',
     ];
     $bundle = [
-      'publish' => EventReadinessResult::create($errors, [], $completed),
+      'publish' => EventReadinessResult::create($errors, $warnings, $completed),
       'promotion' => [
         'ready' => FALSE,
         'status_label' => 'Needs attention before homepage promotion',
@@ -135,11 +145,23 @@ final class EventStudioWorkspaceStateMatrixTest extends UnitTestCase {
       $summary['checklist'],
       static fn(array $item): bool => empty($item['complete']),
     ));
+    $errorRows = array_values(array_filter(
+      $incomplete,
+      static fn(array $item): bool => ($item['tone'] ?? '') === 'attention',
+    ));
+    $warningRows = array_values(array_filter(
+      $incomplete,
+      static fn(array $item): bool => ($item['tone'] ?? '') === 'warning',
+    ));
 
-    $this->assertCount(4, $incomplete);
+    $this->assertCount(4, $errorRows);
+    $this->assertCount(2, $warningRows);
     $this->assertLessThanOrEqual(8, count($summary['checklist']));
     foreach ($errors as $error) {
-      $this->assertContains(rtrim($error, '.'), array_column($incomplete, 'label'));
+      $this->assertContains(rtrim($error, '.'), array_column($errorRows, 'label'));
+    }
+    foreach ($warnings as $warning) {
+      $this->assertContains(rtrim($warning, '.'), array_column($warningRows, 'label'));
     }
   }
 

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceStateMatrixTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceStateMatrixTest.php
@@ -190,6 +190,10 @@ final class EventStudioWorkspaceStateMatrixTest extends UnitTestCase {
     $this->assertStringContainsString('updateReadinessChecklist', $js);
     $this->assertStringContainsString('strip_explanation', $js);
     $this->assertStringContainsString('data-mel-readiness-explain', $js);
+    // Count-mode copy must match mel-event-studio-workspace.html.twig.
+    $this->assertStringContainsString("@count to finish", $js);
+    $this->assertStringContainsString("@count to review", $js);
+    $this->assertStringNotContainsString('blocker(s)', $js);
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventWorkspaceNavIaTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventWorkspaceNavIaTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Contract tests for VX2 One Event Workspace navigation IA.
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventWorkspaceNavIaTest extends UnitTestCase {
+
+  /**
+   * Confirms primary section plugins match Convergence order and labels.
+   */
+  public function testPrimarySectionsMatchConvergenceOrder(): void {
+    $dir = dirname(__DIR__, 3) . '/src/Plugin/EventStudioSection';
+    $expected = [
+      'overview' => ['Overview', 0, TRUE],
+      'information' => ['Details', 10, TRUE],
+      'schedule' => ['Schedule', 20, TRUE],
+      'venue' => ['Venue', 30, TRUE],
+      'branding' => ['Images', 40, TRUE],
+      'tickets' => ['Tickets', 50, TRUE],
+      'attendees' => ['Attendees', 60, TRUE],
+      'messaging' => ['Messages', 70, TRUE],
+      'marketing' => ['Marketing', 80, TRUE],
+      'orders' => ['Orders', 90, TRUE],
+      'analytics' => ['Analytics', 100, TRUE],
+      'publishing' => ['Publishing', 110, TRUE],
+      'settings' => ['Settings', 120, TRUE],
+    ];
+
+    foreach ($expected as $id => [$title, $weight, $visible]) {
+      $file = match ($id) {
+        'information' => 'InformationSection.php',
+        'branding' => 'BrandingSection.php',
+        'messaging' => 'MessagingSection.php',
+        default => ucfirst($id) . 'Section.php',
+      };
+      $contents = file_get_contents($dir . '/' . $file);
+      $this->assertIsString($contents, $file);
+      $this->assertStringContainsString("title: '$title'", $contents);
+      $this->assertStringContainsString("weight: $weight", $contents);
+      $this->assertStringContainsString("group: 'Workspace'", $contents);
+      if ($visible) {
+        $this->assertStringNotContainsString('navigationVisible: FALSE', $contents);
+      }
+    }
+  }
+
+  /**
+   * Confirms advanced sections stay off the primary Workspace nav.
+   */
+  public function testAdvancedSectionsHiddenFromPrimaryNav(): void {
+    $files = [
+      'ContentSection.php',
+      'QuestionsSection.php',
+      'CapacitySection.php',
+      'ExtrasSection.php',
+      'FulfilmentSection.php',
+    ];
+    foreach ($files as $file) {
+      $contents = file_get_contents(dirname(__DIR__, 3) . '/src/Plugin/EventStudioSection/' . $file);
+      $this->assertIsString($contents);
+      $this->assertStringContainsString('navigationVisible: FALSE', $contents);
+    }
+  }
+
+  /**
+   * Confirms shell copy uses Event Workspace language.
+   */
+  public function testShellUsesEventWorkspaceLanguage(): void {
+    $topbar = file_get_contents(dirname(__DIR__, 3) . '/templates/mel-event-studio-topbar.html.twig');
+    $sidebar = file_get_contents(dirname(__DIR__, 3) . '/templates/mel-event-studio-sidebar.html.twig');
+    $controller = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/EventStudioController.php');
+    $this->assertIsString($topbar);
+    $this->assertIsString($sidebar);
+    $this->assertIsString($controller);
+    $this->assertStringContainsString('Event Workspace', $topbar);
+    $this->assertStringContainsString('Event breadcrumb', $topbar);
+    $this->assertStringContainsString('View page', $topbar);
+    $this->assertStringContainsString('Event workspace', $sidebar);
+    $this->assertStringContainsString('Event Workspace', $controller);
+    $this->assertStringNotContainsString("'Event Studio'|t", $topbar);
+  }
+
+  /**
+   * Confirms Convergence route aliases exist.
+   */
+  public function testWorkspaceRoutesIncludeConvergenceAliases(): void {
+    $routing = file_get_contents(dirname(__DIR__, 3) . '/myeventlane_event_studio.routing.yml');
+    $this->assertIsString($routing);
+    $routes = [
+      'workspace_schedule',
+      'workspace_venue',
+      'workspace_marketing',
+      'workspace_publishing',
+      'workspace_details',
+      'workspace_images',
+      'workspace_messages',
+    ];
+    foreach ($routes as $route) {
+      $this->assertStringContainsString("myeventlane_event_studio.$route:", $routing);
+    }
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventWorkspaceOverviewChecklistTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventWorkspaceOverviewChecklistTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_event_studio\Service\EventWorkspaceOverviewBuilder;
+use Drupal\Tests\UnitTestCase;
+use ReflectionClass;
+
+/**
+ * Overview human checklist tone separation.
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventWorkspaceOverviewChecklistTest extends UnitTestCase {
+
+  public function testWarningsAreNotPresentedAsBlockingAttentionRows(): void {
+    $translator = $this->createMock(TranslationInterface::class);
+    $translator->method('translateString')->willReturnCallback(
+      static fn (\Drupal\Core\StringTranslation\TranslatableMarkup $markup): string => $markup->getUntranslatedString(),
+    );
+
+    $builder = (new ReflectionClass(EventWorkspaceOverviewBuilder::class))
+      ->newInstanceWithoutConstructor();
+    $property = (new ReflectionClass(EventWorkspaceOverviewBuilder::class))
+      ->getProperty('stringTranslation');
+    $property->setValue($builder, $translator);
+
+    $method = (new ReflectionClass(EventWorkspaceOverviewBuilder::class))
+      ->getMethod('buildHumanChecklist');
+
+    $items = $method->invoke(
+      $builder,
+      ['Event title added.'],
+      ['Add tickets.'],
+      ['Cover image could be sharper.'],
+      ['Add a short summary.'],
+    );
+
+    $byTone = [];
+    foreach ($items as $item) {
+      $byTone[$item['tone']][] = $item;
+    }
+
+    $this->assertCount(1, $byTone['success']);
+    $this->assertTrue($byTone['success'][0]['complete']);
+    $this->assertCount(1, $byTone['attention']);
+    $this->assertFalse($byTone['attention'][0]['complete']);
+    $this->assertSame('Add tickets', $byTone['attention'][0]['label']);
+    $this->assertCount(1, $byTone['warning']);
+    $this->assertFalse($byTone['warning'][0]['complete']);
+    $this->assertSame('Cover image could be sharper', $byTone['warning'][0]['label']);
+    $this->assertCount(1, $byTone['idea']);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventWorkspaceOverviewChecklistTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventWorkspaceOverviewChecklistTest.php
@@ -55,4 +55,23 @@ final class EventWorkspaceOverviewChecklistTest extends UnitTestCase {
     $this->assertCount(1, $byTone['idea']);
   }
 
+  public function testOverviewUsesReadinessFacadeForMergedIdeas(): void {
+    $builder = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventWorkspaceOverviewBuilder.php');
+    $services = file_get_contents(dirname(__DIR__, 3) . '/myeventlane_event_studio.services.yml');
+    $twig = file_get_contents(dirname(__DIR__, 3) . '/templates/mel-event-studio-overview.html.twig');
+    $module = file_get_contents(dirname(__DIR__, 3) . '/myeventlane_event_studio.module');
+    $this->assertIsString($builder);
+    $this->assertIsString($services);
+    $this->assertIsString($twig);
+    $this->assertIsString($module);
+
+    $this->assertStringContainsString('EventReadinessFacade $readinessFacade', $builder);
+    $this->assertStringContainsString('$this->readinessFacade->evaluate', $builder);
+    $this->assertStringContainsString('$recommended', $builder);
+    $this->assertStringContainsString("'@myeventlane_event_studio.readiness_facade'", $services);
+    $this->assertStringContainsString("'show' => FALSE", $builder);
+    $this->assertStringContainsString('celebration is iterable', $twig);
+    $this->assertStringContainsString("'show' => FALSE", $module);
+  }
+
 }

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventWorkspaceOverviewNextActionTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventWorkspaceOverviewNextActionTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_event_studio\DTO\EventReadinessResult;
+use Drupal\myeventlane_event_studio\Service\EventWorkspaceOverviewBuilder;
+use Drupal\Tests\UnitTestCase;
+use ReflectionClass;
+
+/**
+ * Overview next-action preference over mission-control placeholders.
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventWorkspaceOverviewNextActionTest extends UnitTestCase {
+
+  public function testDraftGenericMissionControlYieldsPublishingChecklistCta(): void {
+    $action = $this->resolve(
+      [
+        'severity' => 'warning',
+        'title' => 'Finish and publish your event',
+        'message' => 'Review your details and publish when you are ready to go live.',
+        'action_label' => 'Continue editing',
+        'url' => '/vendor/events/1/edit',
+      ],
+      EventReadinessResult::create(['Add tickets.']),
+      FALSE,
+    );
+
+    $this->assertSame('Continue setup', $action['title']);
+    $this->assertSame('Review publishing', $action['action_label']);
+  }
+
+  public function testDraftReadyGenericMissionControlYieldsPublishCta(): void {
+    $action = $this->resolve(
+      [
+        'severity' => 'warning',
+        'title' => 'Finish and publish your event',
+        'message' => 'Review your details and publish when you are ready to go live.',
+        'action_label' => 'Continue editing',
+        'url' => '/vendor/events/1/edit',
+      ],
+      EventReadinessResult::create([], [], ['Event title added.']),
+      FALSE,
+    );
+
+    $this->assertSame('Ready when you are', $action['title']);
+    $this->assertSame('Go to publishing', $action['action_label']);
+  }
+
+  public function testLiveIdleLooksReadyYieldsMarketingCta(): void {
+    $action = $this->resolve(
+      [
+        'severity' => 'success',
+        'title' => 'Event looks ready',
+        'message' => 'Keep an eye on bookings and attendee activity.',
+        'action_label' => NULL,
+        'url' => NULL,
+      ],
+      EventReadinessResult::create([], [], ['Event title added.']),
+      TRUE,
+    );
+
+    $this->assertSame('Share your event', $action['title']);
+    $this->assertSame('Open marketing', $action['action_label']);
+  }
+
+  public function testLiveBookingActivityKeepsMissionControlAction(): void {
+    $action = $this->resolve(
+      [
+        'severity' => 'info',
+        'title' => 'Manage bookings',
+        'message' => 'You have attendee or order activity for this event.',
+        'action_label' => 'View attendees',
+        'url' => '/vendor/events/1/attendees',
+      ],
+      EventReadinessResult::create([], [], ['Event title added.']),
+      TRUE,
+    );
+
+    $this->assertSame('Manage bookings', $action['title']);
+    $this->assertSame('View attendees', $action['action_label']);
+    $this->assertSame('/vendor/events/1/attendees', $action['url']);
+  }
+
+  public function testUnknownTypeErrorKeepsMissionControlActionOnDraft(): void {
+    $action = $this->resolve(
+      [
+        'severity' => 'error',
+        'title' => 'Add RSVP or tickets',
+        'message' => 'Choose how people register so your event can accept bookings.',
+        'action_label' => 'Edit event',
+        'url' => '/vendor/events/1/edit',
+      ],
+      EventReadinessResult::create(['Add tickets.']),
+      FALSE,
+    );
+
+    $this->assertSame('Add RSVP or tickets', $action['title']);
+    $this->assertSame('Edit event', $action['action_label']);
+  }
+
+  /**
+   * @param array<string, mixed> $next
+   *   Mission-control next_action payload.
+   *
+   * @return array{title: string, message: string, action_label: ?string, url: ?string}
+   */
+  private function resolve(array $next, EventReadinessResult $readiness, bool $published): array {
+    $translator = $this->createMock(TranslationInterface::class);
+    $translator->method('translateString')->willReturnCallback(
+      static fn (\Drupal\Core\StringTranslation\TranslatableMarkup $markup): string => $markup->getUntranslatedString(),
+    );
+
+    $builder = (new ReflectionClass(EventWorkspaceOverviewBuilder::class))
+      ->newInstanceWithoutConstructor();
+    $property = (new ReflectionClass(EventWorkspaceOverviewBuilder::class))
+      ->getProperty('stringTranslation');
+    $property->setValue($builder, $translator);
+
+    $method = (new ReflectionClass(EventWorkspaceOverviewBuilder::class))
+      ->getMethod('resolveNextRecommendedAction');
+
+    /** @var array{title: string, message: string, action_label: ?string, url: ?string} $action */
+    $action = $method->invoke($builder, $next, $readiness, $published, 1);
+    return $action;
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor/src/Hook/VendorConsolePagePreprocess.php
+++ b/web/modules/custom/myeventlane_vendor/src/Hook/VendorConsolePagePreprocess.php
@@ -91,14 +91,16 @@ final class VendorConsolePagePreprocess {
     }
 
     $workspace_tabs = [
-      ['key' => 'overview', 'route' => 'myeventlane_vendor.console.event_workspace', 'label' => $this->t('Overview'), 'url' => Url::fromRoute('myeventlane_vendor.console.event_workspace', ['event' => $event_id])->toString()],
-      ['key' => 'tickets', 'route' => 'myeventlane_vendor.console.event_tickets', 'label' => $this->t('Tickets'), 'url' => Url::fromRoute('myeventlane_vendor.console.event_tickets', ['event' => $event_id])->toString()],
-      ['key' => 'attendees', 'route' => 'myeventlane_event_attendees.vendor_list', 'label' => $this->t('Attendees'), 'url' => Url::fromRoute('myeventlane_event_attendees.vendor_list', ['node' => $event_id])->toString()],
-      ['key' => 'orders', 'route' => 'myeventlane_vendor.console.event_orders', 'label' => $this->t('Orders'), 'url' => Url::fromRoute('myeventlane_vendor.console.event_orders', ['event' => $event_id])->toString()],
-      ['key' => 'promotion', 'route' => 'myeventlane_vendor.console.event_promotion', 'label' => $this->t('Messages'), 'url' => Url::fromRoute('myeventlane_vendor.console.event_promotion', ['event' => $event_id])->toString()],
-      ['key' => 'analytics', 'route' => 'myeventlane_vendor.console.event_analytics', 'label' => $this->t('Analytics'), 'url' => Url::fromRoute('myeventlane_vendor.console.event_analytics', ['event' => $event_id])->toString()],
-      ['key' => 'settings', 'route' => 'myeventlane_vendor.console.event_settings', 'label' => $this->t('Settings'), 'url' => Url::fromRoute('myeventlane_vendor.console.event_settings', ['event' => $event_id])->toString()],
-      ['key' => 'publish', 'route' => 'myeventlane_vendor.console.event_publish', 'label' => $this->t('Publish'), 'url' => Url::fromRoute('myeventlane_vendor.console.event_publish', ['event' => $event_id])->toString()],
+      ['key' => 'overview', 'route' => 'myeventlane_event_studio.workspace', 'label' => $this->t('Overview'), 'url' => Url::fromRoute('myeventlane_event_studio.workspace', ['node' => $event_id])->toString()],
+      ['key' => 'details', 'route' => 'myeventlane_event_studio.workspace_information', 'label' => $this->t('Details'), 'url' => Url::fromRoute('myeventlane_event_studio.workspace_information', ['node' => $event_id])->toString()],
+      ['key' => 'tickets', 'route' => 'myeventlane_event_studio.workspace_tickets', 'label' => $this->t('Tickets'), 'url' => Url::fromRoute('myeventlane_event_studio.workspace_tickets', ['node' => $event_id])->toString()],
+      ['key' => 'attendees', 'route' => 'myeventlane_event_studio.workspace_attendees', 'label' => $this->t('Attendees'), 'url' => Url::fromRoute('myeventlane_event_studio.workspace_attendees', ['node' => $event_id])->toString()],
+      ['key' => 'messages', 'route' => 'myeventlane_event_studio.workspace_messaging', 'label' => $this->t('Messages'), 'url' => Url::fromRoute('myeventlane_event_studio.workspace_messaging', ['node' => $event_id])->toString()],
+      ['key' => 'marketing', 'route' => 'myeventlane_event_studio.workspace_marketing', 'label' => $this->t('Marketing'), 'url' => Url::fromRoute('myeventlane_event_studio.workspace_marketing', ['node' => $event_id])->toString()],
+      ['key' => 'orders', 'route' => 'myeventlane_event_studio.workspace_orders', 'label' => $this->t('Orders'), 'url' => Url::fromRoute('myeventlane_event_studio.workspace_orders', ['node' => $event_id])->toString()],
+      ['key' => 'analytics', 'route' => 'myeventlane_event_studio.workspace_analytics', 'label' => $this->t('Analytics'), 'url' => Url::fromRoute('myeventlane_event_studio.workspace_analytics', ['node' => $event_id])->toString()],
+      ['key' => 'publishing', 'route' => 'myeventlane_event_studio.workspace_publishing', 'label' => $this->t('Publishing'), 'url' => Url::fromRoute('myeventlane_event_studio.workspace_publishing', ['node' => $event_id])->toString()],
+      ['key' => 'settings', 'route' => 'myeventlane_event_studio.workspace_settings', 'label' => $this->t('Settings'), 'url' => Url::fromRoute('myeventlane_event_studio.workspace_settings', ['node' => $event_id])->toString()],
     ];
 
     $current_route_name = (string) $this->routeMatch->getRouteName();

--- a/web/modules/custom/myeventlane_vendor/src/Hook/VendorConsolePagePreprocess.php
+++ b/web/modules/custom/myeventlane_vendor/src/Hook/VendorConsolePagePreprocess.php
@@ -104,7 +104,18 @@ final class VendorConsolePagePreprocess {
     ];
 
     $current_route_name = (string) $this->routeMatch->getRouteName();
+    // Overview tab links to Event Workspace studio overview, but staff mission
+    // control lives on myeventlane_vendor.console.event_workspace — treat both
+    // as the Overview active state.
+    $overview_active_routes = [
+      'myeventlane_event_studio.workspace',
+      'myeventlane_vendor.console.event_workspace',
+    ];
     foreach ($workspace_tabs as &$tab) {
+      if (($tab['key'] ?? '') === 'overview') {
+        $tab['active'] = in_array($current_route_name, $overview_active_routes, TRUE);
+        continue;
+      }
       $tab['active'] = ($tab['route'] === $current_route_name);
     }
     unset($tab);

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorEventTabsService.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorEventTabsService.php
@@ -252,6 +252,30 @@ final class VendorEventTabsService {
       ];
     }
 
+    // Legacy Manager pages still call getTabs(..., 'refund_requests'|'boost').
+    // Keep these keys so refund/Boost screens retain an active tab and entry point.
+    if ($this->moduleHandler->moduleExists('myeventlane_refunds')) {
+      $rows[] = [
+        'key' => 'refund_requests',
+        'label' => (string) $t->translate('Refunds'),
+        'route' => 'myeventlane_refunds.vendor_refund_requests',
+        'params' => ['node' => $id],
+        'disabled' => !$isTickets,
+        'disabled_reason' => (string) $t->translate('Refunds apply to ticketed events.'),
+      ];
+    }
+
+    if ($this->routeExists('myeventlane_boost.vendor_event_boost')) {
+      $rows[] = [
+        'key' => 'boost',
+        'label' => (string) $t->translate('Boost'),
+        'route' => 'myeventlane_boost.vendor_event_boost',
+        'params' => ['event' => $id],
+        'disabled' => !$isTickets,
+        'disabled_reason' => (string) $t->translate('Turn on paid tickets for this event to use this section.'),
+      ];
+    }
+
     return $rows;
   }
 

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorEventTabsService.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorEventTabsService.php
@@ -18,10 +18,10 @@ use Drupal\node\NodeInterface;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 /**
- * Builds event console tabs for RSVP vs ticketed mode.
+ * Builds event console tabs aligned to VX2 Event Workspace IA.
  *
  * Primary sections stay consistent; items that do not apply are shown disabled.
- * URLs are generated from canonical routes (TASK 8).
+ * Organisers are redirected into Event Workspace (Studio shell) for most routes.
  */
 final class VendorEventTabsService {
 
@@ -110,43 +110,76 @@ final class VendorEventTabsService {
     $isTickets = $this->eventModeManager->isTicketsEnabled($event);
     $t = $this->stringTranslation;
 
+    // Convergence secondary nav: mirror Event Workspace section map.
     $rows = [
       [
         'key' => 'overview',
         'label' => (string) $t->translate('Overview'),
-        'route' => 'myeventlane_vendor.console.event_workspace',
-        'params' => ['event' => $id],
-        'disabled' => FALSE,
-        'disabled_reason' => '',
-      ],
-      [
-        'key' => 'tickets',
-        'label' => (string) $t->translate('Advanced ticket tools'),
-        'route' => 'myeventlane_vendor.console.event_tickets',
-        'params' => ['event' => $id],
-        'disabled' => !$isTickets,
-        'disabled_reason' => (string) $t->translate('Turn on paid tickets for this event to use this section.'),
-      ],
-      [
-        'key' => 'rsvps',
-        'label' => (string) $t->translate('RSVPs'),
-        'route' => 'myeventlane_vendor.console.event_rsvps',
-        'params' => ['event' => $id],
-        'disabled' => !$isRsvp,
-        'disabled_reason' => (string) $t->translate('RSVPs apply when this event has RSVP enabled.'),
-      ],
-      [
-        'key' => 'attendees',
-        'label' => (string) $t->translate('Attendees'),
-        'route' => 'myeventlane_event_attendees.vendor_list',
+        'route' => 'myeventlane_event_studio.workspace',
         'params' => ['node' => $id],
         'disabled' => FALSE,
         'disabled_reason' => '',
       ],
       [
-        'key' => 'operations',
-        'label' => (string) $t->translate('Door Mode'),
-        'route' => 'myeventlane_event_attendees.vendor_operations',
+        'key' => 'details',
+        'label' => (string) $t->translate('Details'),
+        'route' => 'myeventlane_event_studio.workspace_information',
+        'params' => ['node' => $id],
+        'disabled' => FALSE,
+        'disabled_reason' => '',
+      ],
+      [
+        'key' => 'schedule',
+        'label' => (string) $t->translate('Schedule'),
+        'route' => 'myeventlane_event_studio.workspace_schedule',
+        'params' => ['node' => $id],
+        'disabled' => FALSE,
+        'disabled_reason' => '',
+      ],
+      [
+        'key' => 'venue',
+        'label' => (string) $t->translate('Venue'),
+        'route' => 'myeventlane_event_studio.workspace_venue',
+        'params' => ['node' => $id],
+        'disabled' => FALSE,
+        'disabled_reason' => '',
+      ],
+      [
+        'key' => 'images',
+        'label' => (string) $t->translate('Images'),
+        'route' => 'myeventlane_event_studio.workspace_branding',
+        'params' => ['node' => $id],
+        'disabled' => FALSE,
+        'disabled_reason' => '',
+      ],
+      [
+        'key' => 'tickets',
+        'label' => (string) $t->translate('Tickets'),
+        'route' => 'myeventlane_event_studio.workspace_tickets',
+        'params' => ['node' => $id],
+        'disabled' => FALSE,
+        'disabled_reason' => '',
+      ],
+      [
+        'key' => 'attendees',
+        'label' => (string) $t->translate('Attendees'),
+        'route' => 'myeventlane_event_studio.workspace_attendees',
+        'params' => ['node' => $id],
+        'disabled' => FALSE,
+        'disabled_reason' => '',
+      ],
+      [
+        'key' => 'messages',
+        'label' => (string) $t->translate('Messages'),
+        'route' => 'myeventlane_event_studio.workspace_messaging',
+        'params' => ['node' => $id],
+        'disabled' => FALSE,
+        'disabled_reason' => '',
+      ],
+      [
+        'key' => 'marketing',
+        'label' => (string) $t->translate('Marketing'),
+        'route' => 'myeventlane_event_studio.workspace_marketing',
         'params' => ['node' => $id],
         'disabled' => FALSE,
         'disabled_reason' => '',
@@ -154,16 +187,48 @@ final class VendorEventTabsService {
       [
         'key' => 'orders',
         'label' => (string) $t->translate('Orders'),
-        'route' => 'myeventlane_vendor.console.event_orders',
-        'params' => ['event' => $id],
+        'route' => 'myeventlane_event_studio.workspace_orders',
+        'params' => ['node' => $id],
         'disabled' => !$isTickets,
         'disabled_reason' => (string) $t->translate('Turn on paid tickets for this event to use this section.'),
       ],
+      [
+        'key' => 'analytics',
+        'label' => (string) $t->translate('Analytics'),
+        'route' => 'myeventlane_event_studio.workspace_analytics',
+        'params' => ['node' => $id],
+        'disabled' => FALSE,
+        'disabled_reason' => '',
+      ],
+      [
+        'key' => 'publishing',
+        'label' => (string) $t->translate('Publishing'),
+        'route' => 'myeventlane_event_studio.workspace_publishing',
+        'params' => ['node' => $id],
+        'disabled' => FALSE,
+        'disabled_reason' => '',
+      ],
+      [
+        'key' => 'settings',
+        'label' => (string) $t->translate('Settings'),
+        'route' => 'myeventlane_event_studio.workspace_settings',
+        'params' => ['node' => $id],
+        'disabled' => FALSE,
+        'disabled_reason' => '',
+      ],
+    ];
+
+    // Door Mode remains available as Attendees mode (not a competing product).
+    $rows[] = [
+      'key' => 'operations',
+      'label' => (string) $t->translate('Door Mode'),
+      'route' => 'myeventlane_event_attendees.vendor_operations',
+      'params' => ['node' => $id],
+      'disabled' => FALSE,
+      'disabled_reason' => '',
     ];
 
     if ($this->routeExists('myeventlane_vendor.console.event_operational_addon_orders')) {
-      // Match workspace paid/both gate: linked ticket product, not MODE_PAID alone
-      // (RSVP events with a non-hybrid product still surface operational add-ons).
       $showAddons = $this->eventStateResolver->hasProductTarget($event)
         && $this->vendorOperationalAddonOrderBuilder->shouldSurfaceVendorAddonsTab($event);
       $rows[] = [
@@ -176,56 +241,16 @@ final class VendorEventTabsService {
       ];
     }
 
-    if ($this->moduleHandler->moduleExists('myeventlane_refunds')) {
+    if ($isRsvp && $this->routeExists('myeventlane_vendor.console.event_rsvps')) {
       $rows[] = [
-        'key' => 'refund_requests',
-        'label' => (string) $t->translate('Refund requests'),
-        'route' => 'myeventlane_refunds.vendor_refund_requests',
-        'params' => ['node' => $id],
-        'disabled' => !$isTickets,
-        'disabled_reason' => (string) $t->translate('Refund requests apply to ticketed events.'),
-      ];
-    }
-
-    $rows[] = [
-      'key' => 'analytics',
-      'label' => (string) $t->translate('Analytics'),
-      'route' => 'myeventlane_vendor.console.event_analytics',
-      'params' => ['event' => $id],
-      'disabled' => FALSE,
-      'disabled_reason' => '',
-    ];
-
-    if ($this->routeExists('myeventlane_vendor.console.event_promotion')) {
-      $rows[] = [
-        'key' => 'promotion',
-        'label' => (string) $t->translate('Messages'),
-        'route' => 'myeventlane_vendor.console.event_promotion',
+        'key' => 'rsvps',
+        'label' => (string) $t->translate('RSVPs'),
+        'route' => 'myeventlane_vendor.console.event_rsvps',
         'params' => ['event' => $id],
         'disabled' => FALSE,
         'disabled_reason' => '',
       ];
     }
-
-    if ($this->routeExists('myeventlane_boost.vendor_event_boost')) {
-      $rows[] = [
-        'key' => 'boost',
-        'label' => (string) $t->translate('Boost'),
-        'route' => 'myeventlane_boost.vendor_event_boost',
-        'params' => ['event' => $id],
-        'disabled' => !$isTickets,
-        'disabled_reason' => (string) $t->translate('Turn on paid tickets for this event to use this section.'),
-      ];
-    }
-
-    $rows[] = [
-      'key' => 'settings',
-      'label' => (string) $t->translate('Settings'),
-      'route' => 'myeventlane_vendor.console.event_settings',
-      'params' => ['event' => $id],
-      'disabled' => FALSE,
-      'disabled_reason' => '',
-    ];
 
     return $rows;
   }
@@ -257,25 +282,15 @@ final class VendorEventTabsService {
   /**
    * @param array<string, mixed> $parameters
    */
-  private function routeUrlIfAccessible(string $routeName, array $parameters, AccountInterface $account): ?Url {
-    if (!$account->isAuthenticated()) {
-      return NULL;
-    }
-    if (!$this->routeExists($routeName)) {
+  private function routeUrlIfAccessible(string $route_name, array $parameters, AccountInterface $account): ?Url {
+    if (!$this->routeExists($route_name)) {
       return NULL;
     }
     try {
-      $access = $this->accessManager->checkNamedRoute($routeName, $parameters, $account, TRUE);
-      if (!$access->isAllowed()) {
+      if (!$this->accessManager->checkNamedRoute($route_name, $parameters, $account)) {
         return NULL;
       }
-    }
-    catch (\Throwable) {
-      return NULL;
-    }
-
-    try {
-      return Url::fromRoute($routeName, $parameters);
+      return Url::fromRoute($route_name, $parameters);
     }
     catch (\Throwable) {
       return NULL;

--- a/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorConsolePagePreprocessOverviewActiveTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorConsolePagePreprocessOverviewActiveTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_vendor\Unit;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Routing\UrlGeneratorInterface;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\Utility\UnroutedUrlAssemblerInterface;
+use Drupal\myeventlane_vendor\Hook\VendorConsolePagePreprocess;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_vendor\Hook\VendorConsolePagePreprocess
+ * @group myeventlane_vendor
+ */
+final class VendorConsolePagePreprocessOverviewActiveTest extends UnitTestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function tearDown(): void {
+    \Drupal::unsetContainer();
+    parent::tearDown();
+  }
+
+  /**
+   * @covers ::preprocess
+   */
+  public function testOverviewTabActiveOnStaffMissionControlRoute(): void {
+    $variables = $this->preprocessForRoute('myeventlane_vendor.console.event_workspace');
+    $overview = $this->overviewTab($variables);
+    $this->assertTrue($overview['active'], 'Overview must be active on staff mission control.');
+    $this->assertFalse($this->anyOtherTabActive($variables), 'No other tab should be active on mission control.');
+    $this->assertSame('myeventlane_event_studio.workspace', $overview['route']);
+  }
+
+  /**
+   * @covers ::preprocess
+   */
+  public function testOverviewTabActiveOnStudioWorkspaceRoute(): void {
+    $variables = $this->preprocessForRoute('myeventlane_event_studio.workspace');
+    $overview = $this->overviewTab($variables);
+    $this->assertTrue($overview['active']);
+  }
+
+  /**
+   * @covers ::preprocess
+   */
+  public function testOverviewTabInactiveOnTicketsRoute(): void {
+    $variables = $this->preprocessForRoute('myeventlane_event_studio.workspace_tickets');
+    $overview = $this->overviewTab($variables);
+    $this->assertFalse($overview['active']);
+    $tickets = NULL;
+    foreach ($variables['workspace']['tabs'] as $tab) {
+      if (($tab['key'] ?? '') === 'tickets') {
+        $tickets = $tab;
+        break;
+      }
+    }
+    $this->assertIsArray($tickets);
+    $this->assertTrue($tickets['active']);
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function preprocessForRoute(string $route_name): array {
+    $event = $this->createMock(NodeInterface::class);
+    $event->method('bundle')->willReturn('event');
+    $event->method('id')->willReturn(42);
+    $event->method('label')->willReturn('Test event');
+    $event->method('isPublished')->willReturn(FALSE);
+    $event->method('hasField')->willReturn(FALSE);
+
+    $routeMatch = $this->createMock(RouteMatchInterface::class);
+    $routeMatch->method('getParameter')->with('event')->willReturn($event);
+    $routeMatch->method('getRouteName')->willReturn($route_name);
+
+    $translation = $this->createMock(TranslationInterface::class);
+    $translation->method('translate')->willReturnCallback(
+      static fn (string $string, array $args = [], array $options = []) => $string,
+    );
+
+    $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+    $urlGenerator->method('generateFromRoute')->willReturnCallback(
+      static fn (string $name, array $parameters = [], array $options = []): string => '/' . str_replace('.', '/', $name),
+    );
+    $unrouted = $this->createMock(UnroutedUrlAssemblerInterface::class);
+    $unrouted->method('assemble')->willReturn('/');
+
+    $container = new ContainerBuilder();
+    $container->set('string_translation', $translation);
+    $container->set('url_generator', $urlGenerator);
+    $container->set('unrouted_url_assembler', $unrouted);
+    \Drupal::setContainer($container);
+
+    $preprocess = new VendorConsolePagePreprocess($routeMatch, $translation, NULL);
+    $variables = [];
+    $preprocess->preprocess($variables);
+    return $variables;
+  }
+
+  /**
+   * @param array<string, mixed> $variables
+   *
+   * @return array<string, mixed>
+   */
+  private function overviewTab(array $variables): array {
+    $this->assertArrayHasKey('workspace', $variables);
+    foreach ($variables['workspace']['tabs'] as $tab) {
+      if (($tab['key'] ?? '') === 'overview') {
+        return $tab;
+      }
+    }
+    $this->fail('Overview tab missing.');
+  }
+
+  /**
+   * @param array<string, mixed> $variables
+   */
+  private function anyOtherTabActive(array $variables): bool {
+    foreach ($variables['workspace']['tabs'] as $tab) {
+      if (($tab['key'] ?? '') !== 'overview' && !empty($tab['active'])) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+}


### PR DESCRIPTION
## Summary
- Converge Studio / Manager / Workspace into one Event Workspace chrome with Convergence secondary nav (Overview → Settings).
- Rebuild Overview as the organiser home (next action, readiness, sales, Stripe, marketing, analytics).
- Humanise publishing readiness and warm empty/celebration copy (AU English).

## Test plan
- [ ] Open an event as organiser → Event Workspace (not “Studio” / “Manager”)
- [ ] Confirm single sidebar: Overview…Settings; no Commerce / Studio / Manager labels
- [ ] Overview shows next action + readiness checklist
- [ ] Publishing explains blockers; almost-ready copy when one item left
- [ ] Marketing / Publishing sections load; Boost entry from Marketing when live
- [ ] Legacy Manager paths still redirect for non-staff
- [ ] Keyboard + mobile sidebar toggle; focus / landmarks
- [ ] Create Event + draft choice still work (Sprint 1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad organiser navigation and publish/readiness UX changes across Event Studio and vendor console; publish and paid-ticket Stripe gating paths are touched but access remains route-based.
> 
> **Overview**
> **VX2 Sprint 2 (One Event Workspace)** unifies organiser event chrome under **Event Workspace** instead of Studio/Manager product names, and ships a Convergence secondary nav from Overview through Settings.
> 
> The Studio shell gains **Event Workspace** topbar/sidebar (Events breadcrumb, **Live**/Draft, “View page”), section plugins regrouped under **Workspace** with advanced areas hidden from primary nav, and **route aliases** (Details, Schedule, Venue, Images, Messages) plus new **Marketing** and **Publishing** sections. **Overview** is rebuilt via `EventWorkspaceOverviewBuilder` (next action, human readiness checklist, sales/Stripe/marketing/analytics cards, quick links, subtle celebration). Readiness copy and the publish strip move to organiser-friendly explanations and checklist UI, kept in sync on AJAX publish via shell JS.
> 
> **Schedule/Venue/Details** still share `EventInformationForm` but saves and autosave drafts now stay on the opened section (canonical `information` draft key). Vendor **event tabs** and console preprocess point at Studio workspace routes; staff mission-control Overview stays available with matching active-tab behaviour. Convergence docs record Sprint 2 as shipped on `feature/vx2-event-workspace`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d07f734e401d059a6d685eabf05ed9d1d7fe28ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->