### PR TITLE
feat: VX2-09 organiser Marketing Hub (Event Growth Centre)

### DIFF
--- a/docs/implementation/vx2-09-marketing-hub.md
+++ b/docs/implementation/vx2-09-marketing-hub.md
@@ -9,7 +9,7 @@
 - Organiser **Marketing** hub at `/vendor/marketing` (Event Growth Centre)
 - Sections: Marketing Health · Share Event · Boost · Widgets & Embeds · Social Media · Audience Growth · Marketing Performance · Recommended Actions
 - Shell nav **Marketing** points at the hub (was `/vendor/boost`)
-- `/vendor/boost` redirects to `/vendor/marketing#boost`
+- `/vendor/boost` redirects to `/vendor/marketing?section=boost` (JS scrolls to Boost; fragments are not used on Location)
 - Event Workspace Marketing deepened (share channels, widgets, Boost, Marketing home link)
 - Overview / next-action “Promote” → **Open Marketing** / **Share**
 - Analytics “Open Marketing” CTA → Marketing hub
@@ -30,7 +30,7 @@
 Convergence redirects:
 
 ```text
-/vendor/boost                        → /vendor/marketing#boost
+/vendor/boost                        → /vendor/marketing?section=boost (#boost via JS)
 /vendor/event/{id}/promote           → /vendor/events/{id}/studio/marketing
 ```
 
@@ -77,7 +77,7 @@ Do not invent new telemetry tables in this epic.
 - [ ] Boost eligible — Start Boost deep link
 - [ ] Active Boost — campaign status + end date
 - [ ] Widgets entry opens Tickets widgets
-- [ ] `/vendor/boost` redirects to `#boost`
+- [ ] `/vendor/boost` redirects to Marketing and scrolls to Boost
 - [ ] Analytics Open Marketing → hub
 - [ ] Desktop / tablet / 390px
 - [ ] Keyboard through jump → health → share → Boost

--- a/docs/implementation/vx2-09-marketing-hub.md
+++ b/docs/implementation/vx2-09-marketing-hub.md
@@ -56,7 +56,7 @@ Convergence redirects:
 | `marketing_opened` | Hub builder logger + Twig | Deferred collector |
 | `share_link_copied` | Copy buttons + Twig attrs | Deferred collector |
 | `share_channel_selected` | Social / email links | Deferred collector |
-| `boost_started` | Boost CTAs | Deferred collector |
+| `boost_started` | Start Boost CTAs only (not section / Manage / Explore) | Deferred collector |
 | `boost_completed` | Existing Boost purchase success (unchanged) | Existing |
 | `widget_copied` | Widgets entry CTAs | Deferred collector |
 

--- a/docs/implementation/vx2-09-marketing-hub.md
+++ b/docs/implementation/vx2-09-marketing-hub.md
@@ -1,0 +1,96 @@
+# VX2-09 — Marketing Hub (Event Growth Centre)
+
+**Epic:** VX2-09 Marketing  
+**Branch:** `feature/vx2-marketing`  
+**Date:** 2026-07-24
+
+## What shipped
+
+- Organiser **Marketing** hub at `/vendor/marketing` (Event Growth Centre)
+- Sections: Marketing Health · Share Event · Boost · Widgets & Embeds · Social Media · Audience Growth · Marketing Performance · Recommended Actions
+- Shell nav **Marketing** points at the hub (was `/vendor/boost`)
+- `/vendor/boost` redirects to `/vendor/marketing#boost`
+- Event Workspace Marketing deepened (share channels, widgets, Boost, Marketing home link)
+- Overview / next-action “Promote” → **Open Marketing** / **Share**
+- Analytics “Open Marketing” CTA → Marketing hub
+- AU English, warm, community-first; Boost remains the premium product name
+
+## Architecture
+
+```text
+/vendor/marketing  ← VendorMarketingHubController
+  └─ VendorMarketingHubBuilder
+       ├─ TicketSalesService (managed events + bookings)
+       ├─ DomainDetector (public URLs)
+       ├─ optional BoostManager / BoostHelpContent
+       ├─ optional EventStateResolver
+       └─ optional QrCodeGenerator (share QR from public URL)
+```
+
+Convergence redirects:
+
+```text
+/vendor/boost                        → /vendor/marketing#boost
+/vendor/event/{id}/promote           → /vendor/events/{id}/studio/marketing
+```
+
+## Boost model
+
+- Boost stays a guided premium purchase (wizard unchanged)
+- Hub explains what / who / expected outcome without overselling
+- Active campaigns + eligible events listed with deep links
+- Performance export deep-links existing CSV routes
+
+## Growth strategy (in-product)
+
+1. Publish → share public link / QR / social  
+2. Optional Boost for discovery on MyEventLane  
+3. Widgets for owned websites  
+4. Audience page for return guests  
+5. Analytics for deeper pulse (not invented here)
+
+## Instrumentation (documented; logger + data attributes)
+
+| Event | Where | Pipeline |
+| --- | --- | --- |
+| `marketing_opened` | Hub builder logger + Twig | Deferred collector |
+| `share_link_copied` | Copy buttons + Twig attrs | Deferred collector |
+| `share_channel_selected` | Social / email links | Deferred collector |
+| `boost_started` | Boost CTAs | Deferred collector |
+| `boost_completed` | Existing Boost purchase success (unchanged) | Existing |
+| `widget_copied` | Widgets entry CTAs | Deferred collector |
+
+Do not invent new telemetry tables in this epic.
+
+## Accessibility
+
+- Jump nav + section headings
+- 44px share / CTA targets
+- QR `alt` text names the event
+- Copy status via `aria-live="polite"`
+- Focus-visible rings; `prefers-reduced-motion` respected
+
+## Manual QA checklist
+
+- [ ] New organiser — no live events health + publish CTA
+- [ ] Published event — public link, copy, QR, social channels
+- [ ] Boost eligible — Start Boost deep link
+- [ ] Active Boost — campaign status + end date
+- [ ] Widgets entry opens Tickets widgets
+- [ ] `/vendor/boost` redirects to `#boost`
+- [ ] Analytics Open Marketing → hub
+- [ ] Desktop / tablet / 390px
+- [ ] Keyboard through jump → health → share → Boost
+- [ ] Screen reader: health region, score, QR alt, copy status
+
+## Inventory
+
+See `docs/implementation/vx2-09-marketing-surface-inventory.md`.
+
+## Remaining roadmap
+
+- Wire product analytics collector for documented events
+- Page views / traffic sources / conversion on Marketing home (instrumentation)
+- Optional hide duplicate Boost local task after bake-in
+- Optional redirect `/event/{id}/boost` → vendor workspace Boost
+- Audience export route fix (dead `/vendor/audience/export` noted in inventory)

--- a/docs/implementation/vx2-09-marketing-hub.md
+++ b/docs/implementation/vx2-09-marketing-hub.md
@@ -9,7 +9,7 @@
 - Organiser **Marketing** hub at `/vendor/marketing` (Event Growth Centre)
 - Sections: Marketing Health · Share Event · Boost · Widgets & Embeds · Social Media · Audience Growth · Marketing Performance · Recommended Actions
 - Shell nav **Marketing** points at the hub (was `/vendor/boost`)
-- `/vendor/boost` redirects to `/vendor/marketing?section=boost` (JS scrolls to Boost; fragments are not used on Location)
+- `/vendor/boost` redirects to `/vendor/marketing?section=boost#boost` (JS scrolls/focuses; `#boost` works without JS)
 - Event Workspace Marketing deepened (share channels, widgets, Boost, Marketing home link)
 - Overview / next-action “Promote” → **Open Marketing** / **Share**
 - Analytics “Open Marketing” CTA → Marketing hub
@@ -30,7 +30,7 @@
 Convergence redirects:
 
 ```text
-/vendor/boost                        → /vendor/marketing?section=boost (#boost via JS)
+/vendor/boost                        → /vendor/marketing?section=boost#boost
 /vendor/event/{id}/promote           → /vendor/events/{id}/studio/marketing
 ```
 
@@ -77,7 +77,7 @@ Do not invent new telemetry tables in this epic.
 - [ ] Boost eligible — Start Boost deep link
 - [ ] Active Boost — campaign status + end date
 - [ ] Widgets entry opens Tickets widgets
-- [ ] `/vendor/boost` redirects to Marketing and scrolls to Boost
+- [ ] `/vendor/boost` redirects to Marketing (`?section=boost#boost`) and lands on Boost (JS and no-JS)
 - [ ] Analytics Open Marketing → hub
 - [ ] Desktop / tablet / 390px
 - [ ] Keyboard through jump → health → share → Boost

--- a/docs/implementation/vx2-09-marketing-surface-inventory.md
+++ b/docs/implementation/vx2-09-marketing-surface-inventory.md
@@ -23,7 +23,7 @@
 | Surface | Path | Disposition | Notes |
 | --- | --- | --- | --- |
 | Marketing hub (new) | `/vendor/marketing` | **CREATE** | Event Growth Centre |
-| Boost campaigns page | `/vendor/boost` | **REDIRECT** → `/vendor/marketing#boost` | Content merged into hub Boost section |
+| Boost campaigns page | `/vendor/boost` | **REDIRECT** → `/vendor/marketing?section=boost` | Content merged into hub Boost section; JS scrolls to `#boost` |
 | Audience | `/vendor/audience` | **MERGE** entry | Deep page kept; Marketing · Audience Growth CTA |
 | Boost vendor export | `/vendor/dashboard/boost/export` | **KEEP** | Linked from Marketing Performance |
 | Growth CTA / dismiss | `/vendor/growth/*` | **KEEP** | Infra; guidance surfaces under Marketing |

--- a/docs/implementation/vx2-09-marketing-surface-inventory.md
+++ b/docs/implementation/vx2-09-marketing-surface-inventory.md
@@ -1,0 +1,83 @@
+# VX2-09 — Marketing surface inventory
+
+**Epic:** VX2-09 Marketing (Event Growth Centre)  
+**Branch:** `feature/vx2-marketing`  
+**Date:** 2026-07-24  
+**Authority:** Vendor Experience Convergence · Screen Specs A9/B10 · Language Guide · Implementation Plan
+
+## Disposition legend
+
+| Code | Meaning |
+| --- | --- |
+| **KEEP** | Remains as deep page / infra |
+| **MERGE** | Content or entry absorbed into Marketing hub |
+| **RENAME** | Organiser-facing label changes |
+| **HIDE** | Remove from nav once Marketing owns entry |
+| **REDIRECT** | Legacy URL → Marketing destination |
+| **RETIRE** | Remove after redirect bake-in |
+
+---
+
+## Shell / vendor-global
+
+| Surface | Path | Disposition | Notes |
+| --- | --- | --- | --- |
+| Marketing hub (new) | `/vendor/marketing` | **CREATE** | Event Growth Centre |
+| Boost campaigns page | `/vendor/boost` | **REDIRECT** → `/vendor/marketing#boost` | Content merged into hub Boost section |
+| Audience | `/vendor/audience` | **MERGE** entry | Deep page kept; Marketing · Audience Growth CTA |
+| Boost vendor export | `/vendor/dashboard/boost/export` | **KEEP** | Linked from Marketing Performance |
+| Growth CTA / dismiss | `/vendor/growth/*` | **KEEP** | Infra; guidance surfaces under Marketing |
+| Shell nav Marketing | was → boost | **REPOINT** → marketing hub | Label already Marketing |
+| Analytics “Open Marketing” | CTA → events | **REPOINT** → marketing hub | |
+
+## Event Workspace
+
+| Surface | Path | Disposition | Notes |
+| --- | --- | --- | --- |
+| Marketing section | `/vendor/events/{id}/studio/marketing` | **KEEP / deepen** | Share, social, QR, widgets, Boost |
+| Overview Marketing card CTA “Promote” | Overview | **RENAME** → Share / Open Marketing | |
+| Boost local task / legacy tab | workspace | **HIDE** preferred | Marketing owns entry; Boost deep pages remain |
+| Manage-event promote stub | `/vendor/event/{id}/promote` | **REDIRECT** | → workspace Marketing (was Boost page) |
+
+## Boost product
+
+| Surface | Disposition | Notes |
+| --- | --- | --- |
+| Wizard steps / purchase / success | **KEEP** | Premium guided flow |
+| `/vendor/events/{id}/boost` | **KEEP** | Deep link from Marketing |
+| `/event/{id}/boost` | **KEEP** (optional later redirect) | Still used by some CTAs |
+| Impression beacon / exports / PDF | **KEEP** | Infra |
+
+## Widgets & embeds
+
+| Surface | Disposition | Notes |
+| --- | --- | --- |
+| Ticket widgets CRUD | **KEEP** | Single destination under Tickets |
+| Marketing entry to widgets | **MERGE** | Link only — no second CRUD |
+
+## Share / QR / social
+
+| Surface | Disposition | Notes |
+| --- | --- | --- |
+| Public event URL + view | **KEEP / expand** | Copy link on hub + event Marketing |
+| Publish celebrate social | **MERGE** pattern | Same Facebook / LinkedIn / Email / Instagram guidance |
+| Event-share QR | **CREATE** | Uses existing ticket QR generator for public URL payload only |
+| Ticket / check-in QR | **DO NOT MERGE** | Door ops |
+
+## Explicitly out of Marketing
+
+| Surface | Why |
+| --- | --- |
+| `/vendor/events/{id}/promotion` | Messages compose (VX2-06) |
+| Studio `/studio/promotions` | Redirects to Messages |
+| Waitlist “Promote” | Attendee ops |
+| Staff Boost / Growth admin | Staff only |
+
+## Language
+
+| Avoid | Prefer |
+| --- | --- |
+| Grow / Grow event | Marketing |
+| Promotion / Promote (growth sense) | Marketing / Share / Boost |
+| Purchase surface | Ticket widget / Embed |
+| **Boost** | Keep as product name |

--- a/docs/implementation/vx2-09-marketing-surface-inventory.md
+++ b/docs/implementation/vx2-09-marketing-surface-inventory.md
@@ -23,7 +23,7 @@
 | Surface | Path | Disposition | Notes |
 | --- | --- | --- | --- |
 | Marketing hub (new) | `/vendor/marketing` | **CREATE** | Event Growth Centre |
-| Boost campaigns page | `/vendor/boost` | **REDIRECT** → `/vendor/marketing?section=boost` | Content merged into hub Boost section; JS scrolls to `#boost` |
+| Boost campaigns page | `/vendor/boost` | **REDIRECT** → `/vendor/marketing?section=boost#boost` | Content merged into hub Boost section; JS + native hash target `#boost` |
 | Audience | `/vendor/audience` | **MERGE** entry | Deep page kept; Marketing · Audience Growth CTA |
 | Boost vendor export | `/vendor/dashboard/boost/export` | **KEEP** | Linked from Marketing Performance |
 | Growth CTA / dismiss | `/vendor/growth/*` | **KEEP** | Infra; guidance surfaces under Marketing |

--- a/docs/product-system/LAUNCH_READINESS.md
+++ b/docs/product-system/LAUNCH_READINESS.md
@@ -46,7 +46,7 @@ Success metrics prove outcomes over time; this checklist declares **launch-ready
 | **Messages (VX2-06)** | Needs work | Hub + compose shipped | Audience filters; schedule UI; collector |
 | **Payments (VX2-07)** | Needs work | Hub shipped; strong trust copy | Residual settings strings; refund route ownership; QA |
 | **Analytics (VX2-08)** | Needs work | Hub shipped as Event Intelligence Centre; Insights/Exports redirect; free pulse unlocked | Collector wiring; Audience/Boost depth; QA sign-off |
-| **Marketing (VX2-09)** | Needs work | Boost + Marketing sections | Scan/hierarchy polish; share tools cohesion |
+| **Marketing (VX2-09)** | Needs work | Event Growth Centre at `/vendor/marketing`; share/Boost/widgets; `/vendor/boost` redirect | Collector wiring; page-view instrumentation; QA sign-off |
 | **Settings & Support (VX2-10)** | Needs work | Settings/Support live | Branding satellite consolidation |
 | **Global Orders hub** | Not started | Event-scoped only | C-17 hub |
 | **Instrumentation / metrics pipeline** | Not started | Hooks logged/marked; collector deferred | Wire collector; baselines |
@@ -66,7 +66,7 @@ Success metrics prove outcomes over time; this checklist declares **launch-ready
 | Draft-choice clarity | Ready | Create CTAs through gateway |
 | Commerce jargon impressions | Needs work | Critical paths purged; residual edges |
 | Nav ≤10 | Ready | Sprint 1 Convergence IA |
-| Duplicate surfaces live | Needs work | Messages/Payments/Analytics converged; Check-in residual |
+| Duplicate surfaces live | Needs work | Messages/Payments/Analytics/Marketing converged; Check-in residual |
 | Door Mode task success | Needs work | Pending moderated test |
 | A11y critical on shell + Door Mode | Needs work | Pattern review done; live zero-critical not proven |
 | 403 dead-ends on known P0 | Blocked → Needs work | Partial; C-01/C-02 |
@@ -108,7 +108,7 @@ Runtime implementation of remaining debt is **out of scope** for this documentat
 
 | Dimension | Rating | Rationale |
 | --- | --- | --- |
-| Product maturity | **7.8 / 10** | Spine shipped through Payments/Messages; Orders/Analytics depth open |
+| Product maturity | **8.0 / 10** | Spine shipped through Payments/Messages/Analytics/Marketing; Orders depth open |
 | Design maturity | **8.2 / 10** | Layout + Workspace Home + hubs coherent |
 | Interaction maturity | **7.8 / 10** | Intentional on new surfaces; parallel shells remain |
 | Consistency | **8.0 / 10** | Strong post-VX2; card/Studio CSS edges |

--- a/docs/product-system/MEL_ACCESSIBILITY_REVIEW.md
+++ b/docs/product-system/MEL_ACCESSIBILITY_REVIEW.md
@@ -47,6 +47,7 @@ Core organiser patterns: Dashboard, Event Workspace, Tickets, Attendees / Door M
 | **Empty states** | `role="status"` polite when governed | Wave B + MelComponentAccessibilityHelper |
 | **Payments hub** | Health region heading; keyboard CTAs | In VX2-07 QA checklist |
 | **Messages hub** | Section headings; compose radios | In VX2-06 QA checklist |
+| **Marketing hub** | Jump nav; share controls; QR alt; copy live region | In VX2-09 QA checklist |
 | **Door Mode** | Large targets; SR check-in feedback; no colour-only | Critical path — must pass manual QA before launch claims |
 | **Publish blocked** | Checklist items as text links/buttons | Human readiness strip |
 

--- a/docs/product-system/MEL_PRODUCT_SYSTEM.md
+++ b/docs/product-system/MEL_PRODUCT_SYSTEM.md
@@ -42,7 +42,7 @@ Companion audits in this folder cover patterns, components, microcopy, interacti
 
 # Stage 1 — VX2 sprint review
 
-Evidence base: Convergence pack (2026-07-22), Sprint 1–4 + VX2-02A + Event Home redesign, VX2-06 Messages Hub, VX2-07 Payments Hub (2026-07-24), layout UX scores in `vx2-02a-workspace-layout-convergence.md`.
+Evidence base: Convergence pack (2026-07-22), Sprint 1–4 + VX2-02A + Event Home redesign, VX2-06 Messages Hub, VX2-07 Payments Hub, VX2-08 Analytics Hub, VX2-09 Marketing Hub (2026-07-24), layout UX scores in `vx2-02a-workspace-layout-convergence.md`.
 
 ## Dashboard
 
@@ -97,6 +97,15 @@ Evidence base: Convergence pack (2026-07-22), Sprint 1–4 + VX2-02A + Event Hom
 | **Inconsistent** | Audience filters marked Soon; schedule edit/cancel/retry incomplete; Pro template deep links |
 | **Still Drupal** | Residual admin/platform messaging jargon outside organiser surfaces |
 | **Unfinished** | Schedule UI; advanced audience; analytics collector |
+
+## Marketing (VX2-09)
+
+| Lens | Finding |
+| --- | --- |
+| **Excellent** | Marketing Hub (Event Growth Centre); Health score; Share + QR; honest Boost copy; widgets entry |
+| **Inconsistent** | Boost local task still parallel to Marketing nav; `/event/{id}/boost` alternate path |
+| **Still Drupal** | Growth admin/report labels residual |
+| **Unfinished** | Page views / traffic on hub; collector wiring; Audience export dead link |
 
 ## Cross-sprint verdict
 

--- a/docs/vendor-experience-convergence-implementation-plan.md
+++ b/docs/vendor-experience-convergence-implementation-plan.md
@@ -403,7 +403,7 @@ Promote/Grow/Boost synonym soup reduced to Marketing + Boost.
 **Done** on `feature/vx2-marketing` — see [`implementation/vx2-09-marketing-hub.md`](implementation/vx2-09-marketing-hub.md).
 
 - `/vendor/marketing` Event Growth Centre  
-- Shell Marketing → hub; `/vendor/boost` → `#boost`  
+- Shell Marketing → hub; `/vendor/boost` → `?section=boost` (scroll to Boost)  
 - Event Workspace Marketing deepened  
 - Residual “Promote” CTAs renamed to Share / Open Marketing  
 

--- a/docs/vendor-experience-convergence-implementation-plan.md
+++ b/docs/vendor-experience-convergence-implementation-plan.md
@@ -398,7 +398,15 @@ Boost and share live under Marketing.
 
 Promote/Grow/Boost synonym soup reduced to Marketing + Boost.
 
----
+### Runtime status (2026-07-24)
+
+**Done** on `feature/vx2-marketing` — see [`implementation/vx2-09-marketing-hub.md`](implementation/vx2-09-marketing-hub.md).
+
+- `/vendor/marketing` Event Growth Centre  
+- Shell Marketing → hub; `/vendor/boost` → `#boost`  
+- Event Workspace Marketing deepened  
+- Residual “Promote” CTAs renamed to Share / Open Marketing  
+
 
 ## VX2-10 — Settings & Support
 

--- a/docs/vendor-experience-convergence-navigation.md
+++ b/docs/vendor-experience-convergence-navigation.md
@@ -27,7 +27,7 @@ Commerce · Content · Stores · Media · Taxonomy · Configuration
 | 5 | **Messages** | Brand, templates, history | `/vendor/messages` | Messaging brand + fragmented send UIs |
 | 6 | **Payments** | Stripe, payouts, refunds, tax | `/vendor/payments` | Payouts + Stripe + refunds + finance |
 | 7 | **Analytics** | Business pulse | `/vendor/analytics` | Insights label → Analytics route; merge Insights |
-| 8 | **Marketing** | Boost, share, growth | `/vendor/marketing` | Grow event / Boost hub |
+| 8 | **Marketing** | Boost, share, growth | `/vendor/marketing` | Grow event / Boost hub → Event Growth Centre (VX2-09) |
 | 9 | **Settings** | Profile, venues, defaults | `/vendor/settings` | Organiser settings |
 | 10 | **Support** | Help + escalations | `/vendor/support` | Support + Help |
 

--- a/docs/vendor-experience-convergence-screen-specifications.md
+++ b/docs/vendor-experience-convergence-screen-specifications.md
@@ -101,6 +101,7 @@ Format: Purpose · Primary action · Content · States · Notes
 | **Content** | Boost hub; share tips; widgets entry; audience growth |
 | **States** | No live events; eligible Boost; active campaigns |
 | **Notes** | Renames Grow event |
+| **VX2-09** | Live at `/vendor/marketing` (Event Growth Centre) — see `implementation/vx2-09-marketing-hub.md` |
 
 ### A10. Settings
 
@@ -236,6 +237,7 @@ Format: Purpose · Primary action · Content · States · Notes
 | **Primary action** | Share link / Start Boost |
 | **Content** | Public URL; social share; Boost wizard entry; embed widget |
 | **Notes** | Boost remains guided wizard |
+| **VX2-09** | Deepened share channels + widgets + Marketing home link |
 
 ### B11. Orders (event)
 

--- a/docs/vendor-experience-convergence-success-metrics.md
+++ b/docs/vendor-experience-convergence-success-metrics.md
@@ -98,6 +98,7 @@ Minimum events to log (names illustrative):
 - `access_code_created` / `widget_created`
 - `event_publish_succeeded` / `event_publish_blocked` (+ reason codes)
 - `boost_wizard_step` / `boost_purchased`
+- `marketing_opened` / `share_link_copied` / `share_channel_selected` / `boost_started` / `boost_completed` / `widget_copied` (VX2-09; collector deferred)
 - `message_sent` / `message_failed`
 - `door_checkin_succeeded` / `door_checkin_failed`
 - `attendee_export_requested` / `attendee_export_ready`

--- a/docs/vendor-experience-convergence.md
+++ b/docs/vendor-experience-convergence.md
@@ -191,7 +191,7 @@ Repeat organiser
 | **Questions** | Share link? Boost? What’s the difference? |
 | **Pain points** | Grow / Boost / Promote / Marketing language mix; Boost wizard separate from Messages |
 | **Current** | `/vendor/boost`, event Boost wizard, Studio messaging, promotion routes |
-| **Ideal** | Marketing hub: Share · Boost · Messages · Widgets — one place |
+| **Ideal** | Marketing hub: Share · Boost · Widgets · Audience growth — one place |
 
 ### 9. Watch sales
 
@@ -453,6 +453,6 @@ Full definitions: [`vendor-experience-convergence-success-metrics.md`](vendor-ex
 
 **Biggest organiser friction:** Parallel products for one event (Studio vs Manager vs legacy) plus fragmented Messages, Analytics, and Payments — Attendees/Door Mode and Tickets are now converged.
 
-**Biggest revenue opportunities:** Faster first publish; higher Stripe completion; free Analytics pulse that earns Pro; clearer Boost / Marketing; fewer support dead ends that abandon paid flows.
+**Biggest revenue opportunities:** Faster first publish; higher Stripe completion; free Analytics pulse that earns Pro; clearer Boost / Marketing hub; fewer support dead ends that abandon paid flows.
 
-**Vendor Experience Convergence blueprint is complete.** Sprint 1 delivered Trust, Language & Navigation; Sprint 2 delivered One Event Workspace; Sprint 3 delivered The Ticket Experience; Sprint 4 delivered One Attendee Workspace; VX2-07 delivered the Payments Hub; VX2-06 delivered the Messages Hub; remaining epics follow the roadmap.
+**Vendor Experience Convergence blueprint is complete.** Sprint 1 delivered Trust, Language & Navigation; Sprint 2 delivered One Event Workspace; Sprint 3 delivered The Ticket Experience; Sprint 4 delivered One Attendee Workspace; VX2-07 delivered the Payments Hub; VX2-06 delivered the Messages Hub; VX2-08 delivered the Analytics Hub; VX2-09 delivered the Marketing Hub (Event Growth Centre); remaining epics follow the roadmap.

--- a/web/modules/custom/myeventlane_analytics/src/Service/VendorAnalyticsViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_analytics/src/Service/VendorAnalyticsViewModelBuilder.php
@@ -688,7 +688,8 @@ final class VendorAnalyticsViewModelBuilder {
           ['label' => (string) $this->t('Active Boosts'), 'value' => (string) $boostActive],
         ],
         'cta_label' => (string) $this->t('Open Marketing'),
-        'cta_url' => $this->safeUrlFromRoute('myeventlane_vendor.console.events')?->toString(),
+        'cta_url' => $this->safeUrlFromRoute('myeventlane_vendor.console.marketing')?->toString()
+          ?? $this->safeUrlFromRoute('myeventlane_vendor.console.boost')?->toString(),
         'pro_only' => FALSE,
       ],
       [

--- a/web/modules/custom/myeventlane_boost/src/Service/BoostHelpContent.php
+++ b/web/modules/custom/myeventlane_boost/src/Service/BoostHelpContent.php
@@ -80,9 +80,9 @@ final class BoostHelpContent {
    */
   public function getOnboardingContent(): array {
     return [
-      'title' => 'Promote your event with Boost',
+      'title' => 'Boost your event',
       'intro' => [
-        'Boost can feature your event in promoted placements across the site.',
+        'Boost can feature your event in placements across the site.',
         'You’ll see clear performance metrics so you can understand visibility and interest.',
       ],
       'sections' => [

--- a/web/modules/custom/myeventlane_core/src/Service/DomainDetector.php
+++ b/web/modules/custom/myeventlane_core/src/Service/DomainDetector.php
@@ -179,6 +179,35 @@ final class DomainDetector {
   }
 
   /**
+   * Builds an absolute public URL suitable for sharing, copy, and QR codes.
+   *
+   * Unlike publicUrl(), this never returns a site-relative path: scanners and
+   * social/share paste destinations need a full http(s) URL.
+   *
+   * @param string $internal_path
+   *   A Drupal-generated relative path, e.g. /events/my-event.
+   *
+   * @return string
+   *   Absolute public URL (configured public host when available).
+   */
+  public function absolutePublicUrl(string $internal_path): string {
+    $path = '/' . ltrim($internal_path, '/');
+    $candidate = $this->publicUrl($path);
+
+    if (preg_match('#^https?://#i', $candidate) === 1) {
+      return $candidate;
+    }
+
+    $relative = '/' . ltrim($candidate, '/');
+    try {
+      return $this->buildDomainUrl($relative, 'public');
+    }
+    catch (\Throwable) {
+      return Url::fromUserInput($relative)->setAbsolute()->toString();
+    }
+  }
+
+  /**
    * Converts a Drupal Url object to one pointing at the public domain.
    *
    * Returns the original Url unchanged when already on the public domain

--- a/web/modules/custom/myeventlane_core/src/Service/DomainDetector.php
+++ b/web/modules/custom/myeventlane_core/src/Service/DomainDetector.php
@@ -181,14 +181,19 @@ final class DomainDetector {
   /**
    * Builds an absolute public URL suitable for sharing, copy, and QR codes.
    *
-   * Unlike publicUrl(), this never returns a site-relative path: scanners and
-   * social/share paste destinations need a full http(s) URL.
+   * Prefer absolute http(s) URLs for scanners and social/share paste.
+   *
+   * Never falls back to the vendor/admin console host. When public_domain is
+   * unset, derives the public origin from configured vendor_domain or by
+   * stripping a conventional vendor./admin. request-host prefix. If no public
+   * origin can be determined safely, returns a site-relative path rather than
+   * an absolute URL on the wrong host.
    *
    * @param string $internal_path
    *   A Drupal-generated relative path, e.g. /events/my-event.
    *
    * @return string
-   *   Absolute public URL (configured public host when available).
+   *   Absolute public URL when possible; otherwise a site-relative path.
    */
   public function absolutePublicUrl(string $internal_path): string {
     $path = '/' . ltrim($internal_path, '/');
@@ -203,8 +208,63 @@ final class DomainDetector {
       return $this->buildDomainUrl($relative, 'public');
     }
     catch (\Throwable) {
-      return Url::fromUserInput($relative)->setAbsolute()->toString();
+      $origin = $this->resolvePublicOriginForAbsoluteUrl();
+      if ($origin !== NULL) {
+        return rtrim($origin, '/') . $relative;
+      }
+      // Last resort on a confirmed public/shared host only — never pin share
+      // or QR payloads to vendor/admin console origins.
+      if ($this->isPublicDomain()) {
+        return Url::fromUserInput($relative)->setAbsolute()->toString();
+      }
+      // Console host with no derivable public origin: keep site-relative rather
+      // than invent a wrong absolute URL for scanners/social paste.
+      return $relative;
     }
+  }
+
+  /**
+   * Resolves scheme://host for public share URLs when public_domain is unset.
+   *
+   * @return string|null
+   *   Public origin, or NULL if it cannot be determined safely.
+   */
+  private function resolvePublicOriginForAbsoluteUrl(): ?string {
+    // Prefer deriving from configured vendor_domain (strip vendor. prefix).
+    try {
+      $vendorBase = $this->getConfiguredDomainUrl('vendor_domain');
+      $parsed = parse_url($vendorBase);
+      if (isset($parsed['scheme'], $parsed['host'])) {
+        $host = strtolower((string) $parsed['host']);
+        if (str_starts_with($host, 'vendor.') && strlen($host) > strlen('vendor.')) {
+          return $parsed['scheme'] . '://' . substr($host, strlen('vendor.'));
+        }
+      }
+    }
+    catch (\Throwable) {
+      // Fall through to request-based derivation.
+    }
+
+    $request = $this->getRequest();
+    if ($request === NULL) {
+      return NULL;
+    }
+
+    // Shared / public host (including single-host DDEV): current origin is fine.
+    if ($this->isPublicDomain()) {
+      return $request->getSchemeAndHttpHost();
+    }
+
+    // Vendor/admin console: strip conventional subdomain prefixes.
+    $host = strtolower($request->getHost());
+    $scheme = $request->getScheme();
+    foreach (['vendor.', 'admin.'] as $prefix) {
+      if (str_starts_with($host, $prefix) && strlen($host) > strlen($prefix)) {
+        return $scheme . '://' . substr($host, strlen($prefix));
+      }
+    }
+
+    return NULL;
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_event_studio\Service;
 
+use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -126,7 +127,10 @@ final class EventStudioSectionRenderer {
   }
 
   /**
+   * Builds the Event Workspace Marketing hub for a single event.
+   *
    * @return array<string, mixed>
+   *   Render array for the Marketing section.
    */
   private function buildMarketingHub(NodeInterface $event): array {
     $nid = (int) $event->id();
@@ -140,6 +144,20 @@ final class EventStudioSectionRenderer {
     }
     catch (\Throwable) {
       $boostUrl = NULL;
+    }
+    $widgetsUrl = NULL;
+    try {
+      $widgetsUrl = Url::fromRoute('myeventlane_tickets.event_tickets_widgets', ['event' => $nid])->toString();
+    }
+    catch (\Throwable) {
+      $widgetsUrl = NULL;
+    }
+    $marketingHomeUrl = NULL;
+    try {
+      $marketingHomeUrl = Url::fromRoute('myeventlane_vendor.console.marketing')->toString();
+    }
+    catch (\Throwable) {
+      $marketingHomeUrl = NULL;
     }
 
     if (!$event->isPublished()) {
@@ -162,13 +180,24 @@ final class EventStudioSectionRenderer {
       );
     }
 
+    $title = (string) $event->label();
+    $facebook = 'https://www.facebook.com/sharer/sharer.php?' . UrlHelper::buildQuery(['u' => $publicUrl]);
+    $linkedin = 'https://www.linkedin.com/sharing/share-offsite/?' . UrlHelper::buildQuery(['url' => $publicUrl]);
+    $mailto = 'mailto:?' . UrlHelper::buildQuery([
+      'subject' => (string) $this->t('Join me at @title', ['@title' => $title]),
+      'body' => (string) $this->t("I thought you might like this event on MyEventLane:\n\n@url", ['@url' => $publicUrl]),
+    ]);
+
     return [
       '#type' => 'container',
-      '#attributes' => ['class' => ['mel-event-workspace-marketing']],
+      '#attributes' => [
+        'class' => ['mel-event-workspace-marketing'],
+        'data-mel-analytics-event' => 'marketing_opened',
+      ],
       'intro' => [
         '#type' => 'html_tag',
         '#tag' => 'p',
-        '#value' => $this->t('Drive ticket sales for this event. Share your public page or Boost visibility across MyEventLane.'),
+        '#value' => $this->t('Drive ticket sales for this event. Share your public page, embed a widget, or Boost visibility across MyEventLane.'),
       ],
       'share' => [
         '#type' => 'container',
@@ -182,18 +211,86 @@ final class EventStudioSectionRenderer {
           '#type' => 'html_tag',
           '#tag' => 'p',
           '#value' => $publicUrl,
+          '#attributes' => ['class' => ['mel-event-workspace-marketing__url']],
         ],
-        'view' => [
-          '#type' => 'link',
-          '#title' => $this->t('View page'),
-          '#url' => Url::fromRoute('entity.node.canonical', ['node' => $nid]),
+        'channels' => [
+          '#type' => 'container',
           '#attributes' => [
-            'class' => ['mel-btn', 'mel-btn--secondary'],
-            'target' => '_blank',
-            'rel' => 'noopener noreferrer',
+            'class' => ['mel-event-workspace-marketing__channels'],
+            'role' => 'group',
+            'aria-label' => (string) $this->t('Share channels'),
+          ],
+          'view' => [
+            '#type' => 'link',
+            '#title' => $this->t('View page'),
+            '#url' => Url::fromRoute('entity.node.canonical', ['node' => $nid]),
+            '#attributes' => [
+              'class' => ['mel-btn', 'mel-btn--secondary'],
+              'target' => '_blank',
+              'rel' => 'noopener noreferrer',
+            ],
+          ],
+          'facebook' => [
+            '#type' => 'link',
+            '#title' => $this->t('Facebook'),
+            '#url' => Url::fromUri($facebook),
+            '#attributes' => [
+              'class' => ['mel-btn', 'mel-btn--secondary'],
+              'target' => '_blank',
+              'rel' => 'noopener noreferrer',
+              'data-mel-analytics-event' => 'share_channel_selected',
+            ],
+          ],
+          'linkedin' => [
+            '#type' => 'link',
+            '#title' => $this->t('LinkedIn'),
+            '#url' => Url::fromUri($linkedin),
+            '#attributes' => [
+              'class' => ['mel-btn', 'mel-btn--secondary'],
+              'target' => '_blank',
+              'rel' => 'noopener noreferrer',
+              'data-mel-analytics-event' => 'share_channel_selected',
+            ],
+          ],
+          'email' => [
+            '#type' => 'link',
+            '#title' => $this->t('Email'),
+            '#url' => Url::fromUri($mailto),
+            '#attributes' => [
+              'class' => ['mel-btn', 'mel-btn--secondary'],
+              'data-mel-analytics-event' => 'share_channel_selected',
+            ],
+          ],
+          'instagram' => [
+            '#type' => 'html_tag',
+            '#tag' => 'p',
+            '#value' => $this->t('Instagram: copy the public link above, then paste it into your post or story.'),
+            '#attributes' => ['class' => ['mel-event-workspace-marketing__hint']],
           ],
         ],
       ],
+      'widgets' => $widgetsUrl ? [
+        '#type' => 'container',
+        'title' => [
+          '#type' => 'html_tag',
+          '#tag' => 'h3',
+          '#value' => $this->t('Widgets & embeds'),
+        ],
+        'copy' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->t('Add a ticket widget to your own website.'),
+        ],
+        'cta' => [
+          '#type' => 'link',
+          '#title' => $this->t('Open widgets'),
+          '#url' => Url::fromRoute('myeventlane_tickets.event_tickets_widgets', ['event' => $nid]),
+          '#attributes' => [
+            'class' => ['mel-btn', 'mel-btn--secondary'],
+            'data-mel-analytics-event' => 'widget_copied',
+          ],
+        ],
+      ] : [],
       'boost' => $boostUrl ? [
         '#type' => 'container',
         'title' => [
@@ -204,14 +301,23 @@ final class EventStudioSectionRenderer {
         'copy' => [
           '#type' => 'html_tag',
           '#tag' => 'p',
-          '#value' => $this->t('Feature your event in discovery so more people find you.'),
+          '#value' => $this->t('Feature your event in discovery so more people find you. Boost never guarantees sales.'),
         ],
         'cta' => [
           '#type' => 'link',
           '#title' => $this->t('Start Boost'),
           '#url' => Url::fromRoute('myeventlane_boost.vendor_event_boost', ['event' => $nid]),
-          '#attributes' => ['class' => ['mel-btn', 'mel-btn--primary']],
+          '#attributes' => [
+            'class' => ['mel-btn', 'mel-btn--primary'],
+            'data-mel-analytics-event' => 'boost_started',
+          ],
         ],
+      ] : [],
+      'home' => $marketingHomeUrl ? [
+        '#type' => 'link',
+        '#title' => $this->t('Open Marketing home'),
+        '#url' => Url::fromRoute('myeventlane_vendor.console.marketing'),
+        '#attributes' => ['class' => ['mel-btn', 'mel-btn--secondary']],
       ] : [],
     ];
   }

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
@@ -136,8 +136,8 @@ final class EventStudioSectionRenderer {
     $nid = (int) $event->id();
     $publicPath = Url::fromRoute('entity.node.canonical', ['node' => $nid])->toString();
     $publicUrl = $this->domainDetector instanceof DomainDetector
-      ? $this->domainDetector->publicUrl($publicPath)
-      : $publicPath;
+      ? $this->domainDetector->absolutePublicUrl($publicPath)
+      : Url::fromUserInput('/' . ltrim($publicPath, '/'))->setAbsolute()->toString();
     $boostUrl = NULL;
     try {
       $boostUrl = Url::fromRoute('myeventlane_boost.vendor_event_boost', ['event' => $nid])->toString();

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventWorkspaceOverviewBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventWorkspaceOverviewBuilder.php
@@ -462,8 +462,7 @@ final class EventWorkspaceOverviewBuilder {
 
     $url = !$event->isPublished()
       ? $this->safeUrl('myeventlane_event_studio.workspace_publishing', ['node' => $nid])
-      : ($this->safeUrl('myeventlane_boost.vendor_event_boost', ['event' => $nid])
-        ?? $this->safeUrl('myeventlane_event_studio.workspace_marketing', ['node' => $nid]));
+      : $this->safeUrl('myeventlane_event_studio.workspace_marketing', ['node' => $nid]);
 
     return [
       'title' => (string) $this->t('Marketing'),

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventWorkspaceOverviewBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventWorkspaceOverviewBuilder.php
@@ -457,7 +457,7 @@ final class EventWorkspaceOverviewBuilder {
       ? (string) $this->t('Homepage featured')
       : (string) $this->t('Not homepage featured');
     if (!$event->isPublished()) {
-      $lines = [(string) $this->t('Publish to share and promote.')];
+      $lines = [(string) $this->t('Publish to share and Boost.')];
     }
 
     $url = !$event->isPublished()
@@ -468,7 +468,7 @@ final class EventWorkspaceOverviewBuilder {
     return [
       'title' => (string) $this->t('Marketing'),
       'lines' => $lines,
-      'action_label' => (string) $this->t('Promote'),
+      'action_label' => (string) $this->t('Open Marketing'),
       'url' => $url,
     ];
   }
@@ -973,7 +973,7 @@ final class EventWorkspaceOverviewBuilder {
     return [
       'title' => (string) $this->t('Share your event'),
       'message' => (string) $this->t('Your event is live. Share the page or message your attendees.'),
-      'action_label' => (string) $this->t('Promote'),
+      'action_label' => (string) $this->t('Share'),
       'url' => $this->safeUrl('myeventlane_event_studio.workspace_marketing', ['node' => $nid]),
     ];
   }

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventWorkspaceOverviewNextActionTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventWorkspaceOverviewNextActionTest.php
@@ -65,7 +65,7 @@ final class EventWorkspaceOverviewNextActionTest extends UnitTestCase {
     );
 
     $this->assertSame('Share your event', $action['title']);
-    $this->assertSame('Promote', $action['action_label']);
+    $this->assertSame('Share', $action['action_label']);
   }
 
   public function testLiveBookingActivityKeepsMissionControlAction(): void {

--- a/web/modules/custom/myeventlane_vendor/js/marketing-hub.js
+++ b/web/modules/custom/myeventlane_vendor/js/marketing-hub.js
@@ -1,0 +1,75 @@
+/**
+ * @file
+ * Marketing hub share controls (copy link + live status).
+ */
+(function (Drupal, once) {
+  'use strict';
+
+  /**
+   * Copies text to the clipboard with a textarea fallback.
+   *
+   * @param {string} text
+   * @return {Promise<void>}
+   */
+  function copyText(text) {
+    if (navigator.clipboard && window.isSecureContext) {
+      return navigator.clipboard.writeText(text);
+    }
+    return new Promise(function (resolve, reject) {
+      const area = document.createElement('textarea');
+      area.value = text;
+      area.setAttribute('readonly', '');
+      area.style.position = 'fixed';
+      area.style.left = '-9999px';
+      document.body.appendChild(area);
+      area.select();
+      try {
+        const ok = document.execCommand('copy');
+        document.body.removeChild(area);
+        if (ok) {
+          resolve();
+        }
+        else {
+          reject(new Error('Copy command failed'));
+        }
+      }
+      catch (e) {
+        document.body.removeChild(area);
+        reject(e);
+      }
+    });
+  }
+
+  Drupal.behaviors.melMarketingHub = {
+    attach(context) {
+      once('mel-marketing-hub-copy', '[data-mel-share-copy]', context).forEach(function (button) {
+        button.addEventListener('click', function () {
+          const url = button.getAttribute('data-copy-url') || '';
+          const card = button.closest('[data-mel-share-card]');
+          const status = card ? card.querySelector('[data-mel-copy-status]') : null;
+          if (!url) {
+            if (status) {
+              status.textContent = Drupal.t('Nothing to copy yet.');
+            }
+            return;
+          }
+          copyText(url)
+            .then(function () {
+              if (status) {
+                status.textContent = Drupal.t('Link copied. Paste it wherever your community is.');
+              }
+              button.setAttribute('aria-label', Drupal.t('Link copied'));
+              window.setTimeout(function () {
+                button.removeAttribute('aria-label');
+              }, 2000);
+            })
+            .catch(function () {
+              if (status) {
+                status.textContent = Drupal.t('Could not copy automatically. Select the link and copy it manually.');
+              }
+            });
+        });
+      });
+    },
+  };
+})(Drupal, once);

--- a/web/modules/custom/myeventlane_vendor/js/marketing-hub.js
+++ b/web/modules/custom/myeventlane_vendor/js/marketing-hub.js
@@ -64,6 +64,29 @@
 
   Drupal.behaviors.melMarketingHub = {
     attach(context) {
+      once('mel-marketing-hub-section', '[data-mel-marketing-hub]', context).forEach(function (hub) {
+        const params = new URLSearchParams(window.location.search);
+        if (params.get('section') !== 'boost') {
+          return;
+        }
+        const target = document.getElementById('boost');
+        if (!target) {
+          return;
+        }
+        const reduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        target.scrollIntoView({
+          behavior: reduceMotion ? 'auto' : 'smooth',
+          block: 'start',
+        });
+        if (!target.hasAttribute('tabindex')) {
+          target.setAttribute('tabindex', '-1');
+        }
+        target.focus({ preventScroll: true });
+        if (window.history && window.history.replaceState) {
+          window.history.replaceState(null, '', window.location.pathname + '#boost');
+        }
+      });
+
       once('mel-marketing-hub-copy', '[data-mel-share-copy]', context).forEach(function (button) {
         button.addEventListener('click', function () {
           const url = button.getAttribute('data-copy-url') || '';

--- a/web/modules/custom/myeventlane_vendor/js/marketing-hub.js
+++ b/web/modules/custom/myeventlane_vendor/js/marketing-hub.js
@@ -40,13 +40,34 @@
     });
   }
 
+  /**
+   * Finds the nearest copy-status live region for feedback.
+   *
+   * @param {Element} button
+   * @return {Element|null}
+   */
+  function findStatus(button) {
+    const card = button.closest('[data-mel-share-card]');
+    if (card) {
+      return card.querySelector('[data-mel-copy-status]');
+    }
+    const section = button.closest('section');
+    if (section) {
+      const local = section.querySelector('[data-mel-copy-status]');
+      if (local) {
+        return local;
+      }
+    }
+    const hub = button.closest('[data-mel-marketing-hub]');
+    return hub ? hub.querySelector('[data-mel-copy-status]') : null;
+  }
+
   Drupal.behaviors.melMarketingHub = {
     attach(context) {
       once('mel-marketing-hub-copy', '[data-mel-share-copy]', context).forEach(function (button) {
         button.addEventListener('click', function () {
           const url = button.getAttribute('data-copy-url') || '';
-          const card = button.closest('[data-mel-share-card]');
-          const status = card ? card.querySelector('[data-mel-copy-status]') : null;
+          const status = findStatus(button);
           if (!url) {
             if (status) {
               status.textContent = Drupal.t('Nothing to copy yet.');

--- a/web/modules/custom/myeventlane_vendor/js/marketing-hub.js
+++ b/web/modules/custom/myeventlane_vendor/js/marketing-hub.js
@@ -66,7 +66,9 @@
     attach(context) {
       once('mel-marketing-hub-section', '[data-mel-marketing-hub]', context).forEach(function (hub) {
         const params = new URLSearchParams(window.location.search);
-        if (params.get('section') !== 'boost') {
+        const wantsBoost = params.get('section') === 'boost'
+          || window.location.hash === '#boost';
+        if (!wantsBoost) {
           return;
         }
         const target = document.getElementById('boost');
@@ -83,6 +85,7 @@
         }
         target.focus({ preventScroll: true });
         if (window.history && window.history.replaceState) {
+          // Keep a stable, shareable Boost deep-link (hash for no-JS; drop query noise).
           window.history.replaceState(null, '', window.location.pathname + '#boost');
         }
       });

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.libraries.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.libraries.yml
@@ -129,3 +129,11 @@ event_ticket_manager:
     - core/drupal
     - core/once
 
+marketing_hub:
+  version: 1.x
+  js:
+    js/marketing-hub.js: {}
+  dependencies:
+    - core/drupal
+    - core/once
+

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml
@@ -647,10 +647,19 @@ myeventlane_vendor.console.payouts:
   requirements:
     _custom_access: 'myeventlane_vendor.access.vendor_console:access'
 
+myeventlane_vendor.console.marketing:
+  path: '/vendor/marketing'
+  defaults:
+    _controller: 'myeventlane_vendor.controller.vendor_marketing_hub:hub'
+    _title: 'Marketing'
+  requirements:
+    _custom_access: 'myeventlane_vendor.access.vendor_console:access'
+
+# Legacy Boost hub — redirects into Marketing · Boost (VX2-09).
 myeventlane_vendor.console.boost:
   path: '/vendor/boost'
   defaults:
-    _controller: 'myeventlane_vendor.controller.vendor_boost:boost'
+    _controller: 'myeventlane_vendor.controller.vendor_marketing_hub:redirectBoost'
     _title: 'Boost'
   requirements:
     _custom_access: 'myeventlane_vendor.access.vendor_console:access'

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -590,6 +590,32 @@ services:
     tags:
       - { name: controller.service_arguments }
 
+  myeventlane_vendor.marketing_hub_builder:
+    class: Drupal\myeventlane_vendor\Service\VendorMarketingHubBuilder
+    arguments:
+      - '@current_user'
+      - '@myeventlane_vendor.current_vendor_resolver'
+      - '@myeventlane_vendor.service.ticket_sales'
+      - '@entity_type.manager'
+      - '@module_handler'
+      - '@myeventlane_core.domain_detector'
+      - '@logger.channel.myeventlane_vendor'
+      - '@string_translation'
+      - '@?myeventlane_boost.manager'
+      - '@?myeventlane_boost.help_content'
+      - '@?myeventlane_event_state.resolver'
+      - '@?myeventlane_tickets.qr_code_generator'
+
+  myeventlane_vendor.controller.vendor_marketing_hub:
+    class: Drupal\myeventlane_vendor\Controller\VendorMarketingHubController
+    arguments:
+      - '@myeventlane_core.domain_detector'
+      - '@current_user'
+      - '@messenger'
+      - '@myeventlane_vendor.marketing_hub_builder'
+    tags:
+      - { name: controller.service_arguments }
+
   myeventlane_vendor.controller.vendor_boost:
     class: Drupal\myeventlane_vendor\Controller\VendorBoostController
     arguments:

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -594,7 +594,6 @@ services:
     class: Drupal\myeventlane_vendor\Service\VendorMarketingHubBuilder
     arguments:
       - '@current_user'
-      - '@myeventlane_vendor.current_vendor_resolver'
       - '@myeventlane_vendor.service.ticket_sales'
       - '@entity_type.manager'
       - '@module_handler'

--- a/web/modules/custom/myeventlane_vendor/src/Controller/ManageEventPlaceholderController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/ManageEventPlaceholderController.php
@@ -66,9 +66,9 @@ final class ManageEventPlaceholderController extends ManageEventControllerBase {
   private function destinationForPlaceholder(string $from, NodeInterface $event): array {
     $nid = (int) $event->id();
     return match ($from) {
-      // Promote / Marketing → Boost (not Messages / Publishing & updates).
+      // Promote / Marketing → Event Workspace Marketing.
       'myeventlane_vendor.manage_event.promote' => [
-        'myeventlane_boost.boost_page',
+        'myeventlane_event_studio.workspace_marketing',
         ['node' => $nid],
       ],
       'myeventlane_vendor.manage_event.comms' => [

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorDashboardController.php
@@ -2277,8 +2277,8 @@ final class VendorDashboardController extends VendorConsoleBaseController {
         'style' => 'secondary',
       ],
       [
-        'label' => 'Boost Event',
-        'url' => '/vendor/boost',
+        'label' => 'Open Marketing',
+        'url' => '/vendor/marketing',
         'icon' => 'zap',
         'style' => 'secondary',
       ],
@@ -2379,9 +2379,9 @@ final class VendorDashboardController extends VendorConsoleBaseController {
         'url' => $this->safeRouteUrl('myeventlane_vendor.console.settings'),
       ],
       [
-        'title' => (string) $this->t('Boost an event'),
-        'description' => (string) $this->t('Increase visibility for your published events.'),
-        'url' => $this->safeRouteUrl('myeventlane_vendor.console.boost'),
+        'title' => (string) $this->t('Open Marketing'),
+        'description' => (string) $this->t('Share events, Boost visibility, and grow your audience.'),
+        'url' => $this->safeRouteUrl('myeventlane_vendor.console.marketing'),
       ],
       [
         'title' => (string) $this->t('Review attendees'),

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorMarketingHubController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorMarketingHubController.php
@@ -75,13 +75,14 @@ final class VendorMarketingHubController extends VendorConsoleBaseController imp
   /**
    * Redirects legacy /vendor/boost into the Marketing hub Boost section.
    *
-   * Uses a query param (not a Location fragment). HTTP clients ignore fragments
-   * on redirect targets; JS scrolls to #boost when section=boost is present.
+   * Includes both ?section=boost (JS scroll + focus) and #boost (native
+   * in-page target when JavaScript is unavailable or the library fails).
    */
   public function redirectBoost(): RedirectResponse {
     return new RedirectResponse(
       Url::fromRoute('myeventlane_vendor.console.marketing', [], [
         'query' => ['section' => 'boost'],
+        'fragment' => 'boost',
       ])->toString(),
       302,
     );

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorMarketingHubController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorMarketingHubController.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_vendor\Controller;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\myeventlane_core\Service\DomainDetector;
+use Drupal\myeventlane_vendor\Service\VendorMarketingHubBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Drupal\Core\Url;
+
+/**
+ * Organiser Marketing Hub (Event Growth Centre).
+ *
+ * Product language: Marketing, Share, Boost, Widgets.
+ * Never Grow / Promote / advertising jargon in the hub chrome.
+ */
+final class VendorMarketingHubController extends VendorConsoleBaseController implements ContainerInjectionInterface {
+
+  public function __construct(
+    DomainDetector $domain_detector,
+    AccountProxyInterface $current_user,
+    MessengerInterface $messenger,
+    private readonly VendorMarketingHubBuilder $hubBuilder,
+  ) {
+    parent::__construct($domain_detector, $current_user, $messenger);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): self {
+    return new self(
+      $container->get('myeventlane_core.domain_detector'),
+      $container->get('current_user'),
+      $container->get('messenger'),
+      $container->get('myeventlane_vendor.marketing_hub_builder'),
+    );
+  }
+
+  /**
+   * Renders /vendor/marketing.
+   */
+  public function hub(): array {
+    $hub = $this->hubBuilder->build();
+
+    return $this->buildVendorPage('myeventlane_vendor_console_page', [
+      'title' => (string) $this->t('Marketing'),
+      'body' => [
+        '#theme' => 'myeventlane_vendor_marketing_hub',
+        '#hub' => $hub,
+        '#attached' => [
+          'library' => [
+            'myeventlane_vendor/marketing_hub',
+          ],
+          'drupalSettings' => [
+            'melMarketingHub' => [
+              'analytics' => $hub['analytics'] ?? [],
+            ],
+          ],
+        ],
+      ],
+      '#cache' => [
+        'contexts' => ['user', 'user.permissions'],
+        'max-age' => 60,
+      ],
+    ]);
+  }
+
+  /**
+   * Redirects legacy /vendor/boost into the Marketing hub Boost section.
+   */
+  public function redirectBoost(): RedirectResponse {
+    return new RedirectResponse(
+      Url::fromRoute('myeventlane_vendor.console.marketing')->toString() . '#boost',
+      302,
+    );
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorMarketingHubController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorMarketingHubController.php
@@ -64,19 +64,25 @@ final class VendorMarketingHubController extends VendorConsoleBaseController imp
           ],
         ],
       ],
+      // Booking / Boost / share data are live reads — do not page-cache KPIs.
       '#cache' => [
         'contexts' => ['user', 'user.permissions'],
-        'max-age' => 60,
+        'max-age' => 0,
       ],
     ]);
   }
 
   /**
    * Redirects legacy /vendor/boost into the Marketing hub Boost section.
+   *
+   * Uses a query param (not a Location fragment). HTTP clients ignore fragments
+   * on redirect targets; JS scrolls to #boost when section=boost is present.
    */
   public function redirectBoost(): RedirectResponse {
     return new RedirectResponse(
-      Url::fromRoute('myeventlane_vendor.console.marketing')->toString() . '#boost',
+      Url::fromRoute('myeventlane_vendor.console.marketing', [], [
+        'query' => ['section' => 'boost'],
+      ])->toString(),
       302,
     );
   }

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorOnboardBoostController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorOnboardBoostController.php
@@ -109,8 +109,8 @@ final class VendorOnboardBoostController extends ControllerBase {
       ],
       'open_boost' => [
         '#type' => 'link',
-        '#title' => $this->t('Go to Boost'),
-        '#url' => Url::fromRoute('myeventlane_vendor.console.boost'),
+        '#title' => $this->t('Go to Marketing'),
+        '#url' => Url::fromRoute('myeventlane_vendor.console.marketing'),
         '#attributes' => [
           'class' => ['mel-btn', 'mel-btn-primary', 'mel-btn-lg'],
         ],

--- a/web/modules/custom/myeventlane_vendor/src/Service/TicketSalesService.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/TicketSalesService.php
@@ -763,7 +763,10 @@ final class TicketSalesService {
   }
 
   /**
-   * Gets total order count for a vendor (all published events).
+   * Gets total completed order count for a vendor's authored published events.
+   *
+   * Prefer getCompletedOrderCountForEventIds() when the caller already has a
+   * managed-event ID list (team organisers are not always the node author).
    *
    * @param int $userId
    *   The vendor user ID.
@@ -777,21 +780,38 @@ final class TicketSalesService {
     }
 
     try {
-      $nodeStorage = $this->entityTypeManager->getStorage('node');
-      $eventIds = $nodeStorage->getQuery()
+      $eventIds = $this->entityTypeManager->getStorage('node')->getQuery()
         ->accessCheck(FALSE)
         ->condition('type', 'event')
         ->condition('uid', $userId)
         ->condition('status', 1)
         ->execute();
 
-      if (empty($eventIds)) {
-        return 0;
-      }
+      return $this->getCompletedOrderCountForEventIds(array_map('intval', array_values($eventIds)));
+    }
+    catch (\Exception) {
+      return 0;
+    }
+  }
 
-      $orderItemStorage = $this->entityTypeManager->getStorage('commerce_order_item');
-      $orderItems = $orderItemStorage->loadByProperties([
-        'field_target_event' => array_values($eventIds),
+  /**
+   * Counts distinct completed ticket orders for the given event node IDs.
+   *
+   * @param list<int> $eventIds
+   *   Event node IDs (typically managed / published events).
+   *
+   * @return int
+   *   Distinct completed order count (vendor-revenue-eligible items only).
+   */
+  public function getCompletedOrderCountForEventIds(array $eventIds): int {
+    $eventIds = array_values(array_unique(array_filter(array_map('intval', $eventIds), static fn(int $id): bool => $id > 0)));
+    if ($eventIds === []) {
+      return 0;
+    }
+
+    try {
+      $orderItems = $this->entityTypeManager->getStorage('commerce_order_item')->loadByProperties([
+        'field_target_event' => $eventIds,
       ]);
 
       $processedOrders = [];
@@ -818,10 +838,7 @@ final class TicketSalesService {
             ->getStorage('commerce_order')
             ->load($order_id);
           if ($order && $order->getState()->getId() === 'completed') {
-            $orderId = $order->id();
-            if (!isset($processedOrders[$orderId])) {
-              $processedOrders[$orderId] = TRUE;
-            }
+            $processedOrders[(string) $order->id()] = TRUE;
           }
         }
         catch (\Exception) {

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorDashboardViewModelBuilder.php
@@ -1282,7 +1282,8 @@ final class VendorDashboardViewModelBuilder {
         $actions,
         'promote',
         (string) $this->t('Marketing'),
-        $this->safeUrlFromRouteIfAccessible('myeventlane_vendor.console.boost', [], $account),
+        $this->safeUrlFromRouteIfAccessible('myeventlane_vendor.console.marketing', [], $account)
+          ?? $this->safeUrlFromRouteIfAccessible('myeventlane_vendor.console.boost', [], $account),
       );
     }
     $this->appendOrganiserAction(

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorMarketingHubBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorMarketingHubBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_vendor\Service;
 
+use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
@@ -54,14 +55,19 @@ final class VendorMarketingHubBuilder {
     $eventIds = $this->ticketSales->getManagedEventNidsForUser($uid);
     $events = $this->loadManagedEvents($eventIds);
     $vendor = $this->vendorResolver->resolveFromCurrentUser();
-    $boostPayload = $this->buildBoostPayload($events);
+    $boostPayload = $this->buildBoostPayload($events, $vendor);
     $shareEvents = $this->buildShareEvents($events);
     $primaryShare = $shareEvents[0] ?? NULL;
     $socialReady = $this->isSocialComplete($vendor);
-    $publishedCount = count(array_filter($events, static fn(NodeInterface $n): bool => $n->isPublished()));
+    $publishedEvents = array_values(array_filter($events, static fn(NodeInterface $n): bool => $n->isPublished()));
+    $publishedCount = count($publishedEvents);
     $activeBoosts = count($boostPayload['campaigns']);
     $boostEligible = count($boostPayload['eligible']);
-    $orderCount = $this->ticketSales->getVendorOrderCount($uid);
+    // Bookings must use the same managed-event set as Share / Live events —
+    // getVendorOrderCount() only counts events authored by the current user.
+    $orderCount = $this->ticketSales->getCompletedOrderCountForEventIds(
+      array_map(static fn(NodeInterface $event): int => (int) $event->id(), $publishedEvents),
+    );
     $score = $this->computeMarketingScore($publishedCount, $primaryShare !== NULL, $boostEligible > 0 || $activeBoosts > 0, $socialReady, $activeBoosts > 0);
     $health = $this->buildHealth($publishedCount, $primaryShare, $boostEligible, $activeBoosts, $socialReady, $score);
 
@@ -348,16 +354,19 @@ final class VendorMarketingHubBuilder {
   /**
    * Builds Boost campaigns and eligible event lists.
    *
-   * Uses the same managed-event catalogue as Share and Marketing health so
-   * published events never disappear from Boost rows on this hub.
+   * Unions managed membership events with store-linked events
+   * (BoostManager::getEventsForStore) so field_event_store events outside
+   * membership still appear after /vendor/boost → Marketing redirect.
    *
    * @param list<\Drupal\node\NodeInterface> $events
    *   Managed events (same list as Share / health).
+   * @param \Drupal\myeventlane_vendor\Entity\Vendor|null $vendor
+   *   Current vendor entity when resolved.
    *
    * @return array{campaigns: list<array<string, mixed>>, eligible: list<array<string, mixed>>, faq: array<string, mixed>}
    *   Boost section payload.
    */
-  private function buildBoostPayload(array $events): array {
+  private function buildBoostPayload(array $events, ?Vendor $vendor): array {
     $campaigns = [];
     $eligible = [];
     $faq = [];
@@ -369,7 +378,7 @@ final class VendorMarketingHubBuilder {
       return ['campaigns' => [], 'eligible' => [], 'faq' => $faq];
     }
 
-    foreach ($events as $event) {
+    foreach ($this->resolveBoostEvents($events, $vendor) as $event) {
       if (!$event instanceof NodeInterface || !$event->isPublished()) {
         continue;
       }
@@ -425,6 +434,98 @@ final class VendorMarketingHubBuilder {
       'eligible' => $eligible,
       'faq' => $faq,
     ];
+  }
+
+  /**
+   * Resolves the event set for Boost rows (managed ∪ store catalogue).
+   *
+   * @param list<\Drupal\node\NodeInterface> $managedEvents
+   *   Events from membership / managed query.
+   * @param \Drupal\myeventlane_vendor\Entity\Vendor|null $vendor
+   *   Current vendor when available.
+   *
+   * @return list<\Drupal\node\NodeInterface>
+   *   Deduped event nodes keyed by insertion order.
+   */
+  private function resolveBoostEvents(array $managedEvents, ?Vendor $vendor): array {
+    $byId = [];
+    foreach ($managedEvents as $event) {
+      if ($event instanceof NodeInterface && $event->bundle() === 'event') {
+        $byId[(int) $event->id()] = $event;
+      }
+    }
+
+    $store = $this->resolveVendorStore($vendor);
+    if ($store instanceof StoreInterface
+      && $this->boostManager !== NULL
+      && method_exists($this->boostManager, 'getEventsForStore')) {
+      try {
+        $storeEvents = $this->boostManager->getEventsForStore($store, [
+          'published_only' => TRUE,
+          'access_check' => TRUE,
+          'limit' => 100,
+        ]);
+        foreach ($storeEvents as $event) {
+          if ($event instanceof NodeInterface && $event->bundle() === 'event') {
+            $byId[(int) $event->id()] = $event;
+          }
+        }
+      }
+      catch (\Throwable $e) {
+        $this->logger->warning('Marketing hub store Boost event lookup failed: @message', [
+          '@message' => $e->getMessage(),
+        ]);
+      }
+    }
+
+    return array_values($byId);
+  }
+
+  /**
+   * Resolves the commerce store for the current vendor / user.
+   *
+   * Mirrors VendorBoostController::getCurrentUserStore().
+   */
+  private function resolveVendorStore(?Vendor $vendor): ?StoreInterface {
+    if ($vendor instanceof Vendor
+      && $vendor->hasField('field_vendor_store')
+      && !$vendor->get('field_vendor_store')->isEmpty()) {
+      try {
+        $store = $vendor->get('field_vendor_store')->entity;
+        if ($store instanceof StoreInterface) {
+          return $store;
+        }
+      }
+      catch (\Throwable $e) {
+        $this->logger->warning('Marketing hub could not load vendor store: @message', [
+          '@message' => $e->getMessage(),
+        ]);
+      }
+    }
+
+    $uid = (int) $this->currentUser->id();
+    if ($uid <= 0) {
+      return NULL;
+    }
+
+    try {
+      $storeIds = $this->entityTypeManager->getStorage('commerce_store')->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('uid', $uid)
+        ->range(0, 1)
+        ->execute();
+      if ($storeIds === []) {
+        return NULL;
+      }
+      $store = $this->entityTypeManager->getStorage('commerce_store')->load(reset($storeIds));
+      return $store instanceof StoreInterface ? $store : NULL;
+    }
+    catch (\Throwable $e) {
+      $this->logger->warning('Marketing hub store owner fallback failed: @message', [
+        '@message' => $e->getMessage(),
+      ]);
+      return NULL;
+    }
   }
 
   /**

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorMarketingHubBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorMarketingHubBuilder.php
@@ -29,7 +29,6 @@ final class VendorMarketingHubBuilder {
 
   public function __construct(
     private readonly AccountProxyInterface $currentUser,
-    private readonly CurrentVendorResolverInterface $vendorResolver,
     private readonly TicketSalesService $ticketSales,
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly ModuleHandlerInterface $moduleHandler,
@@ -54,7 +53,11 @@ final class VendorMarketingHubBuilder {
     $uid = (int) $this->currentUser->id();
     $eventIds = $this->ticketSales->getManagedEventNidsForUser($uid);
     $events = $this->loadManagedEvents($eventIds);
-    $vendor = $this->vendorResolver->resolveFromCurrentUser();
+    // Owned vendor first (then team), matching VendorConsoleBaseController /
+    // legacy /vendor/boost — not CurrentVendorResolver's lowest-ID pick.
+    $vendor = $this->resolveConsoleVendor();
+    $boostAvailable = $this->moduleHandler->moduleExists('myeventlane_boost')
+      && $this->boostManager !== NULL;
     $boostPayload = $this->buildBoostPayload($events, $vendor);
     $shareEvents = $this->buildShareEvents($events);
     $primaryShare = $shareEvents[0] ?? NULL;
@@ -69,7 +72,7 @@ final class VendorMarketingHubBuilder {
       array_map(static fn(NodeInterface $event): int => (int) $event->id(), $publishedEvents),
     );
     $score = $this->computeMarketingScore($publishedCount, $primaryShare !== NULL, $boostEligible > 0 || $activeBoosts > 0, $socialReady, $activeBoosts > 0);
-    $health = $this->buildHealth($publishedCount, $primaryShare, $boostEligible, $activeBoosts, $socialReady, $score);
+    $health = $this->buildHealth($publishedCount, $primaryShare, $boostEligible, $activeBoosts, $socialReady, $score, $boostAvailable);
 
     $this->logger->info('marketing_opened uid=@uid events=@events published=@published boosts=@boosts score=@score', [
       '@uid' => (string) $uid,
@@ -101,14 +104,14 @@ final class VendorMarketingHubBuilder {
         'export_url' => $this->safeRouteUrl('myeventlane_vendor.console.boost_vendor_export'),
         'empty_title' => (string) $this->t('No active Boost campaigns'),
         'empty_body' => (string) $this->t('When you Boost an event, its status and end date appear here.'),
-        'available' => $this->moduleHandler->moduleExists('myeventlane_boost'),
+        'available' => $boostAvailable,
       ],
       'widgets' => [
         'title' => (string) $this->t('Widgets & embeds'),
         'body' => (string) $this->t('Add a ticket widget to your own website so people can book without leaving your brand.'),
         'events' => $this->buildWidgetEvents($events),
         'empty_title' => (string) $this->t('Publish an event to add widgets'),
-        'empty_body' => (string) $this->t('Widgets live under Tickets for each event. Marketing brings you there in one click.'),
+        'empty_body' => (string) $this->t('Widgets live under Tickets for each live event. Marketing brings you there in one click.'),
       ],
       'social' => [
         'title' => (string) $this->t('Social media'),
@@ -325,17 +328,23 @@ final class VendorMarketingHubBuilder {
   }
 
   /**
-   * Builds widget deep links for managed events.
+   * Builds widget deep links for published managed events.
+   *
+   * Drafts are omitted so the publish empty state can appear for draft-only
+   * organisers (empty_title / empty_body).
    *
    * @param list<\Drupal\node\NodeInterface> $events
    *   Managed events.
    *
    * @return list<array<string, mixed>>
-   *   Widget deep links.
+   *   Widget deep links for live events only.
    */
   private function buildWidgetEvents(array $events): array {
     $rows = [];
     foreach ($events as $event) {
+      if (!$event->isPublished()) {
+        continue;
+      }
       $nid = (int) $event->id();
       $url = $this->safeRouteUrl('myeventlane_tickets.event_tickets_widgets', ['event' => $nid]);
       if ($url === NULL) {
@@ -345,7 +354,7 @@ final class VendorMarketingHubBuilder {
         'id' => $nid,
         'title' => (string) $event->label(),
         'url' => $url,
-        'published' => $event->isPublished(),
+        'published' => TRUE,
       ];
     }
     return $rows;
@@ -482,6 +491,53 @@ final class VendorMarketingHubBuilder {
   }
 
   /**
+   * Resolves the console vendor: owned first, then team membership.
+   *
+   * Mirrors VendorConsoleBaseController::getCurrentVendorOrNull() so Boost
+   * store catalogues match the retired /vendor/boost page for multi-vendor users.
+   */
+  private function resolveConsoleVendor(): ?Vendor {
+    $uid = (int) $this->currentUser->id();
+    if ($uid === 0) {
+      return NULL;
+    }
+
+    try {
+      $storage = $this->entityTypeManager->getStorage('myeventlane_vendor');
+      $ownerIds = $storage->getQuery()
+        ->accessCheck(TRUE)
+        ->condition('uid', $uid)
+        ->range(0, 1)
+        ->execute();
+      if ($ownerIds !== []) {
+        $vendor = $storage->load(reset($ownerIds));
+        if ($vendor instanceof Vendor) {
+          return $vendor;
+        }
+      }
+
+      $teamIds = $storage->getQuery()
+        ->accessCheck(TRUE)
+        ->condition('field_vendor_users', $uid)
+        ->range(0, 1)
+        ->execute();
+      if ($teamIds !== []) {
+        $vendor = $storage->load(reset($teamIds));
+        if ($vendor instanceof Vendor) {
+          return $vendor;
+        }
+      }
+    }
+    catch (\Throwable $e) {
+      $this->logger->warning('Marketing hub console vendor resolve failed: @message', [
+        '@message' => $e->getMessage(),
+      ]);
+    }
+
+    return NULL;
+  }
+
+  /**
    * Resolves the commerce store for the current vendor / user.
    *
    * Mirrors VendorBoostController::getCurrentUserStore().
@@ -541,6 +597,7 @@ final class VendorMarketingHubBuilder {
     int $activeBoosts,
     bool $socialReady,
     int $score,
+    bool $boostAvailable,
   ): array {
     $needsAttention = $publishedCount === 0 || $primaryShare === NULL;
     $tone = $needsAttention ? 'attention' : ($score >= 75 ? 'success' : 'muted');
@@ -583,6 +640,22 @@ final class VendorMarketingHubBuilder {
       $ctaUrl = '#share';
     }
 
+    if ($activeBoosts > 0) {
+      $boostFact = (string) $this->formatPlural($activeBoosts, '1 campaign active', '@count campaigns active');
+    }
+    elseif ($boostEligible > 0) {
+      $boostFact = (string) $this->t('Eligible to Boost');
+    }
+    elseif ($publishedCount === 0) {
+      $boostFact = (string) $this->t('Publish a live event first');
+    }
+    elseif (!$boostAvailable) {
+      $boostFact = (string) $this->t('Boost not available right now');
+    }
+    else {
+      $boostFact = (string) $this->t('Not boosting yet');
+    }
+
     return [
       'tone' => $tone,
       'headline' => $headline,
@@ -611,11 +684,7 @@ final class VendorMarketingHubBuilder {
         ],
         [
           'label' => (string) $this->t('Boost eligibility'),
-          'value' => $activeBoosts > 0
-            ? (string) $this->formatPlural($activeBoosts, '1 campaign active', '@count campaigns active')
-            : ($boostEligible > 0
-              ? (string) $this->t('Eligible to Boost')
-              : (string) $this->t('Publish a live event first')),
+          'value' => $boostFact,
         ],
         [
           'label' => (string) $this->t('Social completeness'),

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorMarketingHubBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorMarketingHubBuilder.php
@@ -1,0 +1,679 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_vendor\Service;
+
+use Drupal\commerce_store\Entity\StoreInterface;
+use Drupal\Component\Utility\UrlHelper;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\Url;
+use Drupal\myeventlane_core\Service\DomainDetector;
+use Drupal\myeventlane_vendor\Entity\Vendor;
+use Drupal\node\NodeInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Builds the organiser Marketing Hub view model (Event Growth Centre).
+ *
+ * Deep-links Boost, widgets, audience, and share tools.
+ * Does not invent a new advertising or analytics architecture.
+ */
+final class VendorMarketingHubBuilder {
+
+  use StringTranslationTrait;
+
+  public function __construct(
+    private readonly AccountProxyInterface $currentUser,
+    private readonly CurrentVendorResolverInterface $vendorResolver,
+    private readonly TicketSalesService $ticketSales,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly ModuleHandlerInterface $moduleHandler,
+    private readonly DomainDetector $domainDetector,
+    private readonly LoggerInterface $logger,
+    TranslationInterface $stringTranslation,
+    private readonly ?object $boostManager = NULL,
+    private readonly ?object $boostHelpContent = NULL,
+    private readonly ?object $eventStateResolver = NULL,
+    private readonly ?object $qrCodeGenerator = NULL,
+  ) {
+    $this->setStringTranslation($stringTranslation);
+  }
+
+  /**
+   * Builds the global Marketing Hub payload.
+   *
+   * @return array<string, mixed>
+   *   Hub view model for Twig.
+   */
+  public function build(): array {
+    $uid = (int) $this->currentUser->id();
+    $eventIds = $this->ticketSales->getManagedEventNidsForUser($uid);
+    $events = $this->loadManagedEvents($eventIds);
+    $vendor = $this->vendorResolver->resolveFromCurrentUser();
+    $store = $this->resolveStore($vendor);
+    $boostPayload = $this->buildBoostPayload($store, $events);
+    $shareEvents = $this->buildShareEvents($events);
+    $primaryShare = $shareEvents[0] ?? NULL;
+    $socialReady = $this->isSocialComplete($vendor);
+    $publishedCount = count(array_filter($events, static fn(NodeInterface $n): bool => $n->isPublished()));
+    $activeBoosts = count($boostPayload['campaigns']);
+    $boostEligible = count($boostPayload['eligible']);
+    $orderCount = $this->ticketSales->getVendorOrderCount($uid);
+    $score = $this->computeMarketingScore($publishedCount, $primaryShare !== NULL, $boostEligible > 0 || $activeBoosts > 0, $socialReady, $activeBoosts > 0);
+    $health = $this->buildHealth($publishedCount, $primaryShare, $boostEligible, $activeBoosts, $socialReady, $score);
+
+    $this->logger->info('marketing_opened uid=@uid events=@events published=@published boosts=@boosts score=@score', [
+      '@uid' => (string) $uid,
+      '@events' => (string) count($events),
+      '@published' => (string) $publishedCount,
+      '@boosts' => (string) $activeBoosts,
+      '@score' => (string) $score,
+    ]);
+
+    return [
+      'health' => $health,
+      'share' => [
+        'title' => (string) $this->t('Share event'),
+        'body' => (string) $this->t('Copy your public link, download a QR code, or share on social — one click at a time.'),
+        'events' => $shareEvents,
+        'empty_title' => (string) $this->t('No live events to share yet'),
+        'empty_body' => (string) $this->t('Publish an event first. Then you can copy the link, show a QR code, and share with your community.'),
+        'publish_url' => $this->safeRouteUrl('myeventlane_vendor.console.events'),
+      ],
+      'boost' => [
+        'title' => (string) $this->t('Boost'),
+        'eyebrow' => (string) $this->t('Premium visibility'),
+        'what' => (string) $this->t('Boost features your event in selected placements across MyEventLane — such as discovery and category browsing — so more locals can find you.'),
+        'who' => (string) $this->t('People exploring events on MyEventLane see Boosted events in those placements. It does not create a private club or guarantee ticket sales.'),
+        'outcome' => (string) $this->t('Expect more people to discover your page. Sales still depend on your event, price, and timing — we never claim Boost caused a booking.'),
+        'campaigns' => $boostPayload['campaigns'],
+        'eligible' => $boostPayload['eligible'],
+        'faq' => $boostPayload['faq'],
+        'export_url' => $this->safeRouteUrl('myeventlane_vendor.console.boost_vendor_export'),
+        'empty_title' => (string) $this->t('No active Boost campaigns'),
+        'empty_body' => (string) $this->t('When you Boost an event, its status and end date appear here.'),
+        'available' => $this->moduleHandler->moduleExists('myeventlane_boost'),
+      ],
+      'widgets' => [
+        'title' => (string) $this->t('Widgets & embeds'),
+        'body' => (string) $this->t('Add a ticket widget to your own website so people can book without leaving your brand.'),
+        'events' => $this->buildWidgetEvents($events),
+        'empty_title' => (string) $this->t('Publish an event to add widgets'),
+        'empty_body' => (string) $this->t('Widgets live under Tickets for each event. Marketing brings you there in one click.'),
+      ],
+      'social' => [
+        'title' => (string) $this->t('Social media'),
+        'body' => (string) $this->t('Share where your community already gathers. Add your organiser social links so guests can follow you.'),
+        'ready' => $socialReady,
+        'ready_label' => $socialReady
+          ? (string) $this->t('Your social links look ready on your organiser profile.')
+          : (string) $this->t('Add social links in Settings so guests can find you beyond the event page.'),
+        'settings_url' => $this->safeRouteUrl('myeventlane_vendor.console.settings'),
+        'channels' => [
+          ['key' => 'facebook', 'label' => (string) $this->t('Facebook')],
+          ['key' => 'instagram', 'label' => (string) $this->t('Instagram')],
+          ['key' => 'linkedin', 'label' => (string) $this->t('LinkedIn')],
+          ['key' => 'email', 'label' => (string) $this->t('Email')],
+        ],
+      ],
+      'audience' => [
+        'title' => (string) $this->t('Audience growth'),
+        'body' => (string) $this->t('See who has booked or RSVPed across your events, then invite them back to what is next.'),
+        'cta_label' => (string) $this->t('Open Audience'),
+        'cta_url' => $this->safeRouteUrl('myeventlane_vendor.console.audience'),
+        'tips' => [
+          (string) $this->t('Share your public page with local groups and newsletters.'),
+          (string) $this->t('Message past guests when you publish something new (from Messages).'),
+          (string) $this->t('Use Boost when you want wider discovery on MyEventLane.'),
+        ],
+      ],
+      'performance' => [
+        'title' => (string) $this->t('Marketing performance'),
+        'body' => (string) $this->t('A simple pulse from data we already collect. Deeper charts live in Analytics.'),
+        'metrics' => [
+          [
+            'label' => (string) $this->t('Live events'),
+            'value' => (string) $publishedCount,
+            'hint' => (string) $this->t('Published and shareable'),
+          ],
+          [
+            'label' => (string) $this->t('Bookings'),
+            'value' => (string) $orderCount,
+            'hint' => (string) $this->t('Orders across your events'),
+          ],
+          [
+            'label' => (string) $this->t('Active Boosts'),
+            'value' => (string) $activeBoosts,
+            'hint' => (string) $this->t('Campaigns running now'),
+          ],
+        ],
+        'unavailable' => [
+          'title' => (string) $this->t('Coming later'),
+          'items' => [
+            (string) $this->t('Page views on this Marketing home (instrumentation planned).'),
+            (string) $this->t('Traffic sources on this Marketing home (use Analytics for event depth when available).'),
+            (string) $this->t('Conversion rate on this Marketing home (event Analytics holds funnel detail when enabled).'),
+          ],
+        ],
+        'analytics_url' => $this->safeRouteUrl('myeventlane_analytics.dashboard'),
+        'analytics_label' => (string) $this->t('Open Analytics'),
+        'export_url' => $this->safeRouteUrl('myeventlane_vendor.console.boost_vendor_export'),
+        'export_label' => (string) $this->t('Export Boost performance'),
+      ],
+      'actions' => [
+        'title' => (string) $this->t('Recommended actions'),
+        'items' => $this->buildRecommendedActions($publishedCount, $primaryShare, $boostEligible, $activeBoosts, $socialReady),
+      ],
+      'analytics' => [
+        'marketing_opened' => TRUE,
+        'marketing_score' => $score,
+      ],
+    ];
+  }
+
+  /**
+   * Loads managed event nodes for the hub.
+   *
+   * @param list<int> $eventIds
+   *   Managed event node IDs.
+   *
+   * @return list<\Drupal\node\NodeInterface>
+   *   Loaded event nodes (access already gated by TicketSalesService).
+   */
+  private function loadManagedEvents(array $eventIds): array {
+    if ($eventIds === []) {
+      return [];
+    }
+    $nodes = $this->entityTypeManager->getStorage('node')->loadMultiple($eventIds);
+    $events = [];
+    foreach ($nodes as $node) {
+      if ($node instanceof NodeInterface && $node->bundle() === 'event') {
+        $events[] = $node;
+      }
+    }
+    usort($events, static function (NodeInterface $a, NodeInterface $b): int {
+      $pub = ((int) $b->isPublished()) <=> ((int) $a->isPublished());
+      if ($pub !== 0) {
+        return $pub;
+      }
+      return strcasecmp((string) $a->label(), (string) $b->label());
+    });
+    return $events;
+  }
+
+  /**
+   * Builds share cards for published events.
+   *
+   * @param list<\Drupal\node\NodeInterface> $events
+   *   Managed events.
+   *
+   * @return list<array<string, mixed>>
+   *   Share cards for published events.
+   */
+  private function buildShareEvents(array $events): array {
+    $cards = [];
+    foreach ($events as $event) {
+      if (!$event->isPublished()) {
+        continue;
+      }
+      $nid = (int) $event->id();
+      $path = Url::fromRoute('entity.node.canonical', ['node' => $nid])->toString();
+      $publicUrl = $this->domainDetector->publicUrl($path);
+      $title = (string) $event->label();
+      $qrUri = NULL;
+      if ($this->qrCodeGenerator !== NULL && method_exists($this->qrCodeGenerator, 'buildDataUri')) {
+        try {
+          $qrUri = $this->qrCodeGenerator->buildDataUri($publicUrl, 240);
+        }
+        catch (\Throwable $e) {
+          $this->logger->warning('Marketing hub QR generation failed for event @nid: @message', [
+            '@nid' => (string) $nid,
+            '@message' => $e->getMessage(),
+          ]);
+        }
+      }
+
+      $cards[] = [
+        'id' => $nid,
+        'title' => $title,
+        'public_url' => $publicUrl,
+        'view_url' => $publicUrl,
+        'qr_data_uri' => $qrUri,
+        'marketing_url' => $this->safeRouteUrl('myeventlane_event_studio.workspace_marketing', ['node' => $nid]),
+        'boost_url' => $this->safeRouteUrl('myeventlane_boost.vendor_event_boost', ['event' => $nid])
+        ?? $this->safeRouteUrl('myeventlane_boost.boost_page', ['node' => $nid]),
+        'widgets_url' => $this->safeRouteUrl('myeventlane_tickets.event_tickets_widgets', ['event' => $nid]),
+        'channels' => $this->buildShareChannels($publicUrl, $title),
+      ];
+    }
+    return $cards;
+  }
+
+  /**
+   * Builds share channel buttons for a public event URL.
+   *
+   * @return list<array<string, mixed>>
+   *   Share channel buttons.
+   */
+  private function buildShareChannels(string $publicUrl, string $title): array {
+    $encoded = UrlHelper::buildQuery(['u' => $publicUrl]);
+    $linkedIn = 'https://www.linkedin.com/sharing/share-offsite/?' . UrlHelper::buildQuery(['url' => $publicUrl]);
+    $facebook = 'https://www.facebook.com/sharer/sharer.php?' . $encoded;
+    $subject = (string) $this->t('Join me at @title', ['@title' => $title]);
+    $body = (string) $this->t("I thought you might like this event on MyEventLane:\n\n@url", ['@url' => $publicUrl]);
+    $mailto = 'mailto:?' . UrlHelper::buildQuery([
+      'subject' => $subject,
+      'body' => $body,
+    ]);
+
+    return [
+      [
+        'key' => 'copy',
+        'label' => (string) $this->t('Copy link'),
+        'url' => NULL,
+        'action' => 'copy',
+        'analytics' => 'share_link_copied',
+      ],
+      [
+        'key' => 'facebook',
+        'label' => (string) $this->t('Facebook'),
+        'url' => $facebook,
+        'action' => 'external',
+        'analytics' => 'share_channel_selected',
+      ],
+      [
+        'key' => 'instagram',
+        'label' => (string) $this->t('Instagram'),
+        'url' => NULL,
+        'action' => 'copy',
+        'hint' => (string) $this->t('Copy the link, then paste it into your Instagram post or story.'),
+        'analytics' => 'share_channel_selected',
+      ],
+      [
+        'key' => 'linkedin',
+        'label' => (string) $this->t('LinkedIn'),
+        'url' => $linkedIn,
+        'action' => 'external',
+        'analytics' => 'share_channel_selected',
+      ],
+      [
+        'key' => 'email',
+        'label' => (string) $this->t('Email'),
+        'url' => $mailto,
+        'action' => 'external',
+        'analytics' => 'share_channel_selected',
+      ],
+      [
+        'key' => 'embed',
+        'label' => (string) $this->t('Embed widget'),
+        'url' => NULL,
+        'action' => 'widgets',
+        'analytics' => 'widget_copied',
+      ],
+    ];
+  }
+
+  /**
+   * Builds widget deep links for managed events.
+   *
+   * @param list<\Drupal\node\NodeInterface> $events
+   *   Managed events.
+   *
+   * @return list<array<string, mixed>>
+   *   Widget deep links.
+   */
+  private function buildWidgetEvents(array $events): array {
+    $rows = [];
+    foreach ($events as $event) {
+      $nid = (int) $event->id();
+      $url = $this->safeRouteUrl('myeventlane_tickets.event_tickets_widgets', ['event' => $nid]);
+      if ($url === NULL) {
+        continue;
+      }
+      $rows[] = [
+        'id' => $nid,
+        'title' => (string) $event->label(),
+        'url' => $url,
+        'published' => $event->isPublished(),
+      ];
+    }
+    return $rows;
+  }
+
+  /**
+   * Builds Boost campaigns and eligible event lists.
+   *
+   * @param \Drupal\commerce_store\Entity\StoreInterface|null $store
+   *   Vendor store if any.
+   * @param list<\Drupal\node\NodeInterface> $events
+   *   Managed events fallback.
+   *
+   * @return array{campaigns: list<array<string, mixed>>, eligible: list<array<string, mixed>>, faq: array<string, mixed>}
+   *   Boost section payload.
+   */
+  private function buildBoostPayload(?StoreInterface $store, array $events): array {
+    $campaigns = [];
+    $eligible = [];
+    $faq = [];
+    if ($this->boostHelpContent !== NULL && method_exists($this->boostHelpContent, 'getFaqContent')) {
+      $faq = $this->boostHelpContent->getFaqContent();
+    }
+
+    if (!$this->moduleHandler->moduleExists('myeventlane_boost') || $this->boostManager === NULL) {
+      return ['campaigns' => [], 'eligible' => [], 'faq' => $faq];
+    }
+
+    $nodes = $events;
+    if ($store !== NULL && method_exists($this->boostManager, 'getEventsForStore')) {
+      try {
+        $storeEvents = $this->boostManager->getEventsForStore($store, [
+          'published_only' => TRUE,
+          'access_check' => TRUE,
+          'limit' => 100,
+        ]);
+        if (is_array($storeEvents) && $storeEvents !== []) {
+          $nodes = $storeEvents;
+        }
+      }
+      catch (\Throwable $e) {
+        $this->logger->warning('Marketing hub could not load Boost store events: @message', [
+          '@message' => $e->getMessage(),
+        ]);
+      }
+    }
+
+    foreach ($nodes as $event) {
+      if (!$event instanceof NodeInterface || !$event->isPublished()) {
+        continue;
+      }
+      $nid = (int) $event->id();
+      $status = ['active' => FALSE, 'end_timestamp' => NULL];
+      if (method_exists($this->boostManager, 'getBoostStatusForEvent')) {
+        try {
+          $status = $this->boostManager->getBoostStatusForEvent($event);
+        }
+        catch (\Throwable $e) {
+          $this->logger->warning('Marketing hub Boost status failed for @nid: @message', [
+            '@nid' => (string) $nid,
+            '@message' => $e->getMessage(),
+          ]);
+        }
+      }
+
+      $boostUrl = $this->safeRouteUrl('myeventlane_boost.vendor_event_boost', ['event' => $nid])
+        ?? $this->safeRouteUrl('myeventlane_boost.boost_page', ['node' => $nid]);
+      $stateLabel = NULL;
+      if ($this->eventStateResolver !== NULL && method_exists($this->eventStateResolver, 'resolveState')) {
+        try {
+          $stateLabel = (string) $this->eventStateResolver->resolveState($event);
+        }
+        catch (\Throwable) {
+          $stateLabel = NULL;
+        }
+      }
+
+      if (!empty($status['active'])) {
+        $ends = !empty($status['end_timestamp'])
+          ? date('j M Y, g:ia', (int) $status['end_timestamp'])
+          : NULL;
+        $campaigns[] = [
+          'title' => (string) $event->label(),
+          'status' => (string) $this->t('Active'),
+          'ends' => $ends,
+          'url' => $boostUrl,
+        ];
+      }
+      else {
+        $eligible[] = [
+          'title' => (string) $event->label(),
+          'state' => $stateLabel,
+          'url' => $boostUrl,
+          'cta_label' => (string) $this->t('Start Boost'),
+        ];
+      }
+    }
+
+    return [
+      'campaigns' => $campaigns,
+      'eligible' => $eligible,
+      'faq' => $faq,
+    ];
+  }
+
+  /**
+   * Builds the Marketing health hero.
+   *
+   * @return array<string, mixed>
+   *   Marketing health hero.
+   */
+  private function buildHealth(
+    int $publishedCount,
+    ?array $primaryShare,
+    int $boostEligible,
+    int $activeBoosts,
+    bool $socialReady,
+    int $score,
+  ): array {
+    $needsAttention = $publishedCount === 0 || $primaryShare === NULL;
+    $tone = $needsAttention ? 'attention' : ($score >= 75 ? 'success' : 'muted');
+
+    if ($publishedCount === 0) {
+      $headline = (string) $this->t('Publish an event to grow your reach');
+      $summary = (string) $this->t('Marketing tools unlock once your event is live for the public.');
+      $next = (string) $this->t('Finish publishing, then come back to share and Boost.');
+      $ctaLabel = (string) $this->t('Go to events');
+      $ctaUrl = $this->safeRouteUrl('myeventlane_vendor.console.events') ?? '/vendor/events';
+    }
+    elseif ($activeBoosts > 0) {
+      $headline = (string) $this->t('Your events are getting visibility');
+      $summary = (string) $this->t('You have live pages to share and Boost campaigns running.');
+      $next = (string) $this->t('Share your link with local communities while Boost is active.');
+      $ctaLabel = (string) $this->t('Copy public link');
+      $ctaUrl = $primaryShare['public_url'] ?? '#share';
+    }
+    elseif ($boostEligible > 0) {
+      $headline = (string) $this->t('Ready to reach more people');
+      $summary = (string) $this->t('Your event is live. Share it now, or Boost discovery on MyEventLane.');
+      $next = (string) $this->t('Copy your public link, then consider Boost if you want wider discovery.');
+      $ctaLabel = (string) $this->t('Share event');
+      $ctaUrl = '#share';
+    }
+    else {
+      $headline = (string) $this->t('Keep sharing with your community');
+      $summary = (string) $this->t('Your marketing basics are in place. Keep the link handy for every channel.');
+      $next = $socialReady
+        ? (string) $this->t('Share again this week, or check Analytics for bookings.')
+        : (string) $this->t('Add social links in Settings so guests can follow you.');
+      $ctaLabel = (string) $this->t('Share event');
+      $ctaUrl = '#share';
+    }
+
+    return [
+      'tone' => $tone,
+      'headline' => $headline,
+      'summary' => $summary,
+      'next_step' => $next,
+      'needs_attention' => $needsAttention,
+      'score' => $score,
+      'score_label' => (string) $this->t('Marketing score'),
+      'cta_label' => $ctaLabel,
+      'cta_url' => $ctaUrl,
+      'facts' => [
+        [
+          'label' => (string) $this->t('Public status'),
+          'value' => $publishedCount > 0
+            ? (string) $this->formatPlural($publishedCount, '1 live event', '@count live events')
+            : (string) $this->t('No live events yet'),
+        ],
+        [
+          'label' => (string) $this->t('Sharing readiness'),
+          'value' => $primaryShare !== NULL
+            ? (string) $this->t('Public link ready')
+            : (string) $this->t('Publish to unlock sharing'),
+        ],
+        [
+          'label' => (string) $this->t('Boost eligibility'),
+          'value' => $activeBoosts > 0
+            ? (string) $this->formatPlural($activeBoosts, '1 campaign active', '@count campaigns active')
+            : ($boostEligible > 0
+              ? (string) $this->t('Eligible to Boost')
+              : (string) $this->t('Publish a live event first')),
+        ],
+        [
+          'label' => (string) $this->t('Social completeness'),
+          'value' => $socialReady
+            ? (string) $this->t('Social links added')
+            : (string) $this->t('Add social links'),
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * Builds recommended next-step cards.
+   *
+   * @return list<array<string, mixed>>
+   *   Recommended next steps.
+   */
+  private function buildRecommendedActions(
+    int $publishedCount,
+    ?array $primaryShare,
+    int $boostEligible,
+    int $activeBoosts,
+    bool $socialReady,
+  ): array {
+    $items = [];
+    if ($publishedCount === 0) {
+      $items[] = [
+        'title' => (string) $this->t('Publish your first event'),
+        'body' => (string) $this->t('Guests can only find and book a live page.'),
+        'cta_label' => (string) $this->t('Go to events'),
+        'cta_url' => $this->safeRouteUrl('myeventlane_vendor.console.events'),
+      ];
+      return $items;
+    }
+
+    if ($primaryShare !== NULL) {
+      $items[] = [
+        'title' => (string) $this->t('Share your public link'),
+        'body' => (string) $this->t('Send it to friends, local groups, and your email list.'),
+        'cta_label' => (string) $this->t('Copy link'),
+        'cta_url' => '#share',
+        'analytics' => 'share_link_copied',
+      ];
+    }
+
+    if ($activeBoosts === 0 && $boostEligible > 0) {
+      $items[] = [
+        'title' => (string) $this->t('Consider Boost'),
+        'body' => (string) $this->t('Optional paid visibility on MyEventLane discovery — community-first, never a hard sell.'),
+        'cta_label' => (string) $this->t('Explore Boost'),
+        'cta_url' => '#boost',
+        'analytics' => 'boost_started',
+      ];
+    }
+
+    if (!$socialReady) {
+      $items[] = [
+        'title' => (string) $this->t('Add your social links'),
+        'body' => (string) $this->t('Help guests follow you after they discover your event.'),
+        'cta_label' => (string) $this->t('Open Settings'),
+        'cta_url' => $this->safeRouteUrl('myeventlane_vendor.console.settings'),
+      ];
+    }
+
+    $items[] = [
+      'title' => (string) $this->t('Add a ticket widget'),
+      'body' => (string) $this->t('Embed booking on your own site when you are ready.'),
+      'cta_label' => (string) $this->t('Open widgets'),
+      'cta_url' => '#widgets',
+      'analytics' => 'widget_copied',
+    ];
+
+    return $items;
+  }
+
+  /**
+   * Computes a simple 0–100 marketing readiness score.
+   */
+  private function computeMarketingScore(
+    int $publishedCount,
+    bool $shareReady,
+    bool $boostReady,
+    bool $socialReady,
+    bool $boostActive,
+  ): int {
+    $score = 0;
+    if ($publishedCount > 0) {
+      $score += 35;
+    }
+    if ($shareReady) {
+      $score += 25;
+    }
+    if ($boostReady) {
+      $score += 15;
+    }
+    if ($boostActive) {
+      $score += 15;
+    }
+    if ($socialReady) {
+      $score += 10;
+    }
+    return min(100, $score);
+  }
+
+  /**
+   * Whether the organiser profile has social links.
+   */
+  private function isSocialComplete(?Vendor $vendor): bool {
+    if ($vendor === NULL || !$vendor->hasField('field_social_links')) {
+      return FALSE;
+    }
+    return !$vendor->get('field_social_links')->isEmpty();
+  }
+
+  /**
+   * Resolves the Commerce store for Boost listings when available.
+   */
+  private function resolveStore(?Vendor $vendor): ?StoreInterface {
+    if ($vendor && $vendor->hasField('field_vendor_store') && !$vendor->get('field_vendor_store')->isEmpty()) {
+      $store = $vendor->get('field_vendor_store')->entity;
+      if ($store instanceof StoreInterface) {
+        return $store;
+      }
+    }
+
+    $uid = (int) $this->currentUser->id();
+    if ($uid === 0) {
+      return NULL;
+    }
+    $ids = $this->entityTypeManager->getStorage('commerce_store')->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('uid', $uid)
+      ->range(0, 1)
+      ->execute();
+    if ($ids === []) {
+      return NULL;
+    }
+    $store = $this->entityTypeManager->getStorage('commerce_store')->load(reset($ids));
+    return $store instanceof StoreInterface ? $store : NULL;
+  }
+
+  /**
+   * Returns a route URL or NULL when the route is unavailable.
+   */
+  private function safeRouteUrl(string $routeName, array $parameters = []): ?string {
+    try {
+      return Url::fromRoute($routeName, $parameters)->toString();
+    }
+    catch (\Throwable) {
+      return NULL;
+    }
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorMarketingHubBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorMarketingHubBuilder.php
@@ -462,6 +462,10 @@ final class VendorMarketingHubBuilder {
     $needsAttention = $publishedCount === 0 || $primaryShare === NULL;
     $tone = $needsAttention ? 'attention' : ($score >= 75 ? 'success' : 'muted');
 
+    $ctaAction = 'link';
+    $ctaCopyUrl = NULL;
+    $ctaAnalytics = NULL;
+
     if ($publishedCount === 0) {
       $headline = (string) $this->t('Publish an event to grow your reach');
       $summary = (string) $this->t('Marketing tools unlock once your event is live for the public.');
@@ -469,12 +473,15 @@ final class VendorMarketingHubBuilder {
       $ctaLabel = (string) $this->t('Go to events');
       $ctaUrl = $this->safeRouteUrl('myeventlane_vendor.console.events') ?? '/vendor/events';
     }
-    elseif ($activeBoosts > 0) {
+    elseif ($activeBoosts > 0 && is_array($primaryShare) && !empty($primaryShare['public_url'])) {
       $headline = (string) $this->t('Your events are getting visibility');
       $summary = (string) $this->t('You have live pages to share and Boost campaigns running.');
       $next = (string) $this->t('Share your link with local communities while Boost is active.');
       $ctaLabel = (string) $this->t('Copy public link');
-      $ctaUrl = $primaryShare['public_url'] ?? '#share';
+      $ctaUrl = NULL;
+      $ctaAction = 'copy';
+      $ctaCopyUrl = (string) $primaryShare['public_url'];
+      $ctaAnalytics = 'share_link_copied';
     }
     elseif ($boostEligible > 0) {
       $headline = (string) $this->t('Ready to reach more people');
@@ -503,6 +510,9 @@ final class VendorMarketingHubBuilder {
       'score_label' => (string) $this->t('Marketing score'),
       'cta_label' => $ctaLabel,
       'cta_url' => $ctaUrl,
+      'cta_action' => $ctaAction,
+      'cta_copy_url' => $ctaCopyUrl,
+      'cta_analytics' => $ctaAnalytics,
       'facts' => [
         [
           'label' => (string) $this->t('Public status'),
@@ -558,12 +568,13 @@ final class VendorMarketingHubBuilder {
       return $items;
     }
 
-    if ($primaryShare !== NULL) {
+    if ($primaryShare !== NULL && !empty($primaryShare['public_url'])) {
       $items[] = [
         'title' => (string) $this->t('Share your public link'),
         'body' => (string) $this->t('Send it to friends, local groups, and your email list.'),
         'cta_label' => (string) $this->t('Copy link'),
-        'cta_url' => '#share',
+        'cta_action' => 'copy',
+        'cta_copy_url' => (string) $primaryShare['public_url'],
         'analytics' => 'share_link_copied',
       ];
     }

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorMarketingHubBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorMarketingHubBuilder.php
@@ -52,13 +52,17 @@ final class VendorMarketingHubBuilder {
   public function build(): array {
     $uid = (int) $this->currentUser->id();
     $eventIds = $this->ticketSales->getManagedEventNidsForUser($uid);
-    $events = $this->loadManagedEvents($eventIds);
+    $managedEvents = $this->loadManagedEvents($eventIds);
     // Owned vendor first (then team), matching VendorConsoleBaseController /
     // legacy /vendor/boost — not CurrentVendorResolver's lowest-ID pick.
     $vendor = $this->resolveConsoleVendor();
+    // One catalogue for the whole hub: managed membership ∪ store-linked events.
+    // Boost previously unioned store events alone, which could show active
+    // campaigns while health/share/live KPIs still looked empty.
+    $events = $this->resolveHubEvents($managedEvents, $vendor);
     $boostAvailable = $this->moduleHandler->moduleExists('myeventlane_boost')
       && $this->boostManager !== NULL;
-    $boostPayload = $this->buildBoostPayload($events, $vendor);
+    $boostPayload = $this->buildBoostPayload($events);
     $shareEvents = $this->buildShareEvents($events);
     $primaryShare = $shareEvents[0] ?? NULL;
     $socialReady = $this->isSocialComplete($vendor);
@@ -66,8 +70,7 @@ final class VendorMarketingHubBuilder {
     $publishedCount = count($publishedEvents);
     $activeBoosts = count($boostPayload['campaigns']);
     $boostEligible = count($boostPayload['eligible']);
-    // Bookings must use the same managed-event set as Share / Live events —
-    // getVendorOrderCount() only counts events authored by the current user.
+    // Bookings use the same published hub catalogue as Share / Live events.
     $orderCount = $this->ticketSales->getCompletedOrderCountForEventIds(
       array_map(static fn(NodeInterface $event): int => (int) $event->id(), $publishedEvents),
     );
@@ -214,10 +217,10 @@ final class VendorMarketingHubBuilder {
   }
 
   /**
-   * Builds share cards for published events.
+   * Builds share cards for published hub events.
    *
    * @param list<\Drupal\node\NodeInterface> $events
-   *   Managed events.
+   *   Hub events (managed ∪ store).
    *
    * @return list<array<string, mixed>>
    *   Share cards for published events.
@@ -328,13 +331,13 @@ final class VendorMarketingHubBuilder {
   }
 
   /**
-   * Builds widget deep links for published managed events.
+   * Builds widget deep links for published hub events.
    *
    * Drafts are omitted so the publish empty state can appear for draft-only
    * organisers (empty_title / empty_body).
    *
    * @param list<\Drupal\node\NodeInterface> $events
-   *   Managed events.
+   *   Hub events (managed ∪ store).
    *
    * @return list<array<string, mixed>>
    *   Widget deep links for live events only.
@@ -363,19 +366,13 @@ final class VendorMarketingHubBuilder {
   /**
    * Builds Boost campaigns and eligible event lists.
    *
-   * Unions managed membership events with store-linked events
-   * (BoostManager::getEventsForStore) so field_event_store events outside
-   * membership still appear after /vendor/boost → Marketing redirect.
-   *
    * @param list<\Drupal\node\NodeInterface> $events
-   *   Managed events (same list as Share / health).
-   * @param \Drupal\myeventlane_vendor\Entity\Vendor|null $vendor
-   *   Current vendor entity when resolved.
+   *   Hub events already resolved via resolveHubEvents() (managed ∪ store).
    *
    * @return array{campaigns: list<array<string, mixed>>, eligible: list<array<string, mixed>>, faq: array<string, mixed>}
    *   Boost section payload.
    */
-  private function buildBoostPayload(array $events, ?Vendor $vendor): array {
+  private function buildBoostPayload(array $events): array {
     $campaigns = [];
     $eligible = [];
     $faq = [];
@@ -387,7 +384,7 @@ final class VendorMarketingHubBuilder {
       return ['campaigns' => [], 'eligible' => [], 'faq' => $faq];
     }
 
-    foreach ($this->resolveBoostEvents($events, $vendor) as $event) {
+    foreach ($events as $event) {
       if (!$event instanceof NodeInterface || !$event->isPublished()) {
         continue;
       }
@@ -446,7 +443,10 @@ final class VendorMarketingHubBuilder {
   }
 
   /**
-   * Resolves the event set for Boost rows (managed ∪ store catalogue).
+   * Resolves the shared hub event catalogue (managed ∪ store).
+   *
+   * Used by health, share, widgets, bookings KPIs, and Boost so store-linked
+   * published events never appear in Boost alone.
    *
    * @param list<\Drupal\node\NodeInterface> $managedEvents
    *   Events from membership / managed query.
@@ -454,9 +454,9 @@ final class VendorMarketingHubBuilder {
    *   Current vendor when available.
    *
    * @return list<\Drupal\node\NodeInterface>
-   *   Deduped event nodes keyed by insertion order.
+   *   Deduped event nodes.
    */
-  private function resolveBoostEvents(array $managedEvents, ?Vendor $vendor): array {
+  private function resolveHubEvents(array $managedEvents, ?Vendor $vendor): array {
     $byId = [];
     foreach ($managedEvents as $event) {
       if ($event instanceof NodeInterface && $event->bundle() === 'event') {
@@ -465,25 +465,50 @@ final class VendorMarketingHubBuilder {
     }
 
     $store = $this->resolveVendorStore($vendor);
-    if ($store instanceof StoreInterface
-      && $this->boostManager !== NULL
-      && method_exists($this->boostManager, 'getEventsForStore')) {
+    if (!$store instanceof StoreInterface) {
+      return array_values($byId);
+    }
+
+    $storeEvents = [];
+    if ($this->boostManager !== NULL && method_exists($this->boostManager, 'getEventsForStore')) {
       try {
         $storeEvents = $this->boostManager->getEventsForStore($store, [
           'published_only' => TRUE,
           'access_check' => TRUE,
           'limit' => 100,
         ]);
-        foreach ($storeEvents as $event) {
-          if ($event instanceof NodeInterface && $event->bundle() === 'event') {
-            $byId[(int) $event->id()] = $event;
-          }
+      }
+      catch (\Throwable $e) {
+        $this->logger->warning('Marketing hub store event lookup failed: @message', [
+          '@message' => $e->getMessage(),
+        ]);
+      }
+    }
+
+    if ($storeEvents === []) {
+      try {
+        $nids = $this->entityTypeManager->getStorage('node')->getQuery()
+          ->accessCheck(TRUE)
+          ->condition('type', 'event')
+          ->condition('status', 1)
+          ->condition('field_event_store', $store->id())
+          ->sort('created', 'DESC')
+          ->range(0, 100)
+          ->execute();
+        if ($nids !== []) {
+          $storeEvents = $this->entityTypeManager->getStorage('node')->loadMultiple($nids);
         }
       }
       catch (\Throwable $e) {
-        $this->logger->warning('Marketing hub store Boost event lookup failed: @message', [
+        $this->logger->warning('Marketing hub direct store event query failed: @message', [
           '@message' => $e->getMessage(),
         ]);
+      }
+    }
+
+    foreach ($storeEvents as $event) {
+      if ($event instanceof NodeInterface && $event->bundle() === 'event') {
+        $byId[(int) $event->id()] = $event;
       }
     }
 

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorMarketingHubBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorMarketingHubBuilder.php
@@ -221,7 +221,9 @@ final class VendorMarketingHubBuilder {
       }
       $nid = (int) $event->id();
       $path = Url::fromRoute('entity.node.canonical', ['node' => $nid])->toString();
-      $publicUrl = $this->domainDetector->publicUrl($path);
+      // Share / copy / QR must be absolute — publicUrl() can return a relative
+      // path on single-host environments (e.g. DDEV).
+      $publicUrl = $this->domainDetector->absolutePublicUrl($path);
       $title = (string) $event->label();
       $qrUri = NULL;
       if ($this->qrCodeGenerator !== NULL && method_exists($this->qrCodeGenerator, 'buildDataUri')) {
@@ -565,7 +567,6 @@ final class VendorMarketingHubBuilder {
         'body' => (string) $this->t('Optional paid visibility on MyEventLane discovery — community-first, never a hard sell.'),
         'cta_label' => (string) $this->t('Explore Boost'),
         'cta_url' => '#boost',
-        'analytics' => 'boost_started',
       ];
     }
 

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorMarketingHubBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorMarketingHubBuilder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_vendor\Service;
 
-use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
@@ -55,8 +54,7 @@ final class VendorMarketingHubBuilder {
     $eventIds = $this->ticketSales->getManagedEventNidsForUser($uid);
     $events = $this->loadManagedEvents($eventIds);
     $vendor = $this->vendorResolver->resolveFromCurrentUser();
-    $store = $this->resolveStore($vendor);
-    $boostPayload = $this->buildBoostPayload($store, $events);
+    $boostPayload = $this->buildBoostPayload($events);
     $shareEvents = $this->buildShareEvents($events);
     $primaryShare = $shareEvents[0] ?? NULL;
     $socialReady = $this->isSocialComplete($vendor);
@@ -348,15 +346,16 @@ final class VendorMarketingHubBuilder {
   /**
    * Builds Boost campaigns and eligible event lists.
    *
-   * @param \Drupal\commerce_store\Entity\StoreInterface|null $store
-   *   Vendor store if any.
+   * Uses the same managed-event catalogue as Share and Marketing health so
+   * published events never disappear from Boost rows on this hub.
+   *
    * @param list<\Drupal\node\NodeInterface> $events
-   *   Managed events fallback.
+   *   Managed events (same list as Share / health).
    *
    * @return array{campaigns: list<array<string, mixed>>, eligible: list<array<string, mixed>>, faq: array<string, mixed>}
    *   Boost section payload.
    */
-  private function buildBoostPayload(?StoreInterface $store, array $events): array {
+  private function buildBoostPayload(array $events): array {
     $campaigns = [];
     $eligible = [];
     $faq = [];
@@ -368,26 +367,7 @@ final class VendorMarketingHubBuilder {
       return ['campaigns' => [], 'eligible' => [], 'faq' => $faq];
     }
 
-    $nodes = $events;
-    if ($store !== NULL && method_exists($this->boostManager, 'getEventsForStore')) {
-      try {
-        $storeEvents = $this->boostManager->getEventsForStore($store, [
-          'published_only' => TRUE,
-          'access_check' => TRUE,
-          'limit' => 100,
-        ]);
-        if (is_array($storeEvents) && $storeEvents !== []) {
-          $nodes = $storeEvents;
-        }
-      }
-      catch (\Throwable $e) {
-        $this->logger->warning('Marketing hub could not load Boost store events: @message', [
-          '@message' => $e->getMessage(),
-        ]);
-      }
-    }
-
-    foreach ($nodes as $event) {
+    foreach ($events as $event) {
       if (!$event instanceof NodeInterface || !$event->isPublished()) {
         continue;
       }
@@ -646,33 +626,6 @@ final class VendorMarketingHubBuilder {
       return FALSE;
     }
     return !$vendor->get('field_social_links')->isEmpty();
-  }
-
-  /**
-   * Resolves the Commerce store for Boost listings when available.
-   */
-  private function resolveStore(?Vendor $vendor): ?StoreInterface {
-    if ($vendor && $vendor->hasField('field_vendor_store') && !$vendor->get('field_vendor_store')->isEmpty()) {
-      $store = $vendor->get('field_vendor_store')->entity;
-      if ($store instanceof StoreInterface) {
-        return $store;
-      }
-    }
-
-    $uid = (int) $this->currentUser->id();
-    if ($uid === 0) {
-      return NULL;
-    }
-    $ids = $this->entityTypeManager->getStorage('commerce_store')->getQuery()
-      ->accessCheck(FALSE)
-      ->condition('uid', $uid)
-      ->range(0, 1)
-      ->execute();
-    if ($ids === []) {
-      return NULL;
-    }
-    $store = $this->entityTypeManager->getStorage('commerce_store')->load(reset($ids));
-    return $store instanceof StoreInterface ? $store : NULL;
   }
 
   /**

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorNavBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorNavBuilder.php
@@ -96,7 +96,9 @@ final class VendorNavBuilder {
     if ($path === '/vendor/attendees' || str_starts_with($path, '/vendor/attendees/')) {
       return 'attendees';
     }
-    if (str_starts_with($path, '/vendor/boost') || str_starts_with($path, '/vendor/audience')) {
+    if (str_starts_with($path, '/vendor/marketing')
+      || str_starts_with($path, '/vendor/boost')
+      || str_starts_with($path, '/vendor/audience')) {
       return 'marketing';
     }
     if (str_starts_with($path, '/vendor/payments')
@@ -160,6 +162,7 @@ final class VendorNavBuilder {
       'myeventlane_finance.vendor_bas' => 'payments',
       'myeventlane_donations.vendor_mel_billing' => 'payments',
       'myeventlane_escalations_refunds.vendor_refund_summary' => 'payments',
+      'myeventlane_vendor.console.marketing' => 'marketing',
       'myeventlane_vendor.console.boost' => 'marketing',
       'myeventlane_vendor.console.audience' => 'marketing',
       'myeventlane_vendor.console.settings' => 'settings',
@@ -329,7 +332,7 @@ final class VendorNavBuilder {
         'key' => 'marketing',
         'label' => $this->t('Marketing'),
         'icon' => 'growth',
-        'route' => 'myeventlane_vendor.console.boost',
+        'route' => 'myeventlane_vendor.console.marketing',
         'children' => [],
       ],
       [

--- a/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorMarketingHubBuilderTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorMarketingHubBuilderTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_vendor\Unit;
+
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\myeventlane_vendor\Service\VendorMarketingHubBuilder;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_vendor\Service\VendorMarketingHubBuilder
+ *
+ * @group myeventlane_vendor
+ */
+final class VendorMarketingHubBuilderTest extends UnitTestCase {
+
+  /**
+   * @covers ::computeMarketingScore
+   */
+  public function testMarketingScoreWeightsVisibilitySignals(): void {
+    $builder = $this->createBuilderWithoutConstructor();
+    $method = new \ReflectionMethod(VendorMarketingHubBuilder::class, 'computeMarketingScore');
+    $method->setAccessible(TRUE);
+
+    $this->assertSame(0, $method->invoke($builder, 0, FALSE, FALSE, FALSE, FALSE));
+    $this->assertSame(35, $method->invoke($builder, 1, FALSE, FALSE, FALSE, FALSE));
+    $this->assertSame(60, $method->invoke($builder, 1, TRUE, FALSE, FALSE, FALSE));
+    $this->assertSame(100, $method->invoke($builder, 1, TRUE, TRUE, TRUE, TRUE));
+  }
+
+  /**
+   * Instantiates the builder without mocking final collaborators.
+   */
+  private function createBuilderWithoutConstructor(): VendorMarketingHubBuilder {
+    $reflection = new \ReflectionClass(VendorMarketingHubBuilder::class);
+    /** @var \Drupal\myeventlane_vendor\Service\VendorMarketingHubBuilder $builder */
+    $builder = $reflection->newInstanceWithoutConstructor();
+    $translation = $this->createMock(TranslationInterface::class);
+    $translation->method('translate')->willReturnCallback(
+      static fn(string $string, array $args = [], array $options = []) => strtr($string, $args),
+    );
+    $builder->setStringTranslation($translation);
+    return $builder;
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorNavBuilderTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorNavBuilderTest.php
@@ -66,6 +66,7 @@ final class VendorNavBuilderTest extends UnitTestCase {
         'myeventlane_checkout_flow.vendor_attendees',
         'myeventlane_vendor.console.payments',
         'myeventlane_vendor.console.payouts',
+        'myeventlane_vendor.console.marketing',
         'myeventlane_vendor.console.boost',
         'myeventlane_vendor.console.messages',
         'myeventlane_vendor.console.messaging_brand',
@@ -115,6 +116,10 @@ final class VendorNavBuilderTest extends UnitTestCase {
     $messages = $this->findItemByKey($items, 'messages');
     $this->assertNotNull($messages);
     $this->assertSame('myeventlane_vendor.console.messages', $messages['route'] ?? NULL);
+
+    $marketing = $this->findItemByKey($items, 'marketing');
+    $this->assertNotNull($marketing);
+    $this->assertSame('myeventlane_vendor.console.marketing', $marketing['route'] ?? NULL);
   }
 
   /**
@@ -132,6 +137,7 @@ final class VendorNavBuilderTest extends UnitTestCase {
         'myeventlane_checkout_flow.vendor_attendees',
         'myeventlane_vendor.console.payments',
         'myeventlane_vendor.console.payouts',
+        'myeventlane_vendor.console.marketing',
         'myeventlane_vendor.console.boost',
         'myeventlane_vendor.console.messages',
         'myeventlane_vendor.console.messaging_brand',

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
@@ -1479,6 +1479,12 @@ function myeventlane_vendor_theme_theme($existing, $type, $theme, $path): array 
       ],
       'template' => 'messages-hub',
     ],
+    'myeventlane_vendor_marketing_hub' => [
+      'variables' => [
+        'hub' => [],
+      ],
+      'template' => 'marketing-hub',
+    ],
     'myeventlane_vendor_event_messages_panel' => [
       'variables' => [
         'panel' => [],

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
@@ -112,6 +112,7 @@
   @include meta.load-css('pages/vendor-console-stack');
   @include meta.load-css('pages/payments-hub');
   @include meta.load-css('pages/messages-hub');
+  @include meta.load-css('pages/marketing-hub');
   @include meta.load-css('pages/analytics-hub');
 }
 

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_marketing-hub.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/pages/_marketing-hub.scss
@@ -1,0 +1,350 @@
+/**
+ * @file
+ * Organiser Marketing Hub (Event Growth Centre).
+ */
+
+@use '../tokens/colors' as *;
+@use '../tokens/spacing' as *;
+@use '../tokens/typography' as *;
+@use '../tokens/radii' as *;
+@use '../tokens/breakpoints' as *;
+
+.mel-marketing-hub {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mel-space-5, 1.5rem);
+  max-width: var(--mel-layout-marketing, 1400px);
+}
+
+.mel-marketing-hub__jump {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--mel-space-2, 0.5rem);
+  padding: var(--mel-space-2, 0.5rem) 0;
+}
+
+.mel-marketing-hub__jump-link {
+  min-height: 44px;
+  min-width: 44px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--mel-radius-md, 12px);
+  border: 1px solid var(--mel-color-border, #e5e7eb);
+  color: var(--mel-color-text, #111827);
+  text-decoration: none;
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.mel-marketing-hub__jump-link:focus-visible,
+.mel-marketing-hub__share-btn:focus-visible,
+.mel-marketing-hub__actions .mel-button:focus-visible,
+.mel-marketing-hub__section .mel-button:focus-visible,
+.mel-marketing-hub__link:focus-visible,
+.mel-marketing-hub__url-input:focus-visible {
+  outline: 2px solid var(--mel-color-focus, #2563eb);
+  outline-offset: 2px;
+}
+
+.mel-marketing-hub__eyebrow {
+  margin: 0 0 var(--mel-space-1, 0.25rem);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--mel-color-text-secondary, #5b6470);
+}
+
+.mel-marketing-hub__health {
+  padding: var(--mel-space-5, 1.5rem);
+
+  &--success {
+    border-color: rgba(4, 120, 87, 0.28);
+    background: rgba(16, 185, 129, 0.06);
+  }
+
+  &--attention {
+    border-color: rgba(180, 83, 9, 0.35);
+    background: rgba(245, 158, 11, 0.08);
+  }
+
+  &--muted {
+    border-color: var(--mel-color-border, #e5e7eb);
+  }
+}
+
+.mel-marketing-hub__health-title {
+  margin: 0 0 var(--mel-space-2, 0.5rem);
+  font-size: 1.375rem;
+  line-height: 1.3;
+  color: var(--mel-color-text, #111827);
+}
+
+.mel-marketing-hub__health-summary {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: var(--mel-color-text-secondary, #4b5563);
+}
+
+.mel-marketing-hub__score {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  margin: var(--mel-space-4, 1rem) 0;
+  padding: 0.5rem 0.85rem;
+  border-radius: var(--mel-radius-md, 12px);
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid var(--mel-color-border, #e5e7eb);
+}
+
+.mel-marketing-hub__score-label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--mel-color-text-secondary, #5b6470);
+}
+
+.mel-marketing-hub__score-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--mel-color-text, #111827);
+}
+
+.mel-marketing-hub__score-max {
+  font-size: 0.875rem;
+  color: var(--mel-color-text-secondary, #5b6470);
+}
+
+.mel-marketing-hub__section-title,
+.mel-marketing-hub__subsection-title {
+  margin: 0 0 var(--mel-space-3, 0.75rem);
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.mel-marketing-hub__subsection-title {
+  margin-top: var(--mel-space-5, 1.5rem);
+}
+
+.mel-marketing-hub__section {
+  padding: var(--mel-space-5, 1.5rem);
+}
+
+.mel-marketing-hub__section-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--mel-space-2, 0.5rem);
+  margin-bottom: var(--mel-space-2, 0.5rem);
+}
+
+.mel-marketing-hub__facts {
+  display: grid;
+  gap: var(--mel-space-3, 0.75rem);
+  margin: var(--mel-space-4, 1rem) 0;
+
+  &--grid {
+    @media (min-width: 768px) {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+}
+
+.mel-marketing-hub__fact {
+  margin: 0;
+
+  dt {
+    margin: 0 0 0.25rem;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--mel-color-text-secondary, #5b6470);
+  }
+
+  dd {
+    margin: 0;
+    font-size: 0.9375rem;
+    line-height: 1.45;
+    color: var(--mel-color-text, #111827);
+  }
+}
+
+.mel-marketing-hub__actions,
+.mel-marketing-hub__share-channels,
+.mel-marketing-hub__event-item,
+.mel-marketing-hub__campaign-item,
+.mel-marketing-hub__action-item {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--mel-space-2, 0.5rem);
+  align-items: center;
+}
+
+.mel-marketing-hub__event-item,
+.mel-marketing-hub__campaign-item,
+.mel-marketing-hub__action-item {
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--mel-space-3, 0.75rem) 0;
+  border-bottom: 1px solid var(--mel-color-border, #e5e7eb);
+}
+
+.mel-marketing-hub__event-list,
+.mel-marketing-hub__campaign-list,
+.mel-marketing-hub__actions-list,
+.mel-marketing-hub__tips,
+.mel-marketing-hub__channel-list {
+  list-style: none;
+  margin: 0 0 var(--mel-space-4, 1rem);
+  padding: 0;
+}
+
+.mel-marketing-hub__tips li,
+.mel-marketing-hub__channel-list li {
+  margin: 0 0 0.5rem;
+  padding-left: 1rem;
+  position: relative;
+
+  &::before {
+    content: '•';
+    position: absolute;
+    left: 0;
+    color: var(--mel-color-text-secondary, #5b6470);
+  }
+}
+
+.mel-marketing-hub__share-card {
+  margin-top: var(--mel-space-4, 1rem);
+  padding-top: var(--mel-space-4, 1rem);
+  border-top: 1px solid var(--mel-color-border, #e5e7eb);
+}
+
+.mel-marketing-hub__share-title,
+.mel-marketing-hub__event-title,
+.mel-marketing-hub__campaign-title,
+.mel-marketing-hub__action-title {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.mel-marketing-hub__public-url {
+  margin: 0 0 var(--mel-space-3, 0.75rem);
+}
+
+.mel-marketing-hub__url-input {
+  width: 100%;
+  min-height: 44px;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--mel-color-border, #e5e7eb);
+  border-radius: var(--mel-radius-md, 12px);
+  font-size: 0.875rem;
+  background: #fff;
+}
+
+.mel-marketing-hub__share-grid {
+  display: grid;
+  gap: var(--mel-space-4, 1rem);
+
+  @media (min-width: 768px) {
+    grid-template-columns: minmax(0, 1fr) 200px;
+    align-items: start;
+  }
+}
+
+.mel-marketing-hub__share-btn,
+.mel-marketing-hub__actions .mel-button,
+.mel-marketing-hub__section .mel-button {
+  min-height: 44px;
+}
+
+.mel-marketing-hub__qr {
+  margin: 0;
+  text-align: center;
+
+  img {
+    display: inline-block;
+    max-width: 180px;
+    height: auto;
+    border-radius: var(--mel-radius-md, 12px);
+    border: 1px solid var(--mel-color-border, #e5e7eb);
+    background: #fff;
+  }
+}
+
+.mel-marketing-hub__kpi-row {
+  display: grid;
+  gap: var(--mel-space-3, 0.75rem);
+  margin: var(--mel-space-4, 1rem) 0;
+
+  @media (min-width: 640px) {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.mel-marketing-hub__kpi {
+  padding: var(--mel-space-3, 0.75rem);
+  border: 1px solid var(--mel-color-border, #e5e7eb);
+  border-radius: var(--mel-radius-md, 12px);
+  background: rgba(255, 255, 255, 0.65);
+}
+
+.mel-marketing-hub__kpi-label,
+.mel-marketing-hub__kpi-hint {
+  display: block;
+  font-size: 0.8125rem;
+  color: var(--mel-color-text-secondary, #5b6470);
+}
+
+.mel-marketing-hub__kpi-value {
+  display: block;
+  margin: 0.25rem 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--mel-color-text, #111827);
+}
+
+.mel-marketing-hub__callout {
+  margin-top: var(--mel-space-4, 1rem);
+  padding: var(--mel-space-3, 0.75rem);
+  border-radius: var(--mel-radius-md, 12px);
+  border: 1px dashed var(--mel-color-border, #e5e7eb);
+  background: rgba(249, 250, 251, 0.9);
+}
+
+.mel-marketing-hub__callout-title {
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+}
+
+.mel-marketing-hub__muted {
+  margin: 0 0 var(--mel-space-3, 0.75rem);
+  color: var(--mel-color-text-secondary, #4b5563);
+  font-size: 0.9375rem;
+  line-height: 1.5;
+}
+
+.mel-marketing-hub__link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  color: var(--mel-color-link, #1d4ed8);
+  font-weight: 600;
+  text-decoration: underline;
+}
+
+.mel-marketing-hub__channel-hint,
+.mel-marketing-hub__copy-status {
+  flex-basis: 100%;
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--mel-color-text-secondary, #5b6470);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mel-marketing-hub * {
+    transition: none !important;
+    animation: none !important;
+  }
+}

--- a/web/themes/custom/myeventlane_vendor_theme/templates/marketing-hub.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/marketing-hub.html.twig
@@ -1,0 +1,298 @@
+{#
+/**
+ * @file
+ * Organiser Marketing Hub — Event Growth Centre.
+ *
+ * Variables:
+ *   - hub: view model from VendorMarketingHubBuilder
+ */
+#}
+{% set health = hub.health|default({}) %}
+{% set share = hub.share|default({}) %}
+{% set boost = hub.boost|default({}) %}
+{% set widgets = hub.widgets|default({}) %}
+{% set social = hub.social|default({}) %}
+{% set audience = hub.audience|default({}) %}
+{% set performance = hub.performance|default({}) %}
+{% set actions = hub.actions|default({}) %}
+
+<div class="mel-marketing-hub" data-mel-marketing-hub data-mel-analytics-event="marketing_opened">
+
+  <nav class="mel-marketing-hub__jump" aria-label="{{ 'Marketing sections'|t }}">
+    <a class="mel-marketing-hub__jump-link" href="#marketing-health">{{ 'Marketing health'|t }}</a>
+    <a class="mel-marketing-hub__jump-link" href="#share">{{ 'Share'|t }}</a>
+    <a class="mel-marketing-hub__jump-link" href="#boost">{{ 'Boost'|t }}</a>
+    <a class="mel-marketing-hub__jump-link" href="#widgets">{{ 'Widgets'|t }}</a>
+    <a class="mel-marketing-hub__jump-link" href="#social">{{ 'Social'|t }}</a>
+    <a class="mel-marketing-hub__jump-link" href="#audience">{{ 'Audience'|t }}</a>
+    <a class="mel-marketing-hub__jump-link" href="#performance">{{ 'Performance'|t }}</a>
+    <a class="mel-marketing-hub__jump-link" href="#actions">{{ 'Next steps'|t }}</a>
+  </nav>
+
+  <section class="mel-marketing-hub__health mel-card mel-card--status mel-marketing-hub__health--{{ health.tone|default('muted') }}" id="marketing-health" aria-labelledby="mel-marketing-health-heading">
+    <div class="mel-marketing-hub__health-header">
+      <p class="mel-marketing-hub__eyebrow">{{ 'Marketing health'|t }}</p>
+      <h2 id="mel-marketing-health-heading" class="mel-marketing-hub__health-title">{{ health.headline }}</h2>
+      <p class="mel-marketing-hub__health-summary">{{ health.summary }}</p>
+    </div>
+    <div class="mel-marketing-hub__score" role="status" aria-label="{{ health.score_label|default('Marketing score'|t) }} {{ health.score|default(0) }} out of 100">
+      <span class="mel-marketing-hub__score-label">{{ health.score_label|default('Marketing score'|t) }}</span>
+      <span class="mel-marketing-hub__score-value">{{ health.score|default(0) }}</span>
+      <span class="mel-marketing-hub__score-max" aria-hidden="true">/100</span>
+    </div>
+    <dl class="mel-marketing-hub__facts">
+      {% for fact in health.facts|default([]) %}
+        <div class="mel-marketing-hub__fact">
+          <dt>{{ fact.label }}</dt>
+          <dd>{{ fact.value }}</dd>
+        </div>
+      {% endfor %}
+    </dl>
+    {% if health.next_step %}
+      <p class="mel-marketing-hub__muted"><strong>{{ 'Next step'|t }}:</strong> {{ health.next_step }}</p>
+    {% endif %}
+    <div class="mel-marketing-hub__actions">
+      {% if health.cta_url %}
+        <a class="mel-button mel-button--primary" href="{{ health.cta_url }}">{{ health.cta_label }}</a>
+      {% endif %}
+    </div>
+  </section>
+
+  <section class="mel-card mel-marketing-hub__section" id="share" aria-labelledby="mel-marketing-share-heading">
+    <h2 id="mel-marketing-share-heading" class="mel-card__title">{{ share.title }}</h2>
+    <p class="mel-marketing-hub__muted">{{ share.body }}</p>
+
+    {% if share.events is empty %}
+      <div class="mel-empty-state" role="status">
+        <p class="mel-empty-state__title">{{ share.empty_title }}</p>
+        <p class="mel-empty-state__body">{{ share.empty_body }}</p>
+        {% if share.publish_url %}
+          <a class="mel-button mel-button--primary" href="{{ share.publish_url }}">{{ 'Go to events'|t }}</a>
+        {% endif %}
+      </div>
+    {% else %}
+      {% for event in share.events %}
+        <article class="mel-marketing-hub__share-card" data-mel-share-card data-public-url="{{ event.public_url }}">
+          <h3 class="mel-marketing-hub__share-title">{{ event.title }}</h3>
+          <p class="mel-marketing-hub__public-url">
+            <label class="visually-hidden" for="mel-share-url-{{ event.id }}">{{ 'Public event link'|t }}</label>
+            <input id="mel-share-url-{{ event.id }}" class="mel-marketing-hub__url-input" type="text" readonly value="{{ event.public_url }}" aria-describedby="mel-share-url-hint-{{ event.id }}">
+            <span id="mel-share-url-hint-{{ event.id }}" class="visually-hidden">{{ 'Select and copy, or use the Copy link button.'|t }}</span>
+          </p>
+
+          <div class="mel-marketing-hub__share-grid">
+            <div class="mel-marketing-hub__share-channels" role="group" aria-label="{{ 'Share @event'|t({'@event': event.title}) }}">
+              {% for channel in event.channels %}
+                {% if channel.action == 'copy' %}
+                  <button type="button"
+                    class="mel-button mel-button--secondary mel-marketing-hub__share-btn"
+                    data-mel-share-copy
+                    data-mel-analytics-event="{{ channel.analytics|default('share_link_copied') }}"
+                    data-share-channel="{{ channel.key }}"
+                    data-copy-url="{{ event.public_url }}">
+                    {{ channel.label }}
+                  </button>
+                {% elseif channel.action == 'widgets' and event.widgets_url %}
+                  <a class="mel-button mel-button--secondary mel-marketing-hub__share-btn"
+                    href="{{ event.widgets_url }}"
+                    data-mel-analytics-event="{{ channel.analytics|default('widget_copied') }}">{{ channel.label }}</a>
+                {% elseif channel.url %}
+                  <a class="mel-button mel-button--secondary mel-marketing-hub__share-btn"
+                    href="{{ channel.url }}"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-mel-analytics-event="{{ channel.analytics|default('share_channel_selected') }}"
+                    data-share-channel="{{ channel.key }}">{{ channel.label }}</a>
+                {% endif %}
+                {% if channel.hint %}
+                  <p class="mel-marketing-hub__channel-hint">{{ channel.hint }}</p>
+                {% endif %}
+              {% endfor %}
+              {% if event.view_url %}
+                <a class="mel-marketing-hub__link" href="{{ event.view_url }}" target="_blank" rel="noopener noreferrer">{{ 'View page'|t }}</a>
+              {% endif %}
+              {% if event.marketing_url %}
+                <a class="mel-marketing-hub__link" href="{{ event.marketing_url }}">{{ 'Event Marketing'|t }}</a>
+              {% endif %}
+            </div>
+
+            {% if event.qr_data_uri %}
+              <figure class="mel-marketing-hub__qr">
+                <img src="{{ event.qr_data_uri }}" width="180" height="180" alt="{{ 'QR code for @title public page'|t({'@title': event.title}) }}">
+                <figcaption class="mel-marketing-hub__muted">{{ 'Scan to open the public event page'|t }}</figcaption>
+              </figure>
+            {% else %}
+              <p class="mel-marketing-hub__muted" role="status">{{ 'QR code will appear here when available.'|t }}</p>
+            {% endif %}
+          </div>
+          <p class="mel-marketing-hub__copy-status" data-mel-copy-status role="status" aria-live="polite"></p>
+        </article>
+      {% endfor %}
+    {% endif %}
+  </section>
+
+  <section class="mel-card mel-marketing-hub__section" id="boost" aria-labelledby="mel-marketing-boost-heading" data-mel-analytics-event="boost_started">
+    <p class="mel-marketing-hub__eyebrow">{{ boost.eyebrow }}</p>
+    <h2 id="mel-marketing-boost-heading" class="mel-card__title">{{ boost.title }}</h2>
+    {% if not boost.available %}
+      <p class="mel-marketing-hub__muted" role="status">{{ 'Boost is not available on this site yet.'|t }}</p>
+    {% else %}
+      <dl class="mel-marketing-hub__facts mel-marketing-hub__facts--grid">
+        <div class="mel-marketing-hub__fact">
+          <dt>{{ 'What it does'|t }}</dt>
+          <dd>{{ boost.what }}</dd>
+        </div>
+        <div class="mel-marketing-hub__fact">
+          <dt>{{ 'Who sees it'|t }}</dt>
+          <dd>{{ boost.who }}</dd>
+        </div>
+        <div class="mel-marketing-hub__fact">
+          <dt>{{ 'Expected outcome'|t }}</dt>
+          <dd>{{ boost.outcome }}</dd>
+        </div>
+      </dl>
+
+      <h3 class="mel-marketing-hub__subsection-title">{{ 'Current campaigns'|t }}</h3>
+      {% if boost.campaigns is empty %}
+        <div class="mel-empty-state" role="status">
+          <p class="mel-empty-state__title">{{ boost.empty_title }}</p>
+          <p class="mel-empty-state__body">{{ boost.empty_body }}</p>
+        </div>
+      {% else %}
+        <ul class="mel-marketing-hub__campaign-list">
+          {% for campaign in boost.campaigns %}
+            <li class="mel-marketing-hub__campaign-item">
+              <div>
+                <p class="mel-marketing-hub__campaign-title">{{ campaign.title }}</p>
+                <p class="mel-marketing-hub__muted">{{ campaign.status }}{% if campaign.ends %} · {{ 'Ends @date'|t({'@date': campaign.ends}) }}{% endif %}</p>
+              </div>
+              {% if campaign.url %}
+                <a class="mel-button mel-button--secondary" href="{{ campaign.url }}" data-mel-analytics-event="boost_started">{{ 'Manage Boost'|t }}</a>
+              {% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+
+      {% if boost.eligible %}
+        <h3 class="mel-marketing-hub__subsection-title">{{ 'Eligible to Boost'|t }}</h3>
+        <ul class="mel-marketing-hub__campaign-list">
+          {% for item in boost.eligible %}
+            <li class="mel-marketing-hub__campaign-item">
+              <div>
+                <p class="mel-marketing-hub__campaign-title">{{ item.title }}</p>
+                {% if item.state %}<p class="mel-marketing-hub__muted">{{ item.state }}</p>{% endif %}
+              </div>
+              {% if item.url %}
+                <a class="mel-button mel-button--primary" href="{{ item.url }}" data-mel-analytics-event="boost_started">{{ item.cta_label }}</a>
+              {% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+
+      {% if boost.export_url %}
+        <a class="mel-marketing-hub__link" href="{{ boost.export_url }}">{{ 'Export Boost performance'|t }}</a>
+      {% endif %}
+    {% endif %}
+  </section>
+
+  <section class="mel-card mel-marketing-hub__section" id="widgets" aria-labelledby="mel-marketing-widgets-heading">
+    <h2 id="mel-marketing-widgets-heading" class="mel-card__title">{{ widgets.title }}</h2>
+    <p class="mel-marketing-hub__muted">{{ widgets.body }}</p>
+    {% if widgets.events is empty %}
+      <div class="mel-empty-state" role="status">
+        <p class="mel-empty-state__title">{{ widgets.empty_title }}</p>
+        <p class="mel-empty-state__body">{{ widgets.empty_body }}</p>
+      </div>
+    {% else %}
+      <ul class="mel-marketing-hub__event-list">
+        {% for event in widgets.events %}
+          <li class="mel-marketing-hub__event-item">
+            <p class="mel-marketing-hub__event-title">{{ event.title }}</p>
+            <a class="mel-button mel-button--secondary" href="{{ event.url }}" data-mel-analytics-event="widget_copied">{{ 'Open widgets'|t }}</a>
+          </li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+  </section>
+
+  <section class="mel-card mel-marketing-hub__section" id="social" aria-labelledby="mel-marketing-social-heading">
+    <h2 id="mel-marketing-social-heading" class="mel-card__title">{{ social.title }}</h2>
+    <p class="mel-marketing-hub__muted">{{ social.body }}</p>
+    <p class="mel-marketing-hub__muted" role="status">{{ social.ready_label }}</p>
+    <ul class="mel-marketing-hub__channel-list" aria-label="{{ 'Supported share channels'|t }}">
+      {% for channel in social.channels|default([]) %}
+        <li>{{ channel.label }}</li>
+      {% endfor %}
+    </ul>
+    {% if social.settings_url %}
+      <a class="mel-button mel-button--secondary" href="{{ social.settings_url }}">{{ 'Edit social links'|t }}</a>
+    {% endif %}
+  </section>
+
+  <section class="mel-card mel-marketing-hub__section" id="audience" aria-labelledby="mel-marketing-audience-heading">
+    <h2 id="mel-marketing-audience-heading" class="mel-card__title">{{ audience.title }}</h2>
+    <p class="mel-marketing-hub__muted">{{ audience.body }}</p>
+    <ul class="mel-marketing-hub__tips">
+      {% for tip in audience.tips|default([]) %}
+        <li>{{ tip }}</li>
+      {% endfor %}
+    </ul>
+    {% if audience.cta_url %}
+      <a class="mel-button mel-button--secondary" href="{{ audience.cta_url }}">{{ audience.cta_label }}</a>
+    {% endif %}
+  </section>
+
+  <section class="mel-card mel-marketing-hub__section" id="performance" aria-labelledby="mel-marketing-performance-heading">
+    <div class="mel-card__header mel-marketing-hub__section-header">
+      <h2 id="mel-marketing-performance-heading" class="mel-card__title">{{ performance.title }}</h2>
+      {% if performance.analytics_url %}
+        <a class="mel-marketing-hub__link" href="{{ performance.analytics_url }}">{{ performance.analytics_label }}</a>
+      {% endif %}
+    </div>
+    <p class="mel-marketing-hub__muted">{{ performance.body }}</p>
+    <div class="mel-marketing-hub__kpi-row" role="list">
+      {% for metric in performance.metrics|default([]) %}
+        <div class="mel-marketing-hub__kpi" role="listitem">
+          <span class="mel-marketing-hub__kpi-label">{{ metric.label }}</span>
+          <span class="mel-marketing-hub__kpi-value" aria-label="{{ metric.label }} {{ metric.value }}">{{ metric.value }}</span>
+          {% if metric.hint %}
+            <span class="mel-marketing-hub__kpi-hint">{{ metric.hint }}</span>
+          {% endif %}
+        </div>
+      {% endfor %}
+    </div>
+    {% if performance.unavailable %}
+      <div class="mel-marketing-hub__callout" role="note">
+        <p class="mel-marketing-hub__callout-title">{{ performance.unavailable.title }}</p>
+        <ul>
+          {% for item in performance.unavailable.items %}
+            <li>{{ item }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+    {% if performance.export_url %}
+      <a class="mel-marketing-hub__link" href="{{ performance.export_url }}">{{ performance.export_label }}</a>
+    {% endif %}
+  </section>
+
+  <section class="mel-card mel-marketing-hub__section" id="actions" aria-labelledby="mel-marketing-actions-heading">
+    <h2 id="mel-marketing-actions-heading" class="mel-card__title">{{ actions.title }}</h2>
+    <ul class="mel-marketing-hub__actions-list">
+      {% for item in actions.items|default([]) %}
+        <li class="mel-marketing-hub__action-item">
+          <div>
+            <p class="mel-marketing-hub__action-title">{{ item.title }}</p>
+            <p class="mel-marketing-hub__muted">{{ item.body }}</p>
+          </div>
+          {% if item.cta_url %}
+            <a class="mel-button mel-button--secondary" href="{{ item.cta_url }}"{% if item.analytics %} data-mel-analytics-event="{{ item.analytics }}"{% endif %}>{{ item.cta_label }}</a>
+          {% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+  </section>
+
+</div>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/marketing-hub.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/marketing-hub.html.twig
@@ -52,10 +52,19 @@
       <p class="mel-marketing-hub__muted"><strong>{{ 'Next step'|t }}:</strong> {{ health.next_step }}</p>
     {% endif %}
     <div class="mel-marketing-hub__actions">
-      {% if health.cta_url %}
+      {% if health.cta_action|default('link') == 'copy' and health.cta_copy_url %}
+        <button type="button"
+          class="mel-button mel-button--primary mel-marketing-hub__share-btn"
+          data-mel-share-copy
+          data-copy-url="{{ health.cta_copy_url }}"
+          {% if health.cta_analytics %}data-mel-analytics-event="{{ health.cta_analytics }}"{% endif %}>
+          {{ health.cta_label }}
+        </button>
+      {% elseif health.cta_url %}
         <a class="mel-button mel-button--primary" href="{{ health.cta_url }}">{{ health.cta_label }}</a>
       {% endif %}
     </div>
+    <p class="mel-marketing-hub__copy-status" data-mel-copy-status role="status" aria-live="polite"></p>
   </section>
 
   <section class="mel-card mel-marketing-hub__section" id="share" aria-labelledby="mel-marketing-share-heading">
@@ -287,12 +296,21 @@
             <p class="mel-marketing-hub__action-title">{{ item.title }}</p>
             <p class="mel-marketing-hub__muted">{{ item.body }}</p>
           </div>
-          {% if item.cta_url %}
+          {% if item.cta_action|default('link') == 'copy' and item.cta_copy_url %}
+            <button type="button"
+              class="mel-button mel-button--secondary mel-marketing-hub__share-btn"
+              data-mel-share-copy
+              data-copy-url="{{ item.cta_copy_url }}"
+              {% if item.analytics %}data-mel-analytics-event="{{ item.analytics }}"{% endif %}>
+              {{ item.cta_label }}
+            </button>
+          {% elseif item.cta_url %}
             <a class="mel-button mel-button--secondary" href="{{ item.cta_url }}"{% if item.analytics %} data-mel-analytics-event="{{ item.analytics }}"{% endif %}>{{ item.cta_label }}</a>
           {% endif %}
         </li>
       {% endfor %}
     </ul>
+    <p class="mel-marketing-hub__copy-status" data-mel-copy-status role="status" aria-live="polite"></p>
   </section>
 
 </div>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/marketing-hub.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/marketing-hub.html.twig
@@ -140,7 +140,7 @@
     {% endif %}
   </section>
 
-  <section class="mel-card mel-marketing-hub__section" id="boost" aria-labelledby="mel-marketing-boost-heading" data-mel-analytics-event="boost_started">
+  <section class="mel-card mel-marketing-hub__section" id="boost" aria-labelledby="mel-marketing-boost-heading">
     <p class="mel-marketing-hub__eyebrow">{{ boost.eyebrow }}</p>
     <h2 id="mel-marketing-boost-heading" class="mel-card__title">{{ boost.title }}</h2>
     {% if not boost.available %}
@@ -176,7 +176,7 @@
                 <p class="mel-marketing-hub__muted">{{ campaign.status }}{% if campaign.ends %} · {{ 'Ends @date'|t({'@date': campaign.ends}) }}{% endif %}</p>
               </div>
               {% if campaign.url %}
-                <a class="mel-button mel-button--secondary" href="{{ campaign.url }}" data-mel-analytics-event="boost_started">{{ 'Manage Boost'|t }}</a>
+                <a class="mel-button mel-button--secondary" href="{{ campaign.url }}">{{ 'Manage Boost'|t }}</a>
               {% endif %}
             </li>
           {% endfor %}


### PR DESCRIPTION
## Summary
- Introduces the organiser **Marketing Hub** (Event Growth Centre) at `/vendor/marketing` with Marketing Health, Share Event, Boost, Widgets & Embeds, Social Media, Audience Growth, Marketing Performance, and Recommended Actions.
- Converges shell Marketing, `/vendor/boost` (redirect), dashboard/onboarding CTAs, Analytics “Open Marketing”, and Event Workspace Marketing onto one growth home — Boost remains the premium product name.
- Replaces residual Grow/Promote organiser copy with Marketing/Share language (AU English, community-first) and documents inventory, instrumentation gaps, and launch updates.

## Test plan
- [ ] Open `/vendor/marketing` as an organiser with no live events — health prompts publish
- [ ] With a published event — copy link, QR alt text, Facebook/LinkedIn/Email, Instagram copy guidance
- [ ] Boost eligible / active campaign rows deep-link correctly; tone does not oversell
- [ ] Widgets entry opens Tickets widgets for the event
- [ ] `/vendor/boost` redirects to `/vendor/marketing#boost`
- [ ] Analytics “Open Marketing” lands on the hub
- [ ] Event Workspace Marketing shows share channels + Marketing home link
- [ ] Desktop / tablet / 390px; keyboard jump nav; screen reader score + copy status
- [ ] `prefers-reduced-motion` respected


Made with [Cursor](https://cursor.com)