### PR TITLE
feat(vx2): Sprint 3 — The Ticket Experience

### DIFF
--- a/docs/vendor-experience-convergence-implementation-plan.md
+++ b/docs/vendor-experience-convergence-implementation-plan.md
@@ -49,7 +49,7 @@ This plan tells engineering **what to build in what order**. It does not prescri
 | C-16 / C-17 | Messages send unification / Orders hub | VX2-06 / later |
 | C-12 | Check-in stacks → Door Mode | VX2-05 |
 | — | Schedule/Venue dedicated field forms (currently shared information form) | VX2-03 follow-up |
-| C-14 | Tickets app (advanced collapsed UX depth) | VX2-04 |
+| C-14 | Tickets app (advanced collapsed UX depth) | VX2-04 | **Sprint 3 shipped** |
 
 **Screens / surfaces touched (Sprint 2)**
 
@@ -215,7 +215,25 @@ Workspace shell (VX2-03); mel_ticket_type remains abstraction.
 
 GA + VIP creatable without Commerce words; advanced optional.
 
----
+### Sprint 3 shipped (2026-07-22)
+
+| Item | Status |
+| --- | --- |
+| Workspace Tickets app shell | Done — `EventStudioSectionRenderer::buildTicketsStack` |
+| Card UX + empty state (AU English) | Done |
+| Add Ticket / Duplicate / Archive | Done |
+| Advanced Ticket Tools disclosure | Done |
+| Commerce language cleanup on organiser ticket surfaces | Done |
+| Instrumentation hooks (logger + JS) | Done (analytics consumer deferred) |
+| Full retirement of `/vendor/events/{id}/tickets` manager | Remaining — demoted, not deleted |
+| Guest questions under Advanced only | Remaining — still independent Workspace section when enabled |
+
+### Remaining after Sprint 3
+
+- Optional redirect of Advanced manager Overview → Workspace Tickets  
+- Deeper per-ticket drawer edit (vs inline cards) if large inventories need tables  
+- Wire `mel:analytics` / logger hooks into the platform analytics pipeline  
+- VX2-05 Attendees / Door Mode
 
 ## VX2-05 — Attendees
 

--- a/docs/vendor-experience-convergence-screen-specifications.md
+++ b/docs/vendor-experience-convergence-screen-specifications.md
@@ -189,6 +189,14 @@ Format: Purpose · Primary action · Content · States · Notes
 | **Content** | List of ticket types (GA, VIP, etc.); price; capacity; availability windows; free/paid; expand Advanced: groups, access codes, widgets, inventory |
 | **States** | No tickets; RSVP-only mode; sold out; Stripe required for paid |
 | **Notes** | One ticket application — hide Product/Variation |
+| **Sprint 3** | Live in Event Workspace Tickets (`EventStudioOperationalTicketsForm` + `buildAdvancedTicketTools`). Cards first; sticky Add Ticket on mobile; Advanced Ticket Tools collapsed; Commerce product autocomplete admin-only |
+
+### Flows (Sprint 3)
+
+1. **Add ticket** — name → price (or Free RSVP) → capacity → availability → save  
+2. **Duplicate / Archive** — quick actions on each card  
+3. **Access codes / Widgets / Groups** — under Advanced Ticket Tools  
+4. **Inventory sync** — Advanced → Inventory & sync tools (demoted manager)
 
 ### B7. Attendees
 

--- a/docs/vendor-experience-convergence-success-metrics.md
+++ b/docs/vendor-experience-convergence-success-metrics.md
@@ -92,7 +92,10 @@ Minimum events to log (names illustrative):
 - `organiser_onboard_step_completed`
 - `stripe_connect_started` / `stripe_connect_completed` / `stripe_connect_needs_attention`
 - `event_create_started` / `event_draft_resumed` / `event_draft_started_new`
-- `ticket_type_created`
+- `ticket_type_created` (alias of `ticket_created` — Sprint 3 logger uses `ticket_created`)
+- `ticket_created` / `ticket_updated` / `ticket_archived` / `ticket_deleted` (VX2-04 hooks; delete reserved)
+- `advanced_tools_opened` (Tickets Advanced disclosure)
+- `access_code_created` / `widget_created`
 - `event_publish_succeeded` / `event_publish_blocked` (+ reason codes)
 - `boost_wizard_step` / `boost_purchased`
 - `message_sent` / `message_failed`

--- a/docs/vendor-experience-convergence.md
+++ b/docs/vendor-experience-convergence.md
@@ -3,7 +3,7 @@
 **Product Blueprint & Migration Plan**  
 **Status:** Complete — ready to drive the next generation of MyEventLane development  
 **Date:** 2026-07-22  
-**Runtime:** VX2 Sprint 2 (One Event Workspace / VX2-03) on branch `feature/vx2-event-workspace` (2026-07-22); Sprint 1 merged via PR #701  
+**Runtime:** VX2 Sprint 3 (The Ticket Experience / VX2-04) on branch `feature/vx2-ticket-experience` (2026-07-22); Sprint 2 merged via PR #702; Sprint 1 merged via PR #701  
 **Method:** Repository review + synthesis of VX2 product docs and prior audits  
 **Language standard:** Organiser (human) · `vendor` (machine / URLs)
 
@@ -78,7 +78,7 @@ Permanent principles remain in [`vendor-experience-v2-design-principles.md`](ven
 2. Event Studio remains the builder / publish authority; Event Manager and Studio converge into **one Event Workspace**.
 3. `mel_ticket_type` remains the ticket abstraction; Commerce stays hidden.
 4. Workspace ownership (ADR-0008) remains the access contract.
-5. ~~This pack does **not** change runtime behaviour.~~ **Update (Sprint 1):** organiser-visible language, shell navigation, Create Event gateway alignment, and placeholder redirects are live in code. **Update (Sprint 2):** One Event Workspace shell/nav, Overview home, human readiness, Marketing/Publishing sections, and Manager tab convergence are live in code.
+5. ~~This pack does **not** change runtime behaviour.~~ **Update (Sprint 1):** organiser-visible language, shell navigation, Create Event gateway alignment, and placeholder redirects are live in code. **Update (Sprint 2):** One Event Workspace shell/nav, Overview home, human readiness, Marketing/Publishing sections, and Manager tab convergence are live in code. **Update (Sprint 3):** One Tickets app in Event Workspace with card UX, empty states, duplicate/archive, progressive Advanced Ticket Tools, and Commerce terminology removed from organiser ticket surfaces.
 6. Prior VX2 findings are treated as authoritative unless contradicted by the 2026-07-22 inventory.
 
 ---
@@ -423,7 +423,21 @@ Full definitions: [`vendor-experience-convergence-success-metrics.md`](vendor-ex
 | Empty states / celebration | **Done** — AU warm empty copy; publish celebration without emoji gimmick |
 | Manager dual chrome | **Converged** — tabs/preprocess point at Workspace routes; staff mission-control retained |
 | Dedicated Schedule/Venue field forms | **Partial** — nav sections share Event information form (field split deferred) |
-| Full Attendees / Door / Tickets depth | **Deferred** — VX2-04 / VX2-05 |
+| Full Attendees / Door depth | **Deferred** — VX2-05 |
+| Tickets app depth | **Done** — VX2-04 (see Sprint 3) |
+
+## Sprint 3 runtime status (VX2-04 The Ticket Experience)
+
+| Area | Status |
+| --- | --- |
+| One Tickets app in Event Workspace | **Done** — `workspace_tickets` stack: booking mode → ticket cards → preview → Advanced |
+| Ticket cards (name, price, capacity, availability, status, sales) | **Done** — `EventStudioOperationalTicketsForm` |
+| Primary CTA **Add Ticket** | **Done** — empty-state + details + mobile sticky CTA |
+| Duplicate / Archive | **Done** — lifecycle `duplicateTicketOnEvent` + quick actions |
+| Progressive **Advanced Ticket Tools** | **Done** — codes, groups, widgets, settings, inventory/sync nested |
+| Commerce Product / Variation / SKU organiser copy | **Removed** from ticket manager + booking product autocomplete hidden for organisers |
+| Instrumentation hooks | **Partial** — logger + JS hooks for ticket_created/updated/archived, advanced_tools_opened, access_code_created, widget_created; full analytics pipeline deferred |
+| Redirect Advanced manager to Workspace-only | **Partial** — manager demoted with Workspace CTA; deep routes retained under Advanced |
 
 ---
 
@@ -433,4 +447,4 @@ Full definitions: [`vendor-experience-convergence-success-metrics.md`](vendor-ex
 
 **Biggest revenue opportunities:** Faster first publish; higher Stripe completion; free Analytics pulse that earns Pro; clearer Boost / Marketing; fewer support dead ends that abandon paid flows.
 
-**Vendor Experience Convergence blueprint is complete.** Sprint 1 delivered Trust, Language & Navigation; Sprint 2 delivered One Event Workspace; remaining epics follow the roadmap.
+**Vendor Experience Convergence blueprint is complete.** Sprint 1 delivered Trust, Language & Navigation; Sprint 2 delivered One Event Workspace; Sprint 3 delivered The Ticket Experience; remaining epics follow the roadmap.

--- a/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
@@ -136,6 +136,7 @@ services:
       - '@myeventlane_event.ticket_type_manager'
       - '@logger.factory'
       - '@myeventlane_vendor.event_access_checker'
+      - '@database'
 
   myeventlane_event.booking_flow_resolver:
     class: Drupal\myeventlane_event\Service\BookingFlowResolver

--- a/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
+++ b/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
@@ -305,6 +305,71 @@ final class TicketTierLifecycleService implements EventPaidTicketLoaderInterface
   }
 
   /**
+   * Duplicates a ticket type onto the same event as a draft copy.
+   *
+   * Commerce sync runs through {@see createAttachAndSync()}. Best-value is not
+   * copied so organisers intentionally choose a highlight.
+   *
+   * @throws \InvalidArgumentException
+   */
+  public function duplicateTicketOnEvent(
+    NodeInterface $event,
+    TicketTypeInterface $source,
+    AccountInterface $account,
+  ): TicketTypeInterface {
+    if ($event->bundle() !== 'event') {
+      throw new InvalidArgumentException('Duplicate target must be an event node.');
+    }
+    $sourceId = (int) $source->id();
+    if ($sourceId < 1 || !$this->ticketBelongsToEvent($event, $sourceId)) {
+      throw new InvalidArgumentException('Ticket does not belong to this event.');
+    }
+
+    $kind = $source->getTicketKind();
+    $input = [
+      'title' => trim($source->getTitle()) . ' (copy)',
+      'ticket_kind' => $kind,
+      'status' => 0,
+      'field_is_best_value' => 0,
+      'field_is_default_ticket' => 0,
+    ];
+
+    if ($source->hasField('visibility_mode') && !$source->get('visibility_mode')->isEmpty()) {
+      $input['visibility_mode'] = (string) $source->get('visibility_mode')->value;
+    }
+    if ($source->hasField('short_description') && !$source->get('short_description')->isEmpty()) {
+      $input['short_description'] = (string) $source->get('short_description')->value;
+    }
+    if (!$source->get('capacity')->isEmpty()) {
+      $input['capacity'] = (int) $source->get('capacity')->value;
+    }
+    if (!$source->get('sale_start')->isEmpty()) {
+      $input['sale_start'] = (string) $source->get('sale_start')->value;
+    }
+    if (!$source->get('sale_end')->isEmpty()) {
+      $input['sale_end'] = (string) $source->get('sale_end')->value;
+    }
+
+    if ($kind === 'paid') {
+      $price = $source->toPriceValue();
+      if ($price === NULL) {
+        throw new InvalidArgumentException('Paid tickets require a price greater than zero.');
+      }
+      $input['price_amount'] = $price->getNumber();
+      $input['price_currency'] = $price->getCurrencyCode();
+    }
+    if ($kind === 'external') {
+      if ($source->get('external_url')->isEmpty()) {
+        throw new InvalidArgumentException('External tickets require a valid https URL.');
+      }
+      $input['external_uri'] = (string) $source->get('external_url')->uri;
+    }
+
+    $values = $this->buildTicketValuesFromInput($event, $account, $input);
+    return $this->createAttachAndSync($event, $values);
+  }
+
+  /**
    * Unpublishes the tier, detaches it from the event, and syncs Commerce.
    */
   public function archiveTicketOnEvent(NodeInterface $event, TicketTypeInterface $ticket): void {

--- a/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
+++ b/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
@@ -8,6 +8,7 @@ use Drupal\commerce_price\Price;
 use Drupal\commerce_product\Entity\ProductInterface;
 use Drupal\commerce_product\Entity\ProductVariation;
 use Drupal\commerce_product\Entity\ProductVariationInterface;
+use Drupal\Core\Database\Connection;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityPublishedInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -42,6 +43,7 @@ final class TicketTierLifecycleService implements EventPaidTicketLoaderInterface
     private readonly TicketTypeManager $ticketTypeManager,
     private readonly LoggerChannelFactoryInterface $loggerFactory,
     private readonly EventVendorAccessChecker $eventVendorAccessChecker,
+    private readonly Connection $database,
   ) {}
 
   /**
@@ -469,6 +471,41 @@ final class TicketTierLifecycleService implements EventPaidTicketLoaderInterface
       return;
     }
     $this->applyValuesToTicket($ticket, $values);
+  }
+
+  /**
+   * Applies source edits and creates a duplicate in one database transaction.
+   *
+   * Prevents partial outcomes where either the source saves without a copy or
+   * the copy is created while same-request source edits are rolled back.
+   *
+   * @param array<string, mixed> $values
+   *
+   * @throws \InvalidArgumentException
+   * @throws \Throwable
+   */
+  public function updateAndDuplicateTicketOnEvent(
+    NodeInterface $event,
+    TicketTypeInterface $ticket,
+    AccountInterface $account,
+    array $values,
+  ): TicketTypeInterface {
+    $this->applyTicketValuesWithoutSave($ticket, $values);
+    $this->validateTicketTypeForPersist($ticket, $event);
+    // Fail before any write when the copy title cannot be formed.
+    $this->buildDuplicateTicketTitle($ticket->getTitle());
+
+    $transaction = $this->database->startTransaction();
+    try {
+      // Persist source first so a duplicate failure rolls the source edits back
+      // with the same transaction as the copy create/attach.
+      $this->updateTicketType($ticket, $event, []);
+      return $this->duplicateTicketOnEvent($event, $ticket, $account);
+    }
+    catch (\Throwable $e) {
+      $transaction->rollBack();
+      throw $e;
+    }
   }
 
   /**

--- a/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
+++ b/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
@@ -33,6 +33,10 @@ final class TicketTierLifecycleService implements EventPaidTicketLoaderInterface
 
   private const SHORT_DESCRIPTION_MAX_LENGTH = 320;
 
+  private const TICKET_TITLE_MAX_LENGTH = 255;
+
+  private const DUPLICATE_TITLE_SUFFIX = ' (copy)';
+
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly TicketTypeManager $ticketTypeManager,
@@ -334,7 +338,7 @@ final class TicketTierLifecycleService implements EventPaidTicketLoaderInterface
     }
 
     $values = [
-      'title' => trim($source->getTitle()) . ' (copy)',
+      'title' => $this->buildDuplicateTicketTitle($source->getTitle()),
       'ticket_kind' => $kind,
       'vendor_id' => ['target_id' => (int) $account->id()],
       'is_reusable' => FALSE,
@@ -430,6 +434,41 @@ final class TicketTierLifecycleService implements EventPaidTicketLoaderInterface
     }
 
     return $this->createAttachAndSync($event, $values);
+  }
+
+  /**
+   * Builds the duplicate ticket title or rejects names that cannot fit.
+   *
+   * @throws \InvalidArgumentException
+   *   When appending the duplicate suffix would exceed the title max length.
+   */
+  public function buildDuplicateTicketTitle(string $sourceTitle): string {
+    $base = trim($sourceTitle);
+    if ($base === '') {
+      throw new InvalidArgumentException('Ticket title is required.');
+    }
+    $title = $base . self::DUPLICATE_TITLE_SUFFIX;
+    if (mb_strlen($title) > self::TICKET_TITLE_MAX_LENGTH) {
+      throw new InvalidArgumentException(
+        'This ticket name is too long to duplicate. Shorten the name, then try again.',
+      );
+    }
+    return $title;
+  }
+
+  /**
+   * Applies ticket field values in memory without saving.
+   *
+   * Used so duplicate can read same-request edits before the source is
+   * persisted. Callers must still persist via {@see updateTicketType()}.
+   *
+   * @param array<string, mixed> $values
+   */
+  public function applyTicketValuesWithoutSave(TicketTypeInterface $ticket, array $values): void {
+    if ($values === []) {
+      return;
+    }
+    $this->applyValuesToTicket($ticket, $values);
   }
 
   /**

--- a/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
+++ b/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
@@ -307,8 +307,11 @@ final class TicketTierLifecycleService implements EventPaidTicketLoaderInterface
   /**
    * Duplicates a ticket type onto the same event as a draft copy.
    *
-   * Commerce sync runs through {@see createAttachAndSync()}. Best-value is not
-   * copied so organisers intentionally choose a highlight.
+   * Copies the same organiser configuration as
+   * {@see cloneFromReusableTemplate()} (waitlist, hidden checkout label,
+   * group-sale settings, capacity windows, etc.). Commerce variation IDs are
+   * never copied — sync creates a new variation for paid tiers. Best-value /
+   * default flags are reset so organisers choose highlights intentionally.
    *
    * @throws \InvalidArgumentException
    */
@@ -326,46 +329,106 @@ final class TicketTierLifecycleService implements EventPaidTicketLoaderInterface
     }
 
     $kind = $source->getTicketKind();
-    $input = [
+    if (!in_array($kind, ['paid', 'rsvp', 'external'], TRUE)) {
+      throw new InvalidArgumentException('Unsupported ticket kind for duplicate.');
+    }
+
+    $values = [
       'title' => trim($source->getTitle()) . ' (copy)',
       'ticket_kind' => $kind,
+      'vendor_id' => ['target_id' => (int) $account->id()],
+      'is_reusable' => FALSE,
+      'event' => ['target_id' => (int) $event->id()],
       'status' => 0,
+      'lifecycle_status' => TicketTypeInterface::LIFECYCLE_ACTIVE,
       'field_is_best_value' => 0,
       'field_is_default_ticket' => 0,
+      'commerce_variation' => NULL,
     ];
 
-    if ($source->hasField('visibility_mode') && !$source->get('visibility_mode')->isEmpty()) {
-      $input['visibility_mode'] = (string) $source->get('visibility_mode')->value;
-    }
-    if ($source->hasField('short_description') && !$source->get('short_description')->isEmpty()) {
-      $input['short_description'] = (string) $source->get('short_description')->value;
-    }
     if (!$source->get('capacity')->isEmpty()) {
-      $input['capacity'] = (int) $source->get('capacity')->value;
+      $values['capacity'] = (int) $source->get('capacity')->value;
+    }
+    if ($source->hasField('rsvp_limit') && !$source->get('rsvp_limit')->isEmpty()) {
+      $values['rsvp_limit'] = (int) $source->get('rsvp_limit')->value;
     }
     if (!$source->get('sale_start')->isEmpty()) {
-      $input['sale_start'] = (string) $source->get('sale_start')->value;
+      $values['sale_start'] = $source->get('sale_start')->getValue();
     }
     if (!$source->get('sale_end')->isEmpty()) {
-      $input['sale_end'] = (string) $source->get('sale_end')->value;
+      $values['sale_end'] = $source->get('sale_end')->getValue();
+    }
+
+    if ($source->hasField('visibility_mode') && !$source->get('visibility_mode')->isEmpty()) {
+      $values['visibility_mode'] = (string) $source->get('visibility_mode')->value;
+    }
+    if ($source->hasField('hidden_label') && !$source->get('hidden_label')->isEmpty()) {
+      $values['hidden_label'] = (string) $source->get('hidden_label')->value;
+    }
+    if ($source->hasField('short_description') && !$source->get('short_description')->isEmpty()) {
+      $values['short_description'] = (string) $source->get('short_description')->value;
+    }
+    if ($source->hasField('waitlist_enabled')) {
+      $values['waitlist_enabled'] = $source->get('waitlist_enabled')->value ? 1 : 0;
+    }
+    if ($source->hasField('waitlist_capacity') && !$source->get('waitlist_capacity')->isEmpty()) {
+      $values['waitlist_capacity'] = (int) $source->get('waitlist_capacity')->value;
+    }
+    if ($source->hasField('auto_promote_waitlist')) {
+      $values['auto_promote_waitlist'] = $source->get('auto_promote_waitlist')->value ? 1 : 0;
+    }
+    if ($source->hasField('group_sale_mode') && !$source->get('group_sale_mode')->isEmpty()) {
+      $values['group_sale_mode'] = (string) $source->get('group_sale_mode')->value;
+    }
+    if ($source->hasField('group_min_size') && !$source->get('group_min_size')->isEmpty()) {
+      $values['group_min_size'] = (int) $source->get('group_min_size')->value;
+    }
+    if ($source->hasField('group_bundle_size') && !$source->get('group_bundle_size')->isEmpty()) {
+      $values['group_bundle_size'] = (int) $source->get('group_bundle_size')->value;
+    }
+
+    if ($source->hasField('field_use_ticket_attendee_questions')) {
+      $values['field_use_ticket_attendee_questions'] = $source->get('field_use_ticket_attendee_questions')->value ? 1 : 0;
+    }
+    if ($source->hasField('field_attendee_questions') && !$source->get('field_attendee_questions')->isEmpty()) {
+      $refs = [];
+      foreach ($source->get('field_attendee_questions')->referencedEntities() as $paragraph) {
+        if (!$paragraph instanceof \Drupal\paragraphs\ParagraphInterface) {
+          continue;
+        }
+        $dup = $paragraph->createDuplicate();
+        $dup->save();
+        $refs[] = [
+          'target_id' => (int) $dup->id(),
+          'target_revision_id' => (int) $dup->getRevisionId(),
+        ];
+      }
+      if ($refs !== []) {
+        $values['field_attendee_questions'] = $refs;
+      }
     }
 
     if ($kind === 'paid') {
       $price = $source->toPriceValue();
-      if ($price === NULL) {
+      if ($price === NULL || (float) $price->getNumber() <= 0) {
         throw new InvalidArgumentException('Paid tickets require a price greater than zero.');
       }
-      $input['price_amount'] = $price->getNumber();
-      $input['price_currency'] = $price->getCurrencyCode();
+      $values['price'] = [
+        'number' => $price->getNumber(),
+        'currency_code' => $price->getCurrencyCode(),
+      ];
     }
+    else {
+      $values['price'] = NULL;
+    }
+
     if ($kind === 'external') {
       if ($source->get('external_url')->isEmpty()) {
         throw new InvalidArgumentException('External tickets require a valid https URL.');
       }
-      $input['external_uri'] = (string) $source->get('external_url')->uri;
+      $values['external_url'] = $source->get('external_url')->getValue();
     }
 
-    $values = $this->buildTicketValuesFromInput($event, $account, $input);
     return $this->createAttachAndSync($event, $values);
   }
 

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -5641,3 +5641,156 @@
 .mel-event-studio-sidebar__heading:empty {
   display: none;
 }
+
+/* VX2 Sprint 3 — Tickets app */
+.mel-event-studio-tickets-app {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.mel-event-studio-ticket-empty--guided {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.25rem;
+  border: 1px dashed rgba(242, 109, 91, 0.35);
+  border-radius: 1.25rem;
+  background: linear-gradient(180deg, #fff8f5 0%, #ffffff 100%);
+  color: #334155;
+}
+
+.mel-event-studio-ticket-empty__title {
+  margin: 0;
+  color: #0f172a;
+  font-size: 1.15rem;
+  font-weight: 750;
+}
+
+.mel-event-studio-ticket-empty__lead,
+.mel-event-studio-ticket-empty__modes {
+  margin: 0;
+  line-height: 1.55;
+}
+
+.mel-event-studio-ticket-card__summary {
+  display: grid;
+  gap: 0.25rem;
+  margin-bottom: 0.75rem;
+}
+
+.mel-event-studio-ticket-card__summary-price,
+.mel-event-studio-ticket-card__summary-status,
+.mel-event-studio-ticket-card__summary-availability,
+.mel-event-studio-ticket-card__summary-capacity,
+.mel-event-studio-ticket-card__summary-sales {
+  margin: 0;
+  color: #475569;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.mel-event-studio-ticket-card__summary-price {
+  color: #0f172a;
+  font-size: 1.2rem;
+  font-weight: 750;
+}
+
+.mel-event-studio-ticket-card__quick-actions {
+  display: grid;
+  gap: 0.75rem;
+  padding-top: 0.25rem;
+}
+
+.mel-event-studio-ticket-card__quick-actions-hint {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.875rem;
+}
+
+.mel-event-studio-ticket-card__action {
+  min-height: 44px;
+}
+
+.mel-event-studio-ticket-add--primary > summary {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  font-size: 1.05rem;
+}
+
+.mel-event-studio-ticket-sticky-add {
+  display: none;
+}
+
+.mel-event-studio-advanced-tools {
+  padding: 1rem 1.15rem 1.15rem;
+}
+
+.mel-event-studio-advanced-tools__intro {
+  margin: 0 0 0.85rem;
+  color: #475569;
+  line-height: 1.55;
+}
+
+.mel-event-studio-advanced-tools__links {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.mel-event-studio-advanced-tools__link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 0.55rem 0.85rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.9rem;
+  background: #fff;
+  color: #0f172a;
+  font-weight: 650;
+  text-decoration: none;
+}
+
+.mel-event-studio-advanced-tools__link:focus-visible,
+.mel-event-studio-ticket-sticky-add__button:focus-visible {
+  outline: 2px solid #f26d5b;
+  outline-offset: 2px;
+}
+
+@media (max-width: 48rem) {
+  .mel-event-studio-ticket-card__body {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .mel-event-studio-ticket-card__sales-window {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .mel-event-studio-ticket-sticky-add {
+    position: sticky;
+    bottom: 0.75rem;
+    z-index: 20;
+    display: flex;
+    justify-content: stretch;
+    margin-top: 0.5rem;
+    pointer-events: none;
+  }
+
+  .mel-event-studio-ticket-sticky-add__button {
+    pointer-events: auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    min-height: 48px;
+    border-radius: 999px;
+    box-shadow: 0 12px 28px rgba(15, 23, 42, 0.18);
+    text-decoration: none;
+  }
+
+  .mel-event-studio-ticket-add,
+  .mel-event-studio-ticket-save,
+  .mel-event-studio-advanced-tools__link,
+  .mel-event-studio-ticket-card__checkbox {
+    min-height: 44px;
+  }
+}

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-tickets-app.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-tickets-app.js
@@ -1,6 +1,6 @@
 /**
  * @file
- * VX2 Tickets app progressive-disclosure analytics hooks.
+ * VX2 Tickets app: progressive disclosure analytics + Add Ticket sticky CTA.
  */
 (function (Drupal, once) {
   'use strict';
@@ -11,6 +11,28 @@
     if (window.dataLayer && typeof window.dataLayer.push === 'function') {
       window.dataLayer.push(payload);
     }
+  }
+
+  /**
+   * Opens the Add Ticket details panel and focuses the first useful control.
+   *
+   * Workspace routes load shell JS only — not mel-event-studio.js — so fragment
+   * links alone leave a closed <details> collapsed after scroll.
+   */
+  function openAddTicketPanel(details) {
+    if (!(details instanceof HTMLDetailsElement)) {
+      return;
+    }
+    details.open = true;
+    window.requestAnimationFrame(() => {
+      details.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      const focusTarget = details.querySelector(
+        'input:not([type="hidden"]):not([disabled]), select:not([disabled]), textarea:not([disabled])',
+      );
+      if (focusTarget instanceof HTMLElement) {
+        focusTarget.focus({ preventScroll: true });
+      }
+    });
   }
 
   Drupal.behaviors.melEventStudioTicketsApp = {
@@ -27,6 +49,25 @@
           emitAnalytics(details.dataset.melAnalyticsEvent || 'advanced_tools_opened', {
             event_id: details.dataset.melEventId || null,
           });
+        });
+      });
+
+      once('mel-tickets-sticky-add', '.mel-event-studio-ticket-sticky-add__button', context).forEach((link) => {
+        link.addEventListener('click', (event) => {
+          const href = link.getAttribute('href') || '';
+          if (!href.startsWith('#')) {
+            return;
+          }
+          const targetId = href.slice(1);
+          if (!targetId) {
+            return;
+          }
+          const details = document.getElementById(targetId);
+          if (!(details instanceof HTMLDetailsElement)) {
+            return;
+          }
+          event.preventDefault();
+          openAddTicketPanel(details);
         });
       });
     },

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-tickets-app.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-tickets-app.js
@@ -1,0 +1,34 @@
+/**
+ * @file
+ * VX2 Tickets app progressive-disclosure analytics hooks.
+ */
+(function (Drupal, once) {
+  'use strict';
+
+  function emitAnalytics(eventName, detail) {
+    const payload = Object.assign({ mel_analytics_event: eventName }, detail || {});
+    document.dispatchEvent(new CustomEvent('mel:analytics', { detail: payload }));
+    if (window.dataLayer && typeof window.dataLayer.push === 'function') {
+      window.dataLayer.push(payload);
+    }
+  }
+
+  Drupal.behaviors.melEventStudioTicketsApp = {
+    attach(context) {
+      once('mel-tickets-advanced-tools', '.mel-event-studio-advanced-tools', context).forEach((details) => {
+        details.addEventListener('toggle', () => {
+          if (!details.open) {
+            return;
+          }
+          if (details.dataset.melAnalyticsFired === '1') {
+            return;
+          }
+          details.dataset.melAnalyticsFired = '1';
+          emitAnalytics(details.dataset.melAnalyticsEvent || 'advanced_tools_opened', {
+            event_id: details.dataset.melEventId || null,
+          });
+        });
+      });
+    },
+  };
+})(Drupal, once);

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -1,5 +1,5 @@
 mel_event_studio:
-  version: 1.23
+  version: 1.24
   css:
     theme:
       css/mel-event-studio.css: {}
@@ -8,6 +8,7 @@ mel_event_studio:
       css/mel-event-studio-shell.css: { weight: 200 }
   js:
     js/mel-event-studio.js: {}
+    js/mel-event-studio-tickets-app.js: {}
   dependencies:
     - core/drupal
     - core/once
@@ -15,6 +16,14 @@ mel_event_studio:
     - myeventlane_location/address_autocomplete
     - myeventlane_event_studio/mel_event_studio_ai_assist
     - myeventlane_event_studio/mel_event_studio_highlights
+
+mel_event_studio_tickets_app:
+  version: 1.0
+  js:
+    js/mel-event-studio-tickets-app.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
 
 mel_event_studio_highlights:
   version: 1.0

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -18,7 +18,7 @@ mel_event_studio:
     - myeventlane_event_studio/mel_event_studio_highlights
 
 mel_event_studio_tickets_app:
-  version: 1.0
+  version: 1.1
   js:
     js/mel-event-studio-tickets-app.js: {}
   dependencies:

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioOperationalTicketsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioOperationalTicketsForm.php
@@ -391,10 +391,16 @@ final class EventStudioOperationalTicketsForm extends FormBase {
       $row = $this->normalizeExistingTicketRowInput($ticket, $row);
       try {
         $this->ticketTierLifecycle->buildTicketUpdateValuesFromInput($event, $ticket, $this->currentUser, $row);
+        if (!empty($row['duplicate'])) {
+          // Fail before submit so a long name cannot save the source without a copy.
+          $this->ticketTierLifecycle->buildDuplicateTicketTitle((string) ($row['title'] ?? $ticket->getTitle()));
+        }
       }
       catch (\InvalidArgumentException $e) {
         $form_state->setErrorByName(
-          $this->ticketValidationErrorElement((int) $ticket_id, $e),
+          !empty($row['duplicate']) && str_contains($e->getMessage(), 'duplicate')
+            ? 'tickets][' . $ticket_id . '][actions][duplicate]'
+            : $this->ticketValidationErrorElement((int) $ticket_id, $e),
           $this->mapTicketInputExceptionMessage($e),
         );
       }
@@ -436,22 +442,30 @@ final class EventStudioOperationalTicketsForm extends FormBase {
           continue;
         }
 
-        // Apply same-request card edits before optional duplicate so the copy
-        // reflects what the organiser just entered, not only last-saved state.
+        // Apply same-request card edits in memory first. When duplicating, create
+        // the copy from that in-memory state before persisting the source so a
+        // failed duplicate cannot leave a saved source without a copy.
         $row = $this->normalizeExistingTicketRowInput($ticket, $row);
         $values = $this->ticketTierLifecycle->buildTicketUpdateValuesFromInput($event, $ticket, $this->currentUser, $row);
-        $this->ticketTierLifecycle->updateTicketType($ticket, $event, $values);
-        $this->recordTicketAnalyticsEvent('ticket_updated', $event, (int) $ticket->id(), [
-          'source' => 'workspace_tickets_save',
-        ]);
 
         if (!empty($row['duplicate'])) {
+          $this->ticketTierLifecycle->applyTicketValuesWithoutSave($ticket, $values);
           $copy = $this->ticketTierLifecycle->duplicateTicketOnEvent($event, $ticket, $this->currentUser);
+          $this->ticketTierLifecycle->updateTicketType($ticket, $event, []);
+          $this->recordTicketAnalyticsEvent('ticket_updated', $event, (int) $ticket->id(), [
+            'source' => 'workspace_tickets_save',
+          ]);
           $this->recordTicketAnalyticsEvent('ticket_created', $event, (int) $copy->id(), [
             'source' => 'duplicate',
             'source_ticket_id' => (int) $ticket->id(),
           ]);
+          continue;
         }
+
+        $this->ticketTierLifecycle->updateTicketType($ticket, $event, $values);
+        $this->recordTicketAnalyticsEvent('ticket_updated', $event, (int) $ticket->id(), [
+          'source' => 'workspace_tickets_save',
+        ]);
       }
 
       $new = $form_state->getValue('new_ticket');
@@ -851,6 +865,9 @@ final class EventStudioOperationalTicketsForm extends FormBase {
     if ($message === 'Ticket title is required.') {
       return (string) $this->t('Ticket name is required.');
     }
+    if ($message === 'This ticket name is too long to duplicate. Shorten the name, then try again.') {
+      return (string) $this->t('This ticket name is too long to duplicate. Shorten the name, then try again.');
+    }
     return $message !== '' ? $message : (string) $this->t('Ticket row could not be validated.');
   }
 
@@ -858,6 +875,9 @@ final class EventStudioOperationalTicketsForm extends FormBase {
     $message = trim($exception->getMessage());
     if (str_contains($message, 'Best value')) {
       return 'tickets][' . $ticket_id . '][status][best_value';
+    }
+    if (str_contains($message, 'duplicate')) {
+      return 'tickets][' . $ticket_id . '][actions][duplicate]';
     }
     return 'tickets][' . $ticket_id . '][title';
   }

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioOperationalTicketsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioOperationalTicketsForm.php
@@ -159,6 +159,7 @@ final class EventStudioOperationalTicketsForm extends FormBase {
 
     $form['#tree'] = TRUE;
     $form['#attributes']['class'][] = 'mel-event-studio-operational-tickets';
+    $form['#attached']['library'][] = 'myeventlane_event_studio/mel_event_studio_tickets_app';
     $form['event_id'] = [
       '#type' => 'hidden',
       '#value' => (string) $event->id(),

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioOperationalTicketsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioOperationalTicketsForm.php
@@ -11,6 +11,7 @@ use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\mel_ticket\Entity\TicketTypeInterface;
+use Drupal\myeventlane_commerce\Service\TicketTierAnalyticsService;
 use Drupal\myeventlane_event\Service\TicketTierLifecycleService;
 use Drupal\myeventlane_event_studio\Service\EventStudioAutosaveService;
 use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
@@ -56,6 +57,8 @@ final class EventStudioOperationalTicketsForm extends FormBase {
 
   protected LoggerInterface $logger;
 
+  protected ?TicketTierAnalyticsService $ticketTierAnalytics = NULL;
+
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
     AccountProxyInterface $current_user,
@@ -64,6 +67,7 @@ final class EventStudioOperationalTicketsForm extends FormBase {
     EventStudioAutosaveService $autosave_service,
     EventStudioSaveService $save_service,
     LoggerInterface $logger,
+    ?TicketTierAnalyticsService $ticket_tier_analytics = NULL,
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->currentUser = $current_user;
@@ -72,6 +76,7 @@ final class EventStudioOperationalTicketsForm extends FormBase {
     $this->autosaveService = $autosave_service;
     $this->saveService = $save_service;
     $this->logger = $logger;
+    $this->ticketTierAnalytics = $ticket_tier_analytics;
   }
 
   public static function create(ContainerInterface $container): static {
@@ -83,6 +88,9 @@ final class EventStudioOperationalTicketsForm extends FormBase {
       $container->get('myeventlane_event_studio.autosave'),
       $container->get('myeventlane_event_studio.save'),
       $container->get('logger.factory')->get('myeventlane_event_studio'),
+      $container->has('myeventlane_commerce.ticket_tier_analytics')
+        ? $container->get('myeventlane_commerce.ticket_tier_analytics')
+        : NULL,
     );
     $form->setRequestStack($container->get('request_stack'));
     return $form;
@@ -136,6 +144,9 @@ final class EventStudioOperationalTicketsForm extends FormBase {
     if (!isset($this->logger)) {
       $this->logger = $container->get('logger.factory')->get('myeventlane_event_studio');
     }
+    if (!isset($this->ticketTierAnalytics) && $container->has('myeventlane_commerce.ticket_tier_analytics')) {
+      $this->ticketTierAnalytics = $container->get('myeventlane_commerce.ticket_tier_analytics');
+    }
   }
 
   public function getFormId(): string {
@@ -167,13 +178,13 @@ final class EventStudioOperationalTicketsForm extends FormBase {
       'title' => [
         '#type' => 'html_tag',
         '#tag' => 'h3',
-        '#value' => $this->t('Create tickets attendees want to book'),
+        '#value' => $this->t('Tickets'),
         '#attributes' => ['class' => ['mel-es-card__title']],
       ],
       'copy' => [
         '#type' => 'html_tag',
         '#tag' => 'p',
-        '#value' => $this->t('Each ticket should feel like a clear offer: what guests get, what it costs, and whether it is available. Advanced rules stay tucked away until you need them.'),
+        '#value' => $this->t('Create the ticket types people can book — General Admission, VIP, Early Bird, Donation, and more. Focus on pricing, capacity, and availability. Advanced tools stay tucked away until you need them.'),
         '#attributes' => ['class' => ['mel-es-card__hint']],
       ],
     ];
@@ -196,20 +207,55 @@ final class EventStudioOperationalTicketsForm extends FormBase {
     if ($tickets === []) {
       $form['tickets']['empty'] = [
         '#type' => 'container',
-        '#attributes' => ['class' => ['mel-event-studio-ticket-empty']],
-        'copy' => [
+        '#attributes' => [
+          'class' => [
+            'mel-event-studio-ticket-empty',
+            'mel-event-studio-ticket-empty--guided',
+          ],
+          'role' => 'region',
+          'aria-labelledby' => 'mel-tickets-empty-title',
+        ],
+        'title' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h4',
+          '#value' => $this->t('Add your first ticket'),
+          '#attributes' => [
+            'id' => 'mel-tickets-empty-title',
+            'class' => ['mel-event-studio-ticket-empty__title'],
+          ],
+        ],
+        'why' => [
           '#type' => 'html_tag',
           '#tag' => 'p',
-          '#value' => $this->t('No tickets yet. Add a row below and save tickets.'),
+          '#value' => $this->t('Tickets tell guests how they can join — and let you start selling straight away.'),
+          '#attributes' => ['class' => ['mel-event-studio-ticket-empty__lead']],
+        ],
+        'next' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->t('Next, choose a name, set a price (or keep it free), and decide how many spots you have.'),
+        ],
+        'modes' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->t('Free RSVP collects names without payment. Paid tickets take card payments through MyEventLane. You can mix both later if you need to.'),
+          '#attributes' => ['class' => ['mel-event-studio-ticket-empty__modes']],
         ],
       ];
     }
 
     $form['new_ticket'] = [
       '#type' => 'details',
-      '#title' => $this->t('Add a ticket guests can book'),
-      '#open' => FALSE,
-      '#attributes' => ['class' => ['mel-es-card', 'mel-event-studio-ticket-add']],
+      '#title' => $this->t('Add Ticket'),
+      '#open' => $tickets === [],
+      '#attributes' => [
+        'class' => [
+          'mel-es-card',
+          'mel-event-studio-ticket-add',
+          'mel-event-studio-ticket-add--primary',
+        ],
+        'id' => 'mel-add-ticket',
+      ],
       'intro' => [
         '#type' => 'html_tag',
         '#tag' => 'p',
@@ -221,7 +267,7 @@ final class EventStudioOperationalTicketsForm extends FormBase {
         '#title' => $this->t('Type'),
         '#options' => [
           'paid' => $this->t('Paid'),
-          'rsvp' => $this->t('RSVP'),
+          'rsvp' => $this->t('Free RSVP'),
           'external' => $this->t('External'),
         ],
         '#default_value' => 'paid',
@@ -231,14 +277,17 @@ final class EventStudioOperationalTicketsForm extends FormBase {
         '#title' => $this->t('Ticket name'),
         '#required' => FALSE,
         '#maxlength' => 255,
-        '#description' => $this->t('Example: General admission, VIP pass, Workshop seat.'),
+        '#attributes' => [
+          'placeholder' => $this->t('General Admission, VIP, Early Bird…'),
+        ],
+        '#description' => $this->t('Example: General Admission, VIP, Early Bird, Donation.'),
       ],
       'price_amount' => [
         '#type' => 'number',
-        '#title' => $this->t('Attendee price'),
+        '#title' => $this->t('Price'),
         '#min' => 0,
         '#step' => 0.01,
-        '#description' => $this->t('Use 0 for a free ticket.'),
+        '#description' => $this->t('Enter the attendee price. Use Free RSVP above for no payment.'),
         '#states' => [
           'visible' => [
             ':input[name="new_ticket[ticket_kind]"]' => ['value' => 'paid'],
@@ -263,10 +312,10 @@ final class EventStudioOperationalTicketsForm extends FormBase {
       ],
       'visibility_mode' => [
         '#type' => 'select',
-        '#title' => $this->t('Visibility'),
+        '#title' => $this->t('Availability'),
         '#options' => $this->visibilityOptions(),
         '#default_value' => 'public',
-        '#description' => $this->t('Access code tickets require codes to be created in Ticket Tools before customers can see them.'),
+        '#description' => $this->t('Access code tickets need codes from Advanced Ticket Tools before guests can see them.'),
       ],
       'status' => [
         '#type' => 'checkbox',
@@ -280,12 +329,35 @@ final class EventStudioOperationalTicketsForm extends FormBase {
       ],
     ];
 
+    $form['sticky_add'] = [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => ['mel-event-studio-ticket-sticky-add'],
+      ],
+      'cta' => [
+        '#type' => 'html_tag',
+        '#tag' => 'a',
+        '#value' => $this->t('Add Ticket'),
+        '#attributes' => [
+          'href' => '#mel-add-ticket',
+          'class' => [
+            'mel-btn',
+            'mel-btn--primary',
+            'mel-event-studio-ticket-sticky-add__button',
+          ],
+        ],
+      ],
+    ];
+
     $form['actions'] = [
       '#type' => 'actions',
       'submit' => [
         '#type' => 'submit',
         '#value' => $this->t('Save tickets'),
         '#button_type' => 'primary',
+        '#attributes' => [
+          'class' => ['mel-event-studio-ticket-save'],
+        ],
       ],
     ];
 
@@ -306,7 +378,7 @@ final class EventStudioOperationalTicketsForm extends FormBase {
     }
 
     foreach ($this->submittedExistingTicketRows($form_state) as $ticket_id => $row) {
-      if (!empty($row['archive'])) {
+      if (!empty($row['archive']) || !empty($row['duplicate'])) {
         continue;
       }
       $ticket = $this->ticketTierLifecycle->loadWritableTicketForEvent($event, $ticket_id, $this->currentUser);
@@ -356,19 +428,33 @@ final class EventStudioOperationalTicketsForm extends FormBase {
         if (!$ticket instanceof TicketTypeInterface) {
           continue;
         }
+        if (!empty($row['duplicate'])) {
+          $copy = $this->ticketTierLifecycle->duplicateTicketOnEvent($event, $ticket, $this->currentUser);
+          $this->recordTicketAnalyticsEvent('ticket_created', $event, (int) $copy->id(), [
+            'source' => 'duplicate',
+            'source_ticket_id' => (int) $ticket->id(),
+          ]);
+          continue;
+        }
         if (!empty($row['archive'])) {
           $this->ticketTierLifecycle->archiveTicketOnEvent($event, $ticket);
+          $this->recordTicketAnalyticsEvent('ticket_archived', $event, (int) $ticket->id());
           continue;
         }
         $row = $this->normalizeExistingTicketRowInput($ticket, $row);
         $values = $this->ticketTierLifecycle->buildTicketUpdateValuesFromInput($event, $ticket, $this->currentUser, $row);
         $this->ticketTierLifecycle->updateTicketType($ticket, $event, $values);
+        // Instrumentation hook reserved for material field diffs / single-ticket APIs.
+        $this->recordTicketAnalyticsEvent('ticket_updated', $event, (int) $ticket->id(), [
+          'source' => 'workspace_tickets_save',
+        ]);
       }
 
       $new = $form_state->getValue('new_ticket');
       if (is_array($new) && $this->newTicketRowHasIntent($new) && trim((string) ($new['title'] ?? '')) !== '') {
         $values = $this->ticketTierLifecycle->buildTicketValuesFromInput($event, $this->currentUser, $new);
-        $this->ticketTierLifecycle->createAttachAndSync($event, $values);
+        $created = $this->ticketTierLifecycle->createAttachAndSync($event, $values);
+        $this->recordTicketAnalyticsEvent('ticket_created', $event, (int) $created->id());
       }
 
       $this->ticketTierLifecycle->reconcileEventTicketReferences($event);
@@ -410,6 +496,16 @@ final class EventStudioOperationalTicketsForm extends FormBase {
     $capacity_summary = $ticket->get('capacity')->isEmpty()
       ? $this->t('No fixed capacity')
       : $this->t('@count available', ['@count' => (string) $ticket->get('capacity')->value]);
+    $sales_summary = $this->buildTicketSalesSummary($ticket);
+    $availability_label = match (TRUE) {
+      $ticket->isArchived() => $this->t('Archived'),
+      !$ticket->isPublished() => $this->t('Hidden from checkout'),
+      default => $this->visibilityOptions()[
+        $ticket->hasField('visibility_mode') && !$ticket->get('visibility_mode')->isEmpty()
+          ? (string) $ticket->get('visibility_mode')->value
+          : 'public'
+      ] ?? $this->t('Public'),
+    };
 
     return [
       '#type' => 'container',
@@ -442,6 +538,24 @@ final class EventStudioOperationalTicketsForm extends FormBase {
               '#value' => $status_summary,
               '#attributes' => ['class' => ['mel-event-studio-ticket-card__summary-status']],
             ],
+            'availability' => [
+              '#type' => 'html_tag',
+              '#tag' => 'p',
+              '#value' => $availability_label,
+              '#attributes' => ['class' => ['mel-event-studio-ticket-card__summary-availability']],
+            ],
+            'capacity' => [
+              '#type' => 'html_tag',
+              '#tag' => 'p',
+              '#value' => $capacity_summary,
+              '#attributes' => ['class' => ['mel-event-studio-ticket-card__summary-capacity']],
+            ],
+            'sales' => [
+              '#type' => 'html_tag',
+              '#tag' => 'p',
+              '#value' => $sales_summary,
+              '#attributes' => ['class' => ['mel-event-studio-ticket-card__summary-sales']],
+            ],
           ],
           'title' => [
             '#type' => 'textfield',
@@ -457,7 +571,7 @@ final class EventStudioOperationalTicketsForm extends FormBase {
           '#attributes' => ['class' => ['mel-event-studio-ticket-card__pricing']],
           'price_amount' => [
             '#type' => 'number',
-            '#title' => $this->t('Attendee price'),
+            '#title' => $this->t('Price'),
             '#min' => 0,
             '#step' => 0.01,
             '#default_value' => $price?->getNumber() ?? '',
@@ -484,7 +598,11 @@ final class EventStudioOperationalTicketsForm extends FormBase {
           'kind' => [
             '#type' => 'html_tag',
             '#tag' => 'span',
-            '#value' => ucfirst($kind),
+            '#value' => match ($kind) {
+              'rsvp' => $this->t('Free RSVP'),
+              'external' => $this->t('External'),
+              default => $this->t('Paid'),
+            },
             '#attributes' => ['class' => ['mel-event-studio-card-badge', 'mel-event-studio-card-badge--type']],
           ],
           'status' => [
@@ -548,6 +666,11 @@ final class EventStudioOperationalTicketsForm extends FormBase {
             '#tag' => 'span',
             '#value' => $capacity_summary,
           ],
+          'sales' => [
+            '#type' => 'html_tag',
+            '#tag' => 'span',
+            '#value' => $sales_summary,
+          ],
         ],
         'reassurance' => [
           '#type' => 'html_tag',
@@ -589,7 +712,7 @@ final class EventStudioOperationalTicketsForm extends FormBase {
           'heading' => [
             '#type' => 'html_tag',
             '#tag' => 'h4',
-            '#value' => $this->t('Visibility'),
+            '#value' => $this->t('Availability'),
             '#attributes' => ['class' => ['mel-event-studio-ticket-card__group-title']],
           ],
           'visibility_mode' => [
@@ -600,7 +723,7 @@ final class EventStudioOperationalTicketsForm extends FormBase {
             '#default_value' => $ticket->hasField('visibility_mode') && !$ticket->get('visibility_mode')->isEmpty()
               ? (string) $ticket->get('visibility_mode')->value
               : 'public',
-            '#description' => $this->t('Access code tickets require codes to be created in Ticket Tools before customers can see them.'),
+            '#description' => $this->t('Access code tickets need codes from Advanced Ticket Tools before guests can see them.'),
             '#parents' => ['tickets', $ticket_id, 'visibility_mode'],
           ],
         ],
@@ -610,7 +733,7 @@ final class EventStudioOperationalTicketsForm extends FormBase {
           'heading' => [
             '#type' => 'html_tag',
             '#tag' => 'h4',
-            '#value' => $this->t('Availability'),
+            '#value' => $this->t('Status'),
             '#attributes' => ['class' => ['mel-event-studio-ticket-card__group-title']],
           ],
           'published' => [
@@ -632,6 +755,34 @@ final class EventStudioOperationalTicketsForm extends FormBase {
           ],
         ],
       ],
+      'quick_actions' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['mel-event-studio-ticket-card__quick-actions'],
+          'aria-label' => $this->t('Quick actions'),
+        ],
+        'hint' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->t('Quick edit above, then save. Use duplicate or archive when you need a copy or to stop new sales.'),
+          '#attributes' => ['class' => ['mel-event-studio-ticket-card__quick-actions-hint']],
+        ],
+        'duplicate' => [
+          '#type' => 'checkbox',
+          '#title' => $this->t('Duplicate ticket'),
+          '#disabled' => $ticket->isArchived(),
+          '#wrapper_attributes' => ['class' => ['mel-event-studio-ticket-card__checkbox', 'mel-event-studio-ticket-card__action']],
+          '#parents' => ['tickets', $ticket_id, 'actions', 'duplicate'],
+        ],
+        'archive' => [
+          '#type' => 'checkbox',
+          '#title' => $this->t('Archive ticket'),
+          '#description' => $this->t('Stops new checkout sales. Past orders stay intact.'),
+          '#disabled' => $ticket->isArchived(),
+          '#wrapper_attributes' => ['class' => ['mel-event-studio-ticket-card__checkbox', 'mel-event-studio-ticket-card__action']],
+          '#parents' => ['tickets', $ticket_id, 'actions', 'archive'],
+        ],
+      ],
       'advanced' => [
         '#type' => 'container',
         '#attributes' => ['class' => ['mel-event-studio-ticket-card__advanced-content']],
@@ -641,14 +792,6 @@ final class EventStudioOperationalTicketsForm extends FormBase {
           '#type' => 'hidden',
           '#value' => $kind,
           '#parents' => ['tickets', $ticket_id, 'actions', 'ticket_kind'],
-        ],
-        'archive' => [
-          '#type' => 'checkbox',
-          '#title' => $this->t('Archive this ticket'),
-          '#description' => $this->t('Archived tickets stop showing for new checkout sessions but remain attached to historical orders and reports.'),
-          '#disabled' => $ticket->isArchived(),
-          '#wrapper_attributes' => ['class' => ['mel-event-studio-ticket-card__checkbox']],
-          '#parents' => ['tickets', $ticket_id, 'actions', 'archive'],
         ],
       ],
     ];
@@ -740,6 +883,7 @@ final class EventStudioOperationalTicketsForm extends FormBase {
       if (isset($row['actions']) && is_array($row['actions'])) {
         $row['ticket_kind'] = $row['actions']['ticket_kind'] ?? '';
         $row['archive'] = !empty($row['actions']['archive']) ? 1 : 0;
+        $row['duplicate'] = !empty($row['actions']['duplicate']) ? 1 : 0;
       }
       $out[(int) $ticket_id] = $row;
     }
@@ -764,6 +908,47 @@ final class EventStudioOperationalTicketsForm extends FormBase {
       'access_code' => (string) $this->t('Access code'),
       'group_only' => (string) $this->t('Group / partner only'),
     ];
+  }
+
+  private function buildTicketSalesSummary(TicketTypeInterface $ticket): string {
+    if (!$this->ticketTierAnalytics instanceof TicketTierAnalyticsService) {
+      return (string) $this->t('Sales: —');
+    }
+    try {
+      $metrics = $this->ticketTierAnalytics->buildTierMetrics($ticket);
+      $sold = (int) ($metrics['sold'] ?? 0);
+      return (string) $this->formatPlural($sold, 'Sales: 1 sold', 'Sales: @count sold');
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('Ticket sales summary failed for ticket @tid: @message', [
+        '@tid' => (string) $ticket->id(),
+        '@message' => $e->getMessage(),
+      ]);
+      return (string) $this->t('Sales: —');
+    }
+  }
+
+  /**
+   * Records VX2 ticket instrumentation hooks for future analytics wiring.
+   *
+   * @param string $event_name
+   *   Analytics event name (for example ticket_created).
+   * @param \Drupal\node\NodeInterface $event
+   *   The event node.
+   * @param int $ticket_id
+   *   Ticket type entity ID.
+   * @param array<string, mixed> $context
+   *   Extra logger context.
+   */
+  private function recordTicketAnalyticsEvent(string $event_name, NodeInterface $event, int $ticket_id, array $context = []): void {
+    $this->logger->info('MEL ticket analytics hook @event for event @nid ticket @tid.', [
+      '@event' => $event_name,
+      '@nid' => (string) $event->id(),
+      '@tid' => (string) $ticket_id,
+      'mel_analytics_event' => $event_name,
+      'event_id' => (int) $event->id(),
+      'ticket_id' => $ticket_id,
+    ] + $context);
   }
 
   private function getRouteEvent(?NodeInterface $node = NULL): NodeInterface {

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioOperationalTicketsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioOperationalTicketsForm.php
@@ -15,6 +15,7 @@ use Drupal\myeventlane_commerce\Service\TicketTierAnalyticsService;
 use Drupal\myeventlane_event\Service\TicketTierLifecycleService;
 use Drupal\myeventlane_event_studio\Service\EventStudioAutosaveService;
 use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
+use Drupal\myeventlane_rsvp\Service\RsvpCapacityService;
 use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
 use Drupal\node\NodeInterface;
 use Psr\Log\LoggerInterface;
@@ -59,6 +60,8 @@ final class EventStudioOperationalTicketsForm extends FormBase {
 
   protected ?TicketTierAnalyticsService $ticketTierAnalytics = NULL;
 
+  protected ?RsvpCapacityService $rsvpCapacity = NULL;
+
   public function __construct(
     EntityTypeManagerInterface $entity_type_manager,
     AccountProxyInterface $current_user,
@@ -68,6 +71,7 @@ final class EventStudioOperationalTicketsForm extends FormBase {
     EventStudioSaveService $save_service,
     LoggerInterface $logger,
     ?TicketTierAnalyticsService $ticket_tier_analytics = NULL,
+    ?RsvpCapacityService $rsvp_capacity = NULL,
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->currentUser = $current_user;
@@ -77,6 +81,7 @@ final class EventStudioOperationalTicketsForm extends FormBase {
     $this->saveService = $save_service;
     $this->logger = $logger;
     $this->ticketTierAnalytics = $ticket_tier_analytics;
+    $this->rsvpCapacity = $rsvp_capacity;
   }
 
   public static function create(ContainerInterface $container): static {
@@ -90,6 +95,9 @@ final class EventStudioOperationalTicketsForm extends FormBase {
       $container->get('logger.factory')->get('myeventlane_event_studio'),
       $container->has('myeventlane_commerce.ticket_tier_analytics')
         ? $container->get('myeventlane_commerce.ticket_tier_analytics')
+        : NULL,
+      $container->has('myeventlane_rsvp.capacity')
+        ? $container->get('myeventlane_rsvp.capacity')
         : NULL,
     );
     $form->setRequestStack($container->get('request_stack'));
@@ -111,7 +119,8 @@ final class EventStudioOperationalTicketsForm extends FormBase {
    * properties or untracked services can otherwise stay uninitialized.
    */
   private function ensureInjectedServices(): void {
-    if (isset(
+    $container = \Drupal::getContainer();
+    if (!isset(
       $this->entityTypeManager,
       $this->currentUser,
       $this->eventVendorAccessChecker,
@@ -120,32 +129,33 @@ final class EventStudioOperationalTicketsForm extends FormBase {
       $this->saveService,
       $this->logger,
     )) {
-      return;
-    }
-    $container = \Drupal::getContainer();
-    if (!isset($this->entityTypeManager)) {
-      $this->entityTypeManager = $container->get('entity_type.manager');
-    }
-    if (!isset($this->currentUser)) {
-      $this->currentUser = $container->get('current_user');
-    }
-    if (!isset($this->eventVendorAccessChecker)) {
-      $this->eventVendorAccessChecker = $container->get('myeventlane_vendor.event_access_checker');
-    }
-    if (!isset($this->ticketTierLifecycle)) {
-      $this->ticketTierLifecycle = $container->get('myeventlane_event.ticket_tier_lifecycle');
-    }
-    if (!isset($this->autosaveService)) {
-      $this->autosaveService = $container->get('myeventlane_event_studio.autosave');
-    }
-    if (!isset($this->saveService)) {
-      $this->saveService = $container->get('myeventlane_event_studio.save');
-    }
-    if (!isset($this->logger)) {
-      $this->logger = $container->get('logger.factory')->get('myeventlane_event_studio');
+      if (!isset($this->entityTypeManager)) {
+        $this->entityTypeManager = $container->get('entity_type.manager');
+      }
+      if (!isset($this->currentUser)) {
+        $this->currentUser = $container->get('current_user');
+      }
+      if (!isset($this->eventVendorAccessChecker)) {
+        $this->eventVendorAccessChecker = $container->get('myeventlane_vendor.event_access_checker');
+      }
+      if (!isset($this->ticketTierLifecycle)) {
+        $this->ticketTierLifecycle = $container->get('myeventlane_event.ticket_tier_lifecycle');
+      }
+      if (!isset($this->autosaveService)) {
+        $this->autosaveService = $container->get('myeventlane_event_studio.autosave');
+      }
+      if (!isset($this->saveService)) {
+        $this->saveService = $container->get('myeventlane_event_studio.save');
+      }
+      if (!isset($this->logger)) {
+        $this->logger = $container->get('logger.factory')->get('myeventlane_event_studio');
+      }
     }
     if (!isset($this->ticketTierAnalytics) && $container->has('myeventlane_commerce.ticket_tier_analytics')) {
       $this->ticketTierAnalytics = $container->get('myeventlane_commerce.ticket_tier_analytics');
+    }
+    if (!isset($this->rsvpCapacity) && $container->has('myeventlane_rsvp.capacity')) {
+      $this->rsvpCapacity = $container->get('myeventlane_rsvp.capacity');
     }
   }
 
@@ -379,6 +389,13 @@ final class EventStudioOperationalTicketsForm extends FormBase {
     }
 
     foreach ($this->submittedExistingTicketRows($form_state) as $ticket_id => $row) {
+      if (!empty($row['archive']) && !empty($row['duplicate'])) {
+        $form_state->setErrorByName(
+          'tickets][' . $ticket_id . '][actions][duplicate]',
+          $this->t('Choose either Duplicate ticket or Archive ticket, not both.'),
+        );
+        continue;
+      }
       if (!empty($row['archive'])) {
         continue;
       }
@@ -436,7 +453,9 @@ final class EventStudioOperationalTicketsForm extends FormBase {
         if (!$ticket instanceof TicketTypeInterface) {
           continue;
         }
-        if (!empty($row['archive'])) {
+        // Mutual exclusion is enforced in validateForm; never archive when
+        // duplicate was also requested.
+        if (!empty($row['archive']) && empty($row['duplicate'])) {
           $this->ticketTierLifecycle->archiveTicketOnEvent($event, $ticket);
           $this->recordTicketAnalyticsEvent('ticket_archived', $event, (int) $ticket->id());
           continue;
@@ -784,7 +803,7 @@ final class EventStudioOperationalTicketsForm extends FormBase {
         'hint' => [
           '#type' => 'html_tag',
           '#tag' => 'p',
-          '#value' => $this->t('Quick edit above, then save. Use duplicate or archive when you need a copy or to stop new sales.'),
+          '#value' => $this->t('Quick edit above, then save. Choose duplicate or archive — not both.'),
           '#attributes' => ['class' => ['mel-event-studio-ticket-card__quick-actions-hint']],
         ],
         'duplicate' => [
@@ -937,10 +956,23 @@ final class EventStudioOperationalTicketsForm extends FormBase {
   }
 
   private function buildTicketSalesSummary(TicketTypeInterface $ticket): string {
-    if (!$this->ticketTierAnalytics instanceof TicketTierAnalyticsService) {
-      return (string) $this->t('Sales: —');
-    }
     try {
+      if ($ticket->getTicketKind() === 'rsvp') {
+        // RSVP submissions are event-scoped (no per-tier FK). Show confirmed
+        // event RSVPs so Free RSVP cards do not falsely report zero uptake.
+        if (!$this->rsvpCapacity instanceof RsvpCapacityService) {
+          return (string) $this->t('RSVPs: —');
+        }
+        $event_id = !$ticket->get('event')->isEmpty()
+          ? (int) $ticket->get('event')->target_id
+          : 0;
+        $count = $event_id > 0 ? $this->rsvpCapacity->countConfirmedRsvps($event_id) : 0;
+        return (string) $this->formatPlural($count, 'RSVPs: 1 received', 'RSVPs: @count received');
+      }
+
+      if (!$this->ticketTierAnalytics instanceof TicketTierAnalyticsService) {
+        return (string) $this->t('Sales: —');
+      }
       $metrics = $this->ticketTierAnalytics->buildTierMetrics($ticket);
       $sold = (int) ($metrics['sold'] ?? 0);
       return (string) $this->formatPlural($sold, 'Sales: 1 sold', 'Sales: @count sold');
@@ -950,7 +982,9 @@ final class EventStudioOperationalTicketsForm extends FormBase {
         '@tid' => (string) $ticket->id(),
         '@message' => $e->getMessage(),
       ]);
-      return (string) $this->t('Sales: —');
+      return (string) ($ticket->getTicketKind() === 'rsvp'
+        ? $this->t('RSVPs: —')
+        : $this->t('Sales: —'));
     }
   }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioOperationalTicketsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioOperationalTicketsForm.php
@@ -442,16 +442,18 @@ final class EventStudioOperationalTicketsForm extends FormBase {
           continue;
         }
 
-        // Apply same-request card edits in memory first. When duplicating, create
-        // the copy from that in-memory state before persisting the source so a
-        // failed duplicate cannot leave a saved source without a copy.
+        // Duplicate path persists source edits + copy in one DB transaction so
+        // neither can commit without the other.
         $row = $this->normalizeExistingTicketRowInput($ticket, $row);
         $values = $this->ticketTierLifecycle->buildTicketUpdateValuesFromInput($event, $ticket, $this->currentUser, $row);
 
         if (!empty($row['duplicate'])) {
-          $this->ticketTierLifecycle->applyTicketValuesWithoutSave($ticket, $values);
-          $copy = $this->ticketTierLifecycle->duplicateTicketOnEvent($event, $ticket, $this->currentUser);
-          $this->ticketTierLifecycle->updateTicketType($ticket, $event, []);
+          $copy = $this->ticketTierLifecycle->updateAndDuplicateTicketOnEvent(
+            $event,
+            $ticket,
+            $this->currentUser,
+            $values,
+          );
           $this->recordTicketAnalyticsEvent('ticket_updated', $event, (int) $ticket->id(), [
             'source' => 'workspace_tickets_save',
           ]);

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioOperationalTicketsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioOperationalTicketsForm.php
@@ -378,7 +378,7 @@ final class EventStudioOperationalTicketsForm extends FormBase {
     }
 
     foreach ($this->submittedExistingTicketRows($form_state) as $ticket_id => $row) {
-      if (!empty($row['archive']) || !empty($row['duplicate'])) {
+      if (!empty($row['archive'])) {
         continue;
       }
       $ticket = $this->ticketTierLifecycle->loadWritableTicketForEvent($event, $ticket_id, $this->currentUser);
@@ -386,6 +386,7 @@ final class EventStudioOperationalTicketsForm extends FormBase {
         $form_state->setErrorByName('tickets][' . $ticket_id, $this->t('Ticket data could not be matched to this event. Reload and try again.'));
         continue;
       }
+      // Duplicate still applies the same-request inline edits to the source first.
       $row = $this->normalizeExistingTicketRowInput($ticket, $row);
       try {
         $this->ticketTierLifecycle->buildTicketUpdateValuesFromInput($event, $ticket, $this->currentUser, $row);
@@ -428,26 +429,28 @@ final class EventStudioOperationalTicketsForm extends FormBase {
         if (!$ticket instanceof TicketTypeInterface) {
           continue;
         }
+        if (!empty($row['archive'])) {
+          $this->ticketTierLifecycle->archiveTicketOnEvent($event, $ticket);
+          $this->recordTicketAnalyticsEvent('ticket_archived', $event, (int) $ticket->id());
+          continue;
+        }
+
+        // Apply same-request card edits before optional duplicate so the copy
+        // reflects what the organiser just entered, not only last-saved state.
+        $row = $this->normalizeExistingTicketRowInput($ticket, $row);
+        $values = $this->ticketTierLifecycle->buildTicketUpdateValuesFromInput($event, $ticket, $this->currentUser, $row);
+        $this->ticketTierLifecycle->updateTicketType($ticket, $event, $values);
+        $this->recordTicketAnalyticsEvent('ticket_updated', $event, (int) $ticket->id(), [
+          'source' => 'workspace_tickets_save',
+        ]);
+
         if (!empty($row['duplicate'])) {
           $copy = $this->ticketTierLifecycle->duplicateTicketOnEvent($event, $ticket, $this->currentUser);
           $this->recordTicketAnalyticsEvent('ticket_created', $event, (int) $copy->id(), [
             'source' => 'duplicate',
             'source_ticket_id' => (int) $ticket->id(),
           ]);
-          continue;
         }
-        if (!empty($row['archive'])) {
-          $this->ticketTierLifecycle->archiveTicketOnEvent($event, $ticket);
-          $this->recordTicketAnalyticsEvent('ticket_archived', $event, (int) $ticket->id());
-          continue;
-        }
-        $row = $this->normalizeExistingTicketRowInput($ticket, $row);
-        $values = $this->ticketTierLifecycle->buildTicketUpdateValuesFromInput($event, $ticket, $this->currentUser, $row);
-        $this->ticketTierLifecycle->updateTicketType($ticket, $event, $values);
-        // Instrumentation hook reserved for material field diffs / single-ticket APIs.
-        $this->recordTicketAnalyticsEvent('ticket_updated', $event, (int) $ticket->id(), [
-          'source' => 'workspace_tickets_save',
-        ]);
       }
 
       $new = $form_state->getValue('new_ticket');

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioTicketsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioTicketsForm.php
@@ -93,6 +93,8 @@ final class EventStudioTicketsForm extends EventStudioBaseForm {
       ],
       '#default_value' => $melDefaults['field_product_target'] ?? NULL,
       '#attributes' => ['class' => ['mel-input']],
+      // VX2-04: organisers never manage Commerce products directly.
+      '#access' => $this->currentUser()->hasPermission('administer commerce_product'),
       '#states' => [
         'visible' => [
           ':input[name="mel[field_event_type]"]' => ['value' => 'paid'],

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
@@ -308,7 +308,13 @@ final class EventStudioSectionRenderer {
   private function buildTicketsStack(NodeInterface $event): array {
     $build = [
       '#type' => 'container',
-      '#attributes' => ['class' => ['mel-event-studio-section__form-stack']],
+      '#attributes' => [
+        'class' => [
+          'mel-event-studio-section__form-stack',
+          'mel-event-studio-tickets-app',
+        ],
+        'data-mel-tickets-app' => '1',
+      ],
       'mode' => $this->formBuilder->getForm(EventStudioTicketsForm::class, $event),
     ];
 
@@ -323,25 +329,103 @@ final class EventStudioSectionRenderer {
       }
     }
 
-    $event_type = $event->hasField('field_event_type') && !$event->get('field_event_type')->isEmpty()
-      ? (string) $event->get('field_event_type')->value
-      : '';
-    if (in_array($event_type, ['paid', 'both'], TRUE)) {
-      if ($this->accessCodeManagementBuilder instanceof AccessCodeManagementBuilder) {
-        $accessCodePanel = $this->accessCodeManagementBuilder->build($event);
-        if ($accessCodePanel !== []) {
-          $build['access_codes'] = $accessCodePanel;
-          $build['access_codes']['#weight'] = 15;
-        }
-      }
+    $build['advanced'] = $this->buildAdvancedTicketTools($event);
+    $build['advanced']['#weight'] = 20;
 
-      $support = $this->supportResolver->buildCard($event, 'tickets');
-      if ($support !== NULL) {
-        $build['support'] = $support;
-      }
+    $support = $this->supportResolver->buildCard($event, 'tickets');
+    if ($support !== NULL) {
+      $build['support'] = $support;
+      $build['support']['#weight'] = 30;
     }
 
     return $build;
+  }
+
+  /**
+   * Progressive disclosure for groups, codes, widgets, and inventory tools.
+   *
+   * @return array<string, mixed>
+   *   Render array for the Advanced Ticket Tools disclosure.
+   */
+  private function buildAdvancedTicketTools(NodeInterface $event): array {
+    $event_id = (int) $event->id();
+    $links = [];
+    $route_map = [
+      'myeventlane_tickets.event_tickets_access_codes' => $this->t('Access codes'),
+      'myeventlane_tickets.event_tickets_groups' => $this->t('Ticket groups'),
+      'myeventlane_tickets.event_tickets_widgets' => $this->t('Ticket widgets'),
+      'myeventlane_tickets.event_tickets_settings' => $this->t('Ticket settings'),
+      'myeventlane_vendor.console.event_tickets' => $this->t('Inventory & sync tools'),
+    ];
+    foreach ($route_map as $route_name => $label) {
+      try {
+        $links[] = [
+          '#type' => 'link',
+          '#title' => $label,
+          '#url' => Url::fromRoute($route_name, ['event' => $event_id]),
+          '#attributes' => [
+            'class' => ['mel-event-studio-advanced-tools__link'],
+          ],
+        ];
+      }
+      catch (\Throwable) {
+        // Route may be unavailable in partial installs; skip quietly.
+      }
+    }
+
+    $advanced = [
+      '#type' => 'details',
+      '#title' => $this->t('Advanced Ticket Tools'),
+      '#open' => FALSE,
+      '#attributes' => [
+        'class' => ['mel-es-card', 'mel-event-studio-advanced-tools'],
+        'data-mel-analytics-event' => 'advanced_tools_opened',
+        'data-mel-event-id' => (string) $event_id,
+      ],
+      '#attached' => [
+        'library' => [
+          'myeventlane_event_studio/mel_event_studio_tickets_app',
+        ],
+      ],
+      'intro' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('Most organisers only need ticket types, pricing, capacity, and availability. Open these tools when you need access codes, groups, embeds, or deeper inventory controls.'),
+        '#attributes' => ['class' => ['mel-event-studio-advanced-tools__intro']],
+      ],
+      'links' => [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['mel-event-studio-advanced-tools__links'],
+          'role' => 'list',
+        ],
+      ],
+    ];
+
+    foreach ($links as $index => $link) {
+      $advanced['links']['item_' . $index] = [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['mel-event-studio-advanced-tools__item'],
+          'role' => 'listitem',
+        ],
+        'link' => $link,
+      ];
+    }
+
+    $event_type = $event->hasField('field_event_type') && !$event->get('field_event_type')->isEmpty()
+      ? (string) $event->get('field_event_type')->value
+      : '';
+    if (in_array($event_type, ['paid', 'both'], TRUE)
+      && $this->accessCodeManagementBuilder instanceof AccessCodeManagementBuilder) {
+      $accessCodePanel = $this->accessCodeManagementBuilder->build($event);
+      if ($accessCodePanel !== []) {
+        $advanced['access_codes'] = $accessCodePanel;
+        $advanced['access_codes']['#weight'] = 20;
+      }
+    }
+
+    return $advanced;
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioTicketsAppContractTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioTicketsAppContractTest.php
@@ -102,6 +102,23 @@ final class EventStudioTicketsAppContractTest extends TestCase {
     $this->assertStringContainsString('mel-event-studio-advanced-tools', $css);
   }
 
+  public function testRsvpSalesSummaryUsesEventRsvpCount(): void {
+    $form = file_get_contents($this->moduleRoot() . '/src/Form/EventStudioOperationalTicketsForm.php');
+    $this->assertNotFalse($form);
+    $this->assertStringContainsString('RsvpCapacityService', $form);
+    $this->assertStringContainsString('countConfirmedRsvps', $form);
+    $this->assertStringContainsString("RSVPs: 1 received", $form);
+    $this->assertStringContainsString("getTicketKind() === 'rsvp'", $form);
+  }
+
+  public function testDuplicateAndArchiveAreMutuallyExclusive(): void {
+    $form = file_get_contents($this->moduleRoot() . '/src/Form/EventStudioOperationalTicketsForm.php');
+    $this->assertNotFalse($form);
+    $this->assertStringContainsString('Choose either Duplicate ticket or Archive ticket, not both.', $form);
+    $this->assertStringContainsString("!empty(\$row['archive']) && !empty(\$row['duplicate'])", $form);
+    $this->assertStringContainsString("!empty(\$row['archive']) && empty(\$row['duplicate'])", $form);
+  }
+
   public function testOperationalFormAttachesTicketsAppLibrary(): void {
     $form = file_get_contents($this->moduleRoot() . '/src/Form/EventStudioOperationalTicketsForm.php');
     $this->assertNotFalse($form);

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioTicketsAppContractTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioTicketsAppContractTest.php
@@ -43,16 +43,16 @@ final class EventStudioTicketsAppContractTest extends TestCase {
   public function testDuplicateAppliesSameRequestEditsBeforeCopy(): void {
     $form = file_get_contents($this->moduleRoot() . '/src/Form/EventStudioOperationalTicketsForm.php');
     $this->assertNotFalse($form);
-    $duplicatePos = strpos($form, "if (!empty(\$row['duplicate']))");
-    $updatePos = strpos($form, 'updateTicketType($ticket, $event, $values)');
+    $this->assertStringContainsString('applyTicketValuesWithoutSave', $form);
+    $this->assertStringContainsString('buildDuplicateTicketTitle', $form);
+    $applyPos = strpos($form, 'applyTicketValuesWithoutSave($ticket, $values)');
+    $duplicatePos = strpos($form, 'duplicateTicketOnEvent($event, $ticket, $this->currentUser)');
+    $persistPos = strpos($form, 'updateTicketType($ticket, $event, [])');
+    $this->assertNotFalse($applyPos);
     $this->assertNotFalse($duplicatePos);
-    $this->assertNotFalse($updatePos);
-    $this->assertLessThan(
-      $duplicatePos,
-      $updatePos,
-      'Duplicate must run after updateTicketType so same-request card edits are persisted first.',
-    );
-    $this->assertStringContainsString('Apply same-request card edits before optional duplicate', $form);
+    $this->assertNotFalse($persistPos);
+    $this->assertLessThan($duplicatePos, $applyPos, 'In-memory edits must apply before duplicate.');
+    $this->assertLessThan($persistPos, $duplicatePos, 'Source must persist only after duplicate succeeds.');
   }
 
   public function testBookingModeHidesCommerceProductForOrganisers(): void {
@@ -73,13 +73,12 @@ final class EventStudioTicketsAppContractTest extends TestCase {
     $lifecycle = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_event/src/Service/TicketTierLifecycleService.php');
     $this->assertNotFalse($lifecycle);
     $this->assertStringContainsString('function duplicateTicketOnEvent', $lifecycle);
+    $this->assertStringContainsString('function buildDuplicateTicketTitle', $lifecycle);
+    $this->assertStringContainsString('function applyTicketValuesWithoutSave', $lifecycle);
     $this->assertStringContainsString("'waitlist_enabled'", $lifecycle);
     $this->assertStringContainsString("'hidden_label'", $lifecycle);
     $this->assertStringContainsString("'group_sale_mode'", $lifecycle);
-    $this->assertStringNotContainsString(
-      'buildTicketValuesFromInput($event, $account, $input)',
-      $lifecycle,
-    );
+    $this->assertStringContainsString('too long to duplicate', $lifecycle);
   }
 
   public function testTicketsAppAssetsExist(): void {

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioTicketsAppContractTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioTicketsAppContractTest.php
@@ -73,14 +73,32 @@ final class EventStudioTicketsAppContractTest extends TestCase {
     $lifecycle = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_event/src/Service/TicketTierLifecycleService.php');
     $this->assertNotFalse($lifecycle);
     $this->assertStringContainsString('function duplicateTicketOnEvent', $lifecycle);
+    $this->assertStringContainsString("'waitlist_enabled'", $lifecycle);
+    $this->assertStringContainsString("'hidden_label'", $lifecycle);
+    $this->assertStringContainsString("'group_sale_mode'", $lifecycle);
+    $this->assertStringNotContainsString(
+      'buildTicketValuesFromInput($event, $account, $input)',
+      $lifecycle,
+    );
   }
 
   public function testTicketsAppAssetsExist(): void {
     $this->assertFileExists($this->moduleRoot() . '/js/mel-event-studio-tickets-app.js');
+    $js = file_get_contents($this->moduleRoot() . '/js/mel-event-studio-tickets-app.js');
+    $this->assertNotFalse($js);
+    $this->assertStringContainsString('mel-tickets-sticky-add', $js);
+    $this->assertStringContainsString('openAddTicketPanel', $js);
+    $this->assertStringContainsString('details.open = true', $js);
     $css = file_get_contents($this->moduleRoot() . '/css/mel-event-studio-shell.css');
     $this->assertNotFalse($css);
     $this->assertStringContainsString('mel-event-studio-ticket-sticky-add', $css);
     $this->assertStringContainsString('mel-event-studio-advanced-tools', $css);
+  }
+
+  public function testOperationalFormAttachesTicketsAppLibrary(): void {
+    $form = file_get_contents($this->moduleRoot() . '/src/Form/EventStudioOperationalTicketsForm.php');
+    $this->assertNotFalse($form);
+    $this->assertStringContainsString("myeventlane_event_studio/mel_event_studio_tickets_app", $form);
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioTicketsAppContractTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioTicketsAppContractTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Contract tests for VX2 Sprint 3 Tickets app convergence.
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventStudioTicketsAppContractTest extends TestCase {
+
+  private function moduleRoot(): string {
+    return dirname(__DIR__, 3);
+  }
+
+  public function testTicketsStackUsesProgressiveAdvancedTools(): void {
+    $renderer = file_get_contents($this->moduleRoot() . '/src/Service/EventStudioSectionRenderer.php');
+    $this->assertNotFalse($renderer);
+    $this->assertStringContainsString('buildAdvancedTicketTools', $renderer);
+    $this->assertStringContainsString('Advanced Ticket Tools', $renderer);
+    $this->assertStringContainsString('advanced_tools_opened', $renderer);
+    $this->assertStringContainsString('mel-event-studio-tickets-app', $renderer);
+  }
+
+  public function testOperationalTicketsFormUsesOrganiserLanguage(): void {
+    $form = file_get_contents($this->moduleRoot() . '/src/Form/EventStudioOperationalTicketsForm.php');
+    $this->assertNotFalse($form);
+    $this->assertStringContainsString("\$this->t('Add Ticket')", $form);
+    $this->assertStringContainsString("\$this->t('Add your first ticket')", $form);
+    $this->assertStringContainsString('Duplicate ticket', $form);
+    $this->assertStringContainsString('Archive ticket', $form);
+    $this->assertStringContainsString('ticket_created', $form);
+    $this->assertStringContainsString('ticket_archived', $form);
+    $this->assertStringNotContainsString('Commerce Product', $form);
+    $this->assertStringNotContainsString('Create Product', $form);
+    $this->assertStringNotContainsString('SKU', $form);
+  }
+
+  public function testBookingModeHidesCommerceProductForOrganisers(): void {
+    $form = file_get_contents($this->moduleRoot() . '/src/Form/EventStudioTicketsForm.php');
+    $this->assertNotFalse($form);
+    $this->assertStringContainsString("administer commerce_product", $form);
+    $this->assertStringContainsString('organisers never manage Commerce products directly', $form);
+  }
+
+  public function testTicketManagerRemovesCommerceLeakCopy(): void {
+    $form = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_vendor/src/Form/EventTicketManagerForm.php');
+    $this->assertNotFalse($form);
+    $this->assertStringNotContainsString('linked Commerce ticket product', $form);
+    $this->assertStringContainsString('Event Workspace → Tickets', $form);
+  }
+
+  public function testLifecycleSupportsDuplicateTicket(): void {
+    $lifecycle = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_event/src/Service/TicketTierLifecycleService.php');
+    $this->assertNotFalse($lifecycle);
+    $this->assertStringContainsString('function duplicateTicketOnEvent', $lifecycle);
+  }
+
+  public function testTicketsAppAssetsExist(): void {
+    $this->assertFileExists($this->moduleRoot() . '/js/mel-event-studio-tickets-app.js');
+    $css = file_get_contents($this->moduleRoot() . '/css/mel-event-studio-shell.css');
+    $this->assertNotFalse($css);
+    $this->assertStringContainsString('mel-event-studio-ticket-sticky-add', $css);
+    $this->assertStringContainsString('mel-event-studio-advanced-tools', $css);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioTicketsAppContractTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioTicketsAppContractTest.php
@@ -43,16 +43,13 @@ final class EventStudioTicketsAppContractTest extends TestCase {
   public function testDuplicateAppliesSameRequestEditsBeforeCopy(): void {
     $form = file_get_contents($this->moduleRoot() . '/src/Form/EventStudioOperationalTicketsForm.php');
     $this->assertNotFalse($form);
-    $this->assertStringContainsString('applyTicketValuesWithoutSave', $form);
+    $this->assertStringContainsString('updateAndDuplicateTicketOnEvent', $form);
     $this->assertStringContainsString('buildDuplicateTicketTitle', $form);
-    $applyPos = strpos($form, 'applyTicketValuesWithoutSave($ticket, $values)');
-    $duplicatePos = strpos($form, 'duplicateTicketOnEvent($event, $ticket, $this->currentUser)');
-    $persistPos = strpos($form, 'updateTicketType($ticket, $event, [])');
-    $this->assertNotFalse($applyPos);
-    $this->assertNotFalse($duplicatePos);
-    $this->assertNotFalse($persistPos);
-    $this->assertLessThan($duplicatePos, $applyPos, 'In-memory edits must apply before duplicate.');
-    $this->assertLessThan($persistPos, $duplicatePos, 'Source must persist only after duplicate succeeds.');
+    $this->assertStringNotContainsString(
+      'duplicateTicketOnEvent($event, $ticket, $this->currentUser)',
+      $form,
+      'Form must use the transactional updateAndDuplicate helper, not a bare duplicate call.',
+    );
   }
 
   public function testBookingModeHidesCommerceProductForOrganisers(): void {
@@ -73,12 +70,23 @@ final class EventStudioTicketsAppContractTest extends TestCase {
     $lifecycle = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_event/src/Service/TicketTierLifecycleService.php');
     $this->assertNotFalse($lifecycle);
     $this->assertStringContainsString('function duplicateTicketOnEvent', $lifecycle);
+    $this->assertStringContainsString('function updateAndDuplicateTicketOnEvent', $lifecycle);
     $this->assertStringContainsString('function buildDuplicateTicketTitle', $lifecycle);
     $this->assertStringContainsString('function applyTicketValuesWithoutSave', $lifecycle);
+    $this->assertStringContainsString('startTransaction', $lifecycle);
     $this->assertStringContainsString("'waitlist_enabled'", $lifecycle);
     $this->assertStringContainsString("'hidden_label'", $lifecycle);
     $this->assertStringContainsString("'group_sale_mode'", $lifecycle);
     $this->assertStringContainsString('too long to duplicate', $lifecycle);
+    $updatePos = strpos($lifecycle, '$this->updateTicketType($ticket, $event, []);');
+    $duplicatePos = strpos($lifecycle, 'return $this->duplicateTicketOnEvent($event, $ticket, $account);');
+    $this->assertNotFalse($updatePos);
+    $this->assertNotFalse($duplicatePos);
+    $this->assertLessThan(
+      $duplicatePos,
+      $updatePos,
+      'Transactional helper must persist source before creating the copy.',
+    );
   }
 
   public function testTicketsAppAssetsExist(): void {

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioTicketsAppContractTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioTicketsAppContractTest.php
@@ -40,6 +40,21 @@ final class EventStudioTicketsAppContractTest extends TestCase {
     $this->assertStringNotContainsString('SKU', $form);
   }
 
+  public function testDuplicateAppliesSameRequestEditsBeforeCopy(): void {
+    $form = file_get_contents($this->moduleRoot() . '/src/Form/EventStudioOperationalTicketsForm.php');
+    $this->assertNotFalse($form);
+    $duplicatePos = strpos($form, "if (!empty(\$row['duplicate']))");
+    $updatePos = strpos($form, 'updateTicketType($ticket, $event, $values)');
+    $this->assertNotFalse($duplicatePos);
+    $this->assertNotFalse($updatePos);
+    $this->assertLessThan(
+      $duplicatePos,
+      $updatePos,
+      'Duplicate must run after updateTicketType so same-request card edits are persisted first.',
+    );
+    $this->assertStringContainsString('Apply same-request card edits before optional duplicate', $form);
+  }
+
   public function testBookingModeHidesCommerceProductForOrganisers(): void {
     $form = file_get_contents($this->moduleRoot() . '/src/Form/EventStudioTicketsForm.php');
     $this->assertNotFalse($form);

--- a/web/modules/custom/myeventlane_tickets/src/Form/AccessCodeForm.php
+++ b/web/modules/custom/myeventlane_tickets/src/Form/AccessCodeForm.php
@@ -96,6 +96,11 @@ final class AccessCodeForm extends ContentEntityForm {
     $event_id = $entity->getEventId();
 
     if ($status === SAVED_NEW) {
+      $this->logger('myeventlane_tickets')->info('MEL ticket analytics hook access_code_created for event @nid.', [
+        '@nid' => (string) $event_id,
+        'mel_analytics_event' => 'access_code_created',
+        'event_id' => (int) $event_id,
+      ]);
       $this->messenger()->addStatus($this->t('Access code created. The code is: %code — copy it now, it will not be shown again in full.', [
         '%code' => $plaintext_code,
       ]));

--- a/web/modules/custom/myeventlane_tickets/src/Form/PurchaseSurfaceForm.php
+++ b/web/modules/custom/myeventlane_tickets/src/Form/PurchaseSurfaceForm.php
@@ -58,6 +58,11 @@ final class PurchaseSurfaceForm extends ContentEntityForm {
     $event_id = $entity->getEventId();
 
     if ($status === SAVED_NEW) {
+      $this->logger('myeventlane_tickets')->info('MEL ticket analytics hook widget_created for event @nid.', [
+        '@nid' => (string) $event_id,
+        'mel_analytics_event' => 'widget_created',
+        'event_id' => (int) $event_id,
+      ]);
       $this->messenger()->addStatus($this->t('Created the %label widget.', [
         '%label' => $entity->getLabel(),
       ]));

--- a/web/modules/custom/myeventlane_vendor/src/Form/EventTicketManagerForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/EventTicketManagerForm.php
@@ -130,10 +130,10 @@ final class EventTicketManagerForm extends FormBase {
     ];
 
     $workspace_url = Url::fromRoute('myeventlane_vendor.console.event_workspace', ['event' => $event->id()]);
-    $studio_url = Url::fromRoute('myeventlane_event_studio.edit', ['node' => $event->id()]);
+    $tickets_workspace_url = Url::fromRoute('myeventlane_event_studio.workspace_tickets', ['node' => $event->id()]);
     $show_workspace = $workspace_url->access();
-    $show_studio = $studio_url->access();
-    if ($show_workspace || $show_studio) {
+    $show_tickets_workspace = $tickets_workspace_url->access();
+    if ($show_workspace || $show_tickets_workspace) {
       $form['back_nav'] = [
         '#type' => 'container',
         '#attributes' => ['class' => ['mel-ticket-manager-back-nav']],
@@ -146,11 +146,11 @@ final class EventTicketManagerForm extends FormBase {
           '#attributes' => ['class' => ['mel-ticket-manager-back-nav__link']],
         ];
       }
-      if ($show_studio) {
+      if ($show_tickets_workspace) {
         $form['back_nav']['studio'] = [
           '#type' => 'link',
-          '#title' => $this->t('Event Studio'),
-          '#url' => $studio_url,
+          '#title' => $this->t('Tickets in Workspace'),
+          '#url' => $tickets_workspace_url,
           '#attributes' => ['class' => ['mel-ticket-manager-back-nav__link']],
         ];
       }
@@ -167,7 +167,7 @@ final class EventTicketManagerForm extends FormBase {
         '#type' => 'container',
         '#attributes' => ['class' => ['messages', 'messages--error']],
         'message' => [
-          '#markup' => '<p>' . $this->t('This event does not have a linked Commerce ticket product. Link a ticket product before managing tickets.') . '</p>',
+          '#markup' => '<p>' . $this->t('This event is not ready for ticket inventory tools yet. Add a paid ticket in Event Workspace → Tickets first.') . '</p>',
         ],
       ];
       return $form;
@@ -178,7 +178,20 @@ final class EventTicketManagerForm extends FormBase {
         '#type' => 'container',
         '#attributes' => ['class' => ['messages', 'messages--status']],
         'message' => [
-          '#markup' => '<p>' . $this->t('Add a ticket row below. The ticket product will be created when you save and sync tickets.') . '</p>',
+          '#markup' => '<p>' . $this->t('Add a ticket row below. Tickets will be set up automatically when you save and sync.') . '</p>',
+        ],
+      ];
+    }
+
+    $tickets_url = Url::fromRoute('myeventlane_event_studio.workspace_tickets', ['node' => $event->id()]);
+    if ($tickets_url->access()) {
+      $form['workspace_notice'] = [
+        '#type' => 'container',
+        '#attributes' => ['class' => ['messages', 'messages--status', 'mel-ticket-manager-workspace-notice']],
+        'message' => [
+          '#markup' => '<p>' . $this->t('Most organisers manage tickets in <a href=":url">Event Workspace → Tickets</a>. Use this page only for inventory sync and deeper controls.', [
+            ':url' => $tickets_url->toString(),
+          ]) . '</p>',
         ],
       ];
     }


### PR DESCRIPTION
## Summary
- Converge organiser ticket setup into one Event Workspace Tickets app (cards, Add Ticket, duplicate/archive, sales).
- Progressively disclose Advanced Ticket Tools (codes, groups, widgets, settings, inventory sync).
- Remove organiser-visible Commerce Product/Variation language; keep Commerce as the backend engine.
- Document VX2-04 status and instrumentation hooks (`ticket_created`, `advanced_tools_opened`, etc.).

## Test plan
- [ ] Create GA + VIP tickets without seeing Product/Variation/SKU
- [ ] Empty state → Add Ticket → save (paid + Free RSVP)
- [ ] Duplicate and Archive from card quick actions
- [ ] Expand Advanced Ticket Tools; open codes/widgets/groups
- [ ] Mobile ~390px: sticky Add Ticket, 44px targets, keyboard focus
- [ ] Publish paid event still requires Stripe readiness as before

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch paid-ticket lifecycle, Commerce projection, and transactional duplicate/archive paths—core checkout inventory—not just UI copy.
> 
> **Overview**
> **VX2 Sprint 3 (VX2-04)** converges organiser ticket setup into one **Event Workspace → Tickets** experience instead of splitting Studio cards and scattered advanced surfaces.
> 
> The operational tickets form gains **card-first UX**: guided empty state, **Add Ticket** (including a mobile sticky CTA), richer card summaries (availability, sales/RSVP counts), and **Duplicate** / **Archive** quick actions with validation so both cannot run on one save. **Duplicate** is backed by new `TicketTierLifecycleService` APIs (`duplicateTicketOnEvent`, transactional `updateAndDuplicateTicketOnEvent`) so same-request edits and copies stay consistent with Commerce sync.
> 
> **Advanced Ticket Tools** is a collapsed disclosure in the tickets stack (codes, groups, widgets, settings, inventory/sync), with JS for `advanced_tools_opened` and sticky Add Ticket behavior. Organisers no longer see Commerce product autocomplete on booking mode; the legacy **Event Ticket Manager** is demoted with copy and links pointing to Workspace Tickets.
> 
> Docs record Sprint 3 shipped status and instrumentation event names; logger hooks fire on ticket lifecycle and access-code/widget creates (full analytics pipeline still deferred). Contract tests guard the convergence shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edce9dcb23ca64caece8bb158373aead0f638033. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->