### PR TITLE
VX2 Sprint 4 — One Attendee Workspace

### DIFF
--- a/docs/implementation/vx2-sprint4-attendee-surface-inventory.md
+++ b/docs/implementation/vx2-sprint4-attendee-surface-inventory.md
@@ -1,0 +1,41 @@
+# VX2 Sprint 4 — Attendee surface inventory
+
+**Branch:** `feature/vx2-attendee-workspace`  
+**Authority:** Vendor Experience Convergence (VX2-05 / B7 / B8)  
+**Date:** 2026-07-22
+
+Organisers must think **Attendees** only — not RSVP list, Ticket holders, Orders, Waitlist, Check-in module, or Door module as separate products.
+
+| Surface | Path / route | Purpose today | Duplicate? | Disposition | Future location |
+| --- | --- | --- | --- | --- | --- |
+| Event guest list | `/vendor/events/{id}/attendees` (`vendor_list`) | Full guest list (staff/uid1); organisers redirected to Studio | Partial vs Studio metrics | **Redirect** organisers → Workspace Attendees (keep route for staff + deep links) | **Attendees** |
+| Studio Attendees | `/vendor/events/{id}/studio/attendees` | Metrics-only (pre–Sprint 4) | Thin duplicate of guest list | **Merge** — become One Attendee Workspace | **Attendees** (canonical) |
+| Global Attendees hub | `/vendor/attendees` | Cross-event hub | Complements event list | **Keep** | Global **Attendees** |
+| RSVPs console | `/vendor/events/{id}/rsvps` | RSVP-only list | Yes vs Attendees filter | **Redirect** → Attendees `?filter=rsvp` | Attendees · RSVP filter |
+| Legacy Manage RSVPs | `/vendor/event/{id}/rsvps` | Singular RSVP list | Yes | **Redirect** → Attendees | Attendees |
+| Waitlist manage | `/vendor/event/{id}/waitlist` | Waitlist-only admin | Yes | **Redirect** → Attendees `?filter=waitlist` | Attendees · Waitlist filter |
+| Door Mode hub | `/vendor/events/{id}/operations` | Venue ops + metrics | Sibling of door | **Keep** as Attendees mode entry | Attendees · Door Mode |
+| Door Mode scanner | `/vendor/events/{id}/operations/door` | Canonical check-in | Target | **Keep** (canonical) | Attendees · Door Mode |
+| Legacy check-in page | `/vendor/events/{id}/check-in` | Parallel UI | Yes | **Redirect** → Door Mode | Door Mode |
+| Legacy check-in list | `/vendor/events/{id}/check-in/list` | Parallel list | Yes | **Redirect** → Door Mode | Door Mode |
+| Legacy check-in scan | `/vendor/events/{id}/check-in/scan` | Already 302 → Door | — | **Keep** redirect | Door Mode |
+| Ticket check-in form | `/event/{id}/tickets/checkin` | Organiser ticket check-in | Yes | **Redirect** organiser GET → Door Mode; APIs retained | Door Mode |
+| RSVP check-in / QR | `/vendor/event/{id}/rsvps/checkin`, `/scan` | RSVP-only door | Yes | **Redirect** → Door Mode | Door Mode |
+| Export (canonical) | `/vendor/events/{id}/attendees/export` | CSV via MelAttendeeExportBuilder | — | **Keep** — label “Export attendees” | Attendees · Export |
+| Views / paragraph / RSVP / waitlist CSV | various | Parallel exporters | Yes | **Merge** entry points; keep async backends where present | Attendees · Export |
+| Message attendees (Pro) | `/vendor/events/{id}/message` | Blast compose | Parallel vs Studio Messages | **Keep** writer; CTA from Attendees | Messages (VX2-06) + Attendees entry |
+| Studio Messages | `/studio/messages` | Informational | Placeholder | **Keep** until VX2-06 | Messages |
+| Refund form | `/vendor/orders/{order}/refund` | Order refund | — | **Keep**; entry from attendee card when order exists | Payments + Attendees quick action |
+| Order detail attendees | `/vendor/events/{id}/orders/{order}` | Order ↔ guests | Complementary | **Keep** bi-link | Orders |
+| Attendance analytics | Insights / Analytics / ticket check-in analytics | Reporting | Overlaps | **Keep** under Analytics; soft-link from Attendees | Analytics |
+| Vendor API attendees | `/api/v1/vendor/events/{id}/attendees` | API twin | — | **Keep** | API |
+
+## Mental model (after Sprint 4)
+
+```text
+Attendees
+  ↓ Search
+  ↓ Filters (ticket type / RSVP / waitlist / checked in / not checked in / refunded / cancelled)
+  ↓ Guest list (cards; dense table for large events)
+  ↓ Actions (View · Message · Refund · Check in · Door Mode · Export)
+```

--- a/docs/implementation/vx2-sprint4-attendee-workspace.md
+++ b/docs/implementation/vx2-sprint4-attendee-workspace.md
@@ -1,0 +1,44 @@
+# VX2 Sprint 4 — Implementation notes
+
+**Epic:** VX2-05 Attendees  
+**Branch:** `feature/vx2-attendee-workspace`  
+**Date:** 2026-07-22
+
+## What shipped
+
+- One Attendee Workspace in Event Workspace (`workspace_attendees` → `attendees_stack`)
+- Guest cards with name, ticket/RSVP, booking status, check-in, order reference, quick actions
+- Immediate search + filters (ticket, RSVP, waitlist, checked in / not, refunded, cancelled, ticket type)
+- Door Mode treated as Attendees mode; legacy check-in stacks redirect
+- Message / Export attendees / Refund entry points (no messaging rebuild)
+- AU English empty states
+- Instrumentation hooks documented (logger + JS CustomEvent)
+
+## Metrics (instrumentation)
+
+| Hook | Where | Pipeline |
+| --- | --- | --- |
+| `attendee_viewed` | `EventAttendeeWorkspaceBuilder` logger | Deferred |
+| `attendee_checked_in` | Card check-in form JS + existing check-in services | Deferred |
+| `attendee_exported` | Export CTA `data-mel-attendee-analytics` | Deferred |
+| `attendee_filtered` | Filter chips / ticket type JS | Deferred |
+| `door_mode_opened` | Door Mode CTA analytics attr | Deferred |
+| `message_attendees_clicked` | Message CTA analytics attr | Deferred |
+
+## Manual QA checklist
+
+- [ ] Small paid event — cards, search, export
+- [ ] Large event (≥100) — dense layout
+- [ ] RSVP-only — RSVP filter; no separate RSVPs tab
+- [ ] Mixed paid + RSVP
+- [ ] Waitlist filter via legacy waitlist URL redirect
+- [ ] Door Mode from Attendees + legacy `/check-in`
+- [ ] Message attendees entry
+- [ ] Refund entry on ticketed guest with order
+- [ ] Desktop / tablet / 390px mobile
+- [ ] Keyboard: search, filter chips, action buttons
+- [ ] Screen reader: list region, live status, button pressed state
+
+## Inventory
+
+See `docs/implementation/vx2-sprint4-attendee-surface-inventory.md`.

--- a/docs/vendor-experience-convergence-implementation-plan.md
+++ b/docs/vendor-experience-convergence-implementation-plan.md
@@ -233,7 +233,7 @@ GA + VIP creatable without Commerce words; advanced optional.
 - Optional redirect of Advanced manager Overview → Workspace Tickets  
 - Deeper per-ticket drawer edit (vs inline cards) if large inventories need tables  
 - Wire `mel:analytics` / logger hooks into the platform analytics pipeline  
-- VX2-05 Attendees / Door Mode
+- VX2-05 Attendees / Door Mode — **shipped Sprint 4** (see VX2-05 below)
 
 ## VX2-05 — Attendees
 
@@ -256,7 +256,26 @@ VX2-00 check-in trust; Workspace Attendees section.
 
 One place for “who’s coming” and “who’s in”.
 
----
+### Sprint 4 shipped (2026-07-22)
+
+| Item | Status |
+| --- | --- |
+| One Attendee Workspace in Event Workspace | Done — `attendees_stack` + `EventAttendeeWorkspaceBuilder` |
+| Search + filters (ticket / RSVP / waitlist / check-in / refunded / cancelled) | Done — client-side immediate filter |
+| Attendee cards + dense layout for large lists | Done — cards default; dense ≥100 |
+| Door Mode as Attendees mode | Done — tab + redirects from legacy check-in stacks |
+| Message / Export / Refund entry points | Done — no messaging rebuild |
+| Empty states (AU English) | Done |
+| Instrumentation hooks | Documented + logger/JS hooks (pipeline deferred) |
+| Bulk select messaging | Remaining — single + workspace Message CTAs shipped |
+| Mobile Door Mode PWA parity | Remaining — scanner retained; deeper PWA polish later |
+
+### Remaining after Sprint 4
+
+- Wire attendee analytics hooks into platform pipeline  
+- Bulk selection → message ticket type (VX2-06 adjacent)  
+- Deeper Door Mode mobile/PWA polish  
+- VX2-06 Messages product convergence
 
 ## VX2-06 — Messages
 

--- a/docs/vendor-experience-convergence-screen-specifications.md
+++ b/docs/vendor-experience-convergence-screen-specifications.md
@@ -207,6 +207,7 @@ Format: Purpose · Primary action · Content · States · Notes
 | **Content** | Search; filters (ticket type, RSVP, waitlist, checked in); bulk actions; refunds entry; CSV |
 | **Mobile** | Check-in dense list; large targets |
 | **Notes** | Merge paid + RSVP + waitlist UI |
+| **Sprint 4** | Shipped in Event Workspace (`attendees_stack`): cards, immediate search/filters, Door Mode / Message / Export / Refund entry points; dense layout ≥100 guests |
 
 ### B8. Door Mode
 
@@ -216,6 +217,7 @@ Format: Purpose · Primary action · Content · States · Notes
 | **Primary action** | Scan / Search / Toggle check-in |
 | **Content** | Scanner; search; recent activity; capacity remaining |
 | **Notes** | Canonical check-in; retire parallel stacks via redirect |
+| **Sprint 4** | Organiser entry points redirect to `/vendor/events/{id}/operations/door`; Manager tab labelled Door Mode |
 
 ### B9. Messages (event)
 

--- a/docs/vendor-experience-convergence.md
+++ b/docs/vendor-experience-convergence.md
@@ -3,7 +3,7 @@
 **Product Blueprint & Migration Plan**  
 **Status:** Complete — ready to drive the next generation of MyEventLane development  
 **Date:** 2026-07-22  
-**Runtime:** VX2 Sprint 3 (The Ticket Experience / VX2-04) on branch `feature/vx2-ticket-experience` (2026-07-22); Sprint 2 merged via PR #702; Sprint 1 merged via PR #701  
+**Runtime:** VX2 Sprint 4 (One Attendee Workspace / VX2-05) on branch `feature/vx2-attendee-workspace` (2026-07-22); Sprint 3 merged via PR #704; Sprint 2 merged via PR #702; Sprint 1 merged via PR #701  
 **Method:** Repository review + synthesis of VX2 product docs and prior audits  
 **Language standard:** Organiser (human) · `vendor` (machine / URLs)
 
@@ -78,7 +78,7 @@ Permanent principles remain in [`vendor-experience-v2-design-principles.md`](ven
 2. Event Studio remains the builder / publish authority; Event Manager and Studio converge into **one Event Workspace**.
 3. `mel_ticket_type` remains the ticket abstraction; Commerce stays hidden.
 4. Workspace ownership (ADR-0008) remains the access contract.
-5. ~~This pack does **not** change runtime behaviour.~~ **Update (Sprint 1):** organiser-visible language, shell navigation, Create Event gateway alignment, and placeholder redirects are live in code. **Update (Sprint 2):** One Event Workspace shell/nav, Overview home, human readiness, Marketing/Publishing sections, and Manager tab convergence are live in code. **Update (Sprint 3):** One Tickets app in Event Workspace with card UX, empty states, duplicate/archive, progressive Advanced Ticket Tools, and Commerce terminology removed from organiser ticket surfaces.
+5. ~~This pack does **not** change runtime behaviour.~~ **Update (Sprint 1):** organiser-visible language, shell navigation, Create Event gateway alignment, and placeholder redirects are live in code. **Update (Sprint 2):** One Event Workspace shell/nav, Overview home, human readiness, Marketing/Publishing sections, and Manager tab convergence are live in code. **Update (Sprint 3):** One Tickets app in Event Workspace with card UX, empty states, duplicate/archive, progressive Advanced Ticket Tools, and Commerce terminology removed from organiser ticket surfaces. **Update (Sprint 4):** One Attendee Workspace with search/filters/cards, Door Mode as Attendees mode, legacy check-in redirects, and Message/Export/Refund entry points.
 6. Prior VX2 findings are treated as authoritative unless contradicted by the 2026-07-22 inventory.
 
 ---
@@ -409,7 +409,7 @@ Full definitions: [`vendor-experience-convergence-success-metrics.md`](vendor-ex
 | Create Event → gateway / draft-choice | **Done** — shell CTA + account menu |
 | Placeholder manage routes | **Done** — redirect (not “coming soon”) |
 | Payments / Orders hubs | **Deferred** — labels point at existing payouts / event-scoped orders |
-| Door Mode check-in merge | **Deferred** — VX2-05 (removed from shell only) |
+| Door Mode check-in merge | **Done** — VX2-05 Sprint 4 (legacy stacks redirect; Door Mode canonical) |
 
 ## Sprint 2 runtime status (VX2-03 One Event Workspace)
 
@@ -423,28 +423,36 @@ Full definitions: [`vendor-experience-convergence-success-metrics.md`](vendor-ex
 | Empty states / celebration | **Done** — AU warm empty copy; publish celebration without emoji gimmick |
 | Manager dual chrome | **Converged** — tabs/preprocess point at Workspace routes; staff mission-control retained |
 | Dedicated Schedule/Venue field forms | **Partial** — nav sections share Event information form (field split deferred) |
-| Full Attendees / Door depth | **Deferred** — VX2-05 |
+| Full Attendees / Door depth | **Done** — VX2-05 Sprint 4 (see Sprint 4) |
 | Tickets app depth | **Done** — VX2-04 (see Sprint 3) |
 
 ## Sprint 3 runtime status (VX2-04 The Ticket Experience)
 
 | Area | Status |
 | --- | --- |
-| One Tickets app in Event Workspace | **Done** — `workspace_tickets` stack: booking mode → ticket cards → preview → Advanced |
-| Ticket cards (name, price, capacity, availability, status, sales) | **Done** — `EventStudioOperationalTicketsForm` |
-| Primary CTA **Add Ticket** | **Done** — empty-state + details + mobile sticky CTA |
-| Duplicate / Archive | **Done** — lifecycle `duplicateTicketOnEvent` + quick actions |
-| Progressive **Advanced Ticket Tools** | **Done** — codes, groups, widgets, settings, inventory/sync nested |
-| Commerce Product / Variation / SKU organiser copy | **Removed** from ticket manager + booking product autocomplete hidden for organisers |
-| Instrumentation hooks | **Partial** — logger + JS hooks for ticket_created/updated/archived, advanced_tools_opened, access_code_created, widget_created; full analytics pipeline deferred |
-| Redirect Advanced manager to Workspace-only | **Partial** — manager demoted with Workspace CTA; deep routes retained under Advanced |
+| One Tickets app in Event Workspace | **Done** — `workspace_tickets` stack |
+| Ticket cards + Add / Duplicate / Archive | **Done** |
+| Advanced Ticket Tools | **Done** |
+| Commerce language cleanup on ticket surfaces | **Done** |
+
+## Sprint 4 runtime status (VX2-05 One Attendee Workspace)
+
+| Area | Status |
+| --- | --- |
+| One Attendees app in Event Workspace | **Done** — `workspace_attendees` stack: search → filters → guest cards → actions |
+| Paid + RSVP + waitlist in one list | **Done** — filters; RSVP tab removed from Manager chrome |
+| Door Mode as Attendees mode | **Done** — ops tab + legacy check-in redirects |
+| Message / Export / Refund entry | **Done** — CTAs only; messaging product deferred to VX2-06 |
+| Empty states (AU English) | **Done** |
+| Instrumentation hooks | **Partial** — logger + JS; analytics pipeline deferred |
+| Bulk message selection | **Deferred** — VX2-06 |
 
 ---
 
 ## Executive verdict
 
-**Biggest organiser friction:** Parallel products for one event (Studio vs Manager vs legacy) plus fragmented Attendees, Messages, Analytics, and Check-in — compounded by Commerce language leaks.
+**Biggest organiser friction:** Parallel products for one event (Studio vs Manager vs legacy) plus fragmented Messages, Analytics, and Payments — Attendees/Door Mode and Tickets are now converged.
 
 **Biggest revenue opportunities:** Faster first publish; higher Stripe completion; free Analytics pulse that earns Pro; clearer Boost / Marketing; fewer support dead ends that abandon paid flows.
 
-**Vendor Experience Convergence blueprint is complete.** Sprint 1 delivered Trust, Language & Navigation; Sprint 2 delivered One Event Workspace; Sprint 3 delivered The Ticket Experience; remaining epics follow the roadmap.
+**Vendor Experience Convergence blueprint is complete.** Sprint 1 delivered Trust, Language & Navigation; Sprint 2 delivered One Event Workspace; Sprint 3 delivered The Ticket Experience; Sprint 4 delivered One Attendee Workspace; remaining epics follow the roadmap.

--- a/web/modules/custom/myeventlane_checkin/src/Controller/CheckInController.php
+++ b/web/modules/custom/myeventlane_checkin/src/Controller/CheckInController.php
@@ -7,6 +7,7 @@ namespace Drupal\myeventlane_checkin\Controller;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Url;
 use Drupal\myeventlane_checkin\Service\CheckInStorageInterface;
+use Drupal\myeventlane_core\VendorConsoleTrust;
 use Drupal\myeventlane_vendor\Service\EventVendorAccessChecker;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -39,39 +40,94 @@ final class CheckInController extends ControllerBase {
   }
 
   /**
-   * Main check-in page — VX2-05 converges on Door Mode.
+   * Main check-in page — VX2-05 converges on Door Mode for console users.
+   *
+   * Team accounts with check-in-only permission (no vendor console trust) keep
+   * the legacy UI: Door Mode is gated by vendor_console access and would 403.
+   *
+   * @return array<string, mixed>|\Symfony\Component\HttpFoundation\RedirectResponse
+   *   Legacy page build or Door Mode redirect.
    */
-  public function page(NodeInterface $node): RedirectResponse {
+  public function page(NodeInterface $node): array|RedirectResponse {
     $this->assertEventAccess($node);
 
-    return new RedirectResponse(
-      Url::fromRoute('myeventlane_event_attendees.vendor_operations_door', ['node' => $node->id()])->toString(),
-      302,
-    );
+    if ($this->shouldConvergeToDoorMode()) {
+      return new RedirectResponse(
+        Url::fromRoute('myeventlane_event_attendees.vendor_operations_door', ['node' => $node->id()])->toString(),
+        302,
+      );
+    }
+
+    $attendees = $this->checkInStorage->getAttendees($node);
+    $checkedInCount = count(array_filter($attendees, fn($a) => $a['checked_in']));
+    $totalCount = count($attendees);
+
+    return [
+      '#theme' => 'myeventlane_checkin_page',
+      '#event' => $node,
+      '#attendees' => $attendees,
+      '#stats' => [
+        'total' => $totalCount,
+        'checked_in' => $checkedInCount,
+        'remaining' => $totalCount - $checkedInCount,
+      ],
+      '#attached' => [
+        'library' => ['myeventlane_checkin/checkin'],
+      ],
+    ];
   }
 
   /**
-   * Legacy QR scan route — redirects to canonical Door Mode.
+   * Legacy QR scan route — Door Mode for console users; otherwise scan UI.
+   *
+   * @return array<string, mixed>|\Symfony\Component\HttpFoundation\RedirectResponse
+   *   Legacy scan build or Door Mode redirect.
    */
-  public function scan(NodeInterface $node): RedirectResponse {
+  public function scan(NodeInterface $node): array|RedirectResponse {
     $this->assertEventAccess($node);
 
-    return new RedirectResponse(
-      Url::fromRoute('myeventlane_event_attendees.vendor_operations_door', ['node' => $node->id()])->toString(),
-      302,
-    );
+    if ($this->shouldConvergeToDoorMode()) {
+      return new RedirectResponse(
+        Url::fromRoute('myeventlane_event_attendees.vendor_operations_door', ['node' => $node->id()])->toString(),
+        302,
+      );
+    }
+
+    return [
+      '#theme' => 'myeventlane_checkin_scan',
+      '#event' => $node,
+      '#attached' => [
+        'library' => ['myeventlane_checkin/checkin'],
+      ],
+    ];
   }
 
   /**
-   * Attendee list page — VX2-05 converges on Door Mode.
+   * Attendee list page — Door Mode for console users; otherwise legacy list.
+   *
+   * @return array<string, mixed>|\Symfony\Component\HttpFoundation\RedirectResponse
+   *   Legacy list build or Door Mode redirect.
    */
-  public function list(NodeInterface $node): RedirectResponse {
+  public function list(NodeInterface $node): array|RedirectResponse {
     $this->assertEventAccess($node);
 
-    return new RedirectResponse(
-      Url::fromRoute('myeventlane_event_attendees.vendor_operations_door', ['node' => $node->id()])->toString(),
-      302,
-    );
+    if ($this->shouldConvergeToDoorMode()) {
+      return new RedirectResponse(
+        Url::fromRoute('myeventlane_event_attendees.vendor_operations_door', ['node' => $node->id()])->toString(),
+        302,
+      );
+    }
+
+    $attendees = $this->checkInStorage->getAttendees($node);
+
+    return [
+      '#theme' => 'myeventlane_checkin_list',
+      '#event' => $node,
+      '#attendees' => $attendees,
+      '#attached' => [
+        'library' => ['myeventlane_checkin/checkin'],
+      ],
+    ];
   }
 
   /**
@@ -117,6 +173,16 @@ final class CheckInController extends ControllerBase {
     return new JsonResponse([
       'results' => $results,
     ]);
+  }
+
+  /**
+   * Whether this account may use Door Mode (vendor console trust).
+   *
+   * Door Mode routes use vendor_console access; check-in-only team accounts
+   * must not be redirected into a surface they cannot open.
+   */
+  private function shouldConvergeToDoorMode(): bool {
+    return VendorConsoleTrust::accountIsTrustedForVendorConsole($this->currentUser());
   }
 
   /**

--- a/web/modules/custom/myeventlane_checkin/src/Controller/CheckInController.php
+++ b/web/modules/custom/myeventlane_checkin/src/Controller/CheckInController.php
@@ -39,30 +39,15 @@ final class CheckInController extends ControllerBase {
   }
 
   /**
-   * Main check-in page.
+   * Main check-in page — VX2-05 converges on Door Mode.
    */
-  public function page(NodeInterface $node): array {
+  public function page(NodeInterface $node): RedirectResponse {
     $this->assertEventAccess($node);
 
-    $attendees = $this->checkInStorage->getAttendees($node);
-    $checkedInCount = count(array_filter($attendees, fn($a) => $a['checked_in']));
-    $totalCount = count($attendees);
-
-    $build = [
-      '#theme' => 'myeventlane_checkin_page',
-      '#event' => $node,
-      '#attendees' => $attendees,
-      '#stats' => [
-        'total' => $totalCount,
-        'checked_in' => $checkedInCount,
-        'remaining' => $totalCount - $checkedInCount,
-      ],
-      '#attached' => [
-        'library' => ['myeventlane_checkin/checkin'],
-      ],
-    ];
-
-    return $build;
+    return new RedirectResponse(
+      Url::fromRoute('myeventlane_event_attendees.vendor_operations_door', ['node' => $node->id()])->toString(),
+      302,
+    );
   }
 
   /**
@@ -78,23 +63,15 @@ final class CheckInController extends ControllerBase {
   }
 
   /**
-   * Attendee list page.
+   * Attendee list page — VX2-05 converges on Door Mode.
    */
-  public function list(NodeInterface $node): array {
+  public function list(NodeInterface $node): RedirectResponse {
     $this->assertEventAccess($node);
 
-    $attendees = $this->checkInStorage->getAttendees($node);
-
-    $build = [
-      '#theme' => 'myeventlane_checkin_list',
-      '#event' => $node,
-      '#attendees' => $attendees,
-      '#attached' => [
-        'library' => ['myeventlane_checkin/checkin'],
-      ],
-    ];
-
-    return $build;
+    return new RedirectResponse(
+      Url::fromRoute('myeventlane_event_attendees.vendor_operations_door', ['node' => $node->id()])->toString(),
+      302,
+    );
   }
 
   /**

--- a/web/modules/custom/myeventlane_checkin/src/Controller/CheckInController.php
+++ b/web/modules/custom/myeventlane_checkin/src/Controller/CheckInController.php
@@ -176,13 +176,18 @@ final class CheckInController extends ControllerBase {
   }
 
   /**
-   * Whether this account may use Door Mode (vendor console trust).
+   * Whether this account should be redirected from legacy check-in to Door Mode.
    *
-   * Door Mode routes use vendor_console access; check-in-only team accounts
-   * must not be redirected into a surface they cannot open.
+   * Aligns with VendorLegacyWizardRedirectSubscriber: staff (administer nodes /
+   * uid 1) keep the parallel legacy UI. Check-in-only team accounts without
+   * vendor console trust also keep legacy surfaces (Door Mode is console-gated).
    */
   private function shouldConvergeToDoorMode(): bool {
-    return VendorConsoleTrust::accountIsTrustedForVendorConsole($this->currentUser());
+    $account = $this->currentUser();
+    if ($account->hasPermission('administer nodes') || (int) $account->id() === 1) {
+      return FALSE;
+    }
+    return VendorConsoleTrust::accountIsTrustedForVendorConsole($account);
   }
 
   /**

--- a/web/modules/custom/myeventlane_checkin/tests/src/Unit/CheckinRoutingSafetyTest.php
+++ b/web/modules/custom/myeventlane_checkin/tests/src/Unit/CheckinRoutingSafetyTest.php
@@ -43,6 +43,8 @@ final class CheckinRoutingSafetyTest extends TestCase {
     $raw = (string) file_get_contents($path);
     $this->assertStringContainsString('attendeeBelongsToEvent', $raw);
     $this->assertStringContainsString('AccessDeniedHttpException', $raw);
+    $this->assertStringContainsString('shouldConvergeToDoorMode', $raw);
+    $this->assertStringContainsString('VendorConsoleTrust', $raw);
   }
 
 }

--- a/web/modules/custom/myeventlane_checkin/tests/src/Unit/CheckinRoutingSafetyTest.php
+++ b/web/modules/custom/myeventlane_checkin/tests/src/Unit/CheckinRoutingSafetyTest.php
@@ -45,6 +45,7 @@ final class CheckinRoutingSafetyTest extends TestCase {
     $this->assertStringContainsString('AccessDeniedHttpException', $raw);
     $this->assertStringContainsString('shouldConvergeToDoorMode', $raw);
     $this->assertStringContainsString('VendorConsoleTrust', $raw);
+    $this->assertStringContainsString('administer nodes', $raw);
   }
 
 }

--- a/web/modules/custom/myeventlane_checkout_flow/templates/mel-venue-operations.html.twig
+++ b/web/modules/custom/myeventlane_checkout_flow/templates/mel-venue-operations.html.twig
@@ -249,6 +249,7 @@
                   data-mel-ops-attendee-id="{{ row.id }}"
                 >
                   <input type="hidden" name="_token" value="{{ checkin_csrf|e('html_attr') }}">
+                  <input type="hidden" name="destination" value="{{ path('myeventlane_event_attendees.vendor_operations', {'node': event.id()}) }}">
                   <button type="submit" class="mel-btn mel-btn--primary mel-live-ops__check-btn">{{ 'Check in'|t }}</button>
                 </form>
               {% else %}

--- a/web/modules/custom/myeventlane_event_attendees/myeventlane_event_attendees.routing.yml
+++ b/web/modules/custom/myeventlane_event_attendees/myeventlane_event_attendees.routing.yml
@@ -60,7 +60,7 @@ myeventlane_event_attendees.vendor_operations_door:
   path: '/vendor/events/{node}/operations/door'
   defaults:
     _controller: 'myeventlane_checkout_flow.controller.vendor_event_operations:doorPage'
-    _title: 'Door check-in'
+    _title: 'Door Mode'
   requirements:
     _custom_access: 'myeventlane_vendor.access.vendor_console:access'
     node: '\d+'
@@ -92,7 +92,7 @@ myeventlane_event_attendees.vendor_export:
   path: '/vendor/events/{node}/attendees/export'
   defaults:
     _controller: '\Drupal\myeventlane_event_attendees\Controller\VendorAttendeeController::export'
-    _title: 'Export Attendees'
+    _title: 'Export attendees'
   requirements:
     _custom_access: '\Drupal\myeventlane_event_attendees\Controller\VendorAttendeeController::access'
     node: '\d+'

--- a/web/modules/custom/myeventlane_event_attendees/myeventlane_event_attendees.services.yml
+++ b/web/modules/custom/myeventlane_event_attendees/myeventlane_event_attendees.services.yml
@@ -36,3 +36,18 @@ services:
       - '@date.formatter'
       - '@logger.channel.myeventlane_event_attendees'
       - '@string_translation'
+
+  # VX2-05 One Attendee Workspace view model (Event Workspace · Attendees).
+  myeventlane_event_attendees.attendee_workspace_builder:
+    class: Drupal\myeventlane_event_attendees\Service\EventAttendeeWorkspaceBuilder
+    arguments:
+      - '@myeventlane_event_attendees.manager'
+      - '@myeventlane_event_attendees.vendor_presentation'
+      - '@myeventlane_event_attendees.attendee_export_builder'
+      - '@csrf_token'
+      - '@module_handler'
+      - '@router.route_provider'
+      - '@request_stack'
+      - '@current_user'
+      - '@logger.channel.myeventlane_event_attendees'
+      - '@string_translation'

--- a/web/modules/custom/myeventlane_event_attendees/src/Controller/VendorAttendeeController.php
+++ b/web/modules/custom/myeventlane_event_attendees/src/Controller/VendorAttendeeController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_event_attendees\Controller;
 
+use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Url;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Access\AccessResultInterface;
@@ -431,15 +432,15 @@ final class VendorAttendeeController extends ControllerBase {
    * Dual-mode endpoint that preserves the canonical writer
    * (`MelAttendeeCheckinManager::checkInAttendee`) and the JSON contract
    * for AJAX clients, while giving non-XHR (progressive enhancement /
-   * no-JS) browser submissions a redirect back to the operations page so
-   * the user never sees raw JSON.
+   * no-JS) browser submissions a redirect back to the surface they posted
+   * from so the user never sees raw JSON.
    *
    *  - XHR (`X-Requested-With: XMLHttpRequest`) → JSON Response (unchanged).
-   *  - Non-XHR browser POST → flash message + 303 redirect to
-   *    `myeventlane_event_attendees.vendor_operations` for the attendee's
-   *    event. Falls back to the public check-in page if the event cannot be
-   *    resolved (defensive — should not happen because access already
-   *    requires an event-bound attendee).
+   *  - Non-XHR browser POST → flash message + 303 redirect:
+   *      1. Safe internal `destination` POST/query (Workspace Attendees or
+   *         Live Operations forms supply this).
+   *      2. Else Event Workspace Attendees for the attendee's event (VX2).
+   *      3. Else Live Operations, then front page as last resorts.
    *
    * Security:
    *   - Vendor ownership is enforced server-side via `accessAttendee()` on
@@ -473,7 +474,8 @@ final class VendorAttendeeController extends ControllerBase {
         $event_attendee,
         $isXhr,
         'csrf_invalid',
-        $this->t('Your session has expired. Please refresh the page and try again.')
+        $this->t('Your session has expired. Please refresh the page and try again.'),
+        $request,
       );
     }
 
@@ -503,7 +505,7 @@ final class VendorAttendeeController extends ControllerBase {
       $this->messenger()->addWarning($message);
     }
 
-    return $this->redirectToOperationsForAttendee($event_attendee);
+    return $this->redirectAfterManualCheckin($event_attendee, $request);
   }
 
   /**
@@ -548,6 +550,7 @@ final class VendorAttendeeController extends ControllerBase {
     bool $isXhr,
     string $reason,
     \Stringable|string $message,
+    ?Request $request = NULL,
   ): Response {
     if ($isXhr) {
       return new Response(
@@ -562,7 +565,7 @@ final class VendorAttendeeController extends ControllerBase {
       );
     }
     $this->messenger()->addError($message);
-    return $this->redirectToOperationsForAttendee($event_attendee);
+    return $this->redirectAfterManualCheckin($event_attendee, $request);
   }
 
   /**
@@ -604,21 +607,35 @@ final class VendorAttendeeController extends ControllerBase {
   }
 
   /**
-   * Builds a redirect back to Live Operations for the attendee's event.
+   * Builds a 303 redirect after a non-XHR manual check-in POST.
    *
-   * If the event cannot be resolved (defensive — should not happen because
-   * the route's accessAttendee gate requires an event-bound attendee) we
-   * fall back to the user's referrer or the front page rather than emitting
-   * a JSON page.
+   * Prefers a safe internal `destination` from the form (Workspace Attendees
+   * or Live Operations), then Event Workspace Attendees, then Live Operations.
    */
-  private function redirectToOperationsForAttendee(EventAttendee $event_attendee): RedirectResponse {
+  private function redirectAfterManualCheckin(EventAttendee $event_attendee, ?Request $request = NULL): RedirectResponse {
+    $destination = '';
+    if ($request instanceof Request) {
+      $destination = trim((string) ($request->request->get('destination') ?? $request->query->get('destination') ?? ''));
+    }
+    if ($destination !== '' && $this->isSafeInternalCheckinDestination($destination)) {
+      return new RedirectResponse($destination, 303);
+    }
+
     $event = $event_attendee->getEvent();
     if ($event instanceof NodeInterface) {
-      $url = Url::fromRoute(
+      $eventId = (int) $event->id();
+      foreach ([
+        'myeventlane_event_studio.workspace_attendees',
         'myeventlane_event_attendees.vendor_operations',
-        ['node' => (int) $event->id()],
-      )->toString();
-      return new RedirectResponse($url, 303);
+      ] as $routeName) {
+        try {
+          $url = Url::fromRoute($routeName, ['node' => $eventId])->toString();
+          return new RedirectResponse($url, 303);
+        }
+        catch (\Throwable) {
+          // Try the next fallback route.
+        }
+      }
     }
 
     \Drupal::logger('myeventlane_event_attendees')->warning(
@@ -626,6 +643,23 @@ final class VendorAttendeeController extends ControllerBase {
       ['@id' => (int) $event_attendee->id()]
     );
     return new RedirectResponse(Url::fromRoute('<front>')->toString(), 303);
+  }
+
+  /**
+   * Whether a check-in form destination is a safe same-site relative path.
+   */
+  private function isSafeInternalCheckinDestination(string $destination): bool {
+    if ($destination === '' || UrlHelper::isExternal($destination)) {
+      return FALSE;
+    }
+    if (!str_starts_with($destination, '/')) {
+      return FALSE;
+    }
+    // Reject protocol-relative and scheme-smuggling forms.
+    if (str_starts_with($destination, '//') || str_contains($destination, '://')) {
+      return FALSE;
+    }
+    return TRUE;
   }
 
 }

--- a/web/modules/custom/myeventlane_event_attendees/src/Service/EventAttendeeWorkspaceBuilder.php
+++ b/web/modules/custom/myeventlane_event_attendees/src/Service/EventAttendeeWorkspaceBuilder.php
@@ -108,10 +108,22 @@ final class EventAttendeeWorkspaceBuilder {
     $total = count($rows);
     $layout = $total >= self::DENSE_TABLE_THRESHOLD ? 'dense' : 'cards';
 
+    $initialMatchCount = 0;
+    foreach ($rows as &$row) {
+      $keys = $row['filter_keys'] ?? [];
+      $matches = $initialFilter === 'all' || in_array($initialFilter, $keys, TRUE);
+      $row['matches_initial_filter'] = $matches;
+      if ($matches) {
+        $initialMatchCount++;
+      }
+    }
+    unset($row);
+
     $this->recordAnalyticsHook('attendee_viewed', $event, [
       'attendee_count' => $total,
       'layout' => $layout,
       'filter' => $initialFilter,
+      'filter_match_count' => $initialMatchCount,
     ]);
 
     $capacity = $availability['capacity'] ?? 0;
@@ -136,6 +148,8 @@ final class EventAttendeeWorkspaceBuilder {
       '#filters' => $this->buildFilterChips(),
       '#ticket_types' => array_values($ticketTypes),
       '#initial_filter' => $initialFilter,
+      '#initial_match_count' => $initialMatchCount,
+      '#empty_filter' => $this->buildEmptyFilterState($initialFilter, $initialMatchCount),
       '#layout' => $layout,
       '#dense_threshold' => self::DENSE_TABLE_THRESHOLD,
       '#actions' => $this->buildWorkspaceActions($event),
@@ -369,6 +383,31 @@ final class EventAttendeeWorkspaceBuilder {
       'prompt' => (string) $this->t('Guests who buy a ticket or RSVP will appear here in one guest list.'),
       'cta_label' => (string) $this->t('View event page'),
       'cta_url' => $publicUrl,
+    ];
+  }
+
+  /**
+   * Builds empty-filter copy for an initial ?filter= that matches zero guests.
+   *
+   * Server-rendered so legacy redirects and no-JS see guidance without waiting
+   * for the Attendees app behaviour.
+   *
+   * @return array{show: bool, title: string, body: string}
+   *   Empty-filter panel payload for Twig.
+   */
+  private function buildEmptyFilterState(string $initialFilter, int $initialMatchCount): array {
+    $show = $initialFilter !== 'all' && $initialMatchCount === 0;
+    if ($initialFilter === 'checked_in') {
+      return [
+        'show' => $show,
+        'title' => (string) $this->t('No checked-in guests'),
+        'body' => (string) $this->t('Door Mode will update this list as guests arrive.'),
+      ];
+    }
+    return [
+      'show' => $show,
+      'title' => (string) $this->t('No matching attendees'),
+      'body' => (string) $this->t('Try another search or clear your filters.'),
     ];
   }
 

--- a/web/modules/custom/myeventlane_event_attendees/src/Service/EventAttendeeWorkspaceBuilder.php
+++ b/web/modules/custom/myeventlane_event_attendees/src/Service/EventAttendeeWorkspaceBuilder.php
@@ -215,7 +215,9 @@ final class EventAttendeeWorkspaceBuilder {
     };
 
     $checkInUrl = NULL;
-    if (!$attendee->isCheckedIn() && $status !== EventAttendee::STATUS_CANCELLED) {
+    // MelAttendeeCheckinManager only transitions MelAttendeeAttendanceState::Registered
+    // (export STATE_REGISTERED). Do not expose Check in for refunded / waitlist / pending.
+    if ($operational === MelAttendeeExportBuilder::STATE_REGISTERED) {
       try {
         $checkInUrl = Url::fromRoute('myeventlane_event_attendees.vendor_checkin', [
           'event_attendee' => $attendee->id(),

--- a/web/modules/custom/myeventlane_event_attendees/src/Service/EventAttendeeWorkspaceBuilder.php
+++ b/web/modules/custom/myeventlane_event_attendees/src/Service/EventAttendeeWorkspaceBuilder.php
@@ -1,0 +1,496 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_attendees\Service;
+
+use Drupal\Core\Access\CsrfTokenGenerator;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Routing\RouteProviderInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\Url;
+use Drupal\myeventlane_event_attendees\Entity\EventAttendee;
+use Drupal\node\NodeInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Builds the VX2 One Attendee Workspace view model (B7).
+ *
+ * Organisers see Attendees only — paid, RSVP, waitlist, and door actions in
+ * one guest list with search, filters, cards, and entry points for Message,
+ * Export, Refund, and Door Mode.
+ */
+final class EventAttendeeWorkspaceBuilder {
+
+  use StringTranslationTrait;
+
+  private const CHECKIN_CSRF_ID = 'mel_vendor_attendee_checkin';
+
+  /**
+   * Card layout below this count; dense table at/above for large events.
+   */
+  public const DENSE_TABLE_THRESHOLD = 100;
+
+  public function __construct(
+    private readonly AttendanceManagerInterface $attendanceManager,
+    private readonly VendorAttendeePresentationServiceInterface $vendorPresentation,
+    private readonly MelAttendeeExportBuilder $exportBuilder,
+    private readonly CsrfTokenGenerator $csrfToken,
+    private readonly ModuleHandlerInterface $moduleHandler,
+    private readonly RouteProviderInterface $routeProvider,
+    private readonly RequestStack $requestStack,
+    private readonly AccountProxyInterface $currentUser,
+    private readonly LoggerChannelInterface $logger,
+    TranslationInterface $string_translation,
+  ) {
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * Builds the workspace render array for an event.
+   *
+   * @return array<string, mixed>
+   *   Theme render array for the Attendees workspace.
+   */
+  public function build(NodeInterface $event): array {
+    $eventId = (int) $event->id();
+    $attendees = $this->attendanceManager->getAttendeesForEvent($eventId);
+    $availability = $this->attendanceManager->getAvailability($event);
+
+    $grouped = [
+      'ticket' => 0,
+      'rsvp' => 0,
+      'manual' => 0,
+      'waitlist' => 0,
+    ];
+    $checkedIn = 0;
+    $ticketTypes = [];
+    $rows = [];
+
+    foreach ($attendees as $attendee) {
+      if (!$attendee instanceof EventAttendee) {
+        continue;
+      }
+      $source = $attendee->getSource();
+      if (isset($grouped[$source])) {
+        $grouped[$source]++;
+      }
+      if ($attendee->getStatus() === EventAttendee::STATUS_WAITLIST) {
+        $grouped['waitlist']++;
+      }
+      if ($attendee->isCheckedIn()) {
+        $checkedIn++;
+      }
+
+      $row = $this->buildRow($attendee, $event);
+      $ticketLabel = trim((string) ($row['ticket_type'] ?? ''));
+      if ($ticketLabel !== '' && $ticketLabel !== '—') {
+        $ticketTypes[$ticketLabel] = $ticketLabel;
+      }
+      $rows[] = $row;
+    }
+
+    ksort($ticketTypes, SORT_NATURAL | SORT_FLAG_CASE);
+
+    $request = $this->requestStack->getCurrentRequest();
+    $initialFilter = $request ? (string) $request->query->get('filter', 'all') : 'all';
+    $allowedFilters = [
+      'all', 'ticket', 'rsvp', 'waitlist', 'checked_in', 'not_checked_in',
+      'refunded', 'cancelled',
+    ];
+    if (!in_array($initialFilter, $allowedFilters, TRUE)) {
+      $initialFilter = 'all';
+    }
+
+    $total = count($rows);
+    $layout = $total >= self::DENSE_TABLE_THRESHOLD ? 'dense' : 'cards';
+
+    $this->recordAnalyticsHook('attendee_viewed', $event, [
+      'attendee_count' => $total,
+      'layout' => $layout,
+      'filter' => $initialFilter,
+    ]);
+
+    $capacity = $availability['capacity'] ?? 0;
+    $summary = [
+      'total' => $total,
+      'checked_in' => $checkedIn,
+      'ticket' => $grouped['ticket'],
+      'rsvp' => $grouped['rsvp'],
+      'manual' => $grouped['manual'],
+      'waitlist' => $grouped['waitlist'],
+      'capacity' => $capacity > 0 ? $capacity : 'Unlimited',
+      'remaining' => $availability['remaining'] ?? NULL,
+    ];
+
+    $publicUrl = Url::fromRoute('entity.node.canonical', ['node' => $eventId])->toString();
+
+    return [
+      '#theme' => 'mel_event_studio_attendees_workspace',
+      '#event' => $event,
+      '#summary' => $summary,
+      '#attendees' => $rows,
+      '#filters' => $this->buildFilterChips(),
+      '#ticket_types' => array_values($ticketTypes),
+      '#initial_filter' => $initialFilter,
+      '#layout' => $layout,
+      '#dense_threshold' => self::DENSE_TABLE_THRESHOLD,
+      '#actions' => $this->buildWorkspaceActions($event),
+      '#checkin_csrf' => $this->csrfToken->get(self::CHECKIN_CSRF_ID),
+      '#public_event_url' => $publicUrl,
+      '#empty' => $this->buildEmptyState($event, $publicUrl),
+      '#attached' => [
+        'library' => [
+          'myeventlane_event_studio/mel_event_studio_attendees_app',
+        ],
+        'drupalSettings' => [
+          'melAttendeesWorkspace' => [
+            'eventId' => $eventId,
+            'initialFilter' => $initialFilter,
+            'denseThreshold' => self::DENSE_TABLE_THRESHOLD,
+            'instrumentation' => [
+              'attendee_filtered' => TRUE,
+              'attendee_exported' => TRUE,
+              'door_mode_opened' => TRUE,
+              'message_attendees_clicked' => TRUE,
+              'attendee_checked_in' => TRUE,
+            ],
+          ],
+        ],
+      ],
+      '#cache' => [
+        'tags' => array_merge($event->getCacheTags(), ['event_attendee_list:' . $eventId]),
+        'contexts' => ['user', 'url.query_args:filter'],
+      ],
+    ];
+  }
+
+  /**
+   * Builds one attendee card row.
+   *
+   * @return array<string, mixed>
+   *   Card view-model for Twig.
+   */
+  private function buildRow(EventAttendee $attendee, NodeInterface $event): array {
+    $vm = $this->vendorPresentation->buildVendorRowFromEventAttendee($attendee);
+    $orderItem = NULL;
+    if ($attendee->hasField('order_item') && !$attendee->get('order_item')->isEmpty()) {
+      $entity = $attendee->get('order_item')->entity;
+      if ($entity && (!method_exists($entity, 'bundle') || $entity->bundle() !== 'boost')) {
+        $orderItem = $entity;
+      }
+    }
+    $operational = $this->exportBuilder->resolveOperationalState($attendee, $orderItem);
+    $orderLink = $this->buildOrderLink($attendee, $event);
+    $refundUrl = $this->buildRefundUrl($attendee, $event);
+    $source = (string) ($vm['source'] ?? $attendee->getSource());
+    $status = $attendee->getStatus();
+    $ticketType = (string) ($vm['ticket_type'] ?? '');
+    if ($ticketType === '' && $source === EventAttendee::SOURCE_RSVP) {
+      $ticketType = (string) $this->t('RSVP');
+    }
+    if ($status === EventAttendee::STATUS_WAITLIST && $ticketType === '') {
+      $ticketType = (string) $this->t('Waitlist');
+    }
+
+    $bookingLabel = match ($operational) {
+      MelAttendeeExportBuilder::STATE_CHECKED_IN => (string) $this->t('Checked in'),
+      MelAttendeeExportBuilder::STATE_CANCELLED => (string) $this->t('Cancelled'),
+      MelAttendeeExportBuilder::STATE_REFUNDED => (string) $this->t('Refunded'),
+      MelAttendeeExportBuilder::STATE_PENDING => $status === EventAttendee::STATUS_WAITLIST
+        ? (string) $this->t('Waitlist')
+        : (string) $this->t('Pending'),
+      MelAttendeeExportBuilder::STATE_REGISTERED => (string) $this->t('Confirmed'),
+      default => (string) $this->t('Needs attention'),
+    };
+
+    $sourceLabel = match ($source) {
+      EventAttendee::SOURCE_RSVP => (string) $this->t('RSVP'),
+      EventAttendee::SOURCE_TICKET => (string) $this->t('Ticket'),
+      EventAttendee::SOURCE_MANUAL => (string) $this->t('Manual'),
+      default => ucfirst($source),
+    };
+
+    $checkInUrl = NULL;
+    if (!$attendee->isCheckedIn() && $status !== EventAttendee::STATUS_CANCELLED) {
+      try {
+        $checkInUrl = Url::fromRoute('myeventlane_event_attendees.vendor_checkin', [
+          'event_attendee' => $attendee->id(),
+        ])->toString();
+      }
+      catch (\Throwable) {
+        $checkInUrl = NULL;
+      }
+    }
+
+    $messageUrl = $this->buildMessageUrl($event);
+    $viewUrl = $orderLink['url'] ?? NULL;
+    if ($viewUrl === NULL && !empty($vm['email'])) {
+      $viewUrl = 'mailto:' . rawurlencode((string) $vm['email']);
+    }
+
+    return [
+      'id' => (int) $attendee->id(),
+      'name' => (string) ($vm['full_name'] ?? $attendee->label() ?? ''),
+      'email' => (string) ($vm['email'] ?? ''),
+      'phone' => (string) ($vm['phone'] ?? ''),
+      'source' => $source,
+      'source_label' => $sourceLabel,
+      'ticket_type' => $ticketType !== '' ? $ticketType : '—',
+      'booking_status' => $bookingLabel,
+      'booking_state' => $operational,
+      'status' => $status,
+      'checked_in' => $attendee->isCheckedIn(),
+      'check_in_label' => $attendee->isCheckedIn()
+        ? (string) $this->t('Checked in')
+        : (string) $this->t('Not checked in'),
+      'order_link' => $orderLink,
+      'order_reference' => $orderLink['label'] ?? '',
+      'ticket_code' => (string) ($vm['ticket_code'] ?? ''),
+      'custom_answers' => $vm['custom_answers'] ?? [],
+      'custom_answers_display' => $vm['custom_answers_display'] ?? '',
+      'actions' => [
+        'view_url' => $viewUrl,
+        'message_url' => $messageUrl,
+        'refund_url' => $refundUrl,
+        'checkin_url' => $checkInUrl,
+      ],
+      'filter_keys' => $this->buildFilterKeys($attendee, $source, $operational),
+    ];
+  }
+
+  /**
+   * Builds filter token keys for a guest row.
+   *
+   * @return list<string>
+   *   Filter keys applied by the Attendees app JS.
+   */
+  private function buildFilterKeys(EventAttendee $attendee, string $source, string $operational): array {
+    $keys = ['all', $source];
+    if ($attendee->getStatus() === EventAttendee::STATUS_WAITLIST) {
+      $keys[] = 'waitlist';
+    }
+    if ($attendee->isCheckedIn()) {
+      $keys[] = 'checked_in';
+    }
+    else {
+      $keys[] = 'not_checked_in';
+    }
+    if ($operational === MelAttendeeExportBuilder::STATE_REFUNDED) {
+      $keys[] = 'refunded';
+    }
+    if ($operational === MelAttendeeExportBuilder::STATE_CANCELLED
+      || $attendee->getStatus() === EventAttendee::STATUS_CANCELLED) {
+      $keys[] = 'cancelled';
+    }
+    return array_values(array_unique($keys));
+  }
+
+  /**
+   * Builds filter chip definitions for the toolbar.
+   *
+   * @return list<array{id: string, label: string}>
+   *   Filter chips shown above the guest list.
+   */
+  private function buildFilterChips(): array {
+    return [
+      ['id' => 'all', 'label' => (string) $this->t('All')],
+      ['id' => 'ticket', 'label' => (string) $this->t('Ticket')],
+      ['id' => 'rsvp', 'label' => (string) $this->t('RSVP')],
+      ['id' => 'waitlist', 'label' => (string) $this->t('Waitlist')],
+      ['id' => 'checked_in', 'label' => (string) $this->t('Checked in')],
+      ['id' => 'not_checked_in', 'label' => (string) $this->t('Not checked in')],
+      ['id' => 'refunded', 'label' => (string) $this->t('Refunded')],
+      ['id' => 'cancelled', 'label' => (string) $this->t('Cancelled')],
+    ];
+  }
+
+  /**
+   * Builds primary workspace actions (Door Mode, Message, Export).
+   *
+   * @return list<array{label: string, url: string, class: string, analytics: string}>
+   *   Header action buttons.
+   */
+  private function buildWorkspaceActions(NodeInterface $event): array {
+    $eventId = (int) $event->id();
+    $actions = [];
+
+    $doorUrl = $this->safeRouteUrl('myeventlane_event_attendees.vendor_operations_door', ['node' => $eventId]);
+    if ($doorUrl === NULL) {
+      $doorUrl = $this->safeRouteUrl('myeventlane_event_attendees.vendor_operations', ['node' => $eventId]);
+    }
+    if ($doorUrl !== NULL) {
+      $actions[] = [
+        'label' => (string) $this->t('Door Mode'),
+        'url' => $doorUrl,
+        'class' => 'mel-btn--primary',
+        'analytics' => 'door_mode_opened',
+      ];
+    }
+
+    $messageUrl = $this->buildMessageUrl($event);
+    if ($messageUrl !== NULL) {
+      $actions[] = [
+        'label' => (string) $this->t('Message attendees'),
+        'url' => $messageUrl,
+        'class' => 'mel-btn--secondary',
+        'analytics' => 'message_attendees_clicked',
+      ];
+    }
+
+    $exportUrl = $this->safeRouteUrl('myeventlane_event_attendees.vendor_export', ['node' => $eventId]);
+    if ($exportUrl !== NULL) {
+      $actions[] = [
+        'label' => (string) $this->t('Export attendees'),
+        'url' => $exportUrl,
+        'class' => 'mel-btn--secondary',
+        'analytics' => 'attendee_exported',
+      ];
+    }
+
+    return $actions;
+  }
+
+  /**
+   * Builds empty-state copy when the guest list has no attendees.
+   *
+   * @return array{title: string, body: string, prompt: string, cta_label: string, cta_url: string}|null
+   *   Empty-state payload for Twig.
+   */
+  private function buildEmptyState(NodeInterface $event, string $publicUrl): ?array {
+    return [
+      'title' => (string) $this->t('No attendees yet'),
+      'body' => (string) $this->t('Publish your event and share it to receive your first booking.'),
+      'prompt' => (string) $this->t('Guests who buy a ticket or RSVP will appear here in one guest list.'),
+      'cta_label' => (string) $this->t('View event page'),
+      'cta_url' => $publicUrl,
+    ];
+  }
+
+  /**
+   * Resolves the Message attendees entry URL for this event.
+   */
+  private function buildMessageUrl(NodeInterface $event): ?string {
+    $eventId = (int) $event->id();
+    if ($this->moduleHandler->moduleExists('myeventlane_pro')) {
+      $url = $this->safeRouteUrl('myeventlane_vendor.message_attendees', ['node' => $eventId]);
+      if ($url !== NULL) {
+        return $url;
+      }
+    }
+    return $this->safeRouteUrl('myeventlane_event_studio.workspace_messaging', ['node' => $eventId]);
+  }
+
+  /**
+   * Builds an order reference link when the guest came from a ticket purchase.
+   *
+   * @return array{url: string, label: string}|null
+   *   Order link payload, or NULL when not applicable.
+   */
+  private function buildOrderLink(EventAttendee $attendee, NodeInterface $event): ?array {
+    if ($attendee->getSource() !== EventAttendee::SOURCE_TICKET) {
+      return NULL;
+    }
+    if (!$attendee->hasField('order_item') || $attendee->get('order_item')->isEmpty()) {
+      return NULL;
+    }
+    $orderItem = $attendee->get('order_item')->entity;
+    if (!$orderItem || (method_exists($orderItem, 'bundle') && $orderItem->bundle() === 'boost')) {
+      return NULL;
+    }
+    try {
+      $order = $orderItem->getOrder();
+    }
+    catch (\Throwable) {
+      return NULL;
+    }
+    if (!$order) {
+      return NULL;
+    }
+    $url = $this->safeRouteUrl('myeventlane_vendor.console.event_order_view', [
+      'event' => $event->id(),
+      'order' => $order->id(),
+    ]);
+    if ($url === NULL) {
+      return NULL;
+    }
+    $label = '#' . ($order->getOrderNumber() ?: $order->id());
+    return ['url' => $url, 'label' => $label];
+  }
+
+  /**
+   * Builds a refund entry URL when the guest has a refundable order.
+   */
+  private function buildRefundUrl(EventAttendee $attendee, NodeInterface $event): ?string {
+    if (!$this->moduleHandler->moduleExists('myeventlane_refunds')) {
+      return NULL;
+    }
+    if ($attendee->getSource() !== EventAttendee::SOURCE_TICKET) {
+      return NULL;
+    }
+    if (!$attendee->hasField('order_item') || $attendee->get('order_item')->isEmpty()) {
+      return NULL;
+    }
+    $orderItem = $attendee->get('order_item')->entity;
+    if (!$orderItem) {
+      return NULL;
+    }
+    $operational = $this->exportBuilder->resolveOperationalState($attendee, $orderItem);
+    if (in_array($operational, [
+      MelAttendeeExportBuilder::STATE_REFUNDED,
+      MelAttendeeExportBuilder::STATE_CANCELLED,
+    ], TRUE)) {
+      return NULL;
+    }
+    try {
+      $order = $orderItem->getOrder();
+    }
+    catch (\Throwable) {
+      return NULL;
+    }
+    if (!$order) {
+      return NULL;
+    }
+    return $this->safeRouteUrl('myeventlane_refunds.vendor_refund', [
+      'commerce_order' => $order->id(),
+    ]);
+  }
+
+  /**
+   * Returns a route URL when the route exists; otherwise NULL.
+   */
+  private function safeRouteUrl(string $routeName, array $params = []): ?string {
+    try {
+      $this->routeProvider->getRouteByName($routeName);
+      return Url::fromRoute($routeName, $params)->toString();
+    }
+    catch (\Throwable) {
+      return NULL;
+    }
+  }
+
+  /**
+   * Records instrumentation hooks until a full analytics pipeline exists.
+   *
+   * @param string $eventName
+   *   Analytics event name (for example attendee_viewed).
+   * @param \Drupal\node\NodeInterface $event
+   *   The event node.
+   * @param array<string, mixed> $context
+   *   Extra logger context.
+   */
+  private function recordAnalyticsHook(string $eventName, NodeInterface $event, array $context = []): void {
+    $this->logger->info('MEL attendee analytics hook @event for event @nid uid @uid.', [
+      '@event' => $eventName,
+      '@nid' => (string) $event->id(),
+      '@uid' => (string) $this->currentUser->id(),
+      'mel_analytics_event' => $eventName,
+      'event_id' => (int) $event->id(),
+      'uid' => (int) $this->currentUser->id(),
+    ] + $context);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_attendees/tests/src/Unit/EventAttendeeWorkspaceBuilderContractTest.php
+++ b/web/modules/custom/myeventlane_event_attendees/tests/src/Unit/EventAttendeeWorkspaceBuilderContractTest.php
@@ -48,4 +48,15 @@ final class EventAttendeeWorkspaceBuilderContractTest extends TestCase {
     );
   }
 
+  /**
+   * Asserts ?filter= is applied server-side for first paint / no-JS.
+   */
+  public function testInitialFilterMarksRowsServerSide(): void {
+    $builder = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventAttendeeWorkspaceBuilder.php');
+    $this->assertNotFalse($builder);
+    $this->assertStringContainsString('matches_initial_filter', $builder);
+    $this->assertStringContainsString('initial_match_count', $builder);
+    $this->assertStringContainsString('buildEmptyFilterState', $builder);
+  }
+
 }

--- a/web/modules/custom/myeventlane_event_attendees/tests/src/Unit/EventAttendeeWorkspaceBuilderContractTest.php
+++ b/web/modules/custom/myeventlane_event_attendees/tests/src/Unit/EventAttendeeWorkspaceBuilderContractTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_attendees\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Contract tests for VX2 attendee workspace builder surface.
+ *
+ * @group myeventlane_event_attendees
+ */
+final class EventAttendeeWorkspaceBuilderContractTest extends TestCase {
+
+  /**
+   * Asserts the workspace builder service is registered.
+   */
+  public function testBuilderServiceIsRegistered(): void {
+    $services = file_get_contents(dirname(__DIR__, 3) . '/myeventlane_event_attendees.services.yml');
+    $this->assertNotFalse($services);
+    $this->assertStringContainsString('myeventlane_event_attendees.attendee_workspace_builder', $services);
+    $this->assertStringContainsString('EventAttendeeWorkspaceBuilder', $services);
+  }
+
+  /**
+   * Asserts filter vocabulary matches the product story.
+   */
+  public function testFilterVocabularyMatchesProductStory(): void {
+    $builder = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventAttendeeWorkspaceBuilder.php');
+    $this->assertNotFalse($builder);
+    foreach (['ticket', 'rsvp', 'waitlist', 'checked_in', 'not_checked_in', 'refunded', 'cancelled'] as $filter) {
+      $this->assertStringContainsString("'$filter'", $builder);
+    }
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_attendees/tests/src/Unit/EventAttendeeWorkspaceBuilderContractTest.php
+++ b/web/modules/custom/myeventlane_event_attendees/tests/src/Unit/EventAttendeeWorkspaceBuilderContractTest.php
@@ -34,4 +34,18 @@ final class EventAttendeeWorkspaceBuilderContractTest extends TestCase {
     }
   }
 
+  /**
+   * Asserts card Check in is gated to registered operational state only.
+   */
+  public function testCheckInActionRequiresRegisteredOperationalState(): void {
+    $builder = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventAttendeeWorkspaceBuilder.php');
+    $this->assertNotFalse($builder);
+    $this->assertStringContainsString('MelAttendeeExportBuilder::STATE_REGISTERED', $builder);
+    $this->assertStringContainsString('vendor_checkin', $builder);
+    $this->assertStringNotContainsString(
+      '!$attendee->isCheckedIn() && $status !== EventAttendee::STATUS_CANCELLED',
+      $builder,
+    );
+  }
+
 }

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -5794,3 +5794,240 @@
     min-height: 44px;
   }
 }
+
+/* ==========================================================================
+   VX2-05 One Attendee Workspace
+   ========================================================================== */
+
+.mel-event-studio-attendees-app {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.mel-attendees-workspace {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.mel-attendees-workspace__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.mel-attendees-workspace__title {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 700;
+}
+
+.mel-attendees-workspace__lede {
+  margin: 0.35rem 0 0;
+  color: var(--mel-text-muted, #5b6472);
+  max-width: 40rem;
+}
+
+.mel-attendees-workspace__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.mel-attendees-workspace__actions .mel-btn {
+  min-height: 44px;
+  min-width: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 1rem;
+  text-decoration: none;
+}
+
+.mel-attendees-workspace__metric-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.25rem;
+  margin: 0;
+  padding: 0.85rem 1rem;
+  list-style: none;
+  border-radius: 0.85rem;
+  background: var(--mel-surface-soft, #f6f4f8);
+}
+
+.mel-attendees-workspace__metric-label {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--mel-text-muted, #5b6472);
+}
+
+.mel-attendees-workspace__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.mel-attendees-workspace__search {
+  flex: 1 1 16rem;
+}
+
+.mel-attendees-workspace__search-input,
+.mel-attendees-workspace__ticket-filter .mel-input {
+  width: 100%;
+  min-height: 44px;
+}
+
+.mel-attendees-workspace__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.mel-attendees-workspace__filter {
+  min-height: 40px;
+  padding: 0.4rem 0.85rem;
+  border: 1px solid var(--mel-border, #d9d3e0);
+  border-radius: 999px;
+  background: #fff;
+  cursor: pointer;
+  font: inherit;
+}
+
+.mel-attendees-workspace__filter.is-active,
+.mel-attendees-workspace__filter[aria-pressed='true'] {
+  border-color: var(--mel-accent, #6b4f8a);
+  background: var(--mel-accent-soft, #f0e8f8);
+  font-weight: 600;
+}
+
+.mel-attendees-workspace__list {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.mel-attendees-workspace__list--cards {
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 48rem) {
+  .mel-attendees-workspace__list--cards {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.mel-attendees-workspace__list--dense {
+  gap: 0.4rem;
+}
+
+.mel-attendees-workspace__list--dense .mel-attendee-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+  align-items: center;
+  padding: 0.65rem 0.85rem;
+}
+
+.mel-attendee-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding: 1rem;
+  border: 1px solid var(--mel-border, #e4dde9);
+  border-radius: 1rem;
+  background: #fff;
+}
+
+.mel-attendee-card__identity {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.mel-attendee-card__avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  background: var(--mel-accent-soft, #f0e8f8);
+  font-weight: 700;
+}
+
+.mel-attendee-card__name {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.mel-attendee-card__email {
+  display: inline-block;
+  margin-top: 0.15rem;
+  font-size: 0.9rem;
+}
+
+.mel-attendee-card__meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+  gap: 0.65rem 1rem;
+  margin: 0.85rem 0 0;
+}
+
+.mel-attendee-card__meta dt {
+  margin: 0;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--mel-text-muted, #5b6472);
+}
+
+.mel-attendee-card__meta dd {
+  margin: 0.15rem 0 0;
+}
+
+.mel-attendee-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.mel-attendee-card__action,
+.mel-attendee-card__checkin .mel-btn {
+  min-height: 44px;
+  min-width: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.45rem 0.85rem;
+  text-decoration: none;
+}
+
+.mel-attendee-card__checkin {
+  display: inline;
+  margin: 0;
+}
+
+.mel-attendees-workspace__empty,
+.mel-attendees-workspace__empty-filter {
+  text-align: center;
+  padding: 2rem 1rem;
+}
+
+@media (max-width: 47.99rem) {
+  .mel-attendees-workspace__list--dense .mel-attendee-card,
+  .mel-attendees-workspace__list--cards .mel-attendee-card {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .mel-attendees-workspace__actions {
+    width: 100%;
+  }
+
+  .mel-attendees-workspace__actions .mel-btn {
+    flex: 1 1 auto;
+  }
+}

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-attendees-app.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-attendees-app.js
@@ -1,0 +1,160 @@
+/**
+ * @file
+ * VX2 One Attendee Workspace — immediate search and filters.
+ */
+(function (Drupal, once, drupalSettings) {
+  'use strict';
+
+  function emitAnalytics(name, detail) {
+    try {
+      document.dispatchEvent(
+        new CustomEvent('mel:attendee-analytics', {
+          detail: Object.assign({ event: name }, detail || {}),
+        }),
+      );
+    } catch (e) {
+      // Analytics hooks are best-effort until a pipeline is wired.
+    }
+  }
+
+  function applyFilters(root) {
+    const search = (root.querySelector('[data-mel-attendee-search]')?.value || '')
+      .trim()
+      .toLowerCase();
+    const ticketType = (
+      root.querySelector('[data-mel-attendee-ticket-type]')?.value || ''
+    )
+      .trim()
+      .toLowerCase();
+    const activeFilter =
+      root.querySelector('[data-mel-attendee-filter].is-active')?.getAttribute(
+        'data-mel-attendee-filter',
+      ) || 'all';
+    const cards = root.querySelectorAll('[data-mel-attendee-card]');
+    let visible = 0;
+
+    cards.forEach(function (card) {
+      const name = card.getAttribute('data-name') || '';
+      const email = card.getAttribute('data-email') || '';
+      const type = card.getAttribute('data-ticket-type') || '';
+      const filters = (card.getAttribute('data-filters') || '').split(/\s+/);
+      const matchesSearch =
+        !search || name.includes(search) || email.includes(search);
+      const matchesType = !ticketType || type === ticketType;
+      const matchesFilter =
+        activeFilter === 'all' || filters.indexOf(activeFilter) !== -1;
+      const show = matchesSearch && matchesType && matchesFilter;
+      card.hidden = !show;
+      if (show) {
+        visible += 1;
+      }
+    });
+
+    const status = root.querySelector('[data-mel-attendee-status]');
+    if (status) {
+      status.textContent =
+        visible === 1
+          ? Drupal.t('Showing 1 attendee')
+          : Drupal.t('Showing @count attendees', { '@count': visible });
+    }
+
+    const emptyFilter = root.querySelector('[data-mel-attendee-empty-filter]');
+    if (emptyFilter) {
+      const showEmpty =
+        visible === 0 &&
+        (activeFilter === 'checked_in' ||
+          activeFilter === 'not_checked_in' ||
+          search ||
+          ticketType);
+      emptyFilter.hidden = !showEmpty;
+      if (showEmpty && activeFilter === 'checked_in' && !search && !ticketType) {
+        emptyFilter.querySelector('.mel-empty-state__title').textContent =
+          Drupal.t('No checked-in guests');
+        emptyFilter.querySelector('.mel-empty-state__text').textContent =
+          Drupal.t('Door Mode will update this list as guests arrive.');
+      } else if (showEmpty) {
+        emptyFilter.querySelector('.mel-empty-state__title').textContent =
+          Drupal.t('No matching attendees');
+        emptyFilter.querySelector('.mel-empty-state__text').textContent =
+          Drupal.t('Try another search or clear your filters.');
+      }
+    }
+
+    const list = root.querySelector('[data-mel-attendee-list]');
+    if (list) {
+      list.hidden = visible === 0 && !!emptyFilter && !emptyFilter.hidden;
+    }
+  }
+
+  Drupal.behaviors.melAttendeesWorkspace = {
+    attach: function (context) {
+      once('mel-attendees-workspace', '[data-mel-attendees-workspace]', context).forEach(
+        function (root) {
+          const initial =
+            root.getAttribute('data-mel-initial-filter') ||
+            drupalSettings.melAttendeesWorkspace?.initialFilter ||
+            'all';
+
+          root.querySelectorAll('[data-mel-attendee-filter]').forEach(function (btn) {
+            const id = btn.getAttribute('data-mel-attendee-filter');
+            const active = id === initial;
+            btn.classList.toggle('is-active', active);
+            btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+            btn.addEventListener('click', function () {
+              root.querySelectorAll('[data-mel-attendee-filter]').forEach(function (other) {
+                const on = other === btn;
+                other.classList.toggle('is-active', on);
+                other.setAttribute('aria-pressed', on ? 'true' : 'false');
+              });
+              emitAnalytics('attendee_filtered', {
+                filter: id,
+                eventId: drupalSettings.melAttendeesWorkspace?.eventId,
+              });
+              applyFilters(root);
+            });
+          });
+
+          const search = root.querySelector('[data-mel-attendee-search]');
+          if (search) {
+            search.addEventListener('input', function () {
+              applyFilters(root);
+            });
+          }
+
+          const ticketSelect = root.querySelector('[data-mel-attendee-ticket-type]');
+          if (ticketSelect) {
+            ticketSelect.addEventListener('change', function () {
+              emitAnalytics('attendee_filtered', {
+                filter: 'ticket_type',
+                ticketType: ticketSelect.value,
+                eventId: drupalSettings.melAttendeesWorkspace?.eventId,
+              });
+              applyFilters(root);
+            });
+          }
+
+          root.querySelectorAll('[data-mel-attendee-analytics]').forEach(function (el) {
+            el.addEventListener('click', function () {
+              const name = el.getAttribute('data-mel-attendee-analytics');
+              if (name) {
+                emitAnalytics(name, {
+                  eventId: drupalSettings.melAttendeesWorkspace?.eventId,
+                });
+              }
+            });
+          });
+
+          root.querySelectorAll('[data-mel-attendee-checkin]').forEach(function (form) {
+            form.addEventListener('submit', function () {
+              emitAnalytics('attendee_checked_in', {
+                eventId: drupalSettings.melAttendeesWorkspace?.eventId,
+              });
+            });
+          });
+
+          applyFilters(root);
+        },
+      );
+    },
+  };
+})(Drupal, once, drupalSettings);

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-attendees-app.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-attendees-app.js
@@ -60,12 +60,12 @@
 
     const emptyFilter = root.querySelector('[data-mel-attendee-empty-filter]');
     if (emptyFilter) {
-      const showEmpty =
-        visible === 0 &&
-        (activeFilter === 'checked_in' ||
-          activeFilter === 'not_checked_in' ||
-          search ||
-          ticketType);
+      // Any narrowing (chip, search, or ticket type) with zero matches needs
+      // guidance — including waitlist/rsvp/ticket/refunded/cancelled chips and
+      // ?filter= from legacy redirects. "all" with no search keeps the list.
+      const hasNarrowing =
+        activeFilter !== 'all' || Boolean(search) || Boolean(ticketType);
+      const showEmpty = visible === 0 && hasNarrowing;
       emptyFilter.hidden = !showEmpty;
       if (showEmpty && activeFilter === 'checked_in' && !search && !ticketType) {
         emptyFilter.querySelector('.mel-empty-state__title').textContent =

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.info.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.info.yml
@@ -21,3 +21,4 @@ dependencies:
 
 optional_dependencies:
   - myeventlane_surface:myeventlane_surface
+  - myeventlane_event_attendees:myeventlane_event_attendees

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -25,6 +25,15 @@ mel_event_studio_tickets_app:
     - core/drupal
     - core/once
 
+mel_event_studio_attendees_app:
+  version: 1.0
+  js:
+    js/mel-event-studio-attendees-app.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
+    - core/drupalSettings
+
 mel_event_studio_highlights:
   version: 1.0
   css:

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
@@ -113,6 +113,23 @@ function myeventlane_event_studio_theme($existing, $type, $theme, $path) {
       ],
       'template' => 'mel-event-studio-empty-state',
     ],
+    'mel_event_studio_attendees_workspace' => [
+      'variables' => [
+        'event' => NULL,
+        'summary' => [],
+        'attendees' => [],
+        'filters' => [],
+        'ticket_types' => [],
+        'initial_filter' => 'all',
+        'layout' => 'cards',
+        'dense_threshold' => 100,
+        'actions' => [],
+        'checkin_csrf' => '',
+        'public_event_url' => NULL,
+        'empty' => [],
+      ],
+      'template' => 'mel-event-studio-attendees-workspace',
+    ],
     'mel_event_studio_ai_assist' => [
       'variables' => [
         'target' => '',

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
@@ -121,6 +121,8 @@ function myeventlane_event_studio_theme($existing, $type, $theme, $path) {
         'filters' => [],
         'ticket_types' => [],
         'initial_filter' => 'all',
+        'initial_match_count' => 0,
+        'empty_filter' => [],
         'layout' => 'cards',
         'dense_threshold' => 100,
         'actions' => [],

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -125,6 +125,7 @@ services:
       - '@?myeventlane_tickets.access_code_management_builder'
       - '@myeventlane_event_studio.overview_builder'
       - '@myeventlane_core.domain_detector'
+      - '@?myeventlane_event_attendees.attendee_workspace_builder'
 
   myeventlane_event_studio.highlight_helper:
     class: Drupal\myeventlane_event_studio\Service\EventHighlightHelper

--- a/web/modules/custom/myeventlane_event_studio/src/EventSubscriber/VendorLegacyWizardRedirectSubscriber.php
+++ b/web/modules/custom/myeventlane_event_studio/src/EventSubscriber/VendorLegacyWizardRedirectSubscriber.php
@@ -20,11 +20,13 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
- * Sends vendors off legacy step-wizard URLs to Event Studio; staff may keep wizard.
+ * Redirects vendors from legacy wizard and ops URLs to Event Workspace.
  */
 final class VendorLegacyWizardRedirectSubscriber implements EventSubscriberInterface {
 
   /**
+   * Legacy event wizard step routes.
+   *
    * @var list<string>
    */
   private const WIZARD_STEP_ROUTES = [
@@ -59,6 +61,7 @@ final class VendorLegacyWizardRedirectSubscriber implements EventSubscriberInter
     'myeventlane_vendor.console.event_order_view',
     'myeventlane_vendor.console.event_tickets',
     'myeventlane_vendor.console.event_rsvps',
+    'myeventlane_rsvp.vendor_event_rsvps',
     'myeventlane_vendor.console.event_analytics',
     'myeventlane_vendor.console.event_settings',
     'myeventlane_vendor.console.event_unpublish',
@@ -83,12 +86,29 @@ final class VendorLegacyWizardRedirectSubscriber implements EventSubscriberInter
     'myeventlane_tickets.event_ticket_type_edit',
   ];
 
+  /**
+   * Legacy check-in stacks that converge on Door Mode (VX2-05).
+   *
+   * @var list<string>
+   */
+  private const DOOR_MODE_REDIRECT_ROUTES = [
+    'myeventlane_checkin.page',
+    'myeventlane_checkin.list',
+    'myeventlane_checkin.scan',
+    'myeventlane_tickets.ticket_checkin',
+    'myeventlane_rsvp.checkin_list',
+    'myeventlane_rsvp.checkin_scan',
+  ];
+
   public function __construct(
     private readonly AccountProxyInterface $currentUser,
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly LoggerInterface $logger,
   ) {}
 
+  /**
+   * {@inheritdoc}
+   */
   public static function getSubscribedEvents(): array {
     return [
       KernelEvents::REQUEST => ['onKernelRequest', 31],
@@ -97,6 +117,9 @@ final class VendorLegacyWizardRedirectSubscriber implements EventSubscriberInter
     ];
   }
 
+  /**
+   * Redirects legacy organiser routes on request.
+   */
   public function onKernelRequest(RequestEvent $event): void {
     if (!$event->isMainRequest()) {
       return;
@@ -112,6 +135,9 @@ final class VendorLegacyWizardRedirectSubscriber implements EventSubscriberInter
     }
   }
 
+  /**
+   * Redirects legacy organiser routes on access-denied exceptions.
+   */
   public function onKernelException(ExceptionEvent $event): void {
     if (!$event->isMainRequest() || !$event->getThrowable() instanceof AccessDeniedHttpException) {
       return;
@@ -127,6 +153,9 @@ final class VendorLegacyWizardRedirectSubscriber implements EventSubscriberInter
     }
   }
 
+  /**
+   * Redirects legacy organiser routes on 403 responses.
+   */
   public function onKernelResponse(ResponseEvent $event): void {
     if (!$event->isMainRequest() || $event->getResponse()->getStatusCode() !== 403) {
       return;
@@ -142,9 +171,16 @@ final class VendorLegacyWizardRedirectSubscriber implements EventSubscriberInter
     }
   }
 
+  /**
+   * Builds a redirect response for a legacy organiser request, if applicable.
+   */
   private function redirectResponseForLegacyRequest(Request $request): ?RedirectResponse {
     $route = (string) ($request->attributes->get('_route') ?? '');
-    $redirect_routes = array_merge(self::WIZARD_STEP_ROUTES, self::VENDOR_LEGACY_OPERATION_ROUTES);
+    $redirect_routes = array_merge(
+      self::WIZARD_STEP_ROUTES,
+      self::VENDOR_LEGACY_OPERATION_ROUTES,
+      self::DOOR_MODE_REDIRECT_ROUTES,
+    );
     if (!in_array($route, $redirect_routes, TRUE)) {
       return NULL;
     }
@@ -165,8 +201,20 @@ final class VendorLegacyWizardRedirectSubscriber implements EventSubscriberInter
       return NULL;
     }
 
-    [$to_route, $params] = $this->destinationForLegacyRoute($route, $node);
-    $url = Url::fromRoute($to_route, $params)->toString();
+    if (in_array($route, self::DOOR_MODE_REDIRECT_ROUTES, TRUE)) {
+      $url = Url::fromRoute('myeventlane_event_attendees.vendor_operations_door', [
+        'node' => (int) $node->id(),
+      ])->toString();
+      $this->logger->notice('Vendor Door Mode redirect: from_route=@from event_id=@eid uid=@uid', [
+        '@from' => $route,
+        '@eid' => (string) $node->id(),
+        '@uid' => (string) $this->currentUser->id(),
+      ]);
+      return new RedirectResponse($url, 302);
+    }
+
+    [$to_route, $params, $query] = $this->destinationForLegacyRoute($route, $node);
+    $url = Url::fromRoute($to_route, $params, ['query' => $query])->toString();
     $this->logger->notice('Vendor legacy wizard redirect: from_route=@from to_route=@to event_id=@eid studio_selected=1 uid=@uid', [
       '@from' => $route,
       '@to' => $to_route,
@@ -180,19 +228,32 @@ final class VendorLegacyWizardRedirectSubscriber implements EventSubscriberInter
   /**
    * Maps a legacy organiser route to a Convergence destination.
    *
-   * @return array{0: string, 1: array<string, int|string>}
-   *   Destination route name and parameters.
+   * @return array{0: string, 1: array<string, int|string>, 2: array<string, string>}
+   *   Destination route name, parameters, and query arguments.
    */
   private function destinationForLegacyRoute(string $route, NodeInterface $node): array {
     $nid = (int) $node->id();
     $to_route = $this->sectionRouteForLegacyRoute($route);
     // Global Payments hub has no event parameter.
     if ($to_route === 'myeventlane_vendor.console.payouts') {
-      return [$to_route, []];
+      return [$to_route, [], []];
     }
-    return [$to_route, ['node' => $nid]];
+    $query = [];
+    if (in_array($route, [
+      'myeventlane_vendor.console.event_rsvps',
+      'myeventlane_rsvp.vendor_event_rsvps',
+    ], TRUE)) {
+      $query['filter'] = 'rsvp';
+    }
+    if ($route === 'myeventlane_event_attendees.waitlist_manage') {
+      $query['filter'] = 'waitlist';
+    }
+    return [$to_route, ['node' => $nid], $query];
   }
 
+  /**
+   * Maps a legacy route name to the Convergence destination route.
+   */
   private function sectionRouteForLegacyRoute(string $route): string {
     return match ($route) {
       'myeventlane_event.wizard.basics',
@@ -226,7 +287,8 @@ final class VendorLegacyWizardRedirectSubscriber implements EventSubscriberInter
       'myeventlane_event_attendees.vendor_list',
       'myeventlane_event_attendees.legacy_vendor_event_attendees_path',
       'myeventlane_event_attendees.waitlist_manage',
-      'myeventlane_vendor.console.event_rsvps' => 'myeventlane_event_studio.workspace_attendees',
+      'myeventlane_vendor.console.event_rsvps',
+      'myeventlane_rsvp.vendor_event_rsvps' => 'myeventlane_event_studio.workspace_attendees',
       'myeventlane_vendor.manage_event.promote' => 'myeventlane_boost.boost_page',
       'myeventlane_vendor.console.event_promotion',
       'myeventlane_vendor.manage_event.comms' => 'myeventlane_event_studio.workspace_messaging',
@@ -246,7 +308,9 @@ final class VendorLegacyWizardRedirectSubscriber implements EventSubscriberInter
   }
 
   /**
-   * Resolves an event node from legacy wizard (`event`) or studio step (`node`) parameters.
+   * Resolves an event node from legacy wizard or studio route parameters.
+   *
+   * Accepts either the `event` or `node` request attribute.
    */
   private function resolveEventNode(Request $request): ?NodeInterface {
     foreach (['event', 'node'] as $key) {

--- a/web/modules/custom/myeventlane_event_studio/src/EventSubscriber/VendorLegacyWizardRedirectSubscriber.php
+++ b/web/modules/custom/myeventlane_event_studio/src/EventSubscriber/VendorLegacyWizardRedirectSubscriber.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
 use Drupal\myeventlane_core\Http\MelKernelAuthRouteSilencer;
+use Drupal\myeventlane_core\VendorConsoleTrust;
 use Drupal\node\NodeInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -202,6 +203,16 @@ final class VendorLegacyWizardRedirectSubscriber implements EventSubscriberInter
     }
 
     if (in_array($route, self::DOOR_MODE_REDIRECT_ROUTES, TRUE)) {
+      // Door Mode requires vendor_console access. Check-in-only team accounts
+      // must keep their legacy surfaces (access check-in / check in tickets).
+      if (!VendorConsoleTrust::accountIsTrustedForVendorConsole($this->currentUser)) {
+        $this->logger->notice('Vendor Door Mode redirect skipped (no console trust): from_route=@from event_id=@eid uid=@uid', [
+          '@from' => $route,
+          '@eid' => (string) $node->id(),
+          '@uid' => (string) $this->currentUser->id(),
+        ]);
+        return NULL;
+      }
       $url = Url::fromRoute('myeventlane_event_attendees.vendor_operations_door', [
         'node' => (int) $node->id(),
       ])->toString();

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/AttendeesSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/AttendeesSection.php
@@ -7,20 +7,20 @@ namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
 use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
 
 /**
- * Attendees section metadata.
+ * Attendees section — VX2 One Attendee Workspace (B7).
  */
 #[EventStudioSection(
   id: 'attendees',
   title: 'Attendees',
   group: 'Workspace',
   routeName: 'myeventlane_event_studio.workspace_attendees',
-  section_state: 'readonly',
+  section_state: 'active',
   weight: 60,
   icon: 'attendees',
-  renderTarget: 'readonly_summary',
+  renderTarget: 'attendees_stack',
   writable: FALSE,
   readiness_participant: FALSE,
-  empty_state_type: 'readonly_empty',
+  empty_state_type: 'default',
   mobile_priority: 50,
   operationalArea: 'operations',
 )]

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioEmptyStateBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioEmptyStateBuilder.php
@@ -123,8 +123,8 @@ final class EventStudioEmptyStateBuilder {
   public function readonlyEmptySection(string $section_label, string $body = ''): array {
     $defaults = [
       'Attendees' => [
-        (string) $this->t('Guests will appear here after your first booking.'),
-        (string) $this->t('Share your event page to start collecting attendees.'),
+        (string) $this->t('Publish your event and share it to receive your first booking.'),
+        (string) $this->t('Guests who buy a ticket or RSVP appear here in one guest list.'),
       ],
       'Orders' => [
         (string) $this->t('Orders will appear here after your first sale.'),
@@ -140,14 +140,21 @@ final class EventStudioEmptyStateBuilder {
       (string) $this->t('Check back after your first booking or publish.'),
     ];
 
+    $guidance = $section_label === 'Attendees'
+      ? [
+        (string) $this->t('Use Door Mode on the day to check guests in.'),
+        (string) $this->t('Message and export stay with this guest list.'),
+      ]
+      : [
+        (string) $this->t('This view is event-scoped and read-only.'),
+        (string) $this->t('Use Tickets, Messages, or Publishing to make changes.'),
+      ];
+
     return $this->build(
       $section_label,
       $pair[0],
       $pair[1],
-      [
-        (string) $this->t('This view is event-scoped and read-only.'),
-        (string) $this->t('Use Tickets, Messages, or Publishing to make changes.'),
-      ],
+      $guidance,
       'reporting',
       'readonly',
     );

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
@@ -11,6 +11,7 @@ use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Url;
 use Drupal\myeventlane_capacity\Service\EventCapacityServiceInterface;
 use Drupal\myeventlane_core\Service\DomainDetector;
+use Drupal\myeventlane_event_attendees\Service\EventAttendeeWorkspaceBuilder;
 use Drupal\myeventlane_event_studio\DTO\EventReadinessResult;
 use Drupal\myeventlane_event_studio\DTO\ReadonlySectionProjection;
 use Drupal\myeventlane_event_studio\Form\EventSettingsForm;
@@ -44,6 +45,7 @@ final class EventStudioSectionRenderer {
     private readonly ?AccessCodeManagementBuilder $accessCodeManagementBuilder = NULL,
     private readonly ?EventWorkspaceOverviewBuilder $overviewBuilder = NULL,
     private readonly ?DomainDetector $domainDetector = NULL,
+    private readonly ?EventAttendeeWorkspaceBuilder $attendeeWorkspaceBuilder = NULL,
   ) {
     $this->stringTranslation = $stringTranslation;
   }
@@ -80,6 +82,7 @@ final class EventStudioSectionRenderer {
     return match ($target) {
       'overview' => $this->buildOverviewSection($event),
       'tickets_stack' => $this->buildTicketsStack($event),
+      'attendees_stack' => $this->buildAttendeesStack($event),
       'settings_with_readiness' => $this->buildSettingsSection($event),
       'capacity_summary' => $this->buildCapacitySection($event, $section),
       'marketing_hub' => $this->buildMarketingHub($event),
@@ -300,6 +303,52 @@ final class EventStudioSectionRenderer {
         '#attributes' => ['class' => ['mel-event-studio-next-steps__list']],
       ],
     ];
+  }
+
+  /**
+   * VX2-05 One Attendee Workspace (paid + RSVP + waitlist + door entry).
+   *
+   * @return array<string, mixed>
+   *   Attendees workspace render stack.
+   */
+  private function buildAttendeesStack(NodeInterface $event): array {
+    if (!$this->attendeeWorkspaceBuilder instanceof EventAttendeeWorkspaceBuilder) {
+      $this->logger->error('Attendee workspace builder unavailable for event @event.', [
+        '@event' => (string) $event->id(),
+      ]);
+      return $this->emptyStateBuilder->unavailableSection((string) $this->t('Attendees'));
+    }
+
+    try {
+      $workspace = $this->attendeeWorkspaceBuilder->build($event);
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('Attendee workspace failed for event @event: @message', [
+        '@event' => (string) $event->id(),
+        '@message' => $e->getMessage(),
+      ]);
+      return $this->emptyStateBuilder->unavailableSection((string) $this->t('Attendees'));
+    }
+
+    $build = [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => [
+          'mel-event-studio-section__form-stack',
+          'mel-event-studio-attendees-app',
+        ],
+        'data-mel-attendees-app' => '1',
+      ],
+      'workspace' => $workspace,
+    ];
+
+    $support = $this->supportResolver->buildCard($event, 'attendees');
+    if ($support !== NULL) {
+      $build['support'] = $support;
+      $build['support']['#weight'] = 30;
+    }
+
+    return $build;
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-attendees-workspace.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-attendees-workspace.html.twig
@@ -1,0 +1,195 @@
+{#
+/**
+ * @file
+ * VX2 One Attendee Workspace (Event Workspace · Attendees).
+ *
+ * Variables: event, summary, attendees, filters, ticket_types, initial_filter,
+ * layout, dense_threshold, actions, checkin_csrf, public_event_url, empty.
+ */
+#}
+{% set layout_mode = layout|default('cards') %}
+<div class="mel-attendees-workspace"
+     data-mel-attendees-workspace
+     data-mel-layout="{{ layout_mode|e('html_attr') }}"
+     data-mel-initial-filter="{{ initial_filter|default('all')|e('html_attr') }}"
+     data-mel-checkin-token="{{ checkin_csrf|default('')|e('html_attr') }}">
+
+  <header class="mel-attendees-workspace__header">
+    <div class="mel-attendees-workspace__intro">
+      <h2 class="mel-attendees-workspace__title">{{ 'Attendees'|t }}</h2>
+      <p class="mel-attendees-workspace__lede">{{ 'One guest list for tickets, RSVPs, and waitlist — including Door Mode on the day.'|t }}</p>
+    </div>
+    {% if actions %}
+      <div class="mel-attendees-workspace__actions" role="group" aria-label="{{ 'Attendee actions'|t }}">
+        {% for action in actions %}
+          <a class="mel-btn {{ action.class|default('mel-btn--secondary') }}"
+             href="{{ action.url }}"
+             data-mel-attendee-analytics="{{ action.analytics|default('')|e('html_attr') }}">
+            {{ action.label }}
+          </a>
+        {% endfor %}
+      </div>
+    {% endif %}
+  </header>
+
+  {% set cap_note = (summary.remaining is not null and summary.capacity is not same as('Unlimited')) ? ('@left spots left'|t({'@left': summary.remaining})) : null %}
+  {% set cap_display = summary.capacity is same as('Unlimited')
+    ? summary.capacity|default('—')
+    : (summary.total|default(0) ~ '/' ~ summary.capacity) %}
+
+  <div class="mel-attendees-workspace__metrics" role="region" aria-labelledby="mel-attendees-metrics-heading">
+    <h3 id="mel-attendees-metrics-heading" class="visually-hidden">{{ 'Attendance summary'|t }}</h3>
+    <ul class="mel-attendees-workspace__metric-list">
+      <li><span class="mel-attendees-workspace__metric-label">{{ 'Total'|t }}</span> <strong>{{ summary.total|default(0) }}</strong></li>
+      <li><span class="mel-attendees-workspace__metric-label">{{ 'Checked in'|t }}</span> <strong>{{ summary.checked_in|default(0) }}</strong></li>
+      <li><span class="mel-attendees-workspace__metric-label">{{ 'Tickets'|t }}</span> <strong>{{ summary.ticket|default(0) }}</strong></li>
+      <li><span class="mel-attendees-workspace__metric-label">{{ 'RSVPs'|t }}</span> <strong>{{ summary.rsvp|default(0) }}</strong></li>
+      {% if summary.waitlist|default(0) > 0 %}
+        <li><span class="mel-attendees-workspace__metric-label">{{ 'Waitlist'|t }}</span> <strong>{{ summary.waitlist }}</strong></li>
+      {% endif %}
+      <li><span class="mel-attendees-workspace__metric-label">{{ 'Capacity'|t }}</span> <strong>{{ cap_display }}</strong>{% if cap_note %} <span class="mel-attendees-workspace__metric-note">{{ cap_note }}</span>{% endif %}</li>
+    </ul>
+  </div>
+
+  {% if attendees|length > 0 %}
+    <div class="mel-attendees-workspace__toolbar">
+      <div class="mel-attendees-workspace__search">
+        <label class="visually-hidden" for="mel-attendee-search">{{ 'Search attendees by name or email'|t }}</label>
+        <input type="search"
+               id="mel-attendee-search"
+               class="mel-input mel-attendees-workspace__search-input"
+               placeholder="{{ 'Search name or email…'|t }}"
+               autocomplete="off"
+               data-mel-attendee-search
+               aria-controls="mel-attendee-guest-list">
+      </div>
+
+      {% if ticket_types|length > 0 %}
+        <div class="mel-attendees-workspace__ticket-filter">
+          <label class="visually-hidden" for="mel-attendee-ticket-type">{{ 'Filter by ticket type'|t }}</label>
+          <select id="mel-attendee-ticket-type" class="mel-input" data-mel-attendee-ticket-type>
+            <option value="">{{ 'All ticket types'|t }}</option>
+            {% for type in ticket_types %}
+              <option value="{{ type|e('html_attr') }}">{{ type }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      {% endif %}
+    </div>
+
+    <div class="mel-attendees-workspace__filters" role="toolbar" aria-label="{{ 'Filter attendees'|t }}">
+      {% for chip in filters %}
+        <button type="button"
+                class="mel-attendees-workspace__filter{{ initial_filter == chip.id ? ' is-active' : '' }}"
+                data-mel-attendee-filter="{{ chip.id|e('html_attr') }}"
+                aria-pressed="{{ initial_filter == chip.id ? 'true' : 'false' }}">
+          {{ chip.label }}
+        </button>
+      {% endfor %}
+    </div>
+
+    <p class="mel-attendees-workspace__result-status visually-hidden" data-mel-attendee-status role="status" aria-live="polite"></p>
+
+    <div id="mel-attendee-guest-list"
+         class="mel-attendees-workspace__list mel-attendees-workspace__list--{{ layout_mode|e('html_attr') }}"
+         data-mel-attendee-list
+         role="list">
+      {% for attendee in attendees %}
+        <article class="mel-attendee-card"
+                 role="listitem"
+                 data-mel-attendee-card
+                 data-name="{{ attendee.name|lower|e('html_attr') }}"
+                 data-email="{{ attendee.email|lower|e('html_attr') }}"
+                 data-ticket-type="{{ attendee.ticket_type|lower|e('html_attr') }}"
+                 data-filters="{{ attendee.filter_keys|join(' ')|e('html_attr') }}">
+          <div class="mel-attendee-card__main">
+            <div class="mel-attendee-card__identity">
+              <span class="mel-attendee-card__avatar" aria-hidden="true">{{ (attendee.name|default('?')|trim|slice(0, 1))|upper }}</span>
+              <div>
+                <h3 class="mel-attendee-card__name">{{ attendee.name|default('—') }}</h3>
+                {% if attendee.email %}
+                  <a class="mel-attendee-card__email" href="mailto:{{ attendee.email }}">{{ attendee.email }}</a>
+                {% endif %}
+              </div>
+            </div>
+            <dl class="mel-attendee-card__meta">
+              <div>
+                <dt>{{ 'Ticket / RSVP'|t }}</dt>
+                <dd>
+                  <span class="mel-badge mel-badge--{{ attendee.source|e('html_attr') }}">{{ attendee.source_label }}</span>
+                  {{ attendee.ticket_type }}
+                </dd>
+              </div>
+              <div>
+                <dt>{{ 'Booking status'|t }}</dt>
+                <dd><span class="mel-badge mel-badge--{{ attendee.booking_state|e('html_attr') }}">{{ attendee.booking_status }}</span></dd>
+              </div>
+              <div>
+                <dt>{{ 'Check-in'|t }}</dt>
+                <dd>
+                  {% if attendee.checked_in %}
+                    <span class="mel-badge mel-badge--success">{{ attendee.check_in_label }}</span>
+                  {% else %}
+                    <span class="mel-badge mel-badge--neutral">{{ attendee.check_in_label }}</span>
+                  {% endif %}
+                </dd>
+              </div>
+              {% if attendee.order_reference %}
+                <div>
+                  <dt>{{ 'Order'|t }}</dt>
+                  <dd>
+                    {% if attendee.order_link %}
+                      <a class="mel-link" href="{{ attendee.order_link.url }}">{{ attendee.order_reference }}</a>
+                    {% else %}
+                      {{ attendee.order_reference }}
+                    {% endif %}
+                  </dd>
+                </div>
+              {% endif %}
+            </dl>
+          </div>
+          <div class="mel-attendee-card__actions" role="group" aria-label="{{ 'Quick actions for @name'|t({'@name': attendee.name}) }}">
+            {% if attendee.actions.view_url %}
+              <a class="mel-btn mel-btn--ghost mel-attendee-card__action" href="{{ attendee.actions.view_url }}">{{ 'View'|t }}</a>
+            {% endif %}
+            {% if attendee.actions.message_url %}
+              <a class="mel-btn mel-btn--ghost mel-attendee-card__action"
+                 href="{{ attendee.actions.message_url }}"
+                 data-mel-attendee-analytics="message_attendees_clicked">{{ 'Message'|t }}</a>
+            {% endif %}
+            {% if attendee.actions.refund_url %}
+              <a class="mel-btn mel-btn--ghost mel-attendee-card__action" href="{{ attendee.actions.refund_url }}">{{ 'Refund'|t }}</a>
+            {% endif %}
+            {% if attendee.actions.checkin_url %}
+              <form class="mel-attendee-card__checkin"
+                    method="post"
+                    action="{{ attendee.actions.checkin_url }}"
+                    data-mel-attendee-checkin>
+                <input type="hidden" name="_token" value="{{ checkin_csrf|e('html_attr') }}">
+                <button type="submit" class="mel-btn mel-btn--primary mel-attendee-card__action">{{ 'Check in'|t }}</button>
+              </form>
+            {% endif %}
+          </div>
+        </article>
+      {% endfor %}
+    </div>
+
+    <div class="mel-attendees-workspace__empty-filter mel-empty-state" hidden data-mel-attendee-empty-filter>
+      <p class="mel-empty-state__title">{{ 'No checked-in guests'|t }}</p>
+      <p class="mel-empty-state__text">{{ 'Door Mode will update this list as guests arrive.'|t }}</p>
+    </div>
+  {% else %}
+    <div class="mel-empty-state mel-attendees-workspace__empty">
+      <p class="mel-empty-state__title">{{ empty.title|default('No attendees yet'|t) }}</p>
+      <p class="mel-empty-state__text">{{ empty.body|default('Publish your event and share it to receive your first booking.'|t) }}</p>
+      {% if empty.prompt %}
+        <p class="mel-empty-state__prompt">{{ empty.prompt }}</p>
+      {% endif %}
+      {% if empty.cta_url %}
+        <div class="mel-action-group">
+          <a class="mel-btn mel-btn--primary" href="{{ empty.cta_url }}" target="_blank" rel="noopener noreferrer">{{ empty.cta_label|default('View event page'|t) }}</a>
+        </div>
+      {% endif %}
+    </div>
+  {% endif %}
+</div>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-attendees-workspace.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-attendees-workspace.html.twig
@@ -4,14 +4,18 @@
  * VX2 One Attendee Workspace (Event Workspace · Attendees).
  *
  * Variables: event, summary, attendees, filters, ticket_types, initial_filter,
- * layout, dense_threshold, actions, checkin_csrf, public_event_url, empty.
+ * initial_match_count, empty_filter, layout, dense_threshold, actions,
+ * checkin_csrf, public_event_url, empty.
  */
 #}
 {% set layout_mode = layout|default('cards') %}
+{% set initial_filter_id = initial_filter|default('all') %}
+{% set match_count = initial_match_count|default(attendees|length) %}
+{% set show_empty_filter = empty_filter.show|default(false) %}
 <div class="mel-attendees-workspace"
      data-mel-attendees-workspace
      data-mel-layout="{{ layout_mode|e('html_attr') }}"
-     data-mel-initial-filter="{{ initial_filter|default('all')|e('html_attr') }}"
+     data-mel-initial-filter="{{ initial_filter_id|e('html_attr') }}"
      data-mel-checkin-token="{{ checkin_csrf|default('')|e('html_attr') }}">
 
   <header class="mel-attendees-workspace__header">
@@ -80,20 +84,26 @@
     <div class="mel-attendees-workspace__filters" role="toolbar" aria-label="{{ 'Filter attendees'|t }}">
       {% for chip in filters %}
         <button type="button"
-                class="mel-attendees-workspace__filter{{ initial_filter == chip.id ? ' is-active' : '' }}"
+                class="mel-attendees-workspace__filter{{ initial_filter_id == chip.id ? ' is-active' : '' }}"
                 data-mel-attendee-filter="{{ chip.id|e('html_attr') }}"
-                aria-pressed="{{ initial_filter == chip.id ? 'true' : 'false' }}">
+                aria-pressed="{{ initial_filter_id == chip.id ? 'true' : 'false' }}">
           {{ chip.label }}
         </button>
       {% endfor %}
     </div>
 
-    <p class="mel-attendees-workspace__result-status visually-hidden" data-mel-attendee-status role="status" aria-live="polite"></p>
+    <p class="mel-attendees-workspace__result-status visually-hidden" data-mel-attendee-status role="status" aria-live="polite">
+      {% if match_count == 1 %}
+        {{ 'Showing 1 attendee'|t }}
+      {% else %}
+        {{ 'Showing @count attendees'|t({'@count': match_count}) }}
+      {% endif %}
+    </p>
 
     <div id="mel-attendee-guest-list"
          class="mel-attendees-workspace__list mel-attendees-workspace__list--{{ layout_mode|e('html_attr') }}"
          data-mel-attendee-list
-         role="list">
+         role="list"{% if show_empty_filter %} hidden{% endif %}>
       {% for attendee in attendees %}
         <article class="mel-attendee-card"
                  role="listitem"
@@ -101,7 +111,8 @@
                  data-name="{{ attendee.name|lower|e('html_attr') }}"
                  data-email="{{ attendee.email|lower|e('html_attr') }}"
                  data-ticket-type="{{ attendee.ticket_type|lower|e('html_attr') }}"
-                 data-filters="{{ attendee.filter_keys|join(' ')|e('html_attr') }}">
+                 data-filters="{{ attendee.filter_keys|join(' ')|e('html_attr') }}"
+                 {% if not attendee.matches_initial_filter|default(true) %}hidden{% endif %}>
           <div class="mel-attendee-card__main">
             <div class="mel-attendee-card__identity">
               <span class="mel-attendee-card__avatar" aria-hidden="true">{{ (attendee.name|default('?')|trim|slice(0, 1))|upper }}</span>
@@ -175,9 +186,11 @@
       {% endfor %}
     </div>
 
-    <div class="mel-attendees-workspace__empty-filter mel-empty-state" hidden data-mel-attendee-empty-filter>
-      <p class="mel-empty-state__title">{{ 'No checked-in guests'|t }}</p>
-      <p class="mel-empty-state__text">{{ 'Door Mode will update this list as guests arrive.'|t }}</p>
+    <div class="mel-attendees-workspace__empty-filter mel-empty-state"
+         data-mel-attendee-empty-filter
+         {% if not show_empty_filter %}hidden{% endif %}>
+      <p class="mel-empty-state__title">{{ empty_filter.title|default('No matching attendees'|t) }}</p>
+      <p class="mel-empty-state__text">{{ empty_filter.body|default('Try another search or clear your filters.'|t) }}</p>
     </div>
   {% else %}
     <div class="mel-empty-state mel-attendees-workspace__empty">

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-attendees-workspace.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-attendees-workspace.html.twig
@@ -166,6 +166,7 @@
                     action="{{ attendee.actions.checkin_url }}"
                     data-mel-attendee-checkin>
                 <input type="hidden" name="_token" value="{{ checkin_csrf|e('html_attr') }}">
+                <input type="hidden" name="destination" value="{{ path('myeventlane_event_studio.workspace_attendees', {'node': event.id()}) }}">
                 <button type="submit" class="mel-btn mel-btn--primary mel-attendee-card__action">{{ 'Check in'|t }}</button>
               </form>
             {% endif %}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioAttendeesAppContractTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioAttendeesAppContractTest.php
@@ -58,6 +58,8 @@ final class EventStudioAttendeesAppContractTest extends TestCase {
     $this->assertStringContainsString('data-mel-attendee-filter', $twig);
     $this->assertStringContainsString("name=\"destination\"", $twig);
     $this->assertStringContainsString('workspace_attendees', $twig);
+    $this->assertStringContainsString('matches_initial_filter', $twig);
+    $this->assertStringContainsString('empty_filter', $twig);
     $this->assertStringNotContainsString('Ticket holders', $twig);
     $this->assertStringNotContainsString('Check-in module', $twig);
   }

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioAttendeesAppContractTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioAttendeesAppContractTest.php
@@ -56,6 +56,8 @@ final class EventStudioAttendeesAppContractTest extends TestCase {
     $this->assertStringContainsString('Door Mode will update this list', $twig);
     $this->assertStringContainsString('data-mel-attendee-search', $twig);
     $this->assertStringContainsString('data-mel-attendee-filter', $twig);
+    $this->assertStringContainsString("name=\"destination\"", $twig);
+    $this->assertStringContainsString('workspace_attendees', $twig);
     $this->assertStringNotContainsString('Ticket holders', $twig);
     $this->assertStringNotContainsString('Check-in module', $twig);
   }
@@ -77,6 +79,9 @@ final class EventStudioAttendeesAppContractTest extends TestCase {
 
   /**
    * Asserts Door Mode and filter redirects are registered.
+   *
+   * Door Mode redirects apply only when the account has vendor console trust;
+   * check-in-only team accounts keep legacy surfaces.
    */
   public function testDoorModeRedirectsAreRegistered(): void {
     $subscriber = file_get_contents($this->moduleRoot() . '/src/EventSubscriber/VendorLegacyWizardRedirectSubscriber.php');
@@ -85,6 +90,8 @@ final class EventStudioAttendeesAppContractTest extends TestCase {
     $this->assertStringContainsString('myeventlane_checkin.page', $subscriber);
     $this->assertStringContainsString('myeventlane_tickets.ticket_checkin', $subscriber);
     $this->assertStringContainsString('myeventlane_rsvp.checkin_list', $subscriber);
+    $this->assertStringContainsString('VendorConsoleTrust', $subscriber);
+    $this->assertStringContainsString('accountIsTrustedForVendorConsole', $subscriber);
     $this->assertStringContainsString("filter'] = 'rsvp'", $subscriber);
     $this->assertStringContainsString("filter'] = 'waitlist'", $subscriber);
   }

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioAttendeesAppContractTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioAttendeesAppContractTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Contract tests for VX2 Sprint 4 One Attendee Workspace convergence.
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventStudioAttendeesAppContractTest extends TestCase {
+
+  /**
+   * Returns the event_studio module root path.
+   */
+  private function moduleRoot(): string {
+    return dirname(__DIR__, 3);
+  }
+
+  /**
+   * Asserts Attendees section is an active workspace stack.
+   */
+  public function testAttendeesSectionUsesActiveWorkspaceStack(): void {
+    $section = file_get_contents($this->moduleRoot() . '/src/Plugin/EventStudioSection/AttendeesSection.php');
+    $this->assertNotFalse($section);
+    $this->assertStringContainsString("section_state: 'active'", $section);
+    $this->assertStringContainsString("renderTarget: 'attendees_stack'", $section);
+  }
+
+  /**
+   * Asserts the section renderer builds the attendees stack.
+   */
+  public function testRendererBuildsAttendeesStack(): void {
+    $renderer = file_get_contents($this->moduleRoot() . '/src/Service/EventStudioSectionRenderer.php');
+    $this->assertNotFalse($renderer);
+    $this->assertStringContainsString('buildAttendeesStack', $renderer);
+    $this->assertStringContainsString("'attendees_stack'", $renderer);
+    $this->assertStringContainsString('mel-event-studio-attendees-app', $renderer);
+    $this->assertStringContainsString('EventAttendeeWorkspaceBuilder', $renderer);
+  }
+
+  /**
+   * Asserts organiser language and controls in the workspace template.
+   */
+  public function testWorkspaceTemplateUsesOrganiserLanguage(): void {
+    $twig = file_get_contents($this->moduleRoot() . '/templates/mel-event-studio-attendees-workspace.html.twig');
+    $this->assertNotFalse($twig);
+    $this->assertStringContainsString('Ticket / RSVP', $twig);
+    $this->assertStringContainsString('Booking status', $twig);
+    $this->assertStringContainsString('No attendees yet', $twig);
+    $this->assertStringContainsString('Publish your event and share it', $twig);
+    $this->assertStringContainsString('No checked-in guests', $twig);
+    $this->assertStringContainsString('Door Mode will update this list', $twig);
+    $this->assertStringContainsString('data-mel-attendee-search', $twig);
+    $this->assertStringContainsString('data-mel-attendee-filter', $twig);
+    $this->assertStringNotContainsString('Ticket holders', $twig);
+    $this->assertStringNotContainsString('Check-in module', $twig);
+  }
+
+  /**
+   * Asserts the attendees app library and JS hooks exist.
+   */
+  public function testAttendeesAppLibraryAndJsExist(): void {
+    $libraries = file_get_contents($this->moduleRoot() . '/myeventlane_event_studio.libraries.yml');
+    $this->assertNotFalse($libraries);
+    $this->assertStringContainsString('mel_event_studio_attendees_app', $libraries);
+    $this->assertFileExists($this->moduleRoot() . '/js/mel-event-studio-attendees-app.js');
+    $js = file_get_contents($this->moduleRoot() . '/js/mel-event-studio-attendees-app.js');
+    $this->assertNotFalse($js);
+    $this->assertStringContainsString('attendee_filtered', $js);
+    $this->assertStringContainsString('attendee_checked_in', $js);
+    $this->assertStringContainsString('data-mel-attendee-search', $js);
+  }
+
+  /**
+   * Asserts Door Mode and filter redirects are registered.
+   */
+  public function testDoorModeRedirectsAreRegistered(): void {
+    $subscriber = file_get_contents($this->moduleRoot() . '/src/EventSubscriber/VendorLegacyWizardRedirectSubscriber.php');
+    $this->assertNotFalse($subscriber);
+    $this->assertStringContainsString('DOOR_MODE_REDIRECT_ROUTES', $subscriber);
+    $this->assertStringContainsString('myeventlane_checkin.page', $subscriber);
+    $this->assertStringContainsString('myeventlane_tickets.ticket_checkin', $subscriber);
+    $this->assertStringContainsString('myeventlane_rsvp.checkin_list', $subscriber);
+    $this->assertStringContainsString("filter'] = 'rsvp'", $subscriber);
+    $this->assertStringContainsString("filter'] = 'waitlist'", $subscriber);
+  }
+
+  /**
+   * Asserts the workspace builder lives in the attendees module.
+   */
+  public function testWorkspaceBuilderLivesInAttendeesModule(): void {
+    $builder = dirname(__DIR__, 4) . '/myeventlane_event_attendees/src/Service/EventAttendeeWorkspaceBuilder.php';
+    $this->assertFileExists($builder);
+    $contents = file_get_contents($builder);
+    $this->assertNotFalse($contents);
+    $this->assertStringContainsString('attendee_viewed', $contents);
+    $this->assertStringContainsString('DENSE_TABLE_THRESHOLD', $contents);
+    $this->assertStringContainsString('Message attendees', $contents);
+    $this->assertStringContainsString('Export attendees', $contents);
+    $this->assertStringContainsString('Door Mode', $contents);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioAttendeesAppContractTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioAttendeesAppContractTest.php
@@ -75,6 +75,8 @@ final class EventStudioAttendeesAppContractTest extends TestCase {
     $this->assertStringContainsString('attendee_filtered', $js);
     $this->assertStringContainsString('attendee_checked_in', $js);
     $this->assertStringContainsString('data-mel-attendee-search', $js);
+    $this->assertStringContainsString('hasNarrowing', $js);
+    $this->assertStringContainsString("activeFilter !== 'all'", $js);
   }
 
   /**

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventAttendeesController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorEventAttendeesController.php
@@ -118,12 +118,12 @@ final class VendorEventAttendeesController extends VendorConsoleBaseController {
       'tabs' => $tabs,
       'actions' => [
         [
-          'label' => $this->t('Check-in'),
+          'label' => $this->t('Door Mode'),
           'url' => $checkin_url,
           'class' => 'mel-btn--primary',
         ],
         [
-          'label' => $this->t('Export CSV'),
+          'label' => $this->t('Export attendees'),
           'url' => Url::fromRoute('myeventlane_event_attendees.vendor_export', ['node' => $node->id()])->toString(),
           'class' => 'mel-btn--secondary',
         ],

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorEventTabsService.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorEventTabsService.php
@@ -106,7 +106,6 @@ final class VendorEventTabsService {
    */
   private function buildTabRows(NodeInterface $event): array {
     $id = (int) $event->id();
-    $isRsvp = $this->eventModeManager->isRsvpEnabled($event);
     $isTickets = $this->eventModeManager->isTicketsEnabled($event);
     $t = $this->stringTranslation;
 
@@ -222,7 +221,7 @@ final class VendorEventTabsService {
     $rows[] = [
       'key' => 'operations',
       'label' => (string) $t->translate('Door Mode'),
-      'route' => 'myeventlane_event_attendees.vendor_operations',
+      'route' => 'myeventlane_event_attendees.vendor_operations_door',
       'params' => ['node' => $id],
       'disabled' => FALSE,
       'disabled_reason' => '',
@@ -241,16 +240,7 @@ final class VendorEventTabsService {
       ];
     }
 
-    if ($isRsvp && $this->routeExists('myeventlane_vendor.console.event_rsvps')) {
-      $rows[] = [
-        'key' => 'rsvps',
-        'label' => (string) $t->translate('RSVPs'),
-        'route' => 'myeventlane_vendor.console.event_rsvps',
-        'params' => ['event' => $id],
-        'disabled' => FALSE,
-        'disabled_reason' => '',
-      ];
-    }
+    // VX2-05: RSVPs are a filter inside Attendees — not a separate application.
 
     // Legacy Manager pages still call getTabs(..., 'refund_requests'|'boost').
     // Keep these keys so refund/Boost screens retain an active tab and entry point.

--- a/web/themes/custom/myeventlane_vendor_theme/templates/event/attendees.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/event/attendees.html.twig
@@ -7,7 +7,7 @@
 #}
 <div class="mel-workspace-page mel-page mel-attendees mel-live-operations mel-vendor-console-stack">
   <p class="mel-page__next" role="status">
-    {% trans %}Next: open <strong>Check-in</strong> on the day — search this list quickly at the door.{% endtrans %}
+    {% trans %}Next: open <strong>Door Mode</strong> on the day — search this list quickly as guests arrive.{% endtrans %}
   </p>
 
   {% set cap_note = (summary.remaining is not null and summary.capacity is not same as('Unlimited')) ? ('@left spots left'|t({'@left': summary.remaining})) : null %}
@@ -138,7 +138,7 @@
             <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2M9 11a4 4 0 100-8 4 4 0 000 8zM23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75"/>
           </svg>
           <p class="mel-empty-state__title">{{ 'No attendees yet'|t }}</p>
-          <p class="mel-empty-state__text">{{ 'When people RSVP or purchase tickets, they will appear here.'|t }}</p>
+          <p class="mel-empty-state__text">{{ 'Publish your event and share it to receive your first booking.'|t }}</p>
           {% if public_event_url %}
             <div class="mel-action-group">
               <a class="mel-btn mel-btn--cta mel-button mel-button--primary" href="{{ public_event_url }}" target="_blank" rel="noopener noreferrer">{{ 'View event page'|t }}</a>
@@ -150,8 +150,8 @@
   </div>
 
   <div class="mel-support-card">
-    <h3 class="mel-support-card__title">{{ 'Need help with check-in?'|t }}</h3>
-    <p class="mel-support-card__text">{{ 'Use the Check-in tool from the header for door mode and QR flows.'|t }}</p>
+    <h3 class="mel-support-card__title">{{ 'Need help at the door?'|t }}</h3>
+    <p class="mel-support-card__text">{{ 'Door Mode is part of Attendees — use it to search and check guests in on the day.'|t }}</p>
     <a class="mel-btn mel-btn--secondary" href="{{ path('myeventlane_help_centre.home') }}">{{ 'Help Centre'|t }}</a>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Converge organiser Attendees into one Event Workspace guest list (paid + RSVP + waitlist) with search, filters, cards, and Message / Export / Refund / Check in actions.
- Treat Door Mode as an Attendees mode and redirect legacy check-in stacks to the canonical door scanner.
- Document Sprint 4 inventory, instrumentation hooks, and remaining VX2 roadmap (Messages next).

## Test plan
- [ ] Event Workspace → Attendees: empty state copy (AU English)
- [ ] Paid / RSVP / mixed events: guest cards show ticket/RSVP, booking status, check-in, order ref
- [ ] Search by name/email feels immediate; filters include waitlist / checked in / refunded / cancelled
- [ ] Door Mode CTA opens `/operations/door`; legacy `/check-in` redirects
- [ ] Message attendees and Export attendees CTAs work; Refund appears on ticketed guests with orders
- [ ] Desktop / tablet / 390px mobile; keyboard + large touch targets
- [ ] Large list (≥100) uses dense layout
- [ ] `php -l` + focused contract PHPUnit + `validate-push.sh` green


Made with [Cursor](https://cursor.com)