### PR TITLE
feat: VX2-08 organiser Analytics Hub (Event Intelligence Centre)

### DIFF
--- a/docs/implementation/vx2-08-analytics-hub.md
+++ b/docs/implementation/vx2-08-analytics-hub.md
@@ -1,0 +1,76 @@
+# VX2-08 — Analytics Hub (Event Intelligence Centre)
+
+**Epic:** VX2-08 Analytics  
+**Branch:** `feature/vx2-analytics`  
+**Date:** 2026-07-24
+
+## What shipped
+
+- Organiser **Analytics** hub at `/vendor/analytics` reframed as the **Event Intelligence Centre**
+- Sections: Business Health · Launch Readiness · Next action · Sales · Attendance · Revenue · Marketing · Audience · Top Events · Recent Activity · Pro / Exports
+- Free organisers can open the hub (bare Pro **403 removed**)
+- Pro depth explained in-product with upgrade CTAs (never a hard deny on the hub)
+- Legacy **Insights** and **Export Centre** list URLs redirect into Analytics
+- Per-event rows deep-link to Event Workspace Analytics (free pulse) + optional Pro deeper trends
+- AU English, warm, actionable copy — not accounting software
+
+## Architecture
+
+```text
+/vendor/analytics  ← AnalyticsDashboardController
+  └─ VendorAnalyticsViewModelBuilder
+       ├─ MetricsAggregator / TicketSalesService / RsvpStatsService
+       ├─ VendorPaymentsHealthService (Stripe readiness)
+       ├─ CurrentVendorResolver (Messages brand readiness)
+       ├─ optional VendorProState
+       └─ optional refunds repository/metrics
+```
+
+Convergence redirects:
+
+```text
+/vendor/insights                 → /vendor/analytics
+/vendor/events/{id}/insights*    → /vendor/events/{id}/studio/analytics
+/vendor/exports                  → /vendor/analytics#exports
+```
+
+## Free vs Pro
+
+| Free | Pro |
+| --- | --- |
+| Business + launch pulse | Longer trends (deep event Analytics) |
+| Event intelligence rows | Comparisons / advanced segmentation (teased) |
+| Recent activity + next action | PDF / Excel exports |
+
+## Instrumentation
+
+| Event | Where | Pipeline |
+| --- | --- | --- |
+| `analytics_viewed` | Hub builder logger + Twig data attribute | Deferred collector |
+| `pro_upgrade_clicked` | Twig upgrade CTAs | Deferred collector |
+| `pro_upgrade_completed` | Existing Pro flows | Existing |
+
+Do not invent new telemetry tables in this epic.
+
+## Manual QA
+
+- [ ] Free organiser opens `/vendor/analytics` (no 403)
+- [ ] Business Health answers “How is my business performing?”
+- [ ] Launch Readiness answers “Can I successfully run this event today?”
+- [ ] Tickets / Stripe / Messages / Door / Refunds / Publishing signals present
+- [ ] Event card → Event Analytics (Studio)
+- [ ] `/vendor/insights` redirects to Analytics
+- [ ] `/vendor/exports` redirects to `#exports`
+- [ ] Pro CTA explains value (no bare deny)
+- [ ] Desktop / tablet / 390px
+- [ ] Keyboard focus order through health → readiness → actions → events
+- [ ] Screen reader: section headings, KPI aria-labels, status text (not colour alone)
+- [ ] `prefers-reduced-motion` respected
+
+## Remaining roadmap
+
+- Wire product analytics collector for documented events
+- Audience deep segments under Pro
+- Merge Boost performance panels into Marketing section depth (P3)
+- Retire orphan Insights controllers after redirect bake-in
+- Optional: move Audience shell page under Analytics nav

--- a/docs/implementation/vx2-08-analytics-surface-inventory.md
+++ b/docs/implementation/vx2-08-analytics-surface-inventory.md
@@ -1,0 +1,67 @@
+# VX2-08 — Analytics surface inventory (Stage 1)
+
+**Date:** 2026-07-24  
+**Branch:** `feature/vx2-analytics`  
+**Authority:** MEL Product System · Vendor Experience Convergence · Screen Spec A8/B12/F
+
+## Disposition map
+
+| Surface | Route / path | Disposition | Notes |
+| --- | --- | --- | --- |
+| Account Analytics hub | `myeventlane_analytics.dashboard` `/vendor/analytics` | **KEEP** | Canonical Event Intelligence Centre; free pulse unlocked |
+| Studio event Analytics | `myeventlane_event_studio.workspace_analytics` | **KEEP** | Free per-event pulse; primary Event Analytics CTA |
+| Deep event Analytics | `myeventlane_analytics.event` | **KEEP** (Pro) | Longer trends / charts; upgrade CTA when locked |
+| PDF / Excel export | `…export_pdf` / `…export_excel` | **KEEP** (Pro) | Linked from Pro depth + event Analytics |
+| Vendor Insights | `/vendor/insights` | **REDIRECT** | → `/vendor/analytics` |
+| Event Insights tabs | `/vendor/events/{id}/insights*` | **REDIRECT** | → Studio Analytics |
+| Export Centre list | `/vendor/exports` | **REDIRECT** | → `/vendor/analytics#exports` |
+| Charts JSON APIs | `/vendor/charts/*` | **HIDE** (product) / **KEEP** (Pro API) | Not a navigable product |
+| Dashboard KPI strip | `/vendor/dashboard` | **KEEP** | Feeder only — not a second Analytics product |
+| Console Growth Analytics | `/vendor/events/{id}/analytics` | **REDIRECT** (existing) | Already → Studio Analytics |
+| Audience page | `/vendor/audience` | **HIDE** (shell) | Nest under Analytics/Marketing later |
+| Boost metric panels | Boost + embedded analytics | **MERGE** | Shown as Marketing pulse on hub |
+| Support Analytics | `/vendor/support/analytics` | **KEEP** | Support product — out of A8 scope |
+| Check-in analytics local task | tickets module | **HIDE** as product | Door Mode / Attendees owns ops metrics |
+| Refund analytics card | event overview | **KEEP** | Payments/overview ownership |
+
+## Product language
+
+| Retire as product name | Use |
+| --- | --- |
+| Insights | Analytics |
+| Charts | Analytics (charts as UI pattern only) |
+| Reports / Reporting (organiser) | Analytics |
+| Export Centre | Exports (inside Analytics) |
+
+## Free vs Pro
+
+| Free | Pro |
+| --- | --- |
+| Business health | Longer-range trends |
+| Launch readiness | Comparisons |
+| Event pulse rows | PDF / spreadsheet exports |
+| Simple sections + recent activity | Advanced segmentation |
+| Next recommended action | Historical analysis depth |
+
+**Never bare 403** on `/vendor/analytics`. Pro depth explains value + upgrade.
+
+## Launch Readiness signals (existing data only)
+
+| Signal | Source |
+| --- | --- |
+| Tickets configured | Event domain state (`has_product` / RSVP) |
+| Stripe connected | `VendorPaymentsHealthService` |
+| Messages ready | Vendor `field_msg_from_name` or vendor name |
+| Door Mode ready | Tickets/RSVP present (Door Mode entry exists) |
+| Refunds awaiting | Escalations refunds metrics (when module present) |
+| Publishing issues | Draft event count |
+
+## Missing collectors (document only — do not invent)
+
+| Success metric event | Status |
+| --- | --- |
+| `analytics_viewed` | Logger + `data-mel-analytics-event` on hub |
+| `pro_upgrade_clicked` | Twig data attribute on upgrade CTAs |
+| `pro_upgrade_completed` | Existing Pro subscribe paths (unchanged) |
+
+Pipeline wiring to a product analytics collector remains deferred (same pattern as VX2-06/07).

--- a/docs/implementation/vx2-08-analytics-surface-inventory.md
+++ b/docs/implementation/vx2-08-analytics-surface-inventory.md
@@ -53,7 +53,7 @@
 | Stripe connected | `VendorPaymentsHealthService` |
 | Messages ready | Vendor `field_msg_from_name` or vendor name |
 | Door Mode ready | Tickets/RSVP present (Door Mode entry exists) |
-| Refunds awaiting | Escalations refunds metrics (when module present) |
+| Refunds awaiting | Escalations refunds metrics (when module present) — same pending formula + `vendor_summary_window_days` as Payments hub |
 | Publishing issues | Draft event count |
 
 ## Missing collectors (document only — do not invent)

--- a/docs/product-system/LAUNCH_READINESS.md
+++ b/docs/product-system/LAUNCH_READINESS.md
@@ -45,7 +45,7 @@ Success metrics prove outcomes over time; this checklist declares **launch-ready
 | **Attendees + Door Mode (VX2-05)** | Needs work | One workspace shipped | **Sign off QA/a11y**; bulk depth |
 | **Messages (VX2-06)** | Needs work | Hub + compose shipped | Audience filters; schedule UI; collector |
 | **Payments (VX2-07)** | Needs work | Hub shipped; strong trust copy | Residual settings strings; refund route ownership; QA |
-| **Analytics (VX2-08)** | Needs work | Pulse exists; naming incomplete | Merge Insights/Charts; honest Pro depth |
+| **Analytics (VX2-08)** | Needs work | Hub shipped as Event Intelligence Centre; Insights/Exports redirect; free pulse unlocked | Collector wiring; Audience/Boost depth; QA sign-off |
 | **Marketing (VX2-09)** | Needs work | Boost + Marketing sections | Scan/hierarchy polish; share tools cohesion |
 | **Settings & Support (VX2-10)** | Needs work | Settings/Support live | Branding satellite consolidation |
 | **Global Orders hub** | Not started | Event-scoped only | C-17 hub |
@@ -66,7 +66,7 @@ Success metrics prove outcomes over time; this checklist declares **launch-ready
 | Draft-choice clarity | Ready | Create CTAs through gateway |
 | Commerce jargon impressions | Needs work | Critical paths purged; residual edges |
 | Nav ≤10 | Ready | Sprint 1 Convergence IA |
-| Duplicate surfaces → 1 canonical | Needs work | Messages/Payments good; Analytics/Check-in residual |
+| Duplicate surfaces live | Needs work | Messages/Payments/Analytics converged; Check-in residual |
 | Door Mode task success | Needs work | Pending moderated test |
 | A11y critical on shell + Door Mode | Needs work | Pattern review done; live zero-critical not proven |
 | 403 dead-ends on known P0 | Blocked → Needs work | Partial; C-01/C-02 |
@@ -82,7 +82,7 @@ Success metrics prove outcomes over time; this checklist declares **launch-ready
 | Shell nav matches Convergence IA | Ready |
 | Commerce group renamed; Ticket Product gone on critical UI | Ready |
 | Event Workspace one nav model | Ready |
-| Analytics free pulse without bare deny | Needs work |
+| Analytics free pulse without bare deny | Ready (VX2-08 hub; QA pending) |
 | Door Mode canonical; others redirect | Ready (verify leftovers) |
 
 ---

--- a/docs/product-system/MEL_DESIGN_DEBT.md
+++ b/docs/product-system/MEL_DESIGN_DEBT.md
@@ -22,7 +22,7 @@ Priorities: **Critical** · **High** · **Medium** · **Low**
 
 | ID | Issue | Evidence | Product impact |
 | --- | --- | --- | --- |
-| D-H01 | Analytics still fragmented (Analytics / Insights / Charts) as product surfaces | Convergence MERGE inventory; VX2-08 open | “Where is reporting?” support |
+| D-H01 | Analytics Pro depth / Audience segments / Boost merge still partial after VX2-08 hub | Hub + redirects shipped; P3 depth open | Support may still ask for “full reports” |
 | D-H02 | Parallel interaction shells (modal/drawer/loading owners) | `mel-interaction-authority-audit.md` | Inconsistent focus/confirm behaviour |
 | D-H03 | Global Orders hub not shipped (event-scoped only) | Roadmap C-17; shell Orders disabled without context | Cross-event money findability |
 | D-H04 | Instrumentation pipelines deferred (hubs + attendees + tickets hooks) | VX2-04/05/06/07 notes | Cannot prove success metrics |

--- a/docs/product-system/MEL_PRODUCT_SYSTEM.md
+++ b/docs/product-system/MEL_PRODUCT_SYSTEM.md
@@ -102,10 +102,10 @@ Evidence base: Convergence pack (2026-07-22), Sprint 1–4 + VX2-02A + Event Hom
 
 | What already feels excellent | What still feels inconsistent | What still feels like Drupal | What still feels unfinished |
 | --- | --- | --- | --- |
-| Event Workspace Home composition | Overview/Home naming | Shared Schedule/Venue forms | Analytics product merge (Insights) |
+| Event Workspace Home composition | Overview/Home naming | Shared Schedule/Venue forms | Analytics Pro depth / Audience segments |
 | Layout container intents | Card header treatments | Studio CSS width islands | Global Orders hub |
 | Tickets card + Advanced collapse | Messages/Marketing scan scores (8.4) | Residual Settings payment strings | Instrumentation pipelines |
-| Payments health framing | Interaction shells (modal/drawer owners) | Legacy path grammar | Onboarding celebration depth |
+| Payments + Analytics health framing | Interaction shells (modal/drawer owners) | Legacy path grammar | Onboarding celebration depth |
 | Language purge on critical paths | Empty-state governance coverage gaps | Drupal Form API dialogs in places | C-01/C-02 permission drift follow-up |
 
 ---

--- a/docs/vendor-experience-convergence-implementation-plan.md
+++ b/docs/vendor-experience-convergence-implementation-plan.md
@@ -359,6 +359,18 @@ One Analytics product; free pulse; Pro depth.
 **P1:** Rename Insights→Analytics; free pulse; Pro upgrade screens  
 **P3:** Charts, compare, date filters, Boost metrics, exports centre  
 
+### Status (2026-07-24)
+
+**P1 shipped** on `feature/vx2-analytics`:
+
+- `/vendor/analytics` Event Intelligence Centre (Business Health + Launch Readiness + next action)
+- Free pulse unlocked (no bare 403 on hub)
+- Insights + Export Centre list → redirects into Analytics
+- Pro depth explained in-product; exports remain Pro-gated
+- Docs: `docs/implementation/vx2-08-analytics-hub.md`
+
+**P3 remaining:** deeper charts/compare, Boost metrics merge, audience segments, collector wiring.
+
 ### Dependencies
 
 Gating honesty (C-11); merge insights routes gradually.

--- a/docs/vendor-experience-convergence.md
+++ b/docs/vendor-experience-convergence.md
@@ -198,9 +198,9 @@ Repeat organiser
 | Field | Detail |
 | --- | --- |
 | **Goal** | Know if the event is working |
-| **Questions** | How many sold? Revenue? Refunds? What’s trending? |
-| **Pain points** | Analytics vs Insights vs Charts vs Studio Insights; Pro bare gates |
-| **Current** | `/vendor/analytics`, `/vendor/insights`, event analytics, Studio analytics, charts/exports |
+| **Questions** | How many sold? Revenue? Refunds? What’s trending? Can I run today? |
+| **Pain points** | Pro depth / Audience segments still partial; collector deferred |
+| **Current (2026-07-24)** | `/vendor/analytics` Event Intelligence Centre; Insights/Exports redirect; free pulse |
 | **Ideal** | One Analytics product: free business pulse + Pro depth |
 
 ### 10. Manage attendees

--- a/web/modules/custom/myeventlane_analytics/myeventlane_analytics.info.yml
+++ b/web/modules/custom/myeventlane_analytics/myeventlane_analytics.info.yml
@@ -1,6 +1,6 @@
 name: 'MyEventLane Analytics'
 type: module
-description: 'Comprehensive analytics and reporting for vendors. Provides time-series sales data, conversion funnels, and detailed event analytics.'
+description: 'Organiser Analytics (Event Intelligence Centre) — business health, launch readiness, and per-event performance.'
 package: MyEventLane
 core_version_requirement: ^11
 lifecycle: stable

--- a/web/modules/custom/myeventlane_analytics/myeventlane_analytics.routing.yml
+++ b/web/modules/custom/myeventlane_analytics/myeventlane_analytics.routing.yml
@@ -10,7 +10,7 @@ myeventlane_analytics.admin_revenue:
   options:
     _admin_route: true
 
-# Analytics dashboard.
+# Analytics hub — Event Intelligence Centre (free pulse; Pro depth in UI).
 myeventlane_analytics.dashboard:
   path: '/vendor/analytics'
   defaults:
@@ -18,7 +18,6 @@ myeventlane_analytics.dashboard:
     _title: 'Analytics'
   requirements:
     _custom_access: 'myeventlane_vendor.access.vendor_console:access'
-    _myeventlane_pro_access: 'TRUE'
 
 # Per-event analytics.
 myeventlane_analytics.event:

--- a/web/modules/custom/myeventlane_analytics/myeventlane_analytics.services.yml
+++ b/web/modules/custom/myeventlane_analytics/myeventlane_analytics.services.yml
@@ -23,7 +23,7 @@ services:
     class: Drupal\myeventlane_analytics\Service\ReportGeneratorService
     arguments: ['@entity_type.manager', '@renderer', '@myeventlane_analytics.data']
 
-  # Vendor-wide `/vendor/analytics` view model (TASK 9 — orchestration only).
+  # Vendor-wide `/vendor/analytics` Event Intelligence Centre view model.
   myeventlane_analytics.vendor_view_model_builder:
     class: Drupal\myeventlane_analytics\Service\VendorAnalyticsViewModelBuilder
     arguments:
@@ -40,6 +40,11 @@ services:
       - '@string_translation'
       - '@myeventlane_surface.state_readiness_helper'
       - '@logger.factory'
+      - '@myeventlane_vendor.payments_health'
+      - '@myeventlane_vendor.current_vendor_resolver'
+      - '@?myeventlane_pro.vendor_pro_state'
+      - '@?myeventlane_escalations_refunds.repository'
+      - '@?myeventlane_escalations_refunds.metrics'
 
   # Logger channel for analytics module.
   logger.channel.myeventlane_analytics:

--- a/web/modules/custom/myeventlane_analytics/myeventlane_analytics.services.yml
+++ b/web/modules/custom/myeventlane_analytics/myeventlane_analytics.services.yml
@@ -42,6 +42,7 @@ services:
       - '@logger.factory'
       - '@myeventlane_vendor.payments_health'
       - '@myeventlane_vendor.current_vendor_resolver'
+      - '@config.factory'
       - '@?myeventlane_pro.vendor_pro_state'
       - '@?myeventlane_escalations_refunds.repository'
       - '@?myeventlane_escalations_refunds.metrics'

--- a/web/modules/custom/myeventlane_analytics/src/Controller/AnalyticsConvergenceRedirectController.php
+++ b/web/modules/custom/myeventlane_analytics/src/Controller/AnalyticsConvergenceRedirectController.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_analytics\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * Converges legacy Insights / Charts / Export Centre URLs into Analytics.
+ *
+ * Product name is Analytics. These routes remain as soft redirects only.
+ */
+final class AnalyticsConvergenceRedirectController extends ControllerBase {
+
+  /**
+   * Redirects /vendor/insights → Analytics hub.
+   */
+  public function vendorInsights(): RedirectResponse {
+    return new RedirectResponse(
+      Url::fromRoute('myeventlane_analytics.dashboard')->toString(),
+      302,
+    );
+  }
+
+  /**
+   * Redirects event Insights tabs → Event Workspace Analytics (free pulse).
+   */
+  public function eventInsights(NodeInterface $event): RedirectResponse {
+    return new RedirectResponse(
+      Url::fromRoute('myeventlane_event_studio.workspace_analytics', [
+        'node' => $event->id(),
+      ])->toString(),
+      302,
+    );
+  }
+
+  /**
+   * Redirects Export Centre → Analytics Pro exports section.
+   */
+  public function exportCentre(): RedirectResponse {
+    return new RedirectResponse(
+      Url::fromRoute('myeventlane_analytics.dashboard', [], [
+        'fragment' => 'exports',
+      ])->toString(),
+      302,
+    );
+  }
+
+}

--- a/web/modules/custom/myeventlane_analytics/src/Controller/AnalyticsDashboardController.php
+++ b/web/modules/custom/myeventlane_analytics/src/Controller/AnalyticsDashboardController.php
@@ -79,9 +79,19 @@ final class AnalyticsDashboardController extends VendorConsoleBaseController imp
     $analyticsModel = $this->vendorAnalyticsViewModelBuilder->build($this->currentUser, []);
 
     $cacheTags = ['node_list', 'user:' . $this->currentUser->id()];
-    foreach ($analyticsModel['events'] ?? [] as $row) {
-      if (!empty($row['nid'])) {
-        $cacheTags[] = 'node:' . (int) $row['nid'];
+    $eventNids = $analyticsModel['cache_event_nids'] ?? [];
+    if ($eventNids === []) {
+      // Fallback for older payloads: at least tag visible intelligence rows.
+      foreach ($analyticsModel['events'] ?? [] as $row) {
+        if (!empty($row['nid'])) {
+          $eventNids[] = (int) $row['nid'];
+        }
+      }
+    }
+    foreach ($eventNids as $nid) {
+      $nid = (int) $nid;
+      if ($nid > 0) {
+        $cacheTags[] = 'node:' . $nid;
       }
     }
 

--- a/web/modules/custom/myeventlane_analytics/src/Controller/AnalyticsDashboardController.php
+++ b/web/modules/custom/myeventlane_analytics/src/Controller/AnalyticsDashboardController.php
@@ -92,6 +92,13 @@ final class AnalyticsDashboardController extends VendorConsoleBaseController imp
         '#analytics_model' => $analyticsModel,
         '#summary_stats' => [],
         '#event_analytics' => [],
+        '#attached' => [
+          'drupalSettings' => [
+            'melAnalyticsHub' => [
+              'analytics' => $analyticsModel['analytics'] ?? [],
+            ],
+          ],
+        ],
       ],
       '#attached' => [
         'library' => [
@@ -100,9 +107,10 @@ final class AnalyticsDashboardController extends VendorConsoleBaseController imp
         ],
       ],
       '#cache' => [
-        'contexts' => ['user'],
+        'contexts' => ['user', 'user.permissions'],
         'tags' => $cacheTags,
-        'max-age' => 300,
+        // Hub mixes live refunds + Stripe health flags — keep short-lived.
+        'max-age' => 60,
       ],
     ]);
   }
@@ -270,7 +278,13 @@ final class AnalyticsDashboardController extends VendorConsoleBaseController imp
   /**
    * Builds a URL string when the route exists; no access check.
    *
+   * @param string $routeName
+   *   Route name.
    * @param array<string, mixed> $parameters
+   *   Route parameters.
+   *
+   * @return string|null
+   *   URL string or NULL.
    */
   private function safeUrlString(string $routeName, array $parameters): ?string {
     try {
@@ -284,7 +298,13 @@ final class AnalyticsDashboardController extends VendorConsoleBaseController imp
   /**
    * Export/download URL only when the current user may run the route.
    *
+   * @param string $routeName
+   *   Route name.
    * @param array<string, mixed> $parameters
+   *   Route parameters.
+   *
+   * @return string|null
+   *   URL string or NULL.
    */
   private function safeExportUrl(string $routeName, array $parameters): ?string {
     try {

--- a/web/modules/custom/myeventlane_analytics/src/Service/VendorAnalyticsViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_analytics/src/Service/VendorAnalyticsViewModelBuilder.php
@@ -16,26 +16,31 @@ use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\Core\Url;
 use Drupal\myeventlane_core\Service\EventStateResolver;
 use Drupal\myeventlane_core\Utility\UpcomingEventEntityQueryHelper;
+use Drupal\myeventlane_core\MelReadinessHelper;
+use Drupal\myeventlane_vendor\Entity\Vendor;
+use Drupal\myeventlane_vendor\Service\CurrentVendorResolverInterface;
 use Drupal\myeventlane_vendor\Service\MetricsAggregator;
 use Drupal\myeventlane_vendor\Service\RsvpStatsService;
 use Drupal\myeventlane_vendor\Service\TicketSalesService;
-use Drupal\myeventlane_core\MelReadinessHelper;
 use Drupal\myeventlane_vendor\Service\UserVendorMembershipQuery;
+use Drupal\myeventlane_vendor\Service\VendorPaymentsHealthService;
 use Drupal\node\NodeInterface;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 /**
- * Vendor-wide analytics view model for `/vendor/analytics`.
+ * Organiser Analytics hub view model (Event Intelligence Centre).
  *
- * Orchestrates existing vendor metrics services only (same semantics as TASK 3
- * dashboard: MetricsAggregator → TicketSalesService / RsvpStatsService). Does
- * not duplicate commerce/order queries or Phase 7 analytics SQL.
+ * Orchestrates existing vendor metrics only. Does not invent telemetry or
+ * duplicate Commerce SQL. Free pulse is always available; Pro depth is
+ * value-gated in the UI (never a bare 403 on the hub route).
  */
 final class VendorAnalyticsViewModelBuilder {
 
   use StringTranslationTrait;
 
   private const MAX_EVENTS = 100;
+
+  private const DETAIL_ENRICH_LIMIT = 12;
 
   public function __construct(
     private readonly UserVendorMembershipQuery $userVendorMembershipQuery,
@@ -51,21 +56,25 @@ final class VendorAnalyticsViewModelBuilder {
     TranslationInterface $string_translation,
     private readonly MelReadinessHelper $readinessHelper,
     private readonly LoggerChannelFactoryInterface $loggerFactory,
+    private readonly VendorPaymentsHealthService $paymentsHealth,
+    private readonly CurrentVendorResolverInterface $vendorResolver,
+    private readonly ?object $vendorProState = NULL,
+    private readonly ?object $refundsRepository = NULL,
+    private readonly ?object $refundsMetrics = NULL,
   ) {
     $this->stringTranslation = $string_translation;
   }
 
   /**
-   * Builds the vendor analytics dashboard model.
+   * Builds the Analytics hub model.
    *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Current organiser account.
    * @param array<string, mixed> $filters
-   *   Reserved for future use (e.g. date range keys). Vendor KPI services used
-   *   here are not date-window aware; filters are ignored until those services
-   *   support ranges.
+   *   Reserved for future date-range filters.
    *
    * @return array<string, mixed>
-   *   TASK 9 contract: title, subtitle, date_range, kpis, events, insights,
-   *   empty_state.
+   *   Hub contract for Twig.
    */
   public function build(AccountInterface $account, array $filters = []): array {
     unset($filters);
@@ -74,8 +83,12 @@ final class VendorAnalyticsViewModelBuilder {
       return $this->emptyGuestModel();
     }
 
+    $isPro = $this->vendorProState !== NULL && method_exists($this->vendorProState, 'isPro')
+      ? (bool) $this->vendorProState->isPro()
+      : FALSE;
+
     try {
-      $kpis = $this->buildKpis($uid, $account);
+      $kpis = $this->buildKpis($uid);
     }
     catch (\Throwable $e) {
       $this->loggerFactory->get('myeventlane_analytics')->warning('Vendor analytics KPI build failed for uid @uid: @message', [
@@ -96,33 +109,70 @@ final class VendorAnalyticsViewModelBuilder {
       $events = [];
     }
 
+    $refundPending = $this->countPendingRefunds();
+    $paymentHealth = $this->paymentsHealth->buildForCurrentUser();
+    $launchReadiness = $this->buildLaunchReadiness($events, $paymentHealth, $refundPending);
+    $businessHealth = $this->buildBusinessHealth($kpis, $events, $refundPending, $launchReadiness);
+    $nextAction = $this->buildNextAction($launchReadiness, $businessHealth, $events, $account);
+    $sections = $this->buildSections($kpis, $events, $refundPending, $isPro);
+    $recentActivity = $this->buildRecentActivity($events);
+    $pro = $this->buildProDepth($isPro, $account);
+
+    $this->loggerFactory->get('myeventlane_analytics')->info('analytics_viewed uid=@uid is_pro=@pro events=@count', [
+      '@uid' => (string) $uid,
+      '@pro' => $isPro ? '1' : '0',
+      '@count' => (string) count($events),
+    ]);
+
     return [
       'title' => (string) $this->t('Analytics'),
-      'subtitle' => (string) $this->t('Understand event performance across your organiser account.'),
+      'subtitle' => (string) $this->t('Your Event Intelligence Centre — how your events are performing, and what to do next.'),
+      'eyebrow' => (string) $this->t('Event Intelligence Centre'),
       'date_range' => [
         'active' => 'all',
         'items' => [],
       ],
+      'is_pro' => $isPro,
+      'business_health' => $businessHealth,
+      'launch_readiness' => $launchReadiness,
       'kpis' => $kpis,
+      'sections' => $sections,
       'events' => $events,
+      'top_events' => array_slice($events, 0, 5),
+      'recent_activity' => $recentActivity,
+      'next_action' => $nextAction,
+      'pro' => $pro,
       'insights' => [],
       'empty_state' => $this->buildEmptyState($account, $events === []),
+      'analytics' => [
+        'analytics_viewed' => TRUE,
+        'is_pro' => $isPro,
+      ],
     ];
   }
 
   /**
+   * Builds an empty model for anonymous visitors.
+   *
    * @return array<string, mixed>
+   *   Guest hub payload.
    */
   private function emptyGuestModel(): array {
     return [
       'title' => (string) $this->t('Analytics'),
-      'subtitle' => (string) $this->t('Understand event performance across your organiser account.'),
-      'date_range' => [
-        'active' => 'all',
-        'items' => [],
-      ],
+      'subtitle' => (string) $this->t('Sign in to see how your events are performing.'),
+      'eyebrow' => (string) $this->t('Event Intelligence Centre'),
+      'date_range' => ['active' => 'all', 'items' => []],
+      'is_pro' => FALSE,
+      'business_health' => NULL,
+      'launch_readiness' => NULL,
       'kpis' => [],
+      'sections' => [],
       'events' => [],
+      'top_events' => [],
+      'recent_activity' => [],
+      'next_action' => NULL,
+      'pro' => $this->buildProDepth(FALSE, NULL),
       'insights' => [],
       'empty_state' => [
         'title' => $this->readinessHelper->vendorOrganiserPortalSignInTitle(),
@@ -130,13 +180,20 @@ final class VendorAnalyticsViewModelBuilder {
         'action_label' => NULL,
         'url' => NULL,
       ],
+      'analytics' => ['analytics_viewed' => FALSE],
     ];
   }
 
   /**
+   * Builds the KPI strip for the hub.
+   *
+   * @param int $uid
+   *   Organiser user ID.
+   *
    * @return list<array<string, mixed>>
+   *   KPI cards.
    */
-  private function buildKpis(int $uid, AccountInterface $account): array {
+  private function buildKpis(int $uid): array {
     $strip = $this->metricsAggregator->getVendorKpis($uid);
     $revenueValue = (string) ($strip[2]['value'] ?? '$0.00');
     $rsvpValue = (string) ($strip[1]['value'] ?? '0');
@@ -145,29 +202,26 @@ final class VendorAnalyticsViewModelBuilder {
     $publishedManaged = $this->userVendorMembershipQuery->getManagedEventNodeIds($uid, TRUE);
     $upcoming = $this->countUpcomingPublishedEvents($publishedManaged);
 
-    $contextManaged = (string) $this->t('Published events you manage · completed ticket orders');
-    $contextNetRevenue = (string) $this->t('Net ticket revenue after refunds · completed orders only');
-
     return [
       [
         'key' => 'revenue',
         'label' => (string) $this->t('Revenue'),
         'value' => $revenueValue,
-        'context' => $contextNetRevenue,
+        'context' => (string) $this->t('Ticket sales after refunds'),
         'severity' => 'neutral',
       ],
       [
         'key' => 'tickets_sold',
         'label' => (string) $this->t('Tickets sold'),
         'value' => $ticketsValue,
-        'context' => $contextManaged,
+        'context' => (string) $this->t('Completed ticket orders'),
         'severity' => 'neutral',
       ],
       [
-        'key' => 'rsvps',
-        'label' => (string) $this->t('RSVPs'),
+        'key' => 'attendance',
+        'label' => (string) $this->t('Attendance'),
         'value' => $rsvpValue,
-        'context' => (string) $this->t('Confirmed RSVPs on published events you manage'),
+        'context' => (string) $this->t('Confirmed RSVPs across your events'),
         'severity' => 'neutral',
       ],
       [
@@ -181,44 +235,502 @@ final class VendorAnalyticsViewModelBuilder {
   }
 
   /**
+   * Returns unavailable KPI placeholders after a load failure.
+   *
    * @return list<array<string, mixed>>
+   *   Fallback KPI cards.
    */
   private function fallbackKpis(): array {
     $na = (string) $this->t('Not available yet');
-    return [
-      [
-        'key' => 'revenue',
-        'label' => (string) $this->t('Revenue'),
+    $keys = [
+      'revenue' => (string) $this->t('Revenue'),
+      'tickets_sold' => (string) $this->t('Tickets sold'),
+      'attendance' => (string) $this->t('Attendance'),
+      'upcoming_events' => (string) $this->t('Upcoming events'),
+    ];
+    $out = [];
+    foreach ($keys as $key => $label) {
+      $out[] = [
+        'key' => $key,
+        'label' => $label,
         'value' => $na,
         'context' => (string) $this->t('Metrics could not be loaded. Try again shortly.'),
         'severity' => 'neutral',
-      ],
-      [
-        'key' => 'tickets_sold',
-        'label' => (string) $this->t('Tickets sold'),
-        'value' => $na,
-        'context' => NULL,
-        'severity' => 'neutral',
-      ],
-      [
-        'key' => 'rsvps',
-        'label' => (string) $this->t('RSVPs'),
-        'value' => $na,
-        'context' => NULL,
-        'severity' => 'neutral',
-      ],
-      [
-        'key' => 'upcoming_events',
-        'label' => (string) $this->t('Upcoming events'),
-        'value' => $na,
-        'context' => NULL,
-        'severity' => 'neutral',
+      ];
+    }
+    return $out;
+  }
+
+  /**
+   * Builds the Business Health hero card.
+   *
+   * @param list<array<string, mixed>> $kpis
+   *   KPI strip.
+   * @param list<array<string, mixed>> $events
+   *   Event intelligence rows.
+   * @param int $refundPending
+   *   Pending refund count.
+   * @param array<string, mixed> $launchReadiness
+   *   Launch readiness payload.
+   *
+   * @return array<string, mixed>
+   *   Business health card.
+   */
+  private function buildBusinessHealth(array $kpis, array $events, int $refundPending, array $launchReadiness): array {
+    $byKey = [];
+    foreach ($kpis as $kpi) {
+      $byKey[(string) ($kpi['key'] ?? '')] = $kpi;
+    }
+
+    $attentionItems = [];
+    foreach ($launchReadiness['items'] ?? [] as $item) {
+      if (($item['tone'] ?? '') === 'attention' || ($item['tone'] ?? '') === 'warning') {
+        $attentionItems[] = $item['label'] ?? '';
+      }
+    }
+
+    $tone = 'success';
+    $headline = (string) $this->t('Your business looks healthy');
+    $summary = (string) $this->t('Sales and setup are on track. Keep an eye on upcoming events.');
+
+    if ($events === []) {
+      $tone = 'muted';
+      $headline = (string) $this->t('Ready when you are');
+      $summary = (string) $this->t('Create an event to start seeing sales, attendance, and health here.');
+    }
+    elseif ($attentionItems !== []) {
+      $tone = 'attention';
+      $headline = (string) $this->t('A few things need attention');
+      $summary = (string) $this->t('Fix the items below so you can run your next event with confidence.');
+    }
+    elseif ($refundPending > 0) {
+      $tone = 'attention';
+      $headline = (string) $this->t('Refunds need a quick look');
+      $summary = (string) $this->formatPlural(
+        $refundPending,
+        '1 refund is waiting for your review.',
+        '@count refunds are waiting for your review.',
+      );
+    }
+
+    $trend = (string) $this->t('Snapshot of your organiser account right now');
+
+    return [
+      'tone' => $tone,
+      'question' => (string) $this->t('How is my business performing?'),
+      'headline' => $headline,
+      'summary' => $summary,
+      'trend_label' => $trend,
+      'metrics' => [
+        [
+          'label' => (string) $this->t('Revenue'),
+          'value' => (string) ($byKey['revenue']['value'] ?? '$0.00'),
+        ],
+        [
+          'label' => (string) $this->t('Tickets sold'),
+          'value' => (string) ($byKey['tickets_sold']['value'] ?? '0'),
+        ],
+        [
+          'label' => (string) $this->t('Attendance'),
+          'value' => (string) ($byKey['attendance']['value'] ?? '0'),
+        ],
+        [
+          'label' => (string) $this->t('Upcoming events'),
+          'value' => (string) ($byKey['upcoming_events']['value'] ?? '0'),
+        ],
+        [
+          'label' => (string) $this->t('Refunds to review'),
+          'value' => (string) $refundPending,
+        ],
       ],
     ];
   }
 
   /**
+   * Builds the Launch Readiness operational checklist.
+   *
+   * @param list<array<string, mixed>> $events
+   *   Event intelligence rows.
+   * @param array<string, mixed> $paymentHealth
+   *   Payments health payload.
+   * @param int $refundPending
+   *   Pending refund count.
+   *
+   * @return array<string, mixed>
+   *   Launch readiness card.
+   */
+  private function buildLaunchReadiness(array $events, array $paymentHealth, int $refundPending): array {
+    $ticketsConfigured = FALSE;
+    $doorReady = FALSE;
+    $publishingIssues = 0;
+
+    foreach ($events as $row) {
+      $type = (string) ($row['event_type_key'] ?? 'unknown');
+      if (in_array($type, ['paid', 'rsvp', 'both'], TRUE)) {
+        $ticketsConfigured = TRUE;
+        $doorReady = TRUE;
+      }
+      if (($row['status_key'] ?? '') === 'draft') {
+        $publishingIssues++;
+      }
+    }
+
+    $stripeReady = !empty($paymentHealth['connected']) && empty($paymentHealth['needs_attention']);
+    $stripeTone = $stripeReady ? 'success' : (!empty($paymentHealth['needs_attention']) ? 'attention' : 'muted');
+    $messagesReady = $this->isMessagesBrandConfigured();
+
+    $items = [
+      [
+        'key' => 'tickets',
+        'label' => (string) $this->t('Tickets configured'),
+        'detail' => $ticketsConfigured
+          ? (string) $this->t('At least one event has tickets or RSVP set up.')
+          : (string) $this->t('Add tickets or RSVP so people can register.'),
+        'tone' => $ticketsConfigured ? 'success' : 'attention',
+        'status_label' => $ticketsConfigured ? (string) $this->t('Ready') : (string) $this->t('Needs attention'),
+        'url' => $this->safeUrlFromRoute('myeventlane_vendor.console.events')?->toString(),
+      ],
+      [
+        'key' => 'stripe',
+        'label' => (string) $this->t('Stripe connected'),
+        'detail' => (string) ($paymentHealth['summary'] ?? $this->t('Connect Stripe to get paid for ticket sales.')),
+        'tone' => $stripeTone,
+        'status_label' => $stripeReady
+          ? (string) $this->t('Ready')
+          : (string) ($paymentHealth['verification_status'] ?? $this->t('Needs attention')),
+        'url' => $this->safeUrlFromRoute('myeventlane_vendor.console.payments')?->toString(),
+      ],
+      [
+        'key' => 'messages',
+        'label' => (string) $this->t('Messages ready'),
+        'detail' => $messagesReady
+          ? (string) $this->t('Your sender name is set for attendee updates.')
+          : (string) $this->t('Set your Messages brand so guests know who is writing.'),
+        'tone' => $messagesReady ? 'success' : 'attention',
+        'status_label' => $messagesReady ? (string) $this->t('Ready') : (string) $this->t('Needs attention'),
+        'url' => $this->safeUrlFromRoute('myeventlane_vendor.console.messages')?->toString(),
+      ],
+      [
+        'key' => 'door',
+        'label' => (string) $this->t('Door Mode ready'),
+        'detail' => $doorReady
+          ? (string) $this->t('You can check guests in from Attendees → Door Mode.')
+          : (string) $this->t('Set up tickets or RSVP first, then Door Mode unlocks.'),
+        'tone' => $doorReady ? 'success' : 'muted',
+        'status_label' => $doorReady ? (string) $this->t('Ready') : (string) $this->t('Not yet'),
+        'url' => $this->safeUrlFromRoute('myeventlane_vendor.console.events')?->toString(),
+      ],
+      [
+        'key' => 'refunds',
+        'label' => $refundPending > 0
+          ? (string) $this->formatPlural($refundPending, '@count refund awaiting review', '@count refunds awaiting review')
+          : (string) $this->t('No refunds awaiting review'),
+        'detail' => $refundPending > 0
+          ? (string) $this->t('Review refund requests so guests are not left waiting.')
+          : (string) $this->t('Nothing in the refund queue right now.'),
+        'tone' => $refundPending > 0 ? 'attention' : 'success',
+        'status_label' => $refundPending > 0 ? (string) $this->t('Needs attention') : (string) $this->t('Ready'),
+        'url' => $this->safeUrlFromRoute('myeventlane_vendor.console.payments', [], ['fragment' => 'refunds'])?->toString()
+        ?? $this->safeUrlFromRoute('myeventlane_vendor.console.payments')?->toString(),
+      ],
+      [
+        'key' => 'publishing',
+        'label' => $publishingIssues > 0
+          ? (string) $this->formatPlural($publishingIssues, '@count draft needs publishing review', '@count drafts need publishing review')
+          : (string) $this->t('No publishing issues'),
+        'detail' => $publishingIssues > 0
+          ? (string) $this->t('Finish and publish drafts when you are ready to go live.')
+          : (string) $this->t('No draft events are waiting on you.'),
+        'tone' => $publishingIssues > 0 ? 'attention' : 'success',
+        'status_label' => $publishingIssues > 0 ? (string) $this->t('Needs attention') : (string) $this->t('Ready'),
+        'url' => $this->safeUrlFromRoute('myeventlane_vendor.console.events')?->toString(),
+      ],
+    ];
+
+    $attentionCount = count(array_filter($items, static fn(array $i): bool => ($i['tone'] ?? '') === 'attention'));
+    $tone = $attentionCount > 0 ? 'attention' : ($events === [] ? 'muted' : 'success');
+    $headline = match ($tone) {
+      'attention' => (string) $this->t('Can I successfully run my next event today?'),
+      'muted' => (string) $this->t('Can I successfully run an event today?'),
+      default => (string) $this->t('Yes — you are set up to run events today'),
+    };
+    $summary = match ($tone) {
+      'attention' => (string) $this->t('A few operational checks still need a quick fix.'),
+      'muted' => (string) $this->t('Create your first event to unlock this checklist.'),
+      default => (string) $this->t('Tickets, payments, messages, and door ops look ready.'),
+    };
+
+    return [
+      'tone' => $tone,
+      'question' => (string) $this->t('Can I successfully run this event today?'),
+      'headline' => $headline,
+      'summary' => $summary,
+      'items' => $items,
+      'attention_count' => $attentionCount,
+    ];
+  }
+
+  /**
+   * Builds the next recommended action card.
+   *
+   * @param array<string, mixed> $launchReadiness
+   *   Launch readiness payload.
+   * @param array<string, mixed> $businessHealth
+   *   Business health payload.
+   * @param list<array<string, mixed>> $events
+   *   Event intelligence rows.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Current organiser account.
+   *
+   * @return array<string, mixed>|null
+   *   Next action card or NULL.
+   */
+  private function buildNextAction(array $launchReadiness, array $businessHealth, array $events, AccountInterface $account): ?array {
+    foreach ($launchReadiness['items'] ?? [] as $item) {
+      if (($item['tone'] ?? '') === 'attention' && !empty($item['url'])) {
+        return [
+          'title' => (string) $this->t('Next recommended action'),
+          'body' => (string) ($item['detail'] ?? $item['label']),
+          'cta_label' => (string) ($item['label'] ?? $this->t('Fix this')),
+          'cta_url' => (string) $item['url'],
+          'tone' => 'attention',
+        ];
+      }
+    }
+
+    if ($events === []) {
+      $url = $this->urlIfAccessible($account, 'myeventlane_vendor.create_event_gateway', []);
+      return [
+        'title' => (string) $this->t('Next recommended action'),
+        'body' => (string) $this->t('Create your first event to start gathering sales and attendance insights.'),
+        'cta_label' => (string) $this->t('Create event'),
+        'cta_url' => $url?->toString(),
+        'tone' => 'muted',
+      ];
+    }
+
+    $top = $events[0] ?? NULL;
+    if (is_array($top) && !empty($top['analytics_url'])) {
+      return [
+        'title' => (string) $this->t('Next recommended action'),
+        'body' => (string) $this->t('Review @title — your strongest event right now.', [
+          '@title' => (string) ($top['title'] ?? $this->t('your top event')),
+        ]),
+        'cta_label' => (string) $this->t('Open event analytics'),
+        'cta_url' => (string) $top['analytics_url'],
+        'tone' => 'success',
+      ];
+    }
+
+    return [
+      'title' => (string) $this->t('Next recommended action'),
+      'body' => (string) ($businessHealth['summary'] ?? $this->t('Keep an eye on sales as your next event approaches.')),
+      'cta_label' => NULL,
+      'cta_url' => NULL,
+      'tone' => (string) ($businessHealth['tone'] ?? 'success'),
+    ];
+  }
+
+  /**
+   * Builds Sales / Attendance / Revenue / Marketing / Audience sections.
+   *
+   * @param list<array<string, mixed>> $kpis
+   *   KPI strip.
+   * @param list<array<string, mixed>> $events
+   *   Event intelligence rows.
+   * @param int $refundPending
+   *   Pending refund count.
+   * @param bool $isPro
+   *   Whether the organiser has Pro.
+   *
+   * @return list<array<string, mixed>>
+   *   Section cards.
+   */
+  private function buildSections(array $kpis, array $events, int $refundPending, bool $isPro): array {
+    $byKey = [];
+    foreach ($kpis as $kpi) {
+      $byKey[(string) ($kpi['key'] ?? '')] = $kpi;
+    }
+
+    $capacityTotal = 0;
+    $checkinsTotal = 0;
+    $attendanceTotal = 0;
+    foreach ($events as $row) {
+      $capacityTotal += (int) ($row['capacity_raw'] ?? 0);
+      $checkinsTotal += (int) ($row['checkins_raw'] ?? 0);
+      $attendanceTotal += (int) ($row['attendance_raw'] ?? 0);
+    }
+
+    $boostActive = 0;
+    foreach ($events as $row) {
+      if (!empty($row['boost_active'])) {
+        $boostActive++;
+      }
+    }
+
+    $sections = [
+      [
+        'key' => 'sales',
+        'title' => (string) $this->t('Sales'),
+        'summary' => (string) $this->t('Tickets sold across your events.'),
+        'metrics' => [
+          ['label' => (string) $this->t('Tickets sold'), 'value' => (string) ($byKey['tickets_sold']['value'] ?? '0')],
+          [
+            'label' => (string) $this->t('Events selling'),
+            'value' => (string) count(array_filter(
+              $events,
+              static fn(array $e): bool => ((int) ($e['_sort_tickets'] ?? 0)) > 0,
+            )),
+          ],
+        ],
+        'pro_only' => FALSE,
+      ],
+      [
+        'key' => 'attendance',
+        'title' => (string) $this->t('Attendance'),
+        'summary' => (string) $this->t('Who is coming, and who has checked in.'),
+        'metrics' => [
+          [
+            'label' => (string) $this->t('Guests'),
+            'value' => (string) max(
+              $attendanceTotal,
+              (int) ($byKey['attendance']['value'] ?? 0),
+            ),
+          ],
+          ['label' => (string) $this->t('Check-ins'), 'value' => (string) $checkinsTotal],
+        ],
+        'pro_only' => FALSE,
+      ],
+      [
+        'key' => 'revenue',
+        'title' => (string) $this->t('Revenue'),
+        'summary' => (string) $this->t('Money from ticket sales after refunds.'),
+        'metrics' => [
+          ['label' => (string) $this->t('Revenue'), 'value' => (string) ($byKey['revenue']['value'] ?? '$0.00')],
+          ['label' => (string) $this->t('Refunds to review'), 'value' => (string) $refundPending],
+        ],
+        'pro_only' => FALSE,
+      ],
+      [
+        'key' => 'marketing',
+        'title' => (string) $this->t('Marketing'),
+        'summary' => (string) $this->t('Boost and reach across your events.'),
+        'metrics' => [
+          ['label' => (string) $this->t('Active Boosts'), 'value' => (string) $boostActive],
+        ],
+        'cta_label' => (string) $this->t('Open Marketing'),
+        'cta_url' => $this->safeUrlFromRoute('myeventlane_vendor.console.events')?->toString(),
+        'pro_only' => FALSE,
+      ],
+      [
+        'key' => 'audience',
+        'title' => (string) $this->t('Audience'),
+        'summary' => $isPro
+          ? (string) $this->t('Segment your guests and compare events over time.')
+          : (string) $this->t('See who is engaging with your events. Deeper segments are included in Pro.'),
+        'metrics' => [
+          ['label' => (string) $this->t('Events'), 'value' => (string) count($events)],
+        ],
+        'pro_only' => TRUE,
+        'pro_teaser' => (string) $this->t('Pro unlocks audience segments, longer history, and side-by-side event comparisons.'),
+      ],
+    ];
+
+    if ($capacityTotal > 0) {
+      $sections[0]['metrics'][] = [
+        'label' => (string) $this->t('Capacity tracked'),
+        'value' => (string) $capacityTotal,
+      ];
+    }
+
+    return $sections;
+  }
+
+  /**
+   * Builds the recent activity list from event rows.
+   *
+   * @param list<array<string, mixed>> $events
+   *   Event intelligence rows.
+   *
+   * @return list<array<string, mixed>>
+   *   Recent activity items.
+   */
+  private function buildRecentActivity(array $events): array {
+    $items = [];
+    foreach (array_slice($events, 0, 6) as $row) {
+      $bits = [];
+      if (!empty($row['tickets_label'])) {
+        $bits[] = (string) $row['tickets_label'];
+      }
+      if (!empty($row['rsvp_label'])) {
+        $bits[] = (string) $row['rsvp_label'];
+      }
+      if (!empty($row['revenue_label'])) {
+        $bits[] = (string) $row['revenue_label'];
+      }
+      $items[] = [
+        'title' => (string) ($row['title'] ?? ''),
+        'meta' => implode(' · ', $bits) ?: (string) ($row['status_label'] ?? ''),
+        'status' => (string) ($row['status_label'] ?? ''),
+        'url' => (string) ($row['analytics_url'] ?? $row['workspace_url'] ?? ''),
+      ];
+    }
+    return $items;
+  }
+
+  /**
+   * Builds the Pro depth / exports value card.
+   *
+   * @param bool $isPro
+   *   Whether the organiser has Pro.
+   * @param \Drupal\Core\Session\AccountInterface|null $account
+   *   Current account (reserved).
+   *
+   * @return array<string, mixed>
+   *   Pro depth card.
+   */
+  private function buildProDepth(bool $isPro, ?AccountInterface $account): array {
+    $upgradeUrl = NULL;
+    if ($this->routeExists('myeventlane_pro.overview')) {
+      $upgradeUrl = $this->safeUrlFromRoute('myeventlane_pro.overview')?->toString();
+    }
+    elseif ($this->routeExists('myeventlane_pro.vendor_overview')) {
+      $upgradeUrl = $this->safeUrlFromRoute('myeventlane_pro.vendor_overview')?->toString();
+    }
+
+    return [
+      'is_pro' => $isPro,
+      'title' => $isPro
+        ? (string) $this->t('Pro analytics')
+        : (string) $this->t('Go deeper with Pro'),
+      'body' => $isPro
+        ? (string) $this->t('Exports, longer trends, and comparisons are included with your Pro plan.')
+        : (string) $this->t('Analytics depth is included in Pro — longer trends, comparisons, exports, and advanced segmentation. See what’s included.'),
+      'benefits' => [
+        (string) $this->t('Longer-range trends'),
+        (string) $this->t('Event comparisons'),
+        (string) $this->t('PDF and spreadsheet exports'),
+        (string) $this->t('Advanced audience segments'),
+      ],
+      'cta_label' => $isPro
+        ? (string) $this->t('Open Pro tools')
+        : (string) $this->t('See Pro analytics'),
+      'cta_url' => $upgradeUrl,
+      'export_label' => (string) $this->t('Exports'),
+      'export_body' => $isPro
+        ? (string) $this->t('Download PDF or spreadsheet reports from an event’s Analytics page.')
+        : (string) $this->t('Exports are included in Pro. Upgrade to download PDF and spreadsheet reports.'),
+    ];
+  }
+
+  /**
+   * Counts upcoming published events for the organiser.
+   *
    * @param list<int> $publishedEventIds
+   *   Published managed event node IDs.
+   *
+   * @return int
+   *   Upcoming event count.
    */
   private function countUpcomingPublishedEvents(array $publishedEventIds): int {
     if ($publishedEventIds === []) {
@@ -243,7 +755,15 @@ final class VendorAnalyticsViewModelBuilder {
   }
 
   /**
+   * Builds per-event intelligence rows.
+   *
+   * @param int $uid
+   *   Organiser user ID.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Current organiser account.
+   *
    * @return list<array<string, mixed>>
+   *   Event rows.
    */
   private function buildEventRows(int $uid, AccountInterface $account): array {
     $ids = $this->userVendorMembershipQuery->getManagedEventNodeIds($uid, FALSE);
@@ -274,8 +794,10 @@ final class VendorAnalyticsViewModelBuilder {
     });
 
     $rows = array_slice($rows, 0, self::MAX_EVENTS);
+    $this->enrichTopEventRows($rows);
+
     foreach ($rows as &$row) {
-      unset($row['_sort_tickets'], $row['_sort_rsvps']);
+      unset($row['_sort_tickets'], $row['_sort_rsvps'], $row['_node']);
     }
     unset($row);
 
@@ -283,7 +805,67 @@ final class VendorAnalyticsViewModelBuilder {
   }
 
   /**
+   * Enriches the strongest events with check-in / capacity / boost signals.
+   *
+   * @param list<array<string, mixed>> $rows
+   *   Event rows (modified in place).
+   */
+  private function enrichTopEventRows(array &$rows): void {
+    $limit = min(self::DETAIL_ENRICH_LIMIT, count($rows));
+    for ($i = 0; $i < $limit; $i++) {
+      $node = $rows[$i]['_node'] ?? NULL;
+      if (!$node instanceof NodeInterface) {
+        continue;
+      }
+      try {
+        $overview = $this->metricsAggregator->getEventOverview($node);
+        $capacity = (int) ($overview['capacity']['total'] ?? 0);
+        $attendees = (int) ($overview['attendees']['total'] ?? 0);
+        $checkins = (int) ($overview['attendees']['checked_in'] ?? 0);
+        $rate = $overview['attendees']['check_in_rate'] ?? NULL;
+        $boostActive = !empty($overview['boost']['active']);
+
+        if ($capacity > 0) {
+          $rows[$i]['capacity_label'] = (string) $this->t('@count capacity', ['@count' => $capacity]);
+          $rows[$i]['capacity_raw'] = $capacity;
+        }
+        if ($attendees > 0) {
+          $rows[$i]['attendance_label'] = (string) $this->t('@count guests', ['@count' => $attendees]);
+          $rows[$i]['attendance_raw'] = $attendees;
+        }
+        if ($checkins > 0 || $attendees > 0) {
+          $rows[$i]['checkins_label'] = (string) $this->t('@count checked in', ['@count' => $checkins]);
+          $rows[$i]['checkins_raw'] = $checkins;
+        }
+        if (is_numeric($rate)) {
+          $rows[$i]['checkin_rate_label'] = (string) $this->t('@rate% checked in', [
+            '@rate' => (string) round((float) $rate, 0),
+          ]);
+        }
+        $rows[$i]['boost_active'] = $boostActive;
+        $rows[$i]['marketing_label'] = $boostActive
+          ? (string) $this->t('Boost running')
+          : (string) $this->t('No active Boost');
+      }
+      catch (\Throwable $e) {
+        $this->loggerFactory->get('myeventlane_analytics')->warning('Event overview enrich failed for nid @nid: @message', [
+          '@nid' => (string) $node->id(),
+          '@message' => $e->getMessage(),
+        ]);
+      }
+    }
+  }
+
+  /**
+   * Builds one event intelligence row.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   Event node.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Current organiser account.
+   *
    * @return array<string, mixed>
+   *   Event row payload.
    */
   private function buildEventRow(NodeInterface $node, AccountInterface $account): array {
     $nid = (int) $node->id();
@@ -293,12 +875,15 @@ final class VendorAnalyticsViewModelBuilder {
     $now = (int) $this->time->getRequestTime();
 
     if (!$published) {
+      $statusKey = 'draft';
       $statusLabel = (string) $this->t('Draft');
     }
     elseif ($endTs > 0 && $endTs < $now) {
+      $statusKey = 'past';
       $statusLabel = (string) $this->t('Past');
     }
     else {
+      $statusKey = 'upcoming';
       $statusLabel = (string) $this->t('Upcoming');
     }
 
@@ -342,7 +927,12 @@ final class VendorAnalyticsViewModelBuilder {
     }
 
     $ticketsSold = (int) ($salesSummary['tickets_sold'] ?? 0);
-    $revenueLabel = isset($salesSummary['gross']) ? (string) $salesSummary['gross'] : NULL;
+    $capacity = (int) ($salesSummary['tickets_available'] ?? 0);
+    $revenueLabel = isset($salesSummary['net']) ? (string) $salesSummary['net'] : ($salesSummary['gross'] ?? NULL);
+    $refundLabel = NULL;
+    if (!empty($salesSummary['refunded']) && ($salesSummary['refunded'] ?? '$0.00') !== '$0.00') {
+      $refundLabel = (string) $salesSummary['refunded'];
+    }
     $ticketsLabel = $ticketsSold > 0
       ? (string) $this->t('@count sold', ['@count' => $ticketsSold])
       : NULL;
@@ -362,26 +952,60 @@ final class VendorAnalyticsViewModelBuilder {
       ? (string) $this->t('@count RSVPs', ['@count' => $rsvpCount])
       : NULL;
 
-    $analyticsUrl = $this->urlIfAccessible($account, 'myeventlane_vendor.console.event_analytics', ['event' => $nid]);
+    $healthTone = 'success';
+    if ($statusKey === 'draft') {
+      $healthTone = 'attention';
+    }
+    elseif ($ticketsSold === 0 && $rsvpCount === 0 && $statusKey === 'upcoming' && $published) {
+      $healthTone = 'muted';
+    }
+
+    $analyticsUrl = $this->urlIfAccessible($account, 'myeventlane_event_studio.workspace_analytics', ['node' => $nid]);
+    $deepAnalyticsUrl = $this->urlIfAccessible($account, 'myeventlane_analytics.event', ['node' => $nid]);
     $workspaceUrl = $this->urlIfAccessible($account, 'myeventlane_vendor.console.event_workspace', ['event' => $nid]);
 
     return [
       'nid' => $nid,
       'title' => (string) $node->getTitle(),
+      'status_key' => $statusKey,
       'status_label' => $statusLabel,
+      'health_tone' => $healthTone,
       'date_label' => $dateLabel,
+      'event_type_key' => $eventTypeKey,
       'event_type_label' => $eventTypeLabel,
-      'revenue_label' => $revenueLabel,
+      'revenue_label' => $revenueLabel ? (string) $revenueLabel : NULL,
       'tickets_label' => $ticketsLabel,
+      'capacity_label' => $capacity > 0 ? (string) $this->t('@count capacity', ['@count' => $capacity]) : NULL,
+      'capacity_raw' => $capacity,
+      'attendance_label' => $rsvpLabel,
+      'attendance_raw' => $rsvpCount + $ticketsSold,
+      'checkins_label' => NULL,
+      'checkins_raw' => 0,
+      'refunds_label' => $refundLabel,
+      'marketing_label' => NULL,
+      'boost_active' => FALSE,
       'rsvp_label' => $rsvpLabel,
       'conversion_label' => NULL,
-      'analytics_url' => $analyticsUrl,
-      'workspace_url' => $workspaceUrl,
+      'analytics_url' => $analyticsUrl?->toString(),
+      'deep_analytics_url' => $deepAnalyticsUrl?->toString(),
+      'workspace_url' => $workspaceUrl?->toString(),
       '_sort_tickets' => $ticketsSold,
       '_sort_rsvps' => $rsvpCount,
+      '_node' => $node,
     ];
   }
 
+  /**
+   * Reads a datetime field timestamp from an event node.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   Event node.
+   * @param string $field
+   *   Field machine name.
+   *
+   * @return int
+   *   Unix timestamp or 0.
+   */
   private function getDateFieldTimestamp(NodeInterface $node, string $field): int {
     if (!$node->hasField($field) || $node->get($field)->isEmpty()) {
       return 0;
@@ -394,7 +1018,73 @@ final class VendorAnalyticsViewModelBuilder {
   }
 
   /**
+   * Counts refund requests awaiting organiser review.
+   *
+   * @return int
+   *   Pending refund count.
+   */
+  private function countPendingRefunds(): int {
+    if ($this->refundsRepository === NULL
+      || $this->refundsMetrics === NULL
+      || !method_exists($this->refundsRepository, 'findVendorSummary')
+      || !method_exists($this->refundsMetrics, 'calculateForVendor')) {
+      return 0;
+    }
+    try {
+      $vendor = $this->vendorResolver->resolveFromCurrentUser();
+      $owner = $vendor?->getOwner();
+      if (!$owner) {
+        return 0;
+      }
+      $data = $this->refundsRepository->findVendorSummary((int) $owner->id(), 90);
+      $metrics = $this->refundsMetrics->calculateForVendor($data['logs'] ?? [], $data['requests'] ?? []);
+      $byRequest = $metrics['requests_by_status'] ?? [];
+      return (int) ($byRequest['requested'] ?? 0) + (int) ($byRequest['pending'] ?? 0);
+    }
+    catch (\Throwable $e) {
+      $this->loggerFactory->get('myeventlane_analytics')->warning('Analytics pending refunds failed: @message', [
+        '@message' => $e->getMessage(),
+      ]);
+      return 0;
+    }
+  }
+
+  /**
+   * Whether the organiser Messages brand has a sender name.
+   *
+   * @return bool
+   *   TRUE when a sender name is available.
+   */
+  private function isMessagesBrandConfigured(): bool {
+    try {
+      $vendor = $this->vendorResolver->resolveFromCurrentUser();
+      if (!$vendor instanceof Vendor) {
+        return FALSE;
+      }
+      $from = '';
+      if ($vendor->hasField('field_msg_from_name') && !$vendor->get('field_msg_from_name')->isEmpty()) {
+        $from = trim((string) $vendor->get('field_msg_from_name')->value);
+      }
+      if ($from === '') {
+        $from = trim((string) ($vendor->getName() ?? ''));
+      }
+      return $from !== '';
+    }
+    catch (\Throwable) {
+      return FALSE;
+    }
+  }
+
+  /**
+   * Builds the empty state when the organiser has no events.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Current organiser account.
+   * @param bool $noEvents
+   *   TRUE when there are no event rows.
+   *
    * @return array<string, string|\Drupal\Core\Url|null>
+   *   Empty state payload.
    */
   private function buildEmptyState(AccountInterface $account, bool $noEvents): array {
     if (!$noEvents) {
@@ -407,9 +1097,7 @@ final class VendorAnalyticsViewModelBuilder {
     }
 
     $copy = $this->readinessHelper->vendorActionNoEventsStrings();
-    $actionLabel = $copy['action_label'];
     $url = NULL;
-
     if ($this->routeExists('myeventlane_vendor.create_event_gateway')) {
       try {
         if ($this->accessManager->checkNamedRoute('myeventlane_vendor.create_event_gateway', [], $account, TRUE)->isAllowed()) {
@@ -424,15 +1112,27 @@ final class VendorAnalyticsViewModelBuilder {
     return [
       'title' => $copy['title'],
       'message' => $copy['message'],
-      'action_label' => $actionLabel,
+      'action_label' => $copy['action_label'],
       'url' => $url,
     ];
   }
 
   /**
+   * Builds a route URL when the account may access it.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Current account.
+   * @param string $route
+   *   Route name.
    * @param array<string, mixed> $parameters
+   *   Route parameters.
+   * @param array<string, mixed> $options
+   *   URL options.
+   *
+   * @return \Drupal\Core\Url|null
+   *   URL or NULL.
    */
-  private function urlIfAccessible(AccountInterface $account, string $route, array $parameters): ?Url {
+  private function urlIfAccessible(AccountInterface $account, string $route, array $parameters, array $options = []): ?Url {
     if (!$this->routeExists($route)) {
       return NULL;
     }
@@ -444,11 +1144,21 @@ final class VendorAnalyticsViewModelBuilder {
     catch (\Throwable) {
       return NULL;
     }
-    return $this->safeUrlFromRoute($route, $parameters);
+    return $this->safeUrlFromRoute($route, $parameters, $options);
   }
 
   /**
+   * Builds a route URL without an access check.
+   *
+   * @param string $route
+   *   Route name.
    * @param array<string, mixed> $parameters
+   *   Route parameters.
+   * @param array<string, mixed> $options
+   *   URL options.
+   *
+   * @return \Drupal\Core\Url|null
+   *   URL or NULL.
    */
   private function safeUrlFromRoute(string $route, array $parameters = [], array $options = []): ?Url {
     if (!$this->routeExists($route)) {
@@ -466,6 +1176,15 @@ final class VendorAnalyticsViewModelBuilder {
     }
   }
 
+  /**
+   * Checks whether a route name is registered.
+   *
+   * @param string $name
+   *   Route name.
+   *
+   * @return bool
+   *   TRUE if the route exists.
+   */
   private function routeExists(string $name): bool {
     try {
       $this->routeProvider->getRouteByName($name);

--- a/web/modules/custom/myeventlane_analytics/src/Service/VendorAnalyticsViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_analytics/src/Service/VendorAnalyticsViewModelBuilder.php
@@ -6,6 +6,7 @@ namespace Drupal\myeventlane_analytics\Service;
 
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Access\AccessManagerInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
@@ -58,6 +59,7 @@ final class VendorAnalyticsViewModelBuilder {
     private readonly LoggerChannelFactoryInterface $loggerFactory,
     private readonly VendorPaymentsHealthService $paymentsHealth,
     private readonly CurrentVendorResolverInterface $vendorResolver,
+    private readonly ConfigFactoryInterface $configFactory,
     private readonly ?object $vendorProState = NULL,
     private readonly ?object $refundsRepository = NULL,
     private readonly ?object $refundsMetrics = NULL,
@@ -1063,7 +1065,10 @@ final class VendorAnalyticsViewModelBuilder {
   }
 
   /**
-   * Counts refund requests awaiting organiser review.
+   * Counts in-flight refunds awaiting organiser / Stripe action.
+   *
+   * Matches VendorPaymentsHubBuilder::buildRefundsSection() so Analytics and
+   * Payments agree on pending volume and summary window.
    *
    * @return int
    *   Pending refund count.
@@ -1081,10 +1086,19 @@ final class VendorAnalyticsViewModelBuilder {
       if (!$owner) {
         return 0;
       }
-      $data = $this->refundsRepository->findVendorSummary((int) $owner->id(), 90);
+      $windowDays = $this->resolveRefundSummaryWindowDays();
+      $data = $this->refundsRepository->findVendorSummary((int) $owner->id(), $windowDays);
       $metrics = $this->refundsMetrics->calculateForVendor($data['logs'] ?? [], $data['requests'] ?? []);
       $byRequest = $metrics['requests_by_status'] ?? [];
-      return (int) ($byRequest['requested'] ?? 0) + (int) ($byRequest['pending'] ?? 0);
+      $byLog = $metrics['logs_by_status'] ?? [];
+      // Buyer requests default to "requested" (awaiting organiser action).
+      // "approved" means still in flight until Stripe completes.
+      return (int) (
+        ($byRequest['requested'] ?? 0)
+        + ($byRequest['pending'] ?? 0)
+        + ($byRequest['approved'] ?? 0)
+        + ($byLog['pending'] ?? 0)
+      );
     }
     catch (\Throwable $e) {
       $this->loggerFactory->get('myeventlane_analytics')->warning('Analytics pending refunds failed: @message', [
@@ -1092,6 +1106,19 @@ final class VendorAnalyticsViewModelBuilder {
       ]);
       return 0;
     }
+  }
+
+  /**
+   * Resolves the refund summary window used by Payments hub / refund activity.
+   *
+   * @return int
+   *   Positive window days (defaults to 90).
+   */
+  private function resolveRefundSummaryWindowDays(): int {
+    $days = (int) ($this->configFactory
+      ->get('myeventlane_escalations_refunds.settings')
+      ->get('vendor_summary_window_days') ?? 90);
+    return $days > 0 ? $days : 90;
   }
 
   /**

--- a/web/modules/custom/myeventlane_analytics/src/Service/VendorAnalyticsViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_analytics/src/Service/VendorAnalyticsViewModelBuilder.php
@@ -98,8 +98,14 @@ final class VendorAnalyticsViewModelBuilder {
       $kpis = $this->fallbackKpis();
     }
 
+    $readinessSignals = [
+      'tickets_configured' => FALSE,
+      'door_ready' => FALSE,
+      'publishing_issues' => 0,
+      'event_count' => 0,
+    ];
     try {
-      $events = $this->buildEventRows($uid, $account);
+      [$events, $readinessSignals] = $this->buildEventRows($uid, $account);
     }
     catch (\Throwable $e) {
       $this->loggerFactory->get('myeventlane_analytics')->warning('Vendor analytics event rows failed for uid @uid: @message', [
@@ -111,7 +117,7 @@ final class VendorAnalyticsViewModelBuilder {
 
     $refundPending = $this->countPendingRefunds();
     $paymentHealth = $this->paymentsHealth->buildForCurrentUser();
-    $launchReadiness = $this->buildLaunchReadiness($events, $paymentHealth, $refundPending);
+    $launchReadiness = $this->buildLaunchReadiness($readinessSignals, $paymentHealth, $refundPending);
     $businessHealth = $this->buildBusinessHealth($kpis, $events, $refundPending, $launchReadiness);
     $nextAction = $this->buildNextAction($launchReadiness, $businessHealth, $events, $account);
     $sections = $this->buildSections($kpis, $events, $refundPending, $isPro);
@@ -349,8 +355,11 @@ final class VendorAnalyticsViewModelBuilder {
   /**
    * Builds the Launch Readiness operational checklist.
    *
-   * @param list<array<string, mixed>> $events
-   *   Event intelligence rows.
+   * Tickets / Door / publishing signals come from all managed events (not the
+   * sales-sorted intelligence rows capped at MAX_EVENTS).
+   *
+   * @param array{tickets_configured: bool, door_ready: bool, publishing_issues: int, event_count: int} $signals
+   *   Catalogue-wide readiness signals.
    * @param array<string, mixed> $paymentHealth
    *   Payments health payload.
    * @param int $refundPending
@@ -359,21 +368,11 @@ final class VendorAnalyticsViewModelBuilder {
    * @return array<string, mixed>
    *   Launch readiness card.
    */
-  private function buildLaunchReadiness(array $events, array $paymentHealth, int $refundPending): array {
-    $ticketsConfigured = FALSE;
-    $doorReady = FALSE;
-    $publishingIssues = 0;
-
-    foreach ($events as $row) {
-      $type = (string) ($row['event_type_key'] ?? 'unknown');
-      if (in_array($type, ['paid', 'rsvp', 'both'], TRUE)) {
-        $ticketsConfigured = TRUE;
-        $doorReady = TRUE;
-      }
-      if (($row['status_key'] ?? '') === 'draft') {
-        $publishingIssues++;
-      }
-    }
+  private function buildLaunchReadiness(array $signals, array $paymentHealth, int $refundPending): array {
+    $ticketsConfigured = !empty($signals['tickets_configured']);
+    $doorReady = !empty($signals['door_ready']);
+    $publishingIssues = (int) ($signals['publishing_issues'] ?? 0);
+    $eventCount = (int) ($signals['event_count'] ?? 0);
 
     $stripeReady = !empty($paymentHealth['connected']) && empty($paymentHealth['needs_attention']);
     $stripeTone = $stripeReady ? 'success' : (!empty($paymentHealth['needs_attention']) ? 'attention' : 'muted');
@@ -448,7 +447,7 @@ final class VendorAnalyticsViewModelBuilder {
     ];
 
     $attentionCount = count(array_filter($items, static fn(array $i): bool => ($i['tone'] ?? '') === 'attention'));
-    $tone = $attentionCount > 0 ? 'attention' : ($events === [] ? 'muted' : 'success');
+    $tone = $attentionCount > 0 ? 'attention' : ($eventCount === 0 ? 'muted' : 'success');
     $headline = match ($tone) {
       'attention' => (string) $this->t('Can I successfully run my next event today?'),
       'muted' => (string) $this->t('Can I successfully run an event today?'),
@@ -755,20 +754,31 @@ final class VendorAnalyticsViewModelBuilder {
   }
 
   /**
-   * Builds per-event intelligence rows.
+   * Builds per-event intelligence rows and catalogue-wide readiness signals.
+   *
+   * Readiness signals are computed from every managed event before the
+   * sales-sorted MAX_EVENTS cap, so low-activity drafts still affect
+   * publishing / tickets / Door Mode checks.
    *
    * @param int $uid
    *   Organiser user ID.
    * @param \Drupal\Core\Session\AccountInterface $account
    *   Current organiser account.
    *
-   * @return list<array<string, mixed>>
-   *   Event rows.
+   * @return array{0: list<array<string, mixed>>, 1: array{tickets_configured: bool, door_ready: bool, publishing_issues: int, event_count: int}}
+   *   Capped intelligence rows plus full-catalogue readiness signals.
    */
   private function buildEventRows(int $uid, AccountInterface $account): array {
+    $emptySignals = [
+      'tickets_configured' => FALSE,
+      'door_ready' => FALSE,
+      'publishing_issues' => 0,
+      'event_count' => 0,
+    ];
+
     $ids = $this->userVendorMembershipQuery->getManagedEventNodeIds($uid, FALSE);
     if ($ids === []) {
-      return [];
+      return [[], $emptySignals];
     }
 
     $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($ids);
@@ -783,6 +793,8 @@ final class VendorAnalyticsViewModelBuilder {
     foreach ($eventNodes as $node) {
       $rows[] = $this->buildEventRow($node, $account);
     }
+
+    $signals = $this->summariseReadinessSignals($rows);
 
     usort($rows, static function (array $a, array $b): int {
       $scoreA = (int) ($a['_sort_tickets'] ?? 0) + (int) ($a['_sort_rsvps'] ?? 0);
@@ -801,7 +813,40 @@ final class VendorAnalyticsViewModelBuilder {
     }
     unset($row);
 
-    return $rows;
+    return [$rows, $signals];
+  }
+
+  /**
+   * Summarises Launch Readiness signals from the full event-row set.
+   *
+   * @param list<array<string, mixed>> $rows
+   *   Uncapped event rows (before MAX_EVENTS slice).
+   *
+   * @return array{tickets_configured: bool, door_ready: bool, publishing_issues: int, event_count: int}
+   *   Catalogue-wide readiness signals.
+   */
+  private function summariseReadinessSignals(array $rows): array {
+    $ticketsConfigured = FALSE;
+    $doorReady = FALSE;
+    $publishingIssues = 0;
+
+    foreach ($rows as $row) {
+      $type = (string) ($row['event_type_key'] ?? 'unknown');
+      if (in_array($type, ['paid', 'rsvp', 'both'], TRUE)) {
+        $ticketsConfigured = TRUE;
+        $doorReady = TRUE;
+      }
+      if (($row['status_key'] ?? '') === 'draft') {
+        $publishingIssues++;
+      }
+    }
+
+    return [
+      'tickets_configured' => $ticketsConfigured,
+      'door_ready' => $doorReady,
+      'publishing_issues' => $publishingIssues,
+      'event_count' => count($rows),
+    ];
   }
 
   /**

--- a/web/modules/custom/myeventlane_analytics/src/Service/VendorAnalyticsViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_analytics/src/Service/VendorAnalyticsViewModelBuilder.php
@@ -204,8 +204,11 @@ final class VendorAnalyticsViewModelBuilder {
   private function buildKpis(int $uid): array {
     $strip = $this->metricsAggregator->getVendorKpis($uid);
     $revenueValue = (string) ($strip[2]['value'] ?? '$0.00');
-    $rsvpValue = (string) ($strip[1]['value'] ?? '0');
-    $ticketsValue = (string) ($strip[3]['value'] ?? '0');
+    $rsvpCount = (int) ($strip[1]['value'] ?? 0);
+    $ticketsSold = (int) ($strip[3]['value'] ?? 0);
+    $ticketsValue = (string) $ticketsSold;
+    // Attendance = ticket holders + confirmed RSVPs (same composition as event rows).
+    $attendanceValue = (string) ($ticketsSold + $rsvpCount);
 
     $publishedManaged = $this->userVendorMembershipQuery->getManagedEventNodeIds($uid, TRUE);
     $upcoming = $this->countUpcomingPublishedEvents($publishedManaged);
@@ -228,8 +231,8 @@ final class VendorAnalyticsViewModelBuilder {
       [
         'key' => 'attendance',
         'label' => (string) $this->t('Attendance'),
-        'value' => $rsvpValue,
-        'context' => (string) $this->t('Confirmed RSVPs across your events'),
+        'value' => $attendanceValue,
+        'context' => (string) $this->t('Ticket holders and confirmed RSVPs'),
         'severity' => 'neutral',
       ],
       [
@@ -301,12 +304,7 @@ final class VendorAnalyticsViewModelBuilder {
     $headline = (string) $this->t('Your business looks healthy');
     $summary = (string) $this->t('Sales and setup are on track. Keep an eye on upcoming events.');
 
-    if ($events === []) {
-      $tone = 'muted';
-      $headline = (string) $this->t('Ready when you are');
-      $summary = (string) $this->t('Create an event to start seeing sales, attendance, and health here.');
-    }
-    elseif ($attentionItems !== []) {
+    if ($attentionItems !== []) {
       $tone = 'attention';
       $headline = (string) $this->t('A few things need attention');
       $summary = (string) $this->t('Fix the items below so you can run your next event with confidence.');
@@ -319,6 +317,11 @@ final class VendorAnalyticsViewModelBuilder {
         '1 refund is waiting for your review.',
         '@count refunds are waiting for your review.',
       );
+    }
+    elseif ($events === []) {
+      $tone = 'muted';
+      $headline = (string) $this->t('Ready when you are');
+      $summary = (string) $this->t('Create an event to start seeing sales, attendance, and health here.');
     }
 
     $trend = (string) $this->t('Snapshot of your organiser account right now');
@@ -580,7 +583,7 @@ final class VendorAnalyticsViewModelBuilder {
             'label' => (string) $this->t('Events selling'),
             'value' => (string) count(array_filter(
               $events,
-              static fn(array $e): bool => ((int) ($e['_sort_tickets'] ?? 0)) > 0,
+              static fn(array $e): bool => ((int) ($e['tickets_sold_raw'] ?? 0)) > 0,
             )),
           ],
         ],
@@ -999,6 +1002,20 @@ final class VendorAnalyticsViewModelBuilder {
       ? (string) $this->t('@count RSVPs', ['@count' => $rsvpCount])
       : NULL;
 
+    $attendanceTotal = $rsvpCount + $ticketsSold;
+    $attendanceLabel = NULL;
+    if ($attendanceTotal > 0) {
+      if ($ticketsSold > 0 && $rsvpCount > 0) {
+        $attendanceLabel = (string) $this->t('@count guests', ['@count' => $attendanceTotal]);
+      }
+      elseif ($ticketsSold > 0) {
+        $attendanceLabel = (string) $this->t('@count ticket holders', ['@count' => $ticketsSold]);
+      }
+      else {
+        $attendanceLabel = $rsvpLabel;
+      }
+    }
+
     $healthTone = 'success';
     if ($statusKey === 'draft') {
       $healthTone = 'attention';
@@ -1022,10 +1039,11 @@ final class VendorAnalyticsViewModelBuilder {
       'event_type_label' => $eventTypeLabel,
       'revenue_label' => $revenueLabel ? (string) $revenueLabel : NULL,
       'tickets_label' => $ticketsLabel,
+      'tickets_sold_raw' => $ticketsSold,
       'capacity_label' => $capacity > 0 ? (string) $this->t('@count capacity', ['@count' => $capacity]) : NULL,
       'capacity_raw' => $capacity,
-      'attendance_label' => $rsvpLabel,
-      'attendance_raw' => $rsvpCount + $ticketsSold,
+      'attendance_label' => $attendanceLabel,
+      'attendance_raw' => $attendanceTotal,
       'checkins_label' => NULL,
       'checkins_raw' => 0,
       'refunds_label' => $refundLabel,

--- a/web/modules/custom/myeventlane_analytics/src/Service/VendorAnalyticsViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_analytics/src/Service/VendorAnalyticsViewModelBuilder.php
@@ -108,9 +108,12 @@ final class VendorAnalyticsViewModelBuilder {
       'load_failed' => FALSE,
     ];
     $eventsLoadFailed = FALSE;
-    $checkinsCatalogueTotal = 0;
+    $cataloguePulse = [
+      'checkins_total' => 0,
+      'boosts_active' => 0,
+    ];
     try {
-      [$events, $readinessSignals, $checkinsCatalogueTotal] = $this->buildEventRows($uid, $account);
+      [$events, $readinessSignals, $cataloguePulse] = $this->buildEventRows($uid, $account);
     }
     catch (\Throwable $e) {
       $this->loggerFactory->get('myeventlane_analytics')->warning('Vendor analytics event rows failed for uid @uid: @message', [
@@ -120,7 +123,7 @@ final class VendorAnalyticsViewModelBuilder {
       $events = [];
       $eventsLoadFailed = TRUE;
       $readinessSignals['load_failed'] = TRUE;
-      $checkinsCatalogueTotal = NULL;
+      $cataloguePulse = NULL;
     }
 
     $refundPending = $this->countPendingRefunds();
@@ -128,7 +131,7 @@ final class VendorAnalyticsViewModelBuilder {
     $launchReadiness = $this->buildLaunchReadiness($readinessSignals, $paymentHealth, $refundPending);
     $businessHealth = $this->buildBusinessHealth($kpis, $events, $refundPending, $launchReadiness);
     $nextAction = $this->buildNextAction($launchReadiness, $businessHealth, $events, $account);
-    $sections = $this->buildSections($kpis, $events, $refundPending, $isPro, $checkinsCatalogueTotal);
+    $sections = $this->buildSections($kpis, $events, $refundPending, $isPro, $cataloguePulse);
     $recentActivity = $this->buildRecentActivity($events);
     $pro = $this->buildProDepth($isPro, $account);
 
@@ -591,14 +594,14 @@ final class VendorAnalyticsViewModelBuilder {
    *   Pending refund count.
    * @param bool $isPro
    *   Whether the organiser has Pro.
-   * @param int|null $checkinsCatalogueTotal
-   *   Catalogue-wide checked-in total (all managed events). NULL when unavailable
+   * @param array{checkins_total?: int, boosts_active?: int}|null $cataloguePulse
+   *   Catalogue-wide pulse totals (all managed events). NULL when unavailable
    *   (e.g. event rows failed to load).
    *
    * @return list<array<string, mixed>>
    *   Section cards.
    */
-  private function buildSections(array $kpis, array $events, int $refundPending, bool $isPro, ?int $checkinsCatalogueTotal = NULL): array {
+  private function buildSections(array $kpis, array $events, int $refundPending, bool $isPro, ?array $cataloguePulse = NULL): array {
     $byKey = [];
     foreach ($kpis as $kpi) {
       $byKey[(string) ($kpi['key'] ?? '')] = $kpi;
@@ -612,16 +615,19 @@ final class VendorAnalyticsViewModelBuilder {
       $checkinsTotal += (int) ($row['checkins_raw'] ?? 0);
       $attendanceTotal += (int) ($row['attendance_raw'] ?? 0);
     }
-    // Hub Check-ins must cover every managed event, not only DETAIL_ENRICH_LIMIT rows.
-    if ($checkinsCatalogueTotal !== NULL) {
-      $checkinsTotal = $checkinsCatalogueTotal;
-    }
 
     $boostActive = 0;
     foreach ($events as $row) {
       if (!empty($row['boost_active'])) {
         $boostActive++;
       }
+    }
+
+    // Hub Check-ins / Active Boosts must cover every managed event, not only
+    // DETAIL_ENRICH_LIMIT rows from enrichTopEventRows().
+    if ($cataloguePulse !== NULL) {
+      $checkinsTotal = (int) ($cataloguePulse['checkins_total'] ?? $checkinsTotal);
+      $boostActive = (int) ($cataloguePulse['boosts_active'] ?? $boostActive);
     }
 
     $sections = [
@@ -822,9 +828,9 @@ final class VendorAnalyticsViewModelBuilder {
    * @param \Drupal\Core\Session\AccountInterface $account
    *   Current organiser account.
    *
-   * @return array{0: list<array<string, mixed>>, 1: array{tickets_configured: bool, door_ready: bool, publishing_issues: int, event_count: int, load_failed?: bool}, 2: int}
+   * @return array{0: list<array<string, mixed>>, 1: array{tickets_configured: bool, door_ready: bool, publishing_issues: int, event_count: int, load_failed?: bool}, 2: array{checkins_total: int, boosts_active: int}}
    *   Capped intelligence rows, full-catalogue readiness signals, and
-   *   catalogue-wide checked-in total.
+   *   catalogue-wide Attendance / Marketing pulse totals.
    */
   private function buildEventRows(int $uid, AccountInterface $account): array {
     $emptySignals = [
@@ -834,10 +840,14 @@ final class VendorAnalyticsViewModelBuilder {
       'event_count' => 0,
       'load_failed' => FALSE,
     ];
+    $emptyPulse = [
+      'checkins_total' => 0,
+      'boosts_active' => 0,
+    ];
 
     $ids = $this->userVendorMembershipQuery->getManagedEventNodeIds($uid, FALSE);
     if ($ids === []) {
-      return [[], $emptySignals, 0];
+      return [[], $emptySignals, $emptyPulse];
     }
 
     $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($ids);
@@ -854,7 +864,10 @@ final class VendorAnalyticsViewModelBuilder {
     }
 
     $signals = $this->summariseReadinessSignals($rows);
-    $checkinsCatalogueTotal = $this->sumCatalogueCheckIns($eventNodes);
+    $cataloguePulse = [
+      'checkins_total' => $this->sumCatalogueCheckIns($eventNodes),
+      'boosts_active' => $this->countCatalogueActiveBoosts($eventNodes),
+    ];
 
     usort($rows, static function (array $a, array $b): int {
       $scoreA = (int) ($a['_sort_tickets'] ?? 0) + (int) ($a['_sort_rsvps'] ?? 0);
@@ -873,7 +886,7 @@ final class VendorAnalyticsViewModelBuilder {
     }
     unset($row);
 
-    return [$rows, $signals, $checkinsCatalogueTotal];
+    return [$rows, $signals, $cataloguePulse];
   }
 
   /**
@@ -896,6 +909,35 @@ final class VendorAnalyticsViewModelBuilder {
       }
       catch (\Throwable $e) {
         $this->loggerFactory->get('myeventlane_analytics')->warning('Check-in total failed for nid @nid: @message', [
+          '@nid' => (string) $node->id(),
+          '@message' => $e->getMessage(),
+        ]);
+      }
+    }
+    return $total;
+  }
+
+  /**
+   * Counts events with an active Boost across the full catalogue.
+   *
+   * Hub Marketing Active Boosts must not rely on DETAIL_ENRICH_LIMIT rows.
+   *
+   * @param list<\Drupal\node\NodeInterface> $eventNodes
+   *   All managed event nodes.
+   *
+   * @return int
+   *   Number of events with Boost currently active.
+   */
+  private function countCatalogueActiveBoosts(array $eventNodes): int {
+    $total = 0;
+    foreach ($eventNodes as $node) {
+      try {
+        if ($this->metricsAggregator->isBoostActive($node)) {
+          $total++;
+        }
+      }
+      catch (\Throwable $e) {
+        $this->loggerFactory->get('myeventlane_analytics')->warning('Active Boost count failed for nid @nid: @message', [
           '@nid' => (string) $node->id(),
           '@message' => $e->getMessage(),
         ]);
@@ -940,8 +982,8 @@ final class VendorAnalyticsViewModelBuilder {
   /**
    * Enriches the strongest events with check-in / capacity / boost labels.
    *
-   * Hub Attendance Check-ins use sumCatalogueCheckIns() across all managed
-   * events — this enrich is display-only for top sales-ranked rows.
+   * Hub Attendance Check-ins and Marketing Active Boosts use catalogue-wide
+   * pulse totals — this enrich is display-only for top sales-ranked rows.
    *
    * @param list<array<string, mixed>> $rows
    *   Event rows (modified in place).

--- a/web/modules/custom/myeventlane_analytics/src/Service/VendorAnalyticsViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_analytics/src/Service/VendorAnalyticsViewModelBuilder.php
@@ -105,9 +105,12 @@ final class VendorAnalyticsViewModelBuilder {
       'door_ready' => FALSE,
       'publishing_issues' => 0,
       'event_count' => 0,
+      'load_failed' => FALSE,
     ];
+    $eventsLoadFailed = FALSE;
+    $checkinsCatalogueTotal = 0;
     try {
-      [$events, $readinessSignals] = $this->buildEventRows($uid, $account);
+      [$events, $readinessSignals, $checkinsCatalogueTotal] = $this->buildEventRows($uid, $account);
     }
     catch (\Throwable $e) {
       $this->loggerFactory->get('myeventlane_analytics')->warning('Vendor analytics event rows failed for uid @uid: @message', [
@@ -115,6 +118,9 @@ final class VendorAnalyticsViewModelBuilder {
         '@message' => $e->getMessage(),
       ]);
       $events = [];
+      $eventsLoadFailed = TRUE;
+      $readinessSignals['load_failed'] = TRUE;
+      $checkinsCatalogueTotal = NULL;
     }
 
     $refundPending = $this->countPendingRefunds();
@@ -122,7 +128,7 @@ final class VendorAnalyticsViewModelBuilder {
     $launchReadiness = $this->buildLaunchReadiness($readinessSignals, $paymentHealth, $refundPending);
     $businessHealth = $this->buildBusinessHealth($kpis, $events, $refundPending, $launchReadiness);
     $nextAction = $this->buildNextAction($launchReadiness, $businessHealth, $events, $account);
-    $sections = $this->buildSections($kpis, $events, $refundPending, $isPro);
+    $sections = $this->buildSections($kpis, $events, $refundPending, $isPro, $checkinsCatalogueTotal);
     $recentActivity = $this->buildRecentActivity($events);
     $pro = $this->buildProDepth($isPro, $account);
 
@@ -151,7 +157,7 @@ final class VendorAnalyticsViewModelBuilder {
       'next_action' => $nextAction,
       'pro' => $pro,
       'insights' => [],
-      'empty_state' => $this->buildEmptyState($account, $events === []),
+      'empty_state' => $this->buildEmptyState($account, $events === [] && !$eventsLoadFailed, $eventsLoadFailed),
       'analytics' => [
         'analytics_viewed' => TRUE,
         'is_pro' => $isPro,
@@ -304,7 +310,12 @@ final class VendorAnalyticsViewModelBuilder {
     $headline = (string) $this->t('Your business looks healthy');
     $summary = (string) $this->t('Sales and setup are on track. Keep an eye on upcoming events.');
 
-    if ($attentionItems !== []) {
+    if (!empty($launchReadiness['load_failed'])) {
+      $tone = 'attention';
+      $headline = (string) $this->t('Some insights could not load');
+      $summary = (string) $this->t('We could not load your event list just now. Refresh shortly — KPI figures above may still be available.');
+    }
+    elseif ($attentionItems !== []) {
       $tone = 'attention';
       $headline = (string) $this->t('A few things need attention');
       $summary = (string) $this->t('Fix the items below so you can run your next event with confidence.');
@@ -363,8 +374,8 @@ final class VendorAnalyticsViewModelBuilder {
    * Tickets / Door / publishing signals come from all managed events (not the
    * sales-sorted intelligence rows capped at MAX_EVENTS).
    *
-   * @param array{tickets_configured: bool, door_ready: bool, publishing_issues: int, event_count: int} $signals
-   *   Catalogue-wide readiness signals.
+   * @param array{tickets_configured?: bool, door_ready?: bool, publishing_issues?: int, event_count?: int, load_failed?: bool} $signals
+   *   Catalogue-wide readiness signals (or load_failed after a catalogue error).
    * @param array<string, mixed> $paymentHealth
    *   Payments health payload.
    * @param int $refundPending
@@ -374,6 +385,7 @@ final class VendorAnalyticsViewModelBuilder {
    *   Launch readiness card.
    */
   private function buildLaunchReadiness(array $signals, array $paymentHealth, int $refundPending): array {
+    $loadFailed = !empty($signals['load_failed']);
     $ticketsConfigured = !empty($signals['tickets_configured']);
     $doorReady = !empty($signals['door_ready']);
     $publishingIssues = (int) ($signals['publishing_issues'] ?? 0);
@@ -383,15 +395,20 @@ final class VendorAnalyticsViewModelBuilder {
     $stripeTone = $stripeReady ? 'success' : (!empty($paymentHealth['needs_attention']) ? 'attention' : 'muted');
     $messagesReady = $this->isMessagesBrandConfigured();
 
+    $unavailable = (string) $this->t('Unavailable');
     $items = [
       [
         'key' => 'tickets',
         'label' => (string) $this->t('Tickets configured'),
-        'detail' => $ticketsConfigured
-          ? (string) $this->t('At least one event has tickets or RSVP set up.')
-          : (string) $this->t('Add tickets or RSVP so people can register.'),
-        'tone' => $ticketsConfigured ? 'success' : 'attention',
-        'status_label' => $ticketsConfigured ? (string) $this->t('Ready') : (string) $this->t('Needs attention'),
+        'detail' => $loadFailed
+          ? (string) $this->t('Could not load event ticket setup just now.')
+          : ($ticketsConfigured
+            ? (string) $this->t('At least one event has tickets or RSVP set up.')
+            : (string) $this->t('Add tickets or RSVP so people can register.')),
+        'tone' => $loadFailed ? 'muted' : ($ticketsConfigured ? 'success' : 'attention'),
+        'status_label' => $loadFailed
+          ? $unavailable
+          : ($ticketsConfigured ? (string) $this->t('Ready') : (string) $this->t('Needs attention')),
         'url' => $this->safeUrlFromRoute('myeventlane_vendor.console.events')?->toString(),
       ],
       [
@@ -417,11 +434,15 @@ final class VendorAnalyticsViewModelBuilder {
       [
         'key' => 'door',
         'label' => (string) $this->t('Door Mode ready'),
-        'detail' => $doorReady
-          ? (string) $this->t('You can check guests in from Attendees → Door Mode.')
-          : (string) $this->t('Set up tickets or RSVP first, then Door Mode unlocks.'),
-        'tone' => $doorReady ? 'success' : 'muted',
-        'status_label' => $doorReady ? (string) $this->t('Ready') : (string) $this->t('Not yet'),
+        'detail' => $loadFailed
+          ? (string) $this->t('Could not confirm Door Mode readiness without your event list.')
+          : ($doorReady
+            ? (string) $this->t('You can check guests in from Attendees → Door Mode.')
+            : (string) $this->t('Set up tickets or RSVP first, then Door Mode unlocks.')),
+        'tone' => $loadFailed ? 'muted' : ($doorReady ? 'success' : 'muted'),
+        'status_label' => $loadFailed
+          ? $unavailable
+          : ($doorReady ? (string) $this->t('Ready') : (string) $this->t('Not yet')),
         'url' => $this->safeUrlFromRoute('myeventlane_vendor.console.events')?->toString(),
       ],
       [
@@ -439,30 +460,43 @@ final class VendorAnalyticsViewModelBuilder {
       ],
       [
         'key' => 'publishing',
-        'label' => $publishingIssues > 0
-          ? (string) $this->formatPlural($publishingIssues, '@count draft needs publishing review', '@count drafts need publishing review')
-          : (string) $this->t('No publishing issues'),
-        'detail' => $publishingIssues > 0
-          ? (string) $this->t('Finish and publish drafts when you are ready to go live.')
-          : (string) $this->t('No draft events are waiting on you.'),
-        'tone' => $publishingIssues > 0 ? 'attention' : 'success',
-        'status_label' => $publishingIssues > 0 ? (string) $this->t('Needs attention') : (string) $this->t('Ready'),
+        'label' => $loadFailed
+          ? (string) $this->t('Publishing status unavailable')
+          : ($publishingIssues > 0
+            ? (string) $this->formatPlural($publishingIssues, '@count draft needs publishing review', '@count drafts need publishing review')
+            : (string) $this->t('No publishing issues')),
+        'detail' => $loadFailed
+          ? (string) $this->t('Could not load draft events just now.')
+          : ($publishingIssues > 0
+            ? (string) $this->t('Finish and publish drafts when you are ready to go live.')
+            : (string) $this->t('No draft events are waiting on you.')),
+        'tone' => $loadFailed ? 'muted' : ($publishingIssues > 0 ? 'attention' : 'success'),
+        'status_label' => $loadFailed
+          ? $unavailable
+          : ($publishingIssues > 0 ? (string) $this->t('Needs attention') : (string) $this->t('Ready')),
         'url' => $this->safeUrlFromRoute('myeventlane_vendor.console.events')?->toString(),
       ],
     ];
 
     $attentionCount = count(array_filter($items, static fn(array $i): bool => ($i['tone'] ?? '') === 'attention'));
-    $tone = $attentionCount > 0 ? 'attention' : ($eventCount === 0 ? 'muted' : 'success');
-    $headline = match ($tone) {
-      'attention' => (string) $this->t('Can I successfully run my next event today?'),
-      'muted' => (string) $this->t('Can I successfully run an event today?'),
-      default => (string) $this->t('Yes — you are set up to run events today'),
-    };
-    $summary = match ($tone) {
-      'attention' => (string) $this->t('A few operational checks still need a quick fix.'),
-      'muted' => (string) $this->t('Create your first event to unlock this checklist.'),
-      default => (string) $this->t('Tickets, payments, messages, and door ops look ready.'),
-    };
+    if ($loadFailed) {
+      $tone = 'attention';
+      $headline = (string) $this->t('Event readiness could not be fully checked');
+      $summary = (string) $this->t('We could not load your events. Stripe and Messages below still reflect live setup.');
+    }
+    else {
+      $tone = $attentionCount > 0 ? 'attention' : ($eventCount === 0 ? 'muted' : 'success');
+      $headline = match ($tone) {
+        'attention' => (string) $this->t('Can I successfully run my next event today?'),
+        'muted' => (string) $this->t('Can I successfully run an event today?'),
+        default => (string) $this->t('Yes — you are set up to run events today'),
+      };
+      $summary = match ($tone) {
+        'attention' => (string) $this->t('A few operational checks still need a quick fix.'),
+        'muted' => (string) $this->t('Create your first event to unlock this checklist.'),
+        default => (string) $this->t('Tickets, payments, messages, and door ops look ready.'),
+      };
+    }
 
     return [
       'tone' => $tone,
@@ -471,6 +505,7 @@ final class VendorAnalyticsViewModelBuilder {
       'summary' => $summary,
       'items' => $items,
       'attention_count' => $attentionCount,
+      'load_failed' => $loadFailed,
     ];
   }
 
@@ -500,6 +535,16 @@ final class VendorAnalyticsViewModelBuilder {
           'tone' => 'attention',
         ];
       }
+    }
+
+    if (!empty($launchReadiness['load_failed'])) {
+      return [
+        'title' => (string) $this->t('Next recommended action'),
+        'body' => (string) $this->t('Refresh Analytics to reload your events and launch checks.'),
+        'cta_label' => NULL,
+        'cta_url' => NULL,
+        'tone' => 'attention',
+      ];
     }
 
     if ($events === []) {
@@ -546,11 +591,14 @@ final class VendorAnalyticsViewModelBuilder {
    *   Pending refund count.
    * @param bool $isPro
    *   Whether the organiser has Pro.
+   * @param int|null $checkinsCatalogueTotal
+   *   Catalogue-wide checked-in total (all managed events). NULL when unavailable
+   *   (e.g. event rows failed to load).
    *
    * @return list<array<string, mixed>>
    *   Section cards.
    */
-  private function buildSections(array $kpis, array $events, int $refundPending, bool $isPro): array {
+  private function buildSections(array $kpis, array $events, int $refundPending, bool $isPro, ?int $checkinsCatalogueTotal = NULL): array {
     $byKey = [];
     foreach ($kpis as $kpi) {
       $byKey[(string) ($kpi['key'] ?? '')] = $kpi;
@@ -563,6 +611,10 @@ final class VendorAnalyticsViewModelBuilder {
       $capacityTotal += (int) ($row['capacity_raw'] ?? 0);
       $checkinsTotal += (int) ($row['checkins_raw'] ?? 0);
       $attendanceTotal += (int) ($row['attendance_raw'] ?? 0);
+    }
+    // Hub Check-ins must cover every managed event, not only DETAIL_ENRICH_LIMIT rows.
+    if ($checkinsCatalogueTotal !== NULL) {
+      $checkinsTotal = $checkinsCatalogueTotal;
     }
 
     $boostActive = 0;
@@ -770,8 +822,9 @@ final class VendorAnalyticsViewModelBuilder {
    * @param \Drupal\Core\Session\AccountInterface $account
    *   Current organiser account.
    *
-   * @return array{0: list<array<string, mixed>>, 1: array{tickets_configured: bool, door_ready: bool, publishing_issues: int, event_count: int}}
-   *   Capped intelligence rows plus full-catalogue readiness signals.
+   * @return array{0: list<array<string, mixed>>, 1: array{tickets_configured: bool, door_ready: bool, publishing_issues: int, event_count: int, load_failed?: bool}, 2: int}
+   *   Capped intelligence rows, full-catalogue readiness signals, and
+   *   catalogue-wide checked-in total.
    */
   private function buildEventRows(int $uid, AccountInterface $account): array {
     $emptySignals = [
@@ -779,11 +832,12 @@ final class VendorAnalyticsViewModelBuilder {
       'door_ready' => FALSE,
       'publishing_issues' => 0,
       'event_count' => 0,
+      'load_failed' => FALSE,
     ];
 
     $ids = $this->userVendorMembershipQuery->getManagedEventNodeIds($uid, FALSE);
     if ($ids === []) {
-      return [[], $emptySignals];
+      return [[], $emptySignals, 0];
     }
 
     $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($ids);
@@ -800,6 +854,7 @@ final class VendorAnalyticsViewModelBuilder {
     }
 
     $signals = $this->summariseReadinessSignals($rows);
+    $checkinsCatalogueTotal = $this->sumCatalogueCheckIns($eventNodes);
 
     usort($rows, static function (array $a, array $b): int {
       $scoreA = (int) ($a['_sort_tickets'] ?? 0) + (int) ($a['_sort_rsvps'] ?? 0);
@@ -818,7 +873,35 @@ final class VendorAnalyticsViewModelBuilder {
     }
     unset($row);
 
-    return [$rows, $signals];
+    return [$rows, $signals, $checkinsCatalogueTotal];
+  }
+
+  /**
+   * Sums checked-in guests across every managed event (hub Attendance pulse).
+   *
+   * Uses the lightweight MetricsAggregator::getCheckedInCount path — not the
+   * full getEventOverview enrich reserved for top sales-ranked rows.
+   *
+   * @param list<\Drupal\node\NodeInterface> $eventNodes
+   *   All managed event nodes.
+   *
+   * @return int
+   *   Catalogue-wide check-in total.
+   */
+  private function sumCatalogueCheckIns(array $eventNodes): int {
+    $total = 0;
+    foreach ($eventNodes as $node) {
+      try {
+        $total += $this->metricsAggregator->getCheckedInCount($node);
+      }
+      catch (\Throwable $e) {
+        $this->loggerFactory->get('myeventlane_analytics')->warning('Check-in total failed for nid @nid: @message', [
+          '@nid' => (string) $node->id(),
+          '@message' => $e->getMessage(),
+        ]);
+      }
+    }
+    return $total;
   }
 
   /**
@@ -855,7 +938,10 @@ final class VendorAnalyticsViewModelBuilder {
   }
 
   /**
-   * Enriches the strongest events with check-in / capacity / boost signals.
+   * Enriches the strongest events with check-in / capacity / boost labels.
+   *
+   * Hub Attendance Check-ins use sumCatalogueCheckIns() across all managed
+   * events — this enrich is display-only for top sales-ranked rows.
    *
    * @param list<array<string, mixed>> $rows
    *   Event rows (modified in place).
@@ -1171,12 +1257,23 @@ final class VendorAnalyticsViewModelBuilder {
    * @param \Drupal\Core\Session\AccountInterface $account
    *   Current organiser account.
    * @param bool $noEvents
-   *   TRUE when there are no event rows.
+   *   TRUE when there are no event rows (and load succeeded).
+   * @param bool $loadFailed
+   *   TRUE when the event catalogue failed to load.
    *
    * @return array<string, string|\Drupal\Core\Url|null>
    *   Empty state payload.
    */
-  private function buildEmptyState(AccountInterface $account, bool $noEvents): array {
+  private function buildEmptyState(AccountInterface $account, bool $noEvents, bool $loadFailed = FALSE): array {
+    if ($loadFailed) {
+      return [
+        'title' => (string) $this->t('Event list unavailable'),
+        'message' => (string) $this->t('We could not load your events just now. Refresh the page to try again.'),
+        'action_label' => NULL,
+        'url' => NULL,
+      ];
+    }
+
     if (!$noEvents) {
       return [
         'title' => '',

--- a/web/modules/custom/myeventlane_analytics/src/Service/VendorAnalyticsViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_analytics/src/Service/VendorAnalyticsViewModelBuilder.php
@@ -112,8 +112,12 @@ final class VendorAnalyticsViewModelBuilder {
       'checkins_total' => 0,
       'boosts_active' => 0,
     ];
+    $recentActivity = [];
+    $cacheEventNids = [];
     try {
-      [$events, $readinessSignals, $cataloguePulse] = $this->buildEventRows($uid, $account);
+      [$events, $readinessSignals, $cataloguePulse, $hubExtras] = $this->buildEventRows($uid, $account);
+      $recentActivity = $hubExtras['recent_activity'] ?? [];
+      $cacheEventNids = $hubExtras['cache_event_nids'] ?? [];
     }
     catch (\Throwable $e) {
       $this->loggerFactory->get('myeventlane_analytics')->warning('Vendor analytics event rows failed for uid @uid: @message', [
@@ -124,6 +128,8 @@ final class VendorAnalyticsViewModelBuilder {
       $eventsLoadFailed = TRUE;
       $readinessSignals['load_failed'] = TRUE;
       $cataloguePulse = NULL;
+      // Still tag every managed event so readiness/pulse rebuild when any event changes.
+      $cacheEventNids = $this->managedEventCacheNids($uid);
     }
 
     $refundPending = $this->countPendingRefunds();
@@ -132,7 +138,6 @@ final class VendorAnalyticsViewModelBuilder {
     $businessHealth = $this->buildBusinessHealth($kpis, $events, $refundPending, $launchReadiness);
     $nextAction = $this->buildNextAction($launchReadiness, $businessHealth, $events, $account);
     $sections = $this->buildSections($kpis, $events, $refundPending, $isPro, $cataloguePulse);
-    $recentActivity = $this->buildRecentActivity($events);
     $pro = $this->buildProDepth($isPro, $account);
 
     $this->loggerFactory->get('myeventlane_analytics')->info('analytics_viewed uid=@uid is_pro=@pro events=@count', [
@@ -161,6 +166,7 @@ final class VendorAnalyticsViewModelBuilder {
       'pro' => $pro,
       'insights' => [],
       'empty_state' => $this->buildEmptyState($account, $events === [] && !$eventsLoadFailed, $eventsLoadFailed),
+      'cache_event_nids' => $cacheEventNids,
       'analytics' => [
         'analytics_viewed' => TRUE,
         'is_pro' => $isPro,
@@ -197,6 +203,7 @@ final class VendorAnalyticsViewModelBuilder {
         'action_label' => NULL,
         'url' => NULL,
       ],
+      'cache_event_nids' => [],
       'analytics' => ['analytics_viewed' => FALSE],
     ];
   }
@@ -709,17 +716,30 @@ final class VendorAnalyticsViewModelBuilder {
   }
 
   /**
-   * Builds the recent activity list from event rows.
+   * Builds the recent activity list from the full event catalogue.
    *
-   * @param list<array<string, mixed>> $events
-   *   Event intelligence rows.
+   * Ordered by node changed time (then start date), not sales rank — the
+   * intelligence table may still be sales-sorted separately.
+   *
+   * @param list<array<string, mixed>> $rows
+   *   Uncapped event rows.
    *
    * @return list<array<string, mixed>>
    *   Recent activity items.
    */
-  private function buildRecentActivity(array $events): array {
+  private function buildRecentActivity(array $rows): array {
+    $sorted = $rows;
+    usort($sorted, static function (array $a, array $b): int {
+      $changedA = (int) ($a['changed_ts'] ?? 0);
+      $changedB = (int) ($b['changed_ts'] ?? 0);
+      if ($changedA !== $changedB) {
+        return $changedB <=> $changedA;
+      }
+      return ((int) ($b['start_ts'] ?? 0)) <=> ((int) ($a['start_ts'] ?? 0));
+    });
+
     $items = [];
-    foreach (array_slice($events, 0, 6) as $row) {
+    foreach (array_slice($sorted, 0, 6) as $row) {
       $bits = [];
       if (!empty($row['tickets_label'])) {
         $bits[] = (string) $row['tickets_label'];
@@ -729,6 +749,12 @@ final class VendorAnalyticsViewModelBuilder {
       }
       if (!empty($row['revenue_label'])) {
         $bits[] = (string) $row['revenue_label'];
+      }
+      $changedTs = (int) ($row['changed_ts'] ?? 0);
+      if ($changedTs > 0) {
+        $bits[] = (string) $this->t('Updated @when', [
+          '@when' => $this->dateFormatter->format($changedTs, 'short'),
+        ]);
       }
       $items[] = [
         'title' => (string) ($row['title'] ?? ''),
@@ -828,9 +854,10 @@ final class VendorAnalyticsViewModelBuilder {
    * @param \Drupal\Core\Session\AccountInterface $account
    *   Current organiser account.
    *
-   * @return array{0: list<array<string, mixed>>, 1: array{tickets_configured: bool, door_ready: bool, publishing_issues: int, event_count: int, load_failed?: bool}, 2: array{checkins_total: int, boosts_active: int}}
-   *   Capped intelligence rows, full-catalogue readiness signals, and
-   *   catalogue-wide Attendance / Marketing pulse totals.
+   * @return array{0: list<array<string, mixed>>, 1: array{tickets_configured: bool, door_ready: bool, publishing_issues: int, event_count: int, load_failed?: bool}, 2: array{checkins_total: int, boosts_active: int}, 3: array{recent_activity: list<array<string, mixed>>, cache_event_nids: list<int>}}
+   *   Capped intelligence rows, full-catalogue readiness signals,
+   *   catalogue-wide Attendance / Marketing pulse totals, and hub extras
+   *   (recent activity + cache node IDs for every managed event).
    */
   private function buildEventRows(int $uid, AccountInterface $account): array {
     $emptySignals = [
@@ -844,10 +871,15 @@ final class VendorAnalyticsViewModelBuilder {
       'checkins_total' => 0,
       'boosts_active' => 0,
     ];
+    $emptyExtras = [
+      'recent_activity' => [],
+      'cache_event_nids' => [],
+    ];
 
     $ids = $this->userVendorMembershipQuery->getManagedEventNodeIds($uid, FALSE);
+    $cacheEventNids = array_values(array_map(static fn($id): int => (int) $id, $ids));
     if ($ids === []) {
-      return [[], $emptySignals, $emptyPulse];
+      return [[], $emptySignals, $emptyPulse, $emptyExtras];
     }
 
     $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($ids);
@@ -868,6 +900,12 @@ final class VendorAnalyticsViewModelBuilder {
       'checkins_total' => $this->sumCatalogueCheckIns($eventNodes),
       'boosts_active' => $this->countCatalogueActiveBoosts($eventNodes),
     ];
+    // Recency feed from the full catalogue before the sales-rank MAX_EVENTS cap.
+    $recentActivity = $this->buildRecentActivity($rows);
+    $hubExtras = [
+      'recent_activity' => $recentActivity,
+      'cache_event_nids' => $cacheEventNids,
+    ];
 
     usort($rows, static function (array $a, array $b): int {
       $scoreA = (int) ($a['_sort_tickets'] ?? 0) + (int) ($a['_sort_rsvps'] ?? 0);
@@ -882,11 +920,34 @@ final class VendorAnalyticsViewModelBuilder {
     $this->enrichTopEventRows($rows);
 
     foreach ($rows as &$row) {
-      unset($row['_sort_tickets'], $row['_sort_rsvps'], $row['_node']);
+      unset($row['_sort_tickets'], $row['_sort_rsvps'], $row['_node'], $row['changed_ts'], $row['start_ts']);
     }
     unset($row);
 
-    return [$rows, $signals, $cataloguePulse];
+    return [$rows, $signals, $cataloguePulse, $hubExtras];
+  }
+
+  /**
+   * Returns managed event node IDs for hub cache tags (best-effort).
+   *
+   * @param int $uid
+   *   Organiser user ID.
+   *
+   * @return list<int>
+   *   Event node IDs.
+   */
+  private function managedEventCacheNids(int $uid): array {
+    try {
+      $ids = $this->userVendorMembershipQuery->getManagedEventNodeIds($uid, FALSE);
+      return array_values(array_map(static fn($id): int => (int) $id, $ids));
+    }
+    catch (\Throwable $e) {
+      $this->loggerFactory->get('myeventlane_analytics')->warning('Managed event cache IDs failed for uid @uid: @message', [
+        '@uid' => (string) $uid,
+        '@message' => $e->getMessage(),
+      ]);
+      return [];
+    }
   }
 
   /**
@@ -1182,6 +1243,8 @@ final class VendorAnalyticsViewModelBuilder {
       'analytics_url' => $analyticsUrl?->toString(),
       'deep_analytics_url' => $deepAnalyticsUrl?->toString(),
       'workspace_url' => $workspaceUrl?->toString(),
+      'changed_ts' => (int) $node->getChangedTime(),
+      'start_ts' => $startTs,
       '_sort_tickets' => $ticketsSold,
       '_sort_rsvps' => $rsvpCount,
       '_node' => $node,

--- a/web/modules/custom/myeventlane_analytics/templates/analytics-dashboard.html.twig
+++ b/web/modules/custom/myeventlane_analytics/templates/analytics-dashboard.html.twig
@@ -15,6 +15,7 @@
 {% set pro = model.pro|default({}) %}
 {% set is_pro = model.is_pro|default(is_pro|default(false)) %}
 {% set upgrade_url = pro.cta_url|default(pro_upgrade_url|default(null)) %}
+{% set top_events = model.top_events|default([]) %}
 
 <div class="mel-analytics-hub" data-mel-analytics-hub data-mel-analytics-event="analytics_viewed" data-mel-analytics-pro="{{ is_pro ? '1' : '0' }}">
 
@@ -30,6 +31,7 @@
     </div>
   </header>
 
+  {# Empty CTA is additive — do not hide Business Health / Launch / Pro when the organiser has no events. #}
   {% if model.empty_state.title and model.events is empty %}
     <section class="mel-card mel-analytics-hub__empty" role="status" aria-labelledby="mel-analytics-empty-heading">
       <h2 id="mel-analytics-empty-heading" class="mel-card__title">{{ model.empty_state.title }}</h2>
@@ -40,104 +42,105 @@
         {{ mel_analytics_events_empty }}
       {% endif %}
     </section>
-  {% else %}
+  {% endif %}
 
-    {# ── Business Health ── #}
-    {% if business %}
-      <section class="mel-card mel-card--status mel-analytics-hub__health mel-analytics-hub__health--{{ business.tone|default('muted') }}" id="business-health" aria-labelledby="mel-analytics-business-heading">
-        <p class="mel-analytics-hub__eyebrow">{{ 'Business health'|t }}</p>
-        <h2 id="mel-analytics-business-heading" class="mel-analytics-hub__health-title">{{ business.headline }}</h2>
-        <p class="mel-analytics-hub__health-question">{{ business.question }}</p>
-        <p class="mel-analytics-hub__health-summary">{{ business.summary }}</p>
-        {% if business.trend_label %}
-          <p class="mel-analytics-hub__trend">{{ business.trend_label }}</p>
-        {% endif %}
-        <div class="mel-analytics-hub__kpi-row" role="list">
-          {% for metric in business.metrics|default([]) %}
-            <div class="mel-analytics-hub__kpi" role="listitem">
-              <span class="mel-analytics-hub__kpi-label">{{ metric.label }}</span>
-              <span class="mel-analytics-hub__kpi-value" aria-label="{{ metric.label }} {{ metric.value }}">{{ metric.value }}</span>
+  {# ── Business Health ── #}
+  {% if business %}
+    <section class="mel-card mel-card--status mel-analytics-hub__health mel-analytics-hub__health--{{ business.tone|default('muted') }}" id="business-health" aria-labelledby="mel-analytics-business-heading">
+      <p class="mel-analytics-hub__eyebrow">{{ 'Business health'|t }}</p>
+      <h2 id="mel-analytics-business-heading" class="mel-analytics-hub__health-title">{{ business.headline }}</h2>
+      <p class="mel-analytics-hub__health-question">{{ business.question }}</p>
+      <p class="mel-analytics-hub__health-summary">{{ business.summary }}</p>
+      {% if business.trend_label %}
+        <p class="mel-analytics-hub__trend">{{ business.trend_label }}</p>
+      {% endif %}
+      <div class="mel-analytics-hub__kpi-row" role="list">
+        {% for metric in business.metrics|default([]) %}
+          <div class="mel-analytics-hub__kpi" role="listitem">
+            <span class="mel-analytics-hub__kpi-label">{{ metric.label }}</span>
+            <span class="mel-analytics-hub__kpi-value" aria-label="{{ metric.label }} {{ metric.value }}">{{ metric.value }}</span>
+          </div>
+        {% endfor %}
+      </div>
+    </section>
+  {% endif %}
+
+  {# ── Launch Readiness ── #}
+  {% if launch %}
+    <section class="mel-card mel-card--status mel-analytics-hub__launch mel-analytics-hub__launch--{{ launch.tone|default('muted') }}" id="launch-readiness" aria-labelledby="mel-analytics-launch-heading">
+      <p class="mel-analytics-hub__eyebrow">{{ 'Launch readiness'|t }}</p>
+      <h2 id="mel-analytics-launch-heading" class="mel-analytics-hub__health-title">{{ launch.headline }}</h2>
+      <p class="mel-analytics-hub__health-question">{{ launch.question }}</p>
+      <p class="mel-analytics-hub__health-summary">{{ launch.summary }}</p>
+      <ul class="mel-analytics-hub__readiness-list">
+        {% for item in launch.items|default([]) %}
+          <li class="mel-analytics-hub__readiness-item mel-analytics-hub__readiness-item--{{ item.tone|default('muted') }}">
+            <span class="mel-analytics-hub__status-dot" aria-hidden="true"></span>
+            <div class="mel-analytics-hub__readiness-copy">
+              <p class="mel-analytics-hub__readiness-label">
+                <span class="visually-hidden">{{ item.status_label }}: </span>{{ item.label }}
+              </p>
+              <p class="mel-analytics-hub__readiness-detail">{{ item.detail }}</p>
             </div>
-          {% endfor %}
-        </div>
-      </section>
-    {% endif %}
+            {% if item.url %}
+              <a class="mel-analytics-hub__readiness-link" href="{{ item.url }}">{{ 'Open'|t }}<span class="visually-hidden"> — {{ item.label }}</span></a>
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+    </section>
+  {% endif %}
 
-    {# ── Launch Readiness ── #}
-    {% if launch %}
-      <section class="mel-card mel-card--status mel-analytics-hub__launch mel-analytics-hub__launch--{{ launch.tone|default('muted') }}" id="launch-readiness" aria-labelledby="mel-analytics-launch-heading">
-        <p class="mel-analytics-hub__eyebrow">{{ 'Launch readiness'|t }}</p>
-        <h2 id="mel-analytics-launch-heading" class="mel-analytics-hub__health-title">{{ launch.headline }}</h2>
-        <p class="mel-analytics-hub__health-question">{{ launch.question }}</p>
-        <p class="mel-analytics-hub__health-summary">{{ launch.summary }}</p>
-        <ul class="mel-analytics-hub__readiness-list">
-          {% for item in launch.items|default([]) %}
-            <li class="mel-analytics-hub__readiness-item mel-analytics-hub__readiness-item--{{ item.tone|default('muted') }}">
-              <span class="mel-analytics-hub__status-dot" aria-hidden="true"></span>
-              <div class="mel-analytics-hub__readiness-copy">
-                <p class="mel-analytics-hub__readiness-label">
-                  <span class="visually-hidden">{{ item.status_label }}: </span>{{ item.label }}
-                </p>
-                <p class="mel-analytics-hub__readiness-detail">{{ item.detail }}</p>
-              </div>
-              {% if item.url %}
-                <a class="mel-analytics-hub__readiness-link" href="{{ item.url }}">{{ 'Open'|t }}<span class="visually-hidden"> — {{ item.label }}</span></a>
+  {# ── Next recommended action ── #}
+  {% if next %}
+    <section class="mel-card mel-analytics-hub__next mel-analytics-hub__next--{{ next.tone|default('success') }}" id="next-action" aria-labelledby="mel-analytics-next-heading">
+      <h2 id="mel-analytics-next-heading" class="mel-card__title">{{ next.title }}</h2>
+      <p>{{ next.body }}</p>
+      {% if next.cta_url and next.cta_label %}
+        <a class="mel-button mel-button--primary" href="{{ next.cta_url }}">{{ next.cta_label }}</a>
+      {% endif %}
+    </section>
+  {% endif %}
+
+  {# ── Pulse sections ── #}
+  {% if model.sections %}
+    <section class="mel-analytics-hub__sections" aria-label="{{ 'Analytics modules'|t }}">
+      <div class="mel-analytics-hub__section-grid">
+        {% for section in model.sections %}
+          <article class="mel-card mel-analytics-hub__section{% if section.pro_only and not is_pro %} mel-analytics-hub__section--pro{% endif %}" id="{{ section.key }}">
+            <h2 class="mel-card__title">{{ section.title }}</h2>
+            <p class="mel-analytics-hub__section-summary">{{ section.summary }}</p>
+            {% if section.pro_only and not is_pro %}
+              <p class="mel-analytics-hub__pro-teaser" role="status">{{ section.pro_teaser }}</p>
+              {% if upgrade_url %}
+                <a class="mel-button mel-button--secondary" href="{{ upgrade_url }}" data-mel-analytics-event="pro_upgrade_clicked">{{ 'See what’s included in Pro'|t }}</a>
               {% endif %}
-            </li>
-          {% endfor %}
-        </ul>
-      </section>
-    {% endif %}
-
-    {# ── Next recommended action ── #}
-    {% if next %}
-      <section class="mel-card mel-analytics-hub__next mel-analytics-hub__next--{{ next.tone|default('success') }}" id="next-action" aria-labelledby="mel-analytics-next-heading">
-        <h2 id="mel-analytics-next-heading" class="mel-card__title">{{ next.title }}</h2>
-        <p>{{ next.body }}</p>
-        {% if next.cta_url and next.cta_label %}
-          <a class="mel-button mel-button--primary" href="{{ next.cta_url }}">{{ next.cta_label }}</a>
-        {% endif %}
-      </section>
-    {% endif %}
-
-    {# ── Pulse sections ── #}
-    {% if model.sections %}
-      <section class="mel-analytics-hub__sections" aria-label="{{ 'Analytics modules'|t }}">
-        <div class="mel-analytics-hub__section-grid">
-          {% for section in model.sections %}
-            <article class="mel-card mel-analytics-hub__section{% if section.pro_only and not is_pro %} mel-analytics-hub__section--pro{% endif %}" id="{{ section.key }}">
-              <h2 class="mel-card__title">{{ section.title }}</h2>
-              <p class="mel-analytics-hub__section-summary">{{ section.summary }}</p>
-              {% if section.pro_only and not is_pro %}
-                <p class="mel-analytics-hub__pro-teaser" role="status">{{ section.pro_teaser }}</p>
-                {% if upgrade_url %}
-                  <a class="mel-button mel-button--secondary" href="{{ upgrade_url }}" data-mel-analytics-event="pro_upgrade_clicked">{{ 'See what’s included in Pro'|t }}</a>
-                {% endif %}
-              {% else %}
-                <dl class="mel-analytics-hub__section-metrics">
-                  {% for metric in section.metrics|default([]) %}
-                    <div>
-                      <dt>{{ metric.label }}</dt>
-                      <dd>{{ metric.value }}</dd>
-                    </div>
-                  {% endfor %}
-                </dl>
-                {% if section.cta_url and section.cta_label %}
-                  <a class="mel-analytics-hub__link" href="{{ section.cta_url }}">{{ section.cta_label }}</a>
-                {% endif %}
+            {% else %}
+              <dl class="mel-analytics-hub__section-metrics">
+                {% for metric in section.metrics|default([]) %}
+                  <div>
+                    <dt>{{ metric.label }}</dt>
+                    <dd>{{ metric.value }}</dd>
+                  </div>
+                {% endfor %}
+              </dl>
+              {% if section.cta_url and section.cta_label %}
+                <a class="mel-analytics-hub__link" href="{{ section.cta_url }}">{{ section.cta_label }}</a>
               {% endif %}
-            </article>
-          {% endfor %}
-        </div>
-      </section>
-    {% endif %}
+            {% endif %}
+          </article>
+        {% endfor %}
+      </div>
+    </section>
+  {% endif %}
 
-    {# ── Top events / per-event intelligence ── #}
+  {# ── Top events (capped list from view model) ── #}
+  {% if business or launch or top_events %}
     <section class="mel-analytics-hub__events" id="top-events" aria-labelledby="mel-analytics-events-heading">
       <h2 id="mel-analytics-events-heading" class="mel-analytics-hub__section-title">{{ 'Top events'|t }}</h2>
-      {% if model.events %}
+      {% if top_events %}
         <ul class="mel-analytics-hub__event-list">
-          {% for row in model.events %}
+          {% for row in top_events %}
             <li class="mel-card mel-analytics-hub__event mel-analytics-hub__event--{{ row.health_tone|default('muted') }}">
               <div class="mel-analytics-hub__event-main">
                 <h3 class="mel-analytics-hub__event-title">{{ row.title }}</h3>
@@ -196,27 +199,29 @@
         </div>
       {% endif %}
     </section>
+  {% endif %}
 
-    {# ── Recent activity ── #}
-    {% if model.recent_activity %}
-      <section class="mel-card mel-analytics-hub__activity" id="recent-activity" aria-labelledby="mel-analytics-activity-heading">
-        <h2 id="mel-analytics-activity-heading" class="mel-card__title">{{ 'Recent activity'|t }}</h2>
-        <ul class="mel-analytics-hub__activity-list">
-          {% for item in model.recent_activity %}
-            <li>
-              {% if item.url %}
-                <a href="{{ item.url }}">{{ item.title }}</a>
-              {% else %}
-                <span>{{ item.title }}</span>
-              {% endif %}
-              <span class="mel-analytics-hub__activity-meta">{{ item.meta }}</span>
-            </li>
-          {% endfor %}
-        </ul>
-      </section>
-    {% endif %}
+  {# ── Recent activity ── #}
+  {% if model.recent_activity %}
+    <section class="mel-card mel-analytics-hub__activity" id="recent-activity" aria-labelledby="mel-analytics-activity-heading">
+      <h2 id="mel-analytics-activity-heading" class="mel-card__title">{{ 'Recent activity'|t }}</h2>
+      <ul class="mel-analytics-hub__activity-list">
+        {% for item in model.recent_activity %}
+          <li>
+            {% if item.url %}
+              <a href="{{ item.url }}">{{ item.title }}</a>
+            {% else %}
+              <span>{{ item.title }}</span>
+            {% endif %}
+            <span class="mel-analytics-hub__activity-meta">{{ item.meta }}</span>
+          </li>
+        {% endfor %}
+      </ul>
+    </section>
+  {% endif %}
 
-    {# ── Pro depth / Exports ── #}
+  {# ── Pro depth / Exports (organisers only — guest model has no business/launch) ── #}
+  {% if pro and (business or launch) %}
     <section class="mel-card mel-analytics-hub__pro" id="exports" aria-labelledby="mel-analytics-pro-heading">
       <h2 id="mel-analytics-pro-heading" class="mel-card__title">{{ pro.title }}</h2>
       <p>{{ pro.body }}</p>
@@ -235,6 +240,6 @@
         <a class="mel-button {{ is_pro ? 'mel-button--secondary' : 'mel-button--primary' }}" href="{{ upgrade_url }}" data-mel-analytics-event="pro_upgrade_clicked">{{ pro.cta_label }}</a>
       {% endif %}
     </section>
-
   {% endif %}
+
 </div>

--- a/web/modules/custom/myeventlane_analytics/templates/analytics-dashboard.html.twig
+++ b/web/modules/custom/myeventlane_analytics/templates/analytics-dashboard.html.twig
@@ -1,144 +1,240 @@
 {#
 /**
  * @file
- * Vendor-wide analytics (`/vendor/analytics`).
+ * Organiser Analytics — Event Intelligence Centre (`/vendor/analytics`).
  *
  * Variables:
- * - analytics_model: TASK 9 view model (title, subtitle, date_range, kpis, events, insights, empty_state).
- * - is_pro, pro_upgrade_url: optional; from myeventlane_pro_preprocess.
- * - summary_stats, event_analytics: legacy keys (empty); kept for compatibility.
+ * - analytics_model: hub view model from VendorAnalyticsViewModelBuilder
+ * - is_pro, pro_upgrade_url: optional; from myeventlane_pro_preprocess
  */
 #}
 {% set model = analytics_model|default({}) %}
-{% set date_items = model.date_range.items|default([]) %}
+{% set business = model.business_health|default({}) %}
+{% set launch = model.launch_readiness|default({}) %}
+{% set next = model.next_action|default({}) %}
+{% set pro = model.pro|default({}) %}
+{% set is_pro = model.is_pro|default(is_pro|default(false)) %}
+{% set upgrade_url = pro.cta_url|default(pro_upgrade_url|default(null)) %}
 
-<div class="mel-vendor-analytics-v2 mel-analytics-dashboard">
+<div class="mel-analytics-hub" data-mel-analytics-hub data-mel-analytics-event="analytics_viewed" data-mel-analytics-pro="{{ is_pro ? '1' : '0' }}">
 
-  <header class="mel-vendor-analytics-v2__header mel-analytics-lock-content">
+  <header class="mel-analytics-hub__header">
     <div>
-      <h1 class="mel-vendor-analytics-v2__title">{{ model.title|default('Analytics'|t) }}</h1>
+      {% if model.eyebrow %}
+        <p class="mel-analytics-hub__eyebrow">{{ model.eyebrow }}</p>
+      {% endif %}
+      <h1 class="mel-analytics-hub__title">{{ model.title|default('Analytics'|t) }}</h1>
       {% if model.subtitle %}
-        <p class="mel-vendor-analytics-v2__subtitle">{{ model.subtitle }}</p>
+        <p class="mel-analytics-hub__subtitle">{{ model.subtitle }}</p>
       {% endif %}
     </div>
-    {% if date_items is not empty %}
-      <nav class="mel-vendor-analytics-v2__range" aria-label="{{ 'Date range'|t }}">
-        <ul class="mel-vendor-analytics-v2__range-list">
-          {% for item in date_items %}
-            <li>
+  </header>
+
+  {% if model.empty_state.title and model.events is empty %}
+    <section class="mel-card mel-analytics-hub__empty" role="status" aria-labelledby="mel-analytics-empty-heading">
+      <h2 id="mel-analytics-empty-heading" class="mel-card__title">{{ model.empty_state.title }}</h2>
+      <p>{{ model.empty_state.message }}</p>
+      {% if model.empty_state.url and model.empty_state.action_label %}
+        <a class="mel-button mel-button--primary" href="{{ model.empty_state.url }}">{{ model.empty_state.action_label }}</a>
+      {% elseif mel_analytics_events_empty is defined and mel_analytics_events_empty %}
+        {{ mel_analytics_events_empty }}
+      {% endif %}
+    </section>
+  {% else %}
+
+    {# ── Business Health ── #}
+    {% if business %}
+      <section class="mel-card mel-card--status mel-analytics-hub__health mel-analytics-hub__health--{{ business.tone|default('muted') }}" id="business-health" aria-labelledby="mel-analytics-business-heading">
+        <p class="mel-analytics-hub__eyebrow">{{ 'Business health'|t }}</p>
+        <h2 id="mel-analytics-business-heading" class="mel-analytics-hub__health-title">{{ business.headline }}</h2>
+        <p class="mel-analytics-hub__health-question">{{ business.question }}</p>
+        <p class="mel-analytics-hub__health-summary">{{ business.summary }}</p>
+        {% if business.trend_label %}
+          <p class="mel-analytics-hub__trend">{{ business.trend_label }}</p>
+        {% endif %}
+        <div class="mel-analytics-hub__kpi-row" role="list">
+          {% for metric in business.metrics|default([]) %}
+            <div class="mel-analytics-hub__kpi" role="listitem">
+              <span class="mel-analytics-hub__kpi-label">{{ metric.label }}</span>
+              <span class="mel-analytics-hub__kpi-value" aria-label="{{ metric.label }} {{ metric.value }}">{{ metric.value }}</span>
+            </div>
+          {% endfor %}
+        </div>
+      </section>
+    {% endif %}
+
+    {# ── Launch Readiness ── #}
+    {% if launch %}
+      <section class="mel-card mel-card--status mel-analytics-hub__launch mel-analytics-hub__launch--{{ launch.tone|default('muted') }}" id="launch-readiness" aria-labelledby="mel-analytics-launch-heading">
+        <p class="mel-analytics-hub__eyebrow">{{ 'Launch readiness'|t }}</p>
+        <h2 id="mel-analytics-launch-heading" class="mel-analytics-hub__health-title">{{ launch.headline }}</h2>
+        <p class="mel-analytics-hub__health-question">{{ launch.question }}</p>
+        <p class="mel-analytics-hub__health-summary">{{ launch.summary }}</p>
+        <ul class="mel-analytics-hub__readiness-list">
+          {% for item in launch.items|default([]) %}
+            <li class="mel-analytics-hub__readiness-item mel-analytics-hub__readiness-item--{{ item.tone|default('muted') }}">
+              <span class="mel-analytics-hub__status-dot" aria-hidden="true"></span>
+              <div class="mel-analytics-hub__readiness-copy">
+                <p class="mel-analytics-hub__readiness-label">
+                  <span class="visually-hidden">{{ item.status_label }}: </span>{{ item.label }}
+                </p>
+                <p class="mel-analytics-hub__readiness-detail">{{ item.detail }}</p>
+              </div>
               {% if item.url %}
-                <a href="{{ item.url }}" class="mel-vendor-analytics-v2__range-link{% if item.active %} is-active{% endif %}">{{ item.label }}</a>
-              {% else %}
-                <span class="mel-vendor-analytics-v2__range-link{% if item.active %} is-active{% endif %}">{{ item.label }}</span>
+                <a class="mel-analytics-hub__readiness-link" href="{{ item.url }}">{{ 'Open'|t }}<span class="visually-hidden"> — {{ item.label }}</span></a>
               {% endif %}
             </li>
           {% endfor %}
         </ul>
-      </nav>
-    {% endif %}
-  </header>
-
-  {% if model.kpis is defined and model.kpis is not empty %}
-    <section class="mel-vendor-analytics-v2__kpis" aria-label="{{ 'Key metrics'|t }}">
-      {% for kpi in model.kpis %}
-        <article class="mel-vendor-analytics-v2__kpi mel-kpi-card mel-kpi-card--neutral">
-          <h2 class="mel-vendor-analytics-v2__kpi-label">{{ kpi.label }}</h2>
-          <p class="mel-vendor-analytics-v2__kpi-value">{{ kpi.value }}</p>
-          {% if kpi.context %}
-            <p class="mel-vendor-analytics-v2__kpi-context">{{ kpi.context }}</p>
-          {% endif %}
-        </article>
-      {% endfor %}
-    </section>
-  {% endif %}
-
-  <div class="mel-analytics-lock-wrapper{% if is_pro is defined and not is_pro %} mel-analytics-lock-wrapper--locked{% endif %}">
-
-    {% if is_pro is defined and not is_pro %}
-      <div class="mel-analytics-lock-overlay">
-        <h2 class="mel-analytics-lock-overlay__title">{{ 'Unlock Full Analytics'|t }}</h2>
-        <p class="mel-analytics-lock-overlay__text">{{ 'Upgrade to Pro for workspace analytics, exports, and deeper per-event views.'|t }}</p>
-        {% if pro_upgrade_url is defined and pro_upgrade_url %}
-          <a href="{{ pro_upgrade_url }}" class="mel-pro-upgrade-btn">{{ 'Upgrade to unlock full analytics'|t }}</a>
-        {% endif %}
-      </div>
+      </section>
     {% endif %}
 
-    <div class="mel-analytics-lock-content">
-
-      {% if model.insights is defined and model.insights is not empty %}
-        <section class="mel-vendor-analytics-v2__insights" aria-label="{{ 'Analytics'|t }}">
-          {% for insight in model.insights %}
-            <div class="mel-vendor-analytics-v2__insight mel-vendor-analytics-v2__insight--{{ insight.severity|default('info') }}" role="status">
-              <h2 class="mel-vendor-analytics-v2__insight-title">{{ insight.title }}</h2>
-              <p class="mel-vendor-analytics-v2__insight-message">{{ insight.message }}</p>
-            </div>
-          {% endfor %}
-        </section>
-      {% endif %}
-
-      <section class="mel-vendor-analytics-v2__events" aria-labelledby="mel-vendor-analytics-events-heading">
-        <h2 id="mel-vendor-analytics-events-heading" class="mel-vendor-analytics-v2__section-title">{{ 'Event performance'|t }}</h2>
-
-        {% if model.events is defined and model.events is not empty %}
-          <ul class="mel-vendor-analytics-v2__event-list">
-            {% for row in model.events %}
-              <li class="mel-vendor-analytics-v2__event-card">
-                <div class="mel-vendor-analytics-v2__event-main">
-                  <h3 class="mel-vendor-analytics-v2__event-title">{{ row.title }}</h3>
-                  <p class="mel-vendor-analytics-v2__event-meta">
-                    <span class="mel-vendor-analytics-v2__badge">{{ row.status_label }}</span>
-                    {% if row.date_label %}
-                      <span class="mel-vendor-analytics-v2__event-date">{{ row.date_label }}</span>
-                    {% endif %}
-                  </p>
-                  <p class="mel-vendor-analytics-v2__event-type">{{ row.event_type_label }}</p>
-                  <dl class="mel-vendor-analytics-v2__metrics">
-                    {% if row.revenue_label %}
-                      <div class="mel-vendor-analytics-v2__metric">
-                        <dt>{{ 'Revenue'|t }}</dt>
-                        <dd>{{ row.revenue_label }}</dd>
-                      </div>
-                    {% endif %}
-                    {% if row.tickets_label %}
-                      <div class="mel-vendor-analytics-v2__metric">
-                        <dt>{{ 'Tickets'|t }}</dt>
-                        <dd>{{ row.tickets_label }}</dd>
-                      </div>
-                    {% endif %}
-                    {% if row.rsvp_label %}
-                      <div class="mel-vendor-analytics-v2__metric">
-                        <dt>{{ 'RSVPs'|t }}</dt>
-                        <dd>{{ row.rsvp_label }}</dd>
-                      </div>
-                    {% endif %}
-                    {% if row.conversion_label %}
-                      <div class="mel-vendor-analytics-v2__metric">
-                        <dt>{{ 'Conversion'|t }}</dt>
-                        <dd>{{ row.conversion_label }}</dd>
-                      </div>
-                    {% endif %}
-                  </dl>
-                </div>
-                <div class="mel-vendor-analytics-v2__event-actions">
-                  {% if row.analytics_url %}
-                    <a href="{{ row.analytics_url }}" class="mel-btn mel-btn-primary">{{ 'View event analytics'|t }}</a>
-                  {% endif %}
-                  {% if row.workspace_url %}
-                    <a href="{{ row.workspace_url }}" class="mel-btn mel-btn-secondary">{{ 'View workspace'|t }}</a>
-                  {% endif %}
-                </div>
-              </li>
-            {% endfor %}
-          </ul>
-        {% else %}
-          <div class="mel-vendor-analytics-v2__empty">
-            {% if mel_analytics_events_empty is defined and mel_analytics_events_empty %}
-              {{ mel_analytics_events_empty }}
-            {% endif %}
-          </div>
+    {# ── Next recommended action ── #}
+    {% if next %}
+      <section class="mel-card mel-analytics-hub__next mel-analytics-hub__next--{{ next.tone|default('success') }}" id="next-action" aria-labelledby="mel-analytics-next-heading">
+        <h2 id="mel-analytics-next-heading" class="mel-card__title">{{ next.title }}</h2>
+        <p>{{ next.body }}</p>
+        {% if next.cta_url and next.cta_label %}
+          <a class="mel-button mel-button--primary" href="{{ next.cta_url }}">{{ next.cta_label }}</a>
         {% endif %}
       </section>
-    </div>
-  </div>
+    {% endif %}
+
+    {# ── Pulse sections ── #}
+    {% if model.sections %}
+      <section class="mel-analytics-hub__sections" aria-label="{{ 'Analytics modules'|t }}">
+        <div class="mel-analytics-hub__section-grid">
+          {% for section in model.sections %}
+            <article class="mel-card mel-analytics-hub__section{% if section.pro_only and not is_pro %} mel-analytics-hub__section--pro{% endif %}" id="{{ section.key }}">
+              <h2 class="mel-card__title">{{ section.title }}</h2>
+              <p class="mel-analytics-hub__section-summary">{{ section.summary }}</p>
+              {% if section.pro_only and not is_pro %}
+                <p class="mel-analytics-hub__pro-teaser" role="status">{{ section.pro_teaser }}</p>
+                {% if upgrade_url %}
+                  <a class="mel-button mel-button--secondary" href="{{ upgrade_url }}" data-mel-analytics-event="pro_upgrade_clicked">{{ 'See what’s included in Pro'|t }}</a>
+                {% endif %}
+              {% else %}
+                <dl class="mel-analytics-hub__section-metrics">
+                  {% for metric in section.metrics|default([]) %}
+                    <div>
+                      <dt>{{ metric.label }}</dt>
+                      <dd>{{ metric.value }}</dd>
+                    </div>
+                  {% endfor %}
+                </dl>
+                {% if section.cta_url and section.cta_label %}
+                  <a class="mel-analytics-hub__link" href="{{ section.cta_url }}">{{ section.cta_label }}</a>
+                {% endif %}
+              {% endif %}
+            </article>
+          {% endfor %}
+        </div>
+      </section>
+    {% endif %}
+
+    {# ── Top events / per-event intelligence ── #}
+    <section class="mel-analytics-hub__events" id="top-events" aria-labelledby="mel-analytics-events-heading">
+      <h2 id="mel-analytics-events-heading" class="mel-analytics-hub__section-title">{{ 'Top events'|t }}</h2>
+      {% if model.events %}
+        <ul class="mel-analytics-hub__event-list">
+          {% for row in model.events %}
+            <li class="mel-card mel-analytics-hub__event mel-analytics-hub__event--{{ row.health_tone|default('muted') }}">
+              <div class="mel-analytics-hub__event-main">
+                <h3 class="mel-analytics-hub__event-title">{{ row.title }}</h3>
+                <p class="mel-analytics-hub__event-meta">
+                  <span class="mel-analytics-hub__badge">{{ row.status_label }}</span>
+                  {% if row.date_label %}<span>{{ row.date_label }}</span>{% endif %}
+                  <span>{{ row.event_type_label }}</span>
+                </p>
+                <dl class="mel-analytics-hub__event-metrics">
+                  {% if row.revenue_label %}
+                    <div><dt>{{ 'Revenue'|t }}</dt><dd>{{ row.revenue_label }}</dd></div>
+                  {% endif %}
+                  {% if row.tickets_label %}
+                    <div><dt>{{ 'Tickets sold'|t }}</dt><dd>{{ row.tickets_label }}</dd></div>
+                  {% endif %}
+                  {% if row.capacity_label %}
+                    <div><dt>{{ 'Capacity'|t }}</dt><dd>{{ row.capacity_label }}</dd></div>
+                  {% endif %}
+                  {% if row.attendance_label %}
+                    <div><dt>{{ 'Attendance'|t }}</dt><dd>{{ row.attendance_label }}</dd></div>
+                  {% endif %}
+                  {% if row.checkins_label %}
+                    <div><dt>{{ 'Check-ins'|t }}</dt><dd>{{ row.checkins_label }}</dd></div>
+                  {% endif %}
+                  {% if row.refunds_label %}
+                    <div><dt>{{ 'Refunds'|t }}</dt><dd>{{ row.refunds_label }}</dd></div>
+                  {% endif %}
+                  {% if row.marketing_label %}
+                    <div><dt>{{ 'Marketing'|t }}</dt><dd>{{ row.marketing_label }}</dd></div>
+                  {% endif %}
+                </dl>
+              </div>
+              <div class="mel-analytics-hub__event-actions">
+                {% if row.analytics_url %}
+                  <a class="mel-button mel-button--primary" href="{{ row.analytics_url }}">{{ 'Event Analytics'|t }}</a>
+                {% endif %}
+                {% if is_pro and row.deep_analytics_url %}
+                  <a class="mel-button mel-button--secondary" href="{{ row.deep_analytics_url }}">{{ 'Deeper trends'|t }}</a>
+                {% elseif not is_pro and upgrade_url %}
+                  <a class="mel-button mel-button--ghost" href="{{ upgrade_url }}" data-mel-analytics-event="pro_upgrade_clicked">{{ 'Unlock deeper trends'|t }}</a>
+                {% endif %}
+                {% if row.workspace_url %}
+                  <a class="mel-analytics-hub__link" href="{{ row.workspace_url }}">{{ 'Open workspace'|t }}</a>
+                {% endif %}
+              </div>
+            </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <div class="mel-analytics-hub__empty-inline" role="status">
+          {% if mel_analytics_events_empty is defined and mel_analytics_events_empty %}
+            {{ mel_analytics_events_empty }}
+          {% else %}
+            <p>{{ 'Event performance will appear here after you create an event.'|t }}</p>
+          {% endif %}
+        </div>
+      {% endif %}
+    </section>
+
+    {# ── Recent activity ── #}
+    {% if model.recent_activity %}
+      <section class="mel-card mel-analytics-hub__activity" id="recent-activity" aria-labelledby="mel-analytics-activity-heading">
+        <h2 id="mel-analytics-activity-heading" class="mel-card__title">{{ 'Recent activity'|t }}</h2>
+        <ul class="mel-analytics-hub__activity-list">
+          {% for item in model.recent_activity %}
+            <li>
+              {% if item.url %}
+                <a href="{{ item.url }}">{{ item.title }}</a>
+              {% else %}
+                <span>{{ item.title }}</span>
+              {% endif %}
+              <span class="mel-analytics-hub__activity-meta">{{ item.meta }}</span>
+            </li>
+          {% endfor %}
+        </ul>
+      </section>
+    {% endif %}
+
+    {# ── Pro depth / Exports ── #}
+    <section class="mel-card mel-analytics-hub__pro" id="exports" aria-labelledby="mel-analytics-pro-heading">
+      <h2 id="mel-analytics-pro-heading" class="mel-card__title">{{ pro.title }}</h2>
+      <p>{{ pro.body }}</p>
+      {% if pro.benefits %}
+        <ul class="mel-analytics-hub__pro-benefits">
+          {% for benefit in pro.benefits %}
+            <li>{{ benefit }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+      <div class="mel-analytics-hub__pro-exports">
+        <h3 class="mel-analytics-hub__pro-exports-title">{{ pro.export_label }}</h3>
+        <p>{{ pro.export_body }}</p>
+      </div>
+      {% if upgrade_url %}
+        <a class="mel-button {{ is_pro ? 'mel-button--secondary' : 'mel-button--primary' }}" href="{{ upgrade_url }}" data-mel-analytics-event="pro_upgrade_clicked">{{ pro.cta_label }}</a>
+      {% endif %}
+    </section>
+
+  {% endif %}
 </div>

--- a/web/modules/custom/myeventlane_pro/myeventlane_pro.module
+++ b/web/modules/custom/myeventlane_pro/myeventlane_pro.module
@@ -278,6 +278,10 @@ function myeventlane_pro_preprocess_myeventlane_analytics_dashboard(array &$vari
   $variables['is_pro'] = $isPro;
   $variables['pro_upgrade_url'] = myeventlane_pro_get_overview_url();
   $variables['#attached']['library'][] = 'myeventlane_pro/pro';
+  // Free organisers always see the hub; Pro depth is explained in-product.
+  if (!$isPro) {
+    $variables['pro_gate_message'] = t('Analytics depth is included in Pro. See what’s included →');
+  }
 }
 
 /**

--- a/web/modules/custom/myeventlane_reporting/myeventlane_reporting.info.yml
+++ b/web/modules/custom/myeventlane_reporting/myeventlane_reporting.info.yml
@@ -1,6 +1,6 @@
 name: MyEventLane Reporting
 type: module
-description: 'Vendor and admin reporting & insights UI with KPIs, charts, and exports.'
+description: 'Vendor and admin reporting surfaces. Organiser Insights/Charts/Export Centre URLs redirect into Analytics (VX2-08).'
 core_version_requirement: ^11
 package: MyEventLane
 dependencies:
@@ -9,3 +9,4 @@ dependencies:
   - myeventlane_vendor
   - myeventlane_event_attendees
   - myeventlane_automation
+  - myeventlane_analytics:myeventlane_analytics

--- a/web/modules/custom/myeventlane_reporting/myeventlane_reporting.routing.yml
+++ b/web/modules/custom/myeventlane_reporting/myeventlane_reporting.routing.yml
@@ -1,24 +1,21 @@
-# Vendor Insights Dashboard
+# Vendor Insights Dashboard → Analytics hub (VX2-08 convergence).
 myeventlane_reporting.vendor_insights:
   path: '/vendor/insights'
   defaults:
-    _controller: 'myeventlane_reporting.vendor_insights:dashboard'
+    _controller: '\Drupal\myeventlane_analytics\Controller\AnalyticsConvergenceRedirectController::vendorInsights'
     _title: 'Analytics'
   requirements:
-    _permission: 'view vendor insights'
-    _custom_access: '\Drupal\myeventlane_reporting\Access\VendorReportingAccess::access'
-    _myeventlane_pro_access: 'TRUE'
+    _custom_access: 'myeventlane_vendor.access.vendor_console:access'
 
-# Event Insights Overview
+# Event Insights → Event Workspace Analytics.
 myeventlane_reporting.event_insights.overview:
   path: '/vendor/events/{event}/insights'
   defaults:
-    _controller: 'myeventlane_reporting.event_insights:overview'
+    _controller: '\Drupal\myeventlane_analytics\Controller\AnalyticsConvergenceRedirectController::eventInsights'
     _title: 'Event analytics'
   requirements:
-    _permission: 'view event insights'
-    _custom_access: 'myeventlane_reporting.event_insights:access'
-    _myeventlane_pro_access: 'TRUE'
+    _custom_access: 'myeventlane_vendor.access.vendor_console:access'
+    event: \d+
   options:
     parameters:
       event:
@@ -26,16 +23,14 @@ myeventlane_reporting.event_insights.overview:
         bundle:
           - event
 
-# Event Insights - Sales Tab
 myeventlane_reporting.event_insights.sales:
   path: '/vendor/events/{event}/insights/sales'
   defaults:
-    _controller: 'myeventlane_reporting.event_insights:sales'
+    _controller: '\Drupal\myeventlane_analytics\Controller\AnalyticsConvergenceRedirectController::eventInsights'
     _title: 'Sales analytics'
   requirements:
-    _permission: 'view event insights'
-    _custom_access: 'myeventlane_reporting.event_insights:access'
-    _myeventlane_pro_access: 'TRUE'
+    _custom_access: 'myeventlane_vendor.access.vendor_console:access'
+    event: \d+
   options:
     parameters:
       event:
@@ -43,16 +38,14 @@ myeventlane_reporting.event_insights.sales:
         bundle:
           - event
 
-# Event Insights - Attendees Tab
 myeventlane_reporting.event_insights.attendees:
   path: '/vendor/events/{event}/insights/attendees'
   defaults:
-    _controller: 'myeventlane_reporting.event_insights:attendees'
+    _controller: '\Drupal\myeventlane_analytics\Controller\AnalyticsConvergenceRedirectController::eventInsights'
     _title: 'Attendee analytics'
   requirements:
-    _permission: 'view event insights'
-    _custom_access: 'myeventlane_reporting.event_insights:access'
-    _myeventlane_pro_access: 'TRUE'
+    _custom_access: 'myeventlane_vendor.access.vendor_console:access'
+    event: \d+
   options:
     parameters:
       event:
@@ -60,16 +53,14 @@ myeventlane_reporting.event_insights.attendees:
         bundle:
           - event
 
-# Event Insights - Check-ins Tab
 myeventlane_reporting.event_insights.checkins:
   path: '/vendor/events/{event}/insights/checkins'
   defaults:
-    _controller: 'myeventlane_reporting.event_insights:checkins'
+    _controller: '\Drupal\myeventlane_analytics\Controller\AnalyticsConvergenceRedirectController::eventInsights'
     _title: 'Check-in analytics'
   requirements:
-    _permission: 'view event insights'
-    _custom_access: 'myeventlane_reporting.event_insights:access'
-    _myeventlane_pro_access: 'TRUE'
+    _custom_access: 'myeventlane_vendor.access.vendor_console:access'
+    event: \d+
   options:
     parameters:
       event:
@@ -77,16 +68,14 @@ myeventlane_reporting.event_insights.checkins:
         bundle:
           - event
 
-# Event Insights - Traffic Tab (stub if pageview tracking not available)
 myeventlane_reporting.event_insights.traffic:
   path: '/vendor/events/{event}/insights/traffic'
   defaults:
-    _controller: 'myeventlane_reporting.event_insights:traffic'
+    _controller: '\Drupal\myeventlane_analytics\Controller\AnalyticsConvergenceRedirectController::eventInsights'
     _title: 'Traffic analytics'
   requirements:
-    _permission: 'view event insights'
-    _custom_access: 'myeventlane_reporting.event_insights:access'
-    _myeventlane_pro_access: 'TRUE'
+    _custom_access: 'myeventlane_vendor.access.vendor_console:access'
+    event: \d+
   options:
     parameters:
       event:
@@ -94,7 +83,7 @@ myeventlane_reporting.event_insights.traffic:
         bundle:
           - event
 
-# Chart Data Endpoints (JSON)
+# Chart Data Endpoints (JSON) — Pro backend for deep charts; not a product surface.
 myeventlane_reporting.chart.sales:
   path: '/vendor/charts/sales/{event}'
   defaults:
@@ -159,16 +148,14 @@ myeventlane_reporting.chart.revenue:
         bundle:
           - event
 
-# Export Centre
+# Export Centre → Analytics exports section.
 myeventlane_reporting.export_centre:
   path: '/vendor/exports'
   defaults:
-    _controller: 'myeventlane_reporting.export_centre:list'
-    _title: 'Export Centre'
+    _controller: '\Drupal\myeventlane_analytics\Controller\AnalyticsConvergenceRedirectController::exportCentre'
+    _title: 'Analytics'
   requirements:
-    _permission: 'request exports'
-    _custom_access: '\Drupal\myeventlane_reporting\Access\VendorReportingAccess::access'
-    _myeventlane_pro_access: 'TRUE'
+    _custom_access: 'myeventlane_vendor.access.vendor_console:access'
 
 myeventlane_reporting.export.request_csv:
   path: '/vendor/exports/request-csv/{event}'

--- a/web/modules/custom/myeventlane_reporting/myeventlane_reporting.routing.yml
+++ b/web/modules/custom/myeventlane_reporting/myeventlane_reporting.routing.yml
@@ -8,13 +8,15 @@ myeventlane_reporting.vendor_insights:
     _custom_access: 'myeventlane_vendor.access.vendor_console:access'
 
 # Event Insights → Event Workspace Analytics.
+# Keep event workspace parity access (deny before redirect) — never 302 into a
+# Studio Analytics URL the organiser cannot open.
 myeventlane_reporting.event_insights.overview:
   path: '/vendor/events/{event}/insights'
   defaults:
     _controller: '\Drupal\myeventlane_analytics\Controller\AnalyticsConvergenceRedirectController::eventInsights'
     _title: 'Event analytics'
   requirements:
-    _custom_access: 'myeventlane_vendor.access.vendor_console:access'
+    _custom_access: 'myeventlane_reporting.event_insights:access'
     event: \d+
   options:
     parameters:
@@ -29,7 +31,7 @@ myeventlane_reporting.event_insights.sales:
     _controller: '\Drupal\myeventlane_analytics\Controller\AnalyticsConvergenceRedirectController::eventInsights'
     _title: 'Sales analytics'
   requirements:
-    _custom_access: 'myeventlane_vendor.access.vendor_console:access'
+    _custom_access: 'myeventlane_reporting.event_insights:access'
     event: \d+
   options:
     parameters:
@@ -44,7 +46,7 @@ myeventlane_reporting.event_insights.attendees:
     _controller: '\Drupal\myeventlane_analytics\Controller\AnalyticsConvergenceRedirectController::eventInsights'
     _title: 'Attendee analytics'
   requirements:
-    _custom_access: 'myeventlane_vendor.access.vendor_console:access'
+    _custom_access: 'myeventlane_reporting.event_insights:access'
     event: \d+
   options:
     parameters:
@@ -59,7 +61,7 @@ myeventlane_reporting.event_insights.checkins:
     _controller: '\Drupal\myeventlane_analytics\Controller\AnalyticsConvergenceRedirectController::eventInsights'
     _title: 'Check-in analytics'
   requirements:
-    _custom_access: 'myeventlane_vendor.access.vendor_console:access'
+    _custom_access: 'myeventlane_reporting.event_insights:access'
     event: \d+
   options:
     parameters:
@@ -74,7 +76,7 @@ myeventlane_reporting.event_insights.traffic:
     _controller: '\Drupal\myeventlane_analytics\Controller\AnalyticsConvergenceRedirectController::eventInsights'
     _title: 'Traffic analytics'
   requirements:
-    _custom_access: 'myeventlane_vendor.access.vendor_console:access'
+    _custom_access: 'myeventlane_reporting.event_insights:access'
     event: \d+
   options:
     parameters:

--- a/web/modules/custom/myeventlane_vendor/src/Service/MetricsAggregator.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/MetricsAggregator.php
@@ -323,6 +323,30 @@ final class MetricsAggregator {
   }
 
   /**
+   * Returns whether Boost is currently active for one event (lightweight pulse).
+   *
+   * Prefer this over getEventOverview() when only the active flag is needed.
+   *
+   * @param \Drupal\node\NodeInterface $event
+   *   The event node.
+   *
+   * @return bool
+   *   TRUE when Boost is active (FALSE for unpublished / errors).
+   */
+  public function isBoostActive(NodeInterface $event): bool {
+    if (!$event->isPublished()) {
+      return FALSE;
+    }
+    try {
+      $status = $this->boostStatusService->getBoostStatusesForEvent($event);
+      return !empty($status['active']);
+    }
+    catch (\Throwable) {
+      return FALSE;
+    }
+  }
+
+  /**
    * Returns checked-in attendee count for one event (lightweight pulse helper).
    *
    * Prefer this over getEventOverview() when only door check-ins are needed.

--- a/web/modules/custom/myeventlane_vendor/src/Service/MetricsAggregator.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/MetricsAggregator.php
@@ -323,6 +323,24 @@ final class MetricsAggregator {
   }
 
   /**
+   * Returns checked-in attendee count for one event (lightweight pulse helper).
+   *
+   * Prefer this over getEventOverview() when only door check-ins are needed.
+   *
+   * @param \Drupal\node\NodeInterface $event
+   *   The event node.
+   *
+   * @return int
+   *   Checked-in count (0 for unpublished / empty).
+   */
+  public function getCheckedInCount(NodeInterface $event): int {
+    if (!$event->isPublished()) {
+      return 0;
+    }
+    return $this->eventMetricsService->getCheckedInCount($event);
+  }
+
+  /**
    * Returns an event overview block using EventMetricsService and other services.
    *
    * Orchestrates calls to multiple services to build complete event metrics.

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
@@ -112,6 +112,7 @@
   @include meta.load-css('pages/vendor-console-stack');
   @include meta.load-css('pages/payments-hub');
   @include meta.load-css('pages/messages-hub');
+  @include meta.load-css('pages/analytics-hub');
 }
 
 // Klaro renders at document root (#klaro), outside .mel-vendor — reuse public theme styles.

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_analytics-hub.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_analytics-hub.scss
@@ -1,0 +1,358 @@
+/**
+ * @file
+ * Organiser Analytics hub — Event Intelligence Centre.
+ */
+
+@use '../tokens/colors' as *;
+@use '../tokens/spacing' as *;
+@use '../tokens/typography' as *;
+@use '../tokens/radii' as *;
+@use '../tokens/breakpoints' as *;
+
+.mel-analytics-hub {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mel-space-5, 1.5rem);
+  max-width: var(--mel-layout-dashboard, 1280px);
+}
+
+.mel-analytics-hub__eyebrow {
+  margin: 0 0 var(--mel-space-1, 0.25rem);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--mel-color-text-secondary, #5b6470);
+}
+
+.mel-analytics-hub__title {
+  margin: 0;
+  font-size: 1.75rem;
+  line-height: 1.25;
+  color: var(--mel-color-text, #111827);
+}
+
+.mel-analytics-hub__subtitle {
+  margin: var(--mel-space-2, 0.5rem) 0 0;
+  max-width: 42rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: var(--mel-color-text-secondary, #4b5563);
+}
+
+.mel-analytics-hub__health,
+.mel-analytics-hub__launch,
+.mel-analytics-hub__next,
+.mel-analytics-hub__section,
+.mel-analytics-hub__event,
+.mel-analytics-hub__activity,
+.mel-analytics-hub__pro,
+.mel-analytics-hub__empty {
+  padding: var(--mel-space-5, 1.5rem);
+}
+
+.mel-analytics-hub__health--success,
+.mel-analytics-hub__launch--success,
+.mel-analytics-hub__next--success,
+.mel-analytics-hub__event--success {
+  border-color: rgba(4, 120, 87, 0.28);
+  background: rgba(16, 185, 129, 0.06);
+}
+
+.mel-analytics-hub__health--attention,
+.mel-analytics-hub__launch--attention,
+.mel-analytics-hub__next--attention,
+.mel-analytics-hub__event--attention {
+  border-color: rgba(180, 83, 9, 0.35);
+  background: rgba(245, 158, 11, 0.08);
+}
+
+.mel-analytics-hub__health--muted,
+.mel-analytics-hub__launch--muted,
+.mel-analytics-hub__next--muted,
+.mel-analytics-hub__event--muted {
+  border-color: var(--mel-color-border, #e5e7eb);
+}
+
+.mel-analytics-hub__health-title {
+  margin: 0 0 var(--mel-space-2, 0.5rem);
+  font-size: 1.375rem;
+  line-height: 1.3;
+}
+
+.mel-analytics-hub__health-question,
+.mel-analytics-hub__health-summary,
+.mel-analytics-hub__trend,
+.mel-analytics-hub__section-summary {
+  margin: 0 0 var(--mel-space-2, 0.5rem);
+  color: var(--mel-color-text-secondary, #4b5563);
+}
+
+.mel-analytics-hub__kpi-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--mel-space-3, 0.75rem);
+  margin-top: var(--mel-space-4, 1rem);
+
+  @media (min-width: 768px) {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  @media (min-width: 1024px) {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+}
+
+.mel-analytics-hub__kpi {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: var(--mel-space-3, 0.75rem);
+  border-radius: var(--mel-radius-card, 12px);
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.mel-analytics-hub__kpi-label {
+  font-size: 0.8125rem;
+  color: var(--mel-color-text-secondary, #5b6470);
+}
+
+.mel-analytics-hub__kpi-value {
+  font-size: 1.375rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+}
+
+.mel-analytics-hub__readiness-list {
+  list-style: none;
+  margin: var(--mel-space-4, 1rem) 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--mel-space-3, 0.75rem);
+}
+
+.mel-analytics-hub__readiness-item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--mel-space-3, 0.75rem);
+  align-items: start;
+  padding: var(--mel-space-3, 0.75rem);
+  border-radius: var(--mel-radius-card, 12px);
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.mel-analytics-hub__status-dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  margin-top: 0.35rem;
+  border-radius: 999px;
+  background: #9ca3af;
+}
+
+.mel-analytics-hub__readiness-item--success .mel-analytics-hub__status-dot {
+  background: #059669;
+}
+
+.mel-analytics-hub__readiness-item--attention .mel-analytics-hub__status-dot,
+.mel-analytics-hub__readiness-item--warning .mel-analytics-hub__status-dot {
+  background: #d97706;
+}
+
+.mel-analytics-hub__readiness-label {
+  margin: 0;
+  font-weight: 600;
+}
+
+.mel-analytics-hub__readiness-detail {
+  margin: 0.15rem 0 0;
+  font-size: 0.9375rem;
+  color: var(--mel-color-text-secondary, #4b5563);
+}
+
+.mel-analytics-hub__readiness-link,
+.mel-analytics-hub__link {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  font-weight: 600;
+}
+
+.mel-analytics-hub__section-title {
+  margin: 0 0 var(--mel-space-3, 0.75rem);
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.mel-analytics-hub__section-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--mel-space-4, 1rem);
+
+  @media (min-width: 768px) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  @media (min-width: 1100px) {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.mel-analytics-hub__section-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--mel-space-3, 0.75rem);
+  margin: var(--mel-space-3, 0.75rem) 0 0;
+
+  dt {
+    font-size: 0.8125rem;
+    color: var(--mel-color-text-secondary, #5b6470);
+  }
+
+  dd {
+    margin: 0.15rem 0 0;
+    font-size: 1.125rem;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+.mel-analytics-hub__pro-teaser {
+  margin: var(--mel-space-3, 0.75rem) 0;
+  padding: var(--mel-space-3, 0.75rem);
+  border-radius: var(--mel-radius-card, 12px);
+  background: rgba(37, 99, 235, 0.06);
+}
+
+.mel-analytics-hub__event-list,
+.mel-analytics-hub__activity-list,
+.mel-analytics-hub__pro-benefits {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.mel-analytics-hub__event-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mel-space-4, 1rem);
+}
+
+.mel-analytics-hub__event {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mel-space-4, 1rem);
+
+  @media (min-width: 900px) {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: stretch;
+  }
+}
+
+.mel-analytics-hub__event-title {
+  margin: 0 0 var(--mel-space-2, 0.5rem);
+  font-size: 1.125rem;
+}
+
+.mel-analytics-hub__event-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--mel-space-2, 0.5rem);
+  margin: 0 0 var(--mel-space-3, 0.75rem);
+  color: var(--mel-color-text-secondary, #4b5563);
+  font-size: 0.9375rem;
+}
+
+.mel-analytics-hub__badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.75rem;
+  padding: 0 0.6rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.06);
+  font-size: 0.8125rem;
+  font-weight: 600;
+}
+
+.mel-analytics-hub__event-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--mel-space-3, 0.75rem);
+
+  @media (min-width: 640px) {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  dt {
+    font-size: 0.75rem;
+    color: var(--mel-color-text-secondary, #5b6470);
+  }
+
+  dd {
+    margin: 0.15rem 0 0;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+.mel-analytics-hub__event-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mel-space-2, 0.5rem);
+  min-width: 12rem;
+}
+
+.mel-analytics-hub__activity-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mel-space-3, 0.75rem);
+
+  li {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    padding-bottom: var(--mel-space-3, 0.75rem);
+    border-bottom: 1px solid var(--mel-color-border, #e5e7eb);
+
+    &:last-child {
+      border-bottom: 0;
+      padding-bottom: 0;
+    }
+  }
+}
+
+.mel-analytics-hub__activity-meta {
+  color: var(--mel-color-text-secondary, #5b6470);
+  font-size: 0.9375rem;
+}
+
+.mel-analytics-hub__pro-benefits {
+  margin: var(--mel-space-3, 0.75rem) 0;
+  padding-left: 1.15rem;
+  list-style: disc;
+
+  li {
+    margin: 0.35rem 0;
+  }
+}
+
+.mel-analytics-hub__pro-exports {
+  margin: var(--mel-space-4, 1rem) 0;
+  padding: var(--mel-space-3, 0.75rem);
+  border-radius: var(--mel-radius-card, 12px);
+  background: rgba(15, 23, 42, 0.03);
+}
+
+.mel-analytics-hub__pro-exports-title {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mel-analytics-hub * {
+    transition: none !important;
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Rebuild `/vendor/analytics` as the organiser **Event Intelligence Centre** with Business Health, Launch Readiness, pulse sections, Top Events, Recent Activity, and Next Recommended Action.
- Unlock free Analytics pulse (remove bare Pro 403 on the hub) and explain Pro depth/exports with upgrade CTAs.
- Converge Insights + Export Centre list into Analytics via soft redirects; keep Pro-gated deep charts/exports.

## Test plan
- [x] Free organiser opens `/vendor/analytics` without 403
- [x] Business Health answers “How is my business performing?”
- [x] Launch Readiness answers “Can I successfully run this event today?” (Tickets / Stripe / Messages / Door / Refunds / Publishing)
- [ ] Event card → Event Analytics (Studio free pulse)
- [ ] `/vendor/insights` → `/vendor/analytics`
- [ ] `/vendor/exports` → `/vendor/analytics#exports`
- [ ] Pro CTA explains value (no bare deny on hub)
- [ ] Desktop / tablet / 390px keyboard + screen reader scan


Made with [Cursor](https://cursor.com)