### PR TITLE
docs(vendor-studio): freeze Product Design System (PDS) v1.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+## Summary
+
+<!-- What changed and why (organiser outcome, not only technical delta). -->
+
+## Vendor Studio Design System References
+
+<!-- Required for any PR that changes Vendor Studio / organiser console experience or `docs/design/vendor-studio/`.
+     Remove this section only for PRs with zero Vendor Studio impact. -->
+
+This implementation follows:
+
+- <!-- e.g. 02-information-architecture.md -->
+- <!-- e.g. 05-component-library.md -->
+- <!-- e.g. 11-design-tokens.md -->
+- <!-- e.g. 16-design-review-checklist.md -->
+- <!-- e.g. 21-definition-of-done.md -->
+- <!-- e.g. ADR-0001 -->
+- <!-- e.g. DDR-003 -->
+
+**PDS home:** `docs/design/vendor-studio/` (Vendor Studio Product Design System v1.0 — FROZEN)
+
+Please also apply the GitHub label: `design-system`
+
+## Definition of Done / checklist
+
+- [ ] Applicable gates in `docs/design/vendor-studio/21-definition-of-done.md`
+- [ ] `docs/design/vendor-studio/16-design-review-checklist.md` completed (or N/A with rationale)
+- [ ] No contradiction of higher-order PDS docs ([ADR-0001](../docs/design/vendor-studio/decisions/ADR-0001-design-authority.md))
+
+## Test plan
+
+- [ ] <!-- Manual / automated checks -->
+
+## Risk
+
+<!-- Access, Commerce, payments, cache, PII — or "None" -->

--- a/docs/design/vendor-studio/01-vendor-studio-vision.md
+++ b/docs/design/vendor-studio/01-vendor-studio-vision.md
@@ -1,0 +1,193 @@
+# Vendor Studio Design Operating System — Vision
+
+**Version:** RC1  
+**Status:** Design authority (documentation only)  
+**Language:** Australian English · Organiser (human) · `vendor` (machine / URLs)
+
+## Purpose
+
+State the mission, product philosophy, Ten Design Principles, Golden Rule, Three Question Framework, and personality that govern every Vendor Studio screen.
+
+## Scope
+
+Foundational product design authority. Does **not** own numeric tokens ([11](11-design-tokens.md)), Dashboard composition depth ([12](12-dashboard-philosophy.md)), Event Workspace section spec ([13](13-event-workspace-philosophy.md)), or metric definitions ([18](18-product-success-metrics.md)).
+
+## Audience
+
+Product, design, theme, and Drupal contributors — especially new contributors (read after the [poster](DESIGN_PRINCIPLES_POSTER.md)).
+
+## Related documents
+
+- [DESIGN_PRINCIPLES_POSTER.md](DESIGN_PRINCIPLES_POSTER.md) · [QUICK_REFERENCE.md](QUICK_REFERENCE.md)
+- [02-information-architecture.md](02-information-architecture.md)
+- [14-visual-identity.md](14-visual-identity.md) · [15-copywriting-guide.md](15-copywriting-guide.md)
+- [18-product-success-metrics.md](18-product-success-metrics.md)
+- [`docs/vendor-experience-convergence.md`](../../vendor-experience-convergence.md)
+- [README.md](README.md)
+
+---
+
+## 1. Mission
+
+Vendor Studio is the organiser’s operating system for creating, running, and growing events on MyEventLane.
+
+It exists so organisers can focus on:
+
+- their event
+- their attendees
+- their tickets
+- their revenue
+
+It must never force them to think about Drupal, Commerce stores, products, variations, media entities, taxonomy, or paragraphs. Those remain implementation details.
+
+**Mission statement:** Help organisers create successful events with calm confidence — from first draft to door check-in to payout.
+
+---
+
+## 2. Product philosophy
+
+Vendor Studio is a **tool for operators**, not a marketing site and not a CMS admin.
+
+| Belief | Consequence |
+| --- | --- |
+| The event is the centre of gravity | Global tools exist to support events; events do not exist to fill a dashboard |
+| Attention is scarce | Surfaces lead with what needs action, not with decorative density |
+| Trust is earned through clarity | Money, capacity, and publish states are explicit and recoverable |
+| Complexity belongs backstage | Progressive disclosure; advanced tools appear when needed |
+| MEL is warm and local | Tone stays community-focused; never exclusive, VIP, or FOMO-driven |
+
+Vendor Studio shares MEL’s public brand soul (Hidden Gem + Guide) but serves a different job: **reliable operations**. Warmth never replaces precision when money, access, or publishing is involved.
+
+Visual feel: [14-visual-identity.md](14-visual-identity.md).
+
+---
+
+## 3. Design principles
+
+**Authoritative home for the Ten Design Principles.** Other documents cite; they do not restate the full list.
+
+These principles govern every future screen. If a proposal violates them, it does not ship.
+
+1. **One primary action** — Each screen (and each mobile viewport) has one obvious next step. Secondary actions stay visually subordinate.
+2. **Guide, don’t overwhelm** — Progressive disclosure, readiness cues, and next-step CTAs. The Guide presence is encouraging, never a mascot occupying chrome.
+3. **Always show the next step** — Empty, error, blocked, and success states all answer “what now?”
+4. **Always explain why** — Blocks include reason and recovery. Never a dead end.
+5. **Hide platform complexity** — Commerce and CMS vocabulary stay out of organiser copy.
+6. **Celebrate progress** — Milestones feel earned; never gamified pressure.
+7. **Mobile-capable operations** — Door Mode, sales monitoring, and urgent actions work on a phone.
+8. **Accessible by default** — WCAG AA contrast, visible focus, keyboard paths, severity not colour-only, `prefers-reduced-motion` respected.
+9. **Cards earn their size** — If removing a border, shadow, or radius does not hurt understanding, it should not be a card.
+10. **Consistency over novelty** — Reuse shell, layout intents, and components before inventing new patterns.
+
+Anti-pattern counterparts: [19-anti-patterns.md](19-anti-patterns.md).
+
+---
+
+## 4. Emotional journey
+
+Organisers move through recurring emotional states. Design must match the state, not fight it.
+
+```text
+Curiosity          →  “Can I run my event here?”
+Commitment         →  “I’ve started; don’t make me regret it.”
+Setup pressure     →  “What am I missing before publish?”
+Launch adrenaline  →  “Is it live? Are tickets selling?”
+Operational focus  →  “Who’s coming? What’s broken?”
+Door stress        →  “I need speed and certainty.”
+Aftermath clarity  →  “What happened? What do I owe / earn?”
+Growth ambition    →  “How do I do better next time?”
+```
+
+| State | Design response |
+| --- | --- |
+| Curiosity / commitment | Short paths, plain language, visible progress |
+| Setup pressure | Readiness + next action, not a wall of fields |
+| Launch / ops | Live status, action queue, calm density |
+| Door stress | Large targets, offline-tolerant patterns, minimal chrome |
+| Aftermath / growth | Clear numbers, exportable truth, non-judgemental insights |
+
+---
+
+## 5. Experience principles
+
+Operational rules that sit under the design principles:
+
+| Experience principle | Why |
+| --- | --- |
+| **Global ↔ Event context switch** | Organisers manage a business and a single event; they do not manage “Studio vs Manager” |
+| **Action before content vanity** | Dashboards lead with attention, not hero theatre |
+| **Readiness is honest** | Publish/block states reflect real capability, not cosmetic green ticks |
+| **Money surfaces are sober** | Payments and refunds use precise language and irreversible-action patterns |
+| **Help is contextual** | Support appears beside the task; staff-only content never leaks to organisers |
+| **Australian English** | Consumer- and organiser-facing copy follows brand + [15](15-copywriting-guide.md) |
+
+---
+
+## 6. Golden Rule
+
+> **If the organiser cannot answer “What should I do next?” within five seconds of landing on a screen, the screen has failed.**
+
+Everything else — visual polish, density, charts, secondary tools — is subordinate to that answer.
+
+---
+
+## 7. Three Questions Framework
+
+Every Vendor Studio screen must answer three questions, in this order:
+
+1. **Where am I?** — Global organiser context or which event / section.
+2. **What needs me?** — Attention, blockers, live status, or empty calm.
+3. **What is the next useful action?** — One primary CTA; secondary paths available but quiet.
+
+Use this framework in critiques, acceptance criteria, and pattern reviews. Screens that only answer “here is data” are incomplete.
+
+---
+
+## 8. Product personality
+
+| Trait | Sounds like | Does not sound like |
+| --- | --- | --- |
+| Warm | “You’re almost ready to publish.” | “Incomplete configuration detected.” |
+| Capable | “Refund this order” with clear consequence | Softening irreversible money actions |
+| Local / community | “Nearby”, “community”, “discover” on public MEL | “VIP”, “exclusive”, “members only” in Studio |
+| Calm | Steady hierarchy, generous whitespace | Dashboard panic, badge spam |
+| Honest | “Payouts unavailable until Stripe is connected — here’s why.” | Fake readiness |
+
+Personality is carried by **copy, hierarchy, and motion restraint** — not by decorative illustration in the shell. Copy authority: [15](15-copywriting-guide.md).
+
+---
+
+## 9. Success measures (summary)
+
+Success is behavioural and operational, not aesthetic.
+
+**Authoritative metric definitions:** [18-product-success-metrics.md](18-product-success-metrics.md).
+
+| Theme | Signal of success |
+| --- | --- |
+| Time to value | First publish, Stripe, ticket, booking without staff rescue |
+| Action clarity | Top Action Queue item resolved without hunting |
+| Door Mode | Check-in under time pressure on mobile |
+| Trust in money | Refund/payout confusion declines; states match reality |
+| Consistency | New screens reuse shell, intents, components |
+
+**Non-goals for this design system:** visual novelty for its own sake; feature parity with every competitor chrome detail; dark mode as a brand statement before operational completeness ([10](10-roadmap.md) Phase 12).
+
+---
+
+## Design implications
+
+- Every Vendor Studio PR must be justifiable against these principles and the Golden Rule
+- Foundational changes to principles require Design Authority review and CHANGELOG entry
+- Visual/token disputes defer to [11](11-design-tokens.md); IA disputes to [02](02-information-architecture.md)
+
+## Future considerations
+
+- Event Workspace and Vendor Studio remain one product with two contexts ([DDR-002](decisions/DDR-002-event-workspace.md))
+- Public MEL brand docs remain authority for consumer discovery; Studio extends for operations
+- When vision and a locked runtime contract conflict, document the conflict; do not silently override checkout, payments, or access rules
+- Level 4–5 ambition lives in [20](20-vendor-studio-v2-vision.md), not in silent principle edits
+
+## Related references
+
+- [README.md](README.md) · [DESIGN_PRINCIPLES_POSTER.md](DESIGN_PRINCIPLES_POSTER.md) · [02](02-information-architecture.md) · [14](14-visual-identity.md) · [15](15-copywriting-guide.md) · [18](18-product-success-metrics.md) · [19](19-anti-patterns.md) · [DDR-001](decisions/DDR-001-shell-navigation.md)

--- a/docs/design/vendor-studio/02-information-architecture.md
+++ b/docs/design/vendor-studio/02-information-architecture.md
@@ -1,0 +1,199 @@
+# Vendor Studio — Information Architecture
+
+**Version:** RC1.1  
+**Status:** Design authority (documentation only)
+
+## Purpose
+
+Define **navigation philosophy** and the **workspace hierarchy** for Vendor Studio — the authoritative home for global IA.
+
+## Scope
+
+Shell navigation, hierarchy order, current vs future IA, object relationships. Does not redefine field-level object models in VX2 IA packs. Event Workspace section philosophy depth: [13](13-event-workspace-philosophy.md). Decision record: [DDR-001](decisions/DDR-001-shell-navigation.md), [DDR-002](decisions/DDR-002-event-workspace.md).
+
+## Audience
+
+Product, design, nav implementers, Technical Authority.
+
+## Related documents
+
+- [01-vendor-studio-vision.md](01-vendor-studio-vision.md)
+- [13-event-workspace-philosophy.md](13-event-workspace-philosophy.md)
+- [DDR-001](decisions/DDR-001-shell-navigation.md) · [DDR-002](decisions/DDR-002-event-workspace.md)
+- [`docs/vendor-experience-convergence-information-architecture.md`](../../vendor-experience-convergence-information-architecture.md)
+- [`docs/vendor-experience-convergence-navigation.md`](../../vendor-experience-convergence-navigation.md)
+- [A01-glossary.md](appendices/A01-glossary.md)
+
+---
+
+## 1. Navigation philosophy
+
+1. **One organiser navigation** — A single global shell. No parallel “Studio nav” vs “Manager nav”.
+2. **Job-based labels** — Labels describe organiser jobs (Events, Payments), not Drupal concepts.
+3. **≤10 top-level items** — Prefer fewer. If a tool is event-scoped, it lives inside Event Workspace.
+4. **Context, not duplication** — The same capability (e.g. Orders) may exist globally and inside an event; the event view is filtered, not a second product.
+5. **Create event is chrome, not a peer destination** — Persistent primary action in the header; not a competing sidebar item named “Event Editor”.
+6. **URL namespace may say `/vendor/*`** — Visible copy says **Organiser**. Machine paths stay stable for continuity.
+
+### What never appears in the shell
+
+Commerce · Content · Stores · Media · Taxonomy · Configuration · Product variations · Entity references · Staff diagnostics
+
+---
+
+## 2. Workspace hierarchy
+
+Vendor Studio has two levels of place. Hierarchy is **context depth**, not a forced click path every session.
+
+```text
+Vendor Studio (global shell)
+│
+├── Dashboard          ← attention home
+├── Events             ← catalogue of events
+│     └── Workspace    ← per-event application (entered from Events)
+├── Orders             ← cross-event sales
+├── Attendees          ← cross-event guest work
+├── Messages           ← brand, templates, history (+ event-scoped send)
+├── Payments           ← Stripe, payouts, refunds, tax
+├── Analytics          ← business pulse
+├── Marketing          ← Boost, share, growth hubs
+├── Settings           ← organiser defaults
+└── Support            ← help + escalations
+```
+
+### Why this order
+
+| Position | Area | Why here |
+| --- | --- | --- |
+| 1 | Dashboard | Answers Golden Rule first: what needs me now |
+| 2 | Events | Events are the product unit; everything else serves them |
+| 3 | Workspace | Not a permanent global peer — a **context entered from Events** |
+| 4 | Orders | Money trail after events exist; global for multi-event organisers |
+| 5 | Attendees | Guest operations often span events; Door Mode remains event-primary |
+| 6 | Messages | Communication tools after people and sales exist |
+| 7 | Payments | Account-level money; high trust, lower daily frequency than orders |
+| 8 | Analytics | Reflection after operational basics work |
+| 9 | Marketing | Growth after the event can be found and sold |
+| 10 | Settings | Infrequent configuration |
+| 11 | Support | Always available; visually separated (footer of nav) |
+
+**Workspace is contextual, not a sidebar twin of Events** — see [DDR-002](decisions/DDR-002-event-workspace.md).
+
+**Orders before Attendees in global nav:** Cross-event sales reconciliation is a primary business job; guest list work is often event-scoped (Door Mode). Global Attendees remains for search across events. (Event Workspace still leads with Attendees for live ops.)
+
+---
+
+## 3. Current IA (runtime evidence)
+
+Authority for convergence mapping: VX2 navigation blueprint and `VendorNavBuilder` → vendor theme sidebar.
+
+**Approximate current shell grouping:**
+
+```text
+Home / Dashboard
+Events (+ Event Editor as competing entry)
+Operations-weighted items (Orders, Ticket holders, Check-in, Refund requests, Payouts)
+Growth (Grow / Boost, Messaging brand-skewed, Insights)
+Account (Support, Organiser settings)
+```
+
+### Problems this OS addresses
+
+| Problem | Why it fails the Golden Rule |
+| --- | --- |
+| Event Editor competes with Events | Two doors to the same house |
+| Check-in / refunds as global peers | Inflates shell; hides that they are event- or money-scoped |
+| Insights vs Analytics naming | Label mismatch creates doubt |
+| Messaging points at brand, not send | Wrong job at the top |
+| No Payments hub | Money scattered across payouts / Stripe / refunds |
+| Studio vs Manager mental model | Forces organisers to learn MEL’s internal history |
+
+Current IA is **not** the target. New work must converge toward Future IA, not extend Current IA.
+
+---
+
+## 4. Future IA
+
+### 4.1 Global organiser workspace
+
+| Nav item | Job | Preferred path pattern |
+| --- | --- | --- |
+| Dashboard | What needs attention now | `/vendor/dashboard` |
+| Events | Create and open events | `/vendor/events` |
+| Orders | Cross-event sales | `/vendor/orders` |
+| Attendees | Cross-event guest work | `/vendor/attendees` |
+| Messages | Brand, templates, history | `/vendor/messages` |
+| Payments | Stripe, payouts, refunds, tax | `/vendor/payments` |
+| Analytics | Business pulse | `/vendor/analytics` |
+| Marketing | Boost, share, growth | `/vendor/marketing` |
+| Settings | Profile, venues, defaults | `/vendor/settings` |
+| Support | Help + escalations | `/vendor/support` |
+
+### 4.2 Event Workspace (per-event application)
+
+Entered from Events / Dashboard. One shell for builder and operations.
+
+```text
+Overview → Details → Schedule → Venue → Images → Tickets
+→ Orders → Attendees → Messages → Marketing → Analytics
+→ Publishing → Settings
+```
+
+| Rule | Why |
+| --- | --- |
+| No Studio / Manager duplicate nav | Context switch is Global ↔ Event only |
+| Door Mode under Attendees | Check-in is a mode of guest ops, not a global product |
+| Advanced ticket tools nested under Tickets | Progressive disclosure |
+| Merch, Series, Diagnostics deferred from top-level | Until job frequency justifies shell weight |
+
+Canonical event paths: `/vendor/events/{id}` and `/vendor/events/{id}/{section}`. Plural `/vendor/events/` is canonical; singular legacy paths redirect.
+
+**Depth authority for Workspace philosophy:** [13-event-workspace-philosophy.md](13-event-workspace-philosophy.md).
+
+### 4.3 Object relationships (organiser mental model)
+
+```text
+Organiser
+  └── Events[]
+        ├── Tickets[]
+        ├── Attendees[]  (orders + RSVPs + waitlist + comps)
+        ├── Orders[]
+        ├── Messages[]
+        ├── Marketing
+        └── Analytics
+  ├── Payments (account)
+  ├── Settings (defaults)
+  └── Support
+```
+
+---
+
+## 5. Decision log (summary)
+
+Full DDRs supersede this summary when present.
+
+| Decision | Reason | DDR |
+| --- | --- | --- |
+| Keep `/vendor/*` URLs | Continuity; copy says Organiser | [DDR-001](decisions/DDR-001-shell-navigation.md) |
+| Workspace not permanent global nav | Avoids empty context and dual products | [DDR-002](decisions/DDR-002-event-workspace.md) |
+| Payments hub over scattered money links | Trust and findability | [DDR-006](decisions/DDR-006-payments-hub.md) |
+| Marketing separate from Analytics | Different jobs: grow vs understand | [DDR-007](decisions/DDR-007-marketing-analytics-separation.md) |
+| Support last + separated | Always reachable; not an operational peer of Events | (IA rule in this doc; promote to DDR if contested) |
+
+---
+
+## Design implications
+
+- Nav PRs cite this document and DDR-001/002
+- New global items require Product Owner justification against ≤10 rule
+- Access remains workspace-ownership based; IA never implies wider visibility than access allows
+
+## Future considerations
+
+- Small-screen collapse may nest Orders under Events and Marketing under Analytics **only if** research shows overload; product default remains the full list
+- Staff-only diagnostics never join organiser IA
+- URL rename to `/organiser/*` is parked ([A03](appendices/A03-future-ideas-parking-lot.md))
+
+## Related references
+
+- [01](01-vendor-studio-vision.md) · [13](13-event-workspace-philosophy.md) · [09](09-drupal-mapping.md) · [DDR-001](decisions/DDR-001-shell-navigation.md) · [DDR-002](decisions/DDR-002-event-workspace.md) · [A01](appendices/A01-glossary.md) · [19](19-anti-patterns.md)

--- a/docs/design/vendor-studio/03-layout-system.md
+++ b/docs/design/vendor-studio/03-layout-system.md
@@ -1,0 +1,220 @@
+# Vendor Studio — Layout System
+
+**Version:** RC1  
+**Status:** Design authority (documentation only)
+
+## Purpose
+
+Define how the Vendor Studio **shell and content regions** structure calm scanning paths — authoritative home for structural layout behaviour.
+
+## Scope
+
+Desktop/tablet/mobile structure, grid behaviour, containers (intents), header/sidebar/workspace/hero/panels. **Numeric token values** (spacing steps, max-widths, gutters) are owned by [11-design-tokens.md](11-design-tokens.md). Decision: [DDR-003](decisions/DDR-003-layout-intents.md).
+
+## Audience
+
+Theme architects, frontend engineers, designers.
+
+## Related documents
+
+- [11-design-tokens.md](11-design-tokens.md) — authoritative numbers
+- [04-design-language.md](04-design-language.md)
+- [08-mobile-guidelines.md](08-mobile-guidelines.md)
+- [DDR-003](decisions/DDR-003-layout-intents.md)
+- [`docs/brand/design-tokens.md`](../../brand/design-tokens.md)
+- [`docs/implementation/vx2-02a-workspace-layout-convergence.md`](../../implementation/vx2-02a-workspace-layout-convergence.md)
+
+---
+
+## Why layout intents
+
+Organisers scan under time pressure. Predictable structure answers “Where am I?” faster than decorative density. Full-width shells with intent-based content widths keep forms readable and boards roomy without inventing per-page pixel forks.
+
+---
+
+## 1. Structural model
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│ Header (organiser identity · Create event · account)        │
+├──────────────┬──────────────────────────────────────────────┤
+│ Sidebar      │  Workspace content                           │
+│ (global nav) │  ┌────────────────────────────────────────┐  │
+│              │  │ Hero / page header                     │  │
+│              │  ├────────────────────────────────────────┤  │
+│              │  │ Panels / grids / tables                │  │
+│              │  └────────────────────────────────────────┘  │
+├──────────────┴──────────────────────────────────────────────┤
+│ Footer (legal / secondary) — optional density               │
+└─────────────────────────────────────────────────────────────┘
+```
+
+On mobile, sidebar becomes a drawer or bottom/priority nav; content stacks. See [08](08-mobile-guidelines.md) and [DDR-005](decisions/DDR-005-mobile-first.md).
+
+---
+
+## 2. Desktop layout (≥1024px)
+
+| Region | Behaviour |
+| --- | --- |
+| **Header** | Full-width chrome; identity left; Create event primary; account/help right |
+| **Sidebar** | Persistent vertical nav; Settings + Support visually separated |
+| **Workspace** | Centred content column using layout intent |
+| **Help rail** | Optional `sidebar_help` region; never steals primary action |
+
+Scanning path: **title → primary action → status / attention → supporting content**.
+
+---
+
+## 3. Tablet layout (768px–1023px)
+
+| Change | Why |
+| --- | --- |
+| Sidebar may collapse to icon rail or overlay | Preserve content width for tables |
+| Gutters use tablet token | Touch-friendly without desktop waste |
+| Metric grids drop from 4 → 2 columns | Avoid cramped KPI cards |
+| Tables keep horizontal scroll rather than inventing a second UI | Consistency with desktop data model |
+
+---
+
+## 4. Mobile layout (<768px)
+
+| Change | Why |
+| --- | --- |
+| Single column; shell nav in drawer / sheet | One job per viewport |
+| Page hero compresses; no decorative empty hero padding | Attention over theatre |
+| Sticky primary action when the task requires commit | Reachability for thumbs |
+| Tables → card rows or scroll containers | [08-mobile-guidelines.md](08-mobile-guidelines.md) |
+| Door Mode uses maximal content, minimal chrome | Stress state |
+
+Baseline design width: **390px**, enhance upward.
+
+---
+
+## 5. Grid
+
+| Rule | Detail |
+| --- | --- |
+| Base unit | 4px (token scale in [11](11-design-tokens.md)) |
+| Content grid | 12-column conceptual grid inside the active container |
+| KPI / metric cards | 2 columns mobile · 2–3 tablet · 4 desktop (max) |
+| Card stacks | Vertical rhythm via spacing scale |
+| Split layouts | Documented split helpers only; avoid one-off 70/30 forks |
+
+Do not introduce a second grid system alongside existing vendor theme layout partials.
+
+---
+
+## 6. Spacing
+
+Use the spacing scale in [11-design-tokens.md](11-design-tokens.md). Whitespace creates hierarchy. If two panels compete equally, reduce one — do not add more chrome. Emotional guidance: [14](14-visual-identity.md).
+
+---
+
+## 7. Containers (layout intents)
+
+Shell stays full width. Content chooses an intent — **numbers in [11](11-design-tokens.md)**:
+
+| Intent | Use |
+| --- | --- |
+| Form | Settings, Stripe connect, messaging brand, wizards |
+| Reading | Support, help, next-action banners, status cards |
+| Workspace | Event Workspace, tickets, attendees, builder, events list |
+| Dashboard | Organiser home, global hubs |
+| Wide / Marketing | Boost grids, placement boards |
+
+**Rule:** Next-action and readiness blocks inside a wide workspace still prefer **Reading** width so urgency stays readable.
+
+Never hardcode content widths in Twig — layout classes and theme tokens own the numbers ([09](09-drupal-mapping.md)).
+
+---
+
+## 8. Header
+
+| Element | Role |
+| --- | --- |
+| MEL mark + organiser name | Answers “whose business is this?” |
+| Create event | Persistent primary chrome action |
+| Context label | Global vs event name when in Workspace |
+| Account / notifications | Secondary; never louder than Create event |
+
+Header is identity and wayfinding — not a second dashboard.
+
+---
+
+## 9. Sidebar
+
+| Rule | Why |
+| --- | --- |
+| Job-based order per [02](02-information-architecture.md) | Predictable mental model |
+| Active state is clear and not colour-only | Accessibility |
+| Badge counts sparingly (unread, needs attention) | Avoid FOMO theatre |
+| No nested mega-menus of Drupal tools | Hide complexity |
+
+---
+
+## 10. Workspace
+
+The workspace is the main content region inside the shell.
+
+| Property | Rule |
+| --- | --- |
+| One H1 | Page title owned by organiser task |
+| Primary action placement | Top-right of page header on desktop; sticky on mobile when needed |
+| Event Workspace subnav | Horizontal or secondary rail inside content — not a second global sidebar of CMS tools |
+| Scroll | Prefer document scroll; freeze only intentional sticky bars |
+
+---
+
+## 11. Hero (Workspace Hero)
+
+Vendor Studio heroes are **operational**, not marketing full-bleed heroes.
+
+| Allowed | Not allowed |
+| --- | --- |
+| Title, one-line status, one primary CTA, optional compact metrics | Full-bleed photo theatre, floating promo stickers, stat strips that bury the next action |
+| Readiness + next action composition | Multiple competing CTAs of equal weight |
+
+Public MEL hero locks in `DESIGN_SYSTEM.md` do **not** automatically apply decorative rules here; do not copy public homepage hero patterns into ops chrome. See [19](19-anti-patterns.md) Dashboard wallpaper.
+
+---
+
+## 12. Panels
+
+Panels group related work. Prefer:
+
+1. **Action / attention panel** (strongest)
+2. **Status / KPI strip** (secondary)
+3. **Data board** (tables, lists)
+4. **Help / guidance** (quiet)
+
+Panels use elevation sparingly ([11](11-design-tokens.md)). Adjacent panels separate primarily by whitespace and a single border token — not stacked heavy shadows.
+
+---
+
+## 13. Responsive rules (summary)
+
+| Breakpoint | Nav | Content | Tables | Actions |
+| --- | --- | --- | --- | --- |
+| Mobile | Drawer / priority | 1 col, form/reading widths | Cards or x-scroll | Sticky primary |
+| Tablet | Compact rail | 2-col metrics | x-scroll OK | Header actions |
+| Desktop | Persistent sidebar | Intent containers | Full tables | Header actions |
+
+`prefers-reduced-motion`: no layout-dependent animation required for comprehension.
+
+---
+
+## Design implications
+
+- New pages declare a layout intent in PR description
+- Competing max-width tokens are regressions ([19](19-anti-patterns.md), [DDR-003](decisions/DDR-003-layout-intents.md))
+
+## Future considerations
+
+- Do not reintroduce competing max-width tokens (`1080`, hardcoded `1120`, dual `.mel-page` contracts). VX2-02A remains the layout authority to extend in code.
+- Ultra-wide monitors: content stays centred at intent max; do not stretch forms to fill the void.
+- Density themes parked ([A03](appendices/A03-future-ideas-parking-lot.md))
+
+## Related references
+
+- [11](11-design-tokens.md) · [02](02-information-architecture.md) · [08](08-mobile-guidelines.md) · [09](09-drupal-mapping.md) · [DDR-003](decisions/DDR-003-layout-intents.md) · [DDR-005](decisions/DDR-005-mobile-first.md)

--- a/docs/design/vendor-studio/04-design-language.md
+++ b/docs/design/vendor-studio/04-design-language.md
@@ -1,0 +1,134 @@
+# Vendor Studio — Design Language
+
+**Version:** RC1  
+**Status:** Design authority (documentation only)
+
+## Purpose
+
+Explain how Vendor Studio **extends MEL’s public brand** for operations — high-level visual language without owning the numeric token tables.
+
+## Scope
+
+Relationship to public MEL, colour/type philosophy summaries, whitespace, borders, radius, elevation, motion, dark mode strategy overview. **Definitive token values:** [11-design-tokens.md](11-design-tokens.md). **Emotional identity:** [14-visual-identity.md](14-visual-identity.md).
+
+## Audience
+
+Designers, brand contributors, theme architects.
+
+## Related documents
+
+- [11-design-tokens.md](11-design-tokens.md)
+- [14-visual-identity.md](14-visual-identity.md)
+- [01-vendor-studio-vision.md](01-vendor-studio-vision.md)
+- [`docs/brand/design-tokens.md`](../../brand/design-tokens.md)
+- [`docs/brand/mel-brand-system-v1.md`](../../brand/mel-brand-system-v1.md)
+
+---
+
+## Why extend, not fork
+
+Organisers move between public MEL and Vendor Studio. A parallel palette or type system would feel like a different company. Extension preserves brand DNA while changing hierarchy and chrome for ops jobs.
+
+---
+
+## 1. Relationship to MEL public theme
+
+| Layer | Authority | Vendor Studio role |
+| --- | --- | --- |
+| Brand strategy / copy | `docs/brand/` | Same warmth, Australian English, no exclusivity language |
+| Public discovery UI | `myeventlane_theme` + `DESIGN_SYSTEM.md` | Do not fork event cards / public heroes into the console |
+| Organiser console | `myeventlane_vendor_theme` | Implements this OS; scoped under `.mel-vendor` |
+| Shared tokens | Brand + [11](11-design-tokens.md) | Console may tune density and focus colour for ops clarity |
+
+**Rule:** Shared MEL DNA (warm cream canvas, purple/coral accents, friendly radius). Different job (ops vs discovery) means different hierarchy and chrome — not a different brand.
+
+---
+
+## 2. Typography
+
+Philosophy: organisers scan under time pressure. Expressive marketing typography belongs on public MEL, not in Door Mode.
+
+Scale and roles: [11-design-tokens.md](11-design-tokens.md). Personality of type: [14](14-visual-identity.md).
+
+---
+
+## 3. Colour system
+
+Brand palette source: `docs/brand/design-tokens.md`. Studio application and semantic rules: [11](11-design-tokens.md).
+
+Summary: warm cream canvas · white surfaces · scarce purple primary · coral focus/accent · rare discovery gold · semantic severity with text/icon.
+
+---
+
+## 4. Vendor colour usage
+
+| Do | Don’t |
+| --- | --- |
+| Use purple for the one primary CTA per region | Paint entire sidebars purple |
+| Use coral as focus / warm accent consistently | Mix coral + gold on the same control |
+| Keep surfaces light for long sessions | Default the console to dark “pro tool” aesthetics before Phase 12 |
+| Align `.mel-vendor` CSS variables with public tokens | Invent one-off hex in component SCSS |
+
+Organiser branding (logos, event colours) may appear in **content previews**, not as a re-skin of the entire shell.
+
+---
+
+## 5. White space rules
+
+1. Prefer spacing scale steps over arbitrary pixel values ([11](11-design-tokens.md)).
+2. Separate competing panels with space before adding borders or shadows.
+3. Compress decorative empty heroes; expand space around primary attention lists.
+4. Forms stay at reading/form width — unused side space on ultra-wide is intentional calm.
+5. Dense tables may tighten row padding; surrounding page chrome stays airy.
+
+---
+
+## 6. Borders
+
+| Use | Guidance |
+| --- | --- |
+| Default panel edge | 1px soft border token (`--mel-border` family) |
+| Dividers | Prefer subtle horizontal rules inside lists |
+| Emphasis | Do not double-border + heavy shadow |
+| Destructive zones | Stronger border or left accent + clear heading |
+
+---
+
+## 7. Radius
+
+Align to brand radius scale; intents in [11](11-design-tokens.md). Avoid sharp 0px admin aesthetics and avoid overusing full pills on every chip (reduces hierarchy).
+
+---
+
+## 8. Elevation
+
+Levels and uses in [11](11-design-tokens.md). **Why restraint:** Heavy multi-layer shadows read as “dashboard fashion” and fight calm ops UI ([19](19-anti-patterns.md)).
+
+---
+
+## 9. Motion
+
+Duration bands in [11](11-design-tokens.md). Behaviour rules in [07](07-interaction-guidelines.md). Motion explains state — it does not entertain. Always honour `prefers-reduced-motion`.
+
+---
+
+## 10. Dark mode strategy
+
+**Phase 12 capability** — not a near-term default. Token-first remap under `.mel-vendor`; full principles in [11](11-design-tokens.md). Until Phase 12, do not partially dark-style individual pages.
+
+---
+
+## Design implications
+
+- Visual PRs cite [11](11-design-tokens.md) for values and this file for brand-extension rationale
+- Do not invent seasonal accent trends without accessibility + Three Questions justification
+
+## Future considerations
+
+- Public discovery gold remains rare in Studio to protect semantic clarity
+- Phase 12 dark mode QA across tables, severity, money
+- Illustration guidance owned by [14](14-visual-identity.md)
+
+## Related references
+
+- [11](11-design-tokens.md) · [14](14-visual-identity.md) · [03](03-layout-system.md) · [07](07-interaction-guidelines.md) · [10](10-roadmap.md) · `docs/brand/`

--- a/docs/design/vendor-studio/05-component-library.md
+++ b/docs/design/vendor-studio/05-component-library.md
@@ -1,0 +1,298 @@
+# Vendor Studio — Component Library
+
+**Version:** RC1  
+**Status:** Design authority (documentation only)
+
+## Purpose
+
+Define reusable **component contracts** for Vendor Studio — purpose, behaviour, accessibility, responsive rules, and Drupal mapping stubs.
+
+## Scope
+
+Component-level contracts. Visual tokens: [11](11-design-tokens.md). Interaction detail: [07](07-interaction-guidelines.md). Philosophy: [DDR-004](decisions/DDR-004-component-philosophy.md). Page composition: [06](06-workspace-patterns.md).
+
+## Audience
+
+Designers, theme engineers, module developers attaching render arrays.
+
+## Related documents
+
+- [03-layout-system.md](03-layout-system.md)
+- [07-interaction-guidelines.md](07-interaction-guidelines.md)
+- [09-drupal-mapping.md](09-drupal-mapping.md)
+- [11-design-tokens.md](11-design-tokens.md)
+- [19-anti-patterns.md](19-anti-patterns.md)
+- [DDR-004](decisions/DDR-004-component-philosophy.md)
+
+---
+
+## Why contracts
+
+Without shared contracts, every surface invents a slightly different button, alert, or empty state — organisers relearn chrome, and theme debt compounds. Prefer extending existing `.mel-*` / vendor partials over new names for the same job.
+
+For each component: **Purpose · Behaviour · Accessibility · Responsive · Future Drupal mapping**.
+
+---
+
+## 1. Workspace Hero
+
+| | |
+| --- | --- |
+| **Purpose** | Orient the page: title, status, one primary action |
+| **Behaviour** | Answers Three Questions Framework lines 1–3 in compact form; optional readiness line |
+| **Accessibility** | Single H1; CTA is a real button/link; status not colour-only |
+| **Responsive** | Stack CTA below title on mobile; no decorative full-bleed media |
+| **Drupal mapping** | Twig page header partials in Event Workspace / console templates; preprocess supplies title, status, primary_url |
+
+---
+
+## 2. Metric Cards
+
+| | |
+| --- | --- |
+| **Purpose** | Show a small set of KPIs that support decisions |
+| **Behaviour** | Max four per row on desktop; each card: label, value, optional delta/context; click only if drill-down exists |
+| **Accessibility** | Text labels; deltas announced with meaning (“up/down”), not colour alone |
+| **Responsive** | 2-col mobile; avoid horizontal metric carousels that hide values |
+| **Drupal mapping** | Render arrays from dashboard / analytics view models; SCSS card grid utilities |
+
+---
+
+## 3. Action Cards
+
+| | |
+| --- | --- |
+| **Purpose** | Promote a single recoverable task (“Connect Stripe”, “Finish tickets”) |
+| **Behaviour** | Severity + title + reason + one CTA; dismiss only when safe |
+| **Accessibility** | Severity icon + text; focusable CTA |
+| **Responsive** | Full width in reading/form containers |
+| **Drupal mapping** | Action queue items (`VendorActionQueueBuilder` pattern); alert/card Twig |
+
+---
+
+## 4. Task Lists
+
+| | |
+| --- | --- |
+| **Purpose** | Ranked work queue (dashboard attention) |
+| **Behaviour** | Sorted by severity from backend; do not re-sort in Twig; empty = calm “caught up” |
+| **Accessibility** | List semantics; each row has clear link name |
+| **Responsive** | Single column; actions inline or overflow menu |
+| **Drupal mapping** | View model list → Twig list component; cache tags from builders |
+
+---
+
+## 5. Data Tables
+
+| | |
+| --- | --- |
+| **Purpose** | Compare and act on many records (orders, attendees) |
+| **Behaviour** | Sticky header optional; row actions secondary; bulk actions explicit |
+| **Accessibility** | `<table>` with headers; sortable columns announce state; row actions keyboardable |
+| **Responsive** | Card-row transformation or horizontal scroll — pick one pattern per surface and keep it |
+| **Drupal mapping** | Views / custom builders → table Twig; libraries for progressive enhancement only |
+
+---
+
+## 6. Forms
+
+| | |
+| --- | --- |
+| **Purpose** | Edit organiser or event data safely |
+| **Behaviour** | Grouped sections; autosave where established (Event Workspace); explicit Save when money/publish risk |
+| **Accessibility** | Visible labels; helpers; field-level errors; `aria-invalid` / describedby |
+| **Responsive** | Form container 800px; stacked fields; 44px targets |
+| **Drupal mapping** | Form API + theme form alters; section forms in workspace plugins |
+
+---
+
+## 7. Inputs
+
+| | |
+| --- | --- |
+| **Purpose** | Collect discrete values |
+| **Behaviour** | Consistent height, focus ring, error/success adjacent text |
+| **Accessibility** | Label association mandatory; placeholders never replace labels |
+| **Responsive** | Full width in form column; avoid side-by-side inputs on mobile unless paired (e.g. time range) |
+| **Drupal mapping** | Core Form API widgets themed in vendor `base/_forms` / `components/_forms` |
+
+---
+
+## 8. Buttons
+
+| | |
+| --- | --- |
+| **Purpose** | Commit or navigate |
+| **Behaviour** | Primary / secondary / quiet / destructive hierarchy; one primary per region |
+| **Accessibility** | Disabled uses `disabled` or `aria-disabled` with explanation; focus visible |
+| **Responsive** | Min 44×44px; full-width primary on mobile when sticky |
+| **Drupal mapping** | `.mel-btn` variants in vendor theme; Form API actions themed consistently |
+
+---
+
+## 9. Badges
+
+| | |
+| --- | --- |
+| **Purpose** | Status at a glance (Draft, Live, Paid, Refunded) |
+| **Behaviour** | Sentence case; one badge emphasis per row/card |
+| **Accessibility** | Text + optional icon; not colour-only |
+| **Responsive** | Truncate with title tooltip only if full text available to AT |
+| **Drupal mapping** | Badge partial / status field formatters |
+
+---
+
+## 10. Alerts
+
+| | |
+| --- | --- |
+| **Purpose** | Page-level or inline system messages |
+| **Behaviour** | Info / warning / error / success; include recovery when blocked |
+| **Accessibility** | `role="status"` or `alert` appropriately; do not auto-dismiss errors |
+| **Responsive** | Full content width of container |
+| **Drupal mapping** | Drupal messengers themed; custom `vendor-alert` partials |
+
+---
+
+## 11. Panels
+
+| | |
+| --- | --- |
+| **Purpose** | Group related content without implying a new page |
+| **Behaviour** | Title optional; body; footer actions rare |
+| **Accessibility** | Heading structure inside panel |
+| **Responsive** | Stack; avoid multi-column panels on mobile |
+| **Drupal mapping** | `.mel-card` / panel Twig; layout hierarchy modifiers (`--status`, `--next`, etc.) |
+
+---
+
+## 12. Charts
+
+| | |
+| --- | --- |
+| **Purpose** | Reveal trends that change decisions |
+| **Behaviour** | Always ship a text/table alternative for critical numbers; empty state when no data |
+| **Accessibility** | Summaries in text; colour-blind safe series; keyboard focus for interactive legends if any |
+| **Responsive** | Simplify series on mobile; prefer one chart per view |
+| **Drupal mapping** | `chartjs` library in vendor theme; analytics templates; data from analytics services |
+
+---
+
+## 13. Drawers
+
+| | |
+| --- | --- |
+| **Purpose** | Secondary context without leaving the page (filters, help, detail peek) |
+| **Behaviour** | Esc closes; focus trap; return focus to opener |
+| **Accessibility** | `dialog` pattern; labelled by title |
+| **Responsive** | Full-height sheet on mobile |
+| **Drupal mapping** | Progressive JS library + Twig wrapper; no business logic in JS beyond UI |
+
+---
+
+## 14. Dialogs
+
+| | |
+| --- | --- |
+| **Purpose** | Confirm destructive or irreversible actions |
+| **Behaviour** | State the consequence; confirm label names the action (“Refund order”); never “OK” for money |
+| **Accessibility** | Focus trap; Esc; initial focus on safe control |
+| **Responsive** | Near full-width on mobile with margins |
+| **Drupal mapping** | Confirm forms / modal patterns; Drupal AJAX dialogs themed carefully |
+
+---
+
+## 15. Notifications
+
+| | |
+| --- | --- |
+| **Purpose** | Time-sensitive feedback (saved, sent, failed) |
+| **Behaviour** | Non-blocking toasts for success; persistent for errors until dismissed or fixed |
+| **Accessibility** | Live region polite for success; assertive for errors |
+| **Responsive** | Top or bottom safe area; do not cover sticky primary CTA |
+| **Drupal mapping** | `mel_notifications` library; messenger integration |
+
+---
+
+## 16. Skeleton loading
+
+| | |
+| --- | --- |
+| **Purpose** | Indicate structure while data loads |
+| **Behaviour** | Mirrors final layout; no fake numbers that look real |
+| **Accessibility** | `aria-busy` on container; text alternative “Loading” |
+| **Responsive** | Same breakpoints as final content |
+| **Drupal mapping** | Twig placeholders + CSS; avoid layout shift |
+
+---
+
+## 17. Empty states
+
+| | |
+| --- | --- |
+| **Purpose** | Explain absence and offer the next step |
+| **Behaviour** | Honest reason + primary CTA; optional secondary learn-more |
+| **Accessibility** | Not image-only; heading + text |
+| **Responsive** | Compact; CTA full width on mobile |
+| **Drupal mapping** | `_empty-states.scss` + Twig empties per surface |
+
+---
+
+## 18. Progress indicators
+
+| | |
+| --- | --- |
+| **Purpose** | Show setup/publish readiness or multi-step flows |
+| **Behaviour** | Steps named in organiser language; current step clear |
+| **Accessibility** | `aria-current`; percentage text if used |
+| **Responsive** | Collapse step labels to current + count on mobile |
+| **Drupal mapping** | Readiness providers / wizard step UIs |
+
+---
+
+## 19. Success panels
+
+| | |
+| --- | --- |
+| **Purpose** | Confirm completion and route to the next useful action |
+| **Behaviour** | Celebrate briefly; always include next step (View event, Share, Door Mode) |
+| **Accessibility** | Status role; focus moves to heading or primary CTA |
+| **Responsive** | Reading width |
+| **Drupal mapping** | Confirmation Twig after publish / send / connect flows |
+
+---
+
+## 20. Help panels
+
+| | |
+| --- | --- |
+| **Purpose** | Contextual guidance beside the task |
+| **Behaviour** | Short, organiser audience only; deep links to Help Centre articles |
+| **Accessibility** | Expand/collapse buttons labelled; content readable without hover |
+| **Responsive** | Stack below content on mobile; drawer optional |
+| **Drupal mapping** | `sidebar_help` region; support panel / help assistant components; enforce audience boundaries |
+
+---
+
+## Composition rules
+
+- Prefer **Task List + Metric Cards** on Dashboard over new “widget” types ([12](12-dashboard-philosophy.md)).
+- Prefer **Table + Drawer detail** over navigating away for lightweight inspection.
+- Do not add a component that duplicates an existing MEL pattern under a new name ([DDR-004](decisions/DDR-004-component-philosophy.md)).
+- Avoid nested cards and triple primaries ([19](19-anti-patterns.md)).
+
+---
+
+## Design implications
+
+- Component additions require: purpose, a11y notes, layout intent, and Drupal mapping stubs in this file
+- Token values defer to [11](11-design-tokens.md)
+
+## Future considerations
+
+- Visual QA against light theme until Phase 12 dark mode tokens exist
+- AI assistant panel components parked ([20](20-vendor-studio-v2-vision.md))
+
+## Related references
+
+- [03](03-layout-system.md) · [07](07-interaction-guidelines.md) · [09](09-drupal-mapping.md) · [11](11-design-tokens.md) · [DDR-004](decisions/DDR-004-component-philosophy.md) · [19](19-anti-patterns.md)

--- a/docs/design/vendor-studio/06-workspace-patterns.md
+++ b/docs/design/vendor-studio/06-workspace-patterns.md
@@ -1,0 +1,187 @@
+# Vendor Studio — Workspace Patterns
+
+**Version:** RC1  
+**Status:** Design authority (documentation only)
+
+## Purpose
+
+Define **page-level composition patterns** for each global hub — how components assemble to answer the Three Questions.
+
+## Scope
+
+Pattern goals, primary/secondary tasks, layout intent choice, component mix, success criteria. **Dashboard philosophy depth:** [12](12-dashboard-philosophy.md). **Event Workspace philosophy depth:** [13](13-event-workspace-philosophy.md). Field inventories remain in VX2 screen specifications.
+
+## Audience
+
+Product designers, theme implementers, feature leads.
+
+## Related documents
+
+- [01-vendor-studio-vision.md](01-vendor-studio-vision.md)
+- [02-information-architecture.md](02-information-architecture.md)
+- [05-component-library.md](05-component-library.md)
+- [12-dashboard-philosophy.md](12-dashboard-philosophy.md)
+- [13-event-workspace-philosophy.md](13-event-workspace-philosophy.md)
+- [`docs/vendor-experience-convergence-screen-specifications.md`](../../vendor-experience-convergence-screen-specifications.md)
+
+---
+
+## Why patterns
+
+Hubs share jobs (find, act, confirm) even when data differs. Patterns prevent every route from inventing a new page grammar.
+
+Each pattern must pass the Three Questions Framework and Golden Rule in [01](01-vendor-studio-vision.md).
+
+Attendees and Payments follow the same structural rules as Orders / Messages even when not listed as separate pattern headings below — see [02](02-information-architecture.md) for scope.
+
+---
+
+## 1. Dashboard
+
+| | |
+| --- | --- |
+| **Goals** | Surface what needs attention; orient the organiser’s business today |
+| **Primary task** | Resolve the top action-queue item |
+| **Secondary tasks** | Open today’s event, scan upcoming, skim activity |
+| **Layout** | Dashboard container. Identity header → Action required (strongest) → Today status → Upcoming → Activity |
+| **Components** | Workspace Hero (compact), Task Lists, Metric Cards, Action Cards, Empty states |
+| **Success criteria** | Action queue is visible without expanding; empty queue feels calm; Create event always reachable |
+
+**Philosophy authority:** [12-dashboard-philosophy.md](12-dashboard-philosophy.md).
+
+---
+
+## 2. Events
+
+| | |
+| --- | --- |
+| **Goals** | Find, create, and open events |
+| **Primary task** | Open an event Workspace or create a new event |
+| **Secondary tasks** | Filter by status; duplicate/archive where allowed |
+| **Layout** | Workspace container. Page header + filters + list/table |
+| **Components** | Buttons, Badges, Data Tables or event rows, Empty states |
+| **Success criteria** | ≤2 clicks from list to Event Workspace overview; draft vs live unmistakable |
+
+---
+
+## 3. Workspace (Event Workspace)
+
+| | |
+| --- | --- |
+| **Goals** | Build and operate one event in a single application shell |
+| **Primary task** | Context-dependent: continue setup, publish, or run ops (tickets/attendees/orders) |
+| **Secondary tasks** | Section navigation; view public page; Boost entry |
+| **Layout** | Workspace container. Event chrome (name, status, section nav) → section body. Overview uses compositional Home: readiness + next action + KPIs + activity |
+| **Components** | Workspace Hero, Progress/readiness, Metric Cards, Forms, Tables, Alerts, Help panels |
+| **Success criteria** | No Studio/Manager dual nav; next step always visible on Overview; publish blockers explained |
+
+**Philosophy authority:** [13-event-workspace-philosophy.md](13-event-workspace-philosophy.md).
+
+---
+
+## 4. Orders
+
+| | |
+| --- | --- |
+| **Goals** | Understand and act on sales records |
+| **Primary task** | Find an order and view detail / refund entry |
+| **Secondary tasks** | Filter by event/status; export where permitted |
+| **Layout** | Workspace/Dashboard hub width for lists; Reading/Form for detail panes |
+| **Components** | Data Tables, Badges, Drawers/Dialogs for confirmations, Alerts |
+| **Success criteria** | Order state matches Commerce truth; refund path is deliberate and confirmed |
+
+**Risk note:** Order ownership and payment state are high risk — UI never invents success.
+
+---
+
+## 5. Messages
+
+| | |
+| --- | --- |
+| **Goals** | Communicate with audiences using brand-consistent tools |
+| **Primary task** | Send or schedule a message to the right audience |
+| **Secondary tasks** | Edit brand/templates; review history |
+| **Layout** | Form width for compose/brand; Workspace for history tables |
+| **Components** | Forms, Inputs, Alerts, Success panels, Empty states |
+| **Success criteria** | Organiser can tell audience + event context before send; failures explain recovery |
+
+---
+
+## 6. Analytics
+
+| | |
+| --- | --- |
+| **Goals** | Answer business questions with trustworthy numbers |
+| **Primary task** | Understand performance for a period or event |
+| **Secondary tasks** | Export; drill into event Workspace analytics |
+| **Layout** | Dashboard/Workspace width; charts + KPI row + supporting table |
+| **Components** | Metric Cards, Charts, Data Tables, Skeleton loading, Empty states |
+| **Success criteria** | Critical figures available as text; empty states do not invent growth stories |
+
+---
+
+## 7. Marketing
+
+| | |
+| --- | --- |
+| **Goals** | Grow reach (Boost, share, embeds) without cluttering ops nav elsewhere |
+| **Primary task** | Start or manage a Boost / share the event |
+| **Secondary tasks** | Placement performance; widgets |
+| **Layout** | Wide/Marketing container for grids; Form for purchase/configure steps |
+| **Components** | Action Cards, Metric Cards, Panels, Buttons, Help panels |
+| **Success criteria** | Growth actions never block publish/check-in paths; pricing/state clear before spend |
+
+---
+
+## 8. Settings
+
+| | |
+| --- | --- |
+| **Goals** | Configure organiser defaults safely |
+| **Primary task** | Update profile, venues, branding defaults, preferences |
+| **Secondary tasks** | Team access where available; commerce-linked fields with guidance |
+| **Layout** | Form container. Sectioned forms; clear save feedback |
+| **Components** | Forms, Inputs, Alerts, Notifications, Help panels |
+| **Success criteria** | Destructive settings confirmed; Stripe/business fields explain payout impact |
+
+---
+
+## 9. Support
+
+| | |
+| --- | --- |
+| **Goals** | Resolve blockers with organiser-safe help |
+| **Primary task** | Find an answer or escalate |
+| **Secondary tasks** | Browse Help Centre; contact paths |
+| **Layout** | Reading container. Search + article list + contact |
+| **Components** | Help panels, Alerts, Empty states, Forms (contact) |
+| **Success criteria** | Staff-only content never appears; articles match organiser audience |
+
+---
+
+## Pattern checklist (all pages)
+
+1. Where am I?
+2. What needs me?
+3. What is the next useful action?
+4. Empty / error / success states defined
+5. Layout intent class chosen (no hardcoded widths)
+6. One primary CTA
+7. Anti-patterns checked ([19](19-anti-patterns.md))
+
+---
+
+## Design implications
+
+- New hubs reuse an existing pattern before inventing a twelfth grammar
+- Dashboard/Workspace PRs must also satisfy [12](12-dashboard-philosophy.md) / [13](13-event-workspace-philosophy.md)
+
+## Future considerations
+
+- Global Attendees and Payments hubs use Orders/Messages structural patterns (list → detail → deliberate action)
+- Screen-level field inventories remain in VX2 screen specifications
+- Customisable widgets parked ([A03](appendices/A03-future-ideas-parking-lot.md))
+
+## Related references
+
+- [01](01-vendor-studio-vision.md) · [05](05-component-library.md) · [12](12-dashboard-philosophy.md) · [13](13-event-workspace-philosophy.md) · [10](10-roadmap.md) · [16](16-design-review-checklist.md)

--- a/docs/design/vendor-studio/07-interaction-guidelines.md
+++ b/docs/design/vendor-studio/07-interaction-guidelines.md
@@ -1,0 +1,176 @@
+# Vendor Studio — Interaction Guidelines
+
+**Version:** RC1  
+**Status:** Design authority (documentation only)
+
+## Purpose
+
+Define how Vendor Studio **behaves** under pointer, keyboard, save, load, and validation — so interactions increase certainty.
+
+## Scope
+
+Hover, focus, animation, transitions, autosave, notifications, loading, validation, keyboard shortcuts, accessibility behaviour. Motion **token durations**: [11](11-design-tokens.md). Autosave/publish philosophy in Workspace: [13](13-event-workspace-philosophy.md).
+
+## Audience
+
+Designers, frontend engineers, accessibility reviewers.
+
+## Related documents
+
+- [04-design-language.md](04-design-language.md)
+- [05-component-library.md](05-component-library.md)
+- [08-mobile-guidelines.md](08-mobile-guidelines.md)
+- [11-design-tokens.md](11-design-tokens.md)
+- [13-event-workspace-philosophy.md](13-event-workspace-philosophy.md)
+
+---
+
+## Why certainty over cleverness
+
+If motion, hover, or autosave obscures state, remove it. Organisers under door stress and money risk need predictable feedback more than delightful chrome.
+
+---
+
+## 1. Hover
+
+| Rule | Why |
+| --- | --- |
+| Hover may enhance affordance (lift, underline, background) | Helps pointer users scan |
+| Hover never reveals essential information alone | Touch and keyboard users must still succeed |
+| Row hover on tables is subtle | Avoid noisy zebra + heavy shadow |
+| Disabled controls show default cursor and no hover affordance | Honesty |
+
+Duration: motion-fast (~120ms) per [11](11-design-tokens.md).
+
+---
+
+## 2. Focus
+
+| Rule | Why |
+| --- | --- |
+| Visible focus ring on all interactive elements | Keyboard accessibility (WCAG) |
+| Focus colour uses vendor focus token (coral/accent family) | Distinct from purple primary fill |
+| Focus order follows reading order | Predictability |
+| Modals/drawers trap focus and restore on close | Prevents lost context |
+| Skip link to main content in shell | Efficient navigation |
+
+Never remove focus outlines for aesthetics.
+
+---
+
+## 3. Animations
+
+| Allowed | Disallowed |
+| --- | --- |
+| Short panel expand/collapse | Decorative looping motion in chrome |
+| Dialog enter ≤400ms | Parallax or large layout thrash |
+| Success check moments that do not block | Confetti/FOMO celebration patterns |
+| Skeleton shimmer reduced under `prefers-reduced-motion` | Motion required to understand state |
+
+---
+
+## 4. Transitions
+
+| Property | Guidance |
+| --- | --- |
+| Colour / opacity / shadow | Prefer for hover/focus |
+| Width / height | Avoid animating layout dimensions when possible; use transform/opacity |
+| Route changes | Instant or soft fade; do not delay primary content for animation |
+
+---
+
+## 5. Autosave
+
+| Context | Behaviour |
+| --- | --- |
+| Event Workspace section forms (where established) | Autosave with explicit “Saving / Saved / Error” status |
+| Money, publish, refunds, Stripe | **No silent autosave commits** — explicit confirmation |
+| Failure | Error stays visible with retry; do not claim Saved |
+| Conflict / session | Fail loudly with recovery path (see Event Studio draft recovery docs) |
+
+**Why:** Autosave reduces anxiety in long forms; silent money mutations destroy trust. Workspace philosophy: [13](13-event-workspace-philosophy.md).
+
+---
+
+## 6. Notifications
+
+| Type | Behaviour |
+| --- | --- |
+| Success | Polite toast; auto-dismiss after short delay |
+| Error | Persistent until dismissed or corrected |
+| Warning | Persistent or sticky to the relevant panel |
+| Background job | Progress + completion notification |
+
+Do not stack endless toasts; coalesce where possible. Copy: [15](15-copywriting-guide.md).
+
+---
+
+## 7. Loading
+
+| Pattern | When |
+| --- | --- |
+| Skeleton | Initial page structure known |
+| Inline spinner | Small component refresh |
+| Button busy state | Preventing double-submit |
+| Full-page blocker | Rare — only when leaving mid-state is harmful |
+
+Never show fabricated metrics during load ([19](19-anti-patterns.md)).
+
+---
+
+## 8. Validation
+
+| Rule | Why |
+| --- | --- |
+| Validate on submit; inline on blur for corrected fields | Balance noise vs guidance |
+| Field-level messages adjacent to inputs | Recoverability |
+| Summaries at top for multi-error forms | Orientation |
+| Server errors mapped to fields when possible | Trust |
+| Publishing readiness separate from field validation | Different jobs |
+
+Copy explains how to fix, not only that something is wrong ([15](15-copywriting-guide.md)).
+
+---
+
+## 9. Keyboard shortcuts
+
+| Principle | Detail |
+| --- | --- |
+| Optional accelerators | Never the only path |
+| Document in Support / tooltips | Discoverability |
+| Avoid browser conflicts | No hijacking of reserved shortcuts |
+| Door Mode | Prefer large controls over shortcut memorisation under stress |
+
+Suggested future set (parked for v1 runtime): `/` focus search where search exists; `Esc` close overlay; `?` shortcut help. See [A03](appendices/A03-future-ideas-parking-lot.md).
+
+---
+
+## 10. Accessibility behaviour
+
+| Requirement | Standard |
+| --- | --- |
+| Contrast | WCAG AA for text and essential icons |
+| Targets | ≥44×44px interactive targets |
+| Semantics | Buttons for actions, links for navigation |
+| Live regions | For save/notification status |
+| Reduced motion | Honoured globally |
+| Severity | Icon + text + colour |
+| Forms | Labels, instructions, errors programmatically associated |
+
+Vendor isolation and access checks remain server-side — interaction design never “hides” as security.
+
+---
+
+## Design implications
+
+- New JS behaviour ships with keyboard and screen-reader notes in the PR
+- Money/publish interactions require explicit confirmation patterns
+
+## Future considerations
+
+- Shortcut maps confirmed with organiser testing before promotion
+- Command palette parked ([20](20-vendor-studio-v2-vision.md))
+
+## Related references
+
+- [05](05-component-library.md) · [08](08-mobile-guidelines.md) · [11](11-design-tokens.md) · [13](13-event-workspace-philosophy.md) · [15](15-copywriting-guide.md) · [16](16-design-review-checklist.md)

--- a/docs/design/vendor-studio/08-mobile-guidelines.md
+++ b/docs/design/vendor-studio/08-mobile-guidelines.md
@@ -1,0 +1,165 @@
+# Vendor Studio — Mobile Guidelines
+
+**Version:** RC1  
+**Status:** Design authority (documentation only)
+
+## Purpose
+
+Define mobile-first operating rules so urgent organiser jobs succeed on a phone — authoritative home for mobile behaviour (with [DDR-005](decisions/DDR-005-mobile-first.md)).
+
+## Scope
+
+Navigation, cards, tables, forms, sticky/bottom actions, touch targets, responsive priorities, Door Mode mobile. Layout structure: [03](03-layout-system.md). Tokens: [11](11-design-tokens.md).
+
+## Audience
+
+Designers, frontend engineers, Door Mode implementers.
+
+## Related documents
+
+- [03-layout-system.md](03-layout-system.md)
+- [07-interaction-guidelines.md](07-interaction-guidelines.md)
+- [13-event-workspace-philosophy.md](13-event-workspace-philosophy.md)
+- [DDR-005](decisions/DDR-005-mobile-first.md)
+- [11-design-tokens.md](11-design-tokens.md)
+
+---
+
+## Why mobile-first ops
+
+Mobile is a first-class operating surface for urgent jobs (Door Mode, today’s attention, quick sales checks). It is not a shrunk desktop.
+
+**Baseline:** 390px width; enhance upward.
+
+---
+
+## 1. Navigation
+
+| Rule | Why |
+| --- | --- |
+| Global nav in drawer / sheet, not a permanent miniature sidebar | Preserves content width |
+| Show current section in header | Answers “Where am I?” |
+| Event Workspace uses horizontal scroll tabs or a section picker | Many sections; avoid nested drawers of doom |
+| Create event remains reachable from header or FAB-equivalent primary | Chrome primary action |
+| Limit visible priority destinations if using bottom nav | ≤5 items; remainder in menu |
+
+Do not ship two competing mobile nav systems on one surface ([19](19-anti-patterns.md)).
+
+---
+
+## 2. Cards
+
+| Rule | Why |
+| --- | --- |
+| Cards for interactive units (event row, action item) | Touch scanning |
+| One primary action per card | Golden Rule |
+| Avoid card-inside-card nesting | Hierarchy collapse |
+| Metric cards in 2-column grids max | Readability |
+
+If a card is only decorative grouping, prefer flat panels with spacing ([DDR-004](decisions/DDR-004-component-philosophy.md)).
+
+---
+
+## 3. Tables
+
+Choose **one** pattern per surface and keep it:
+
+| Pattern | Best for |
+| --- | --- |
+| **Card rows** | Attendees, events list — few columns matter |
+| **Horizontal scroll table** | Orders with many comparable columns |
+
+| Rule | Why |
+| --- | --- |
+| Sticky first column optional for scroll tables | Context while scanning |
+| Row actions behind a clear “Actions” control | Prevent mis-taps |
+| Never rely on hover-only actions | Touch |
+
+---
+
+## 4. Forms
+
+| Rule | Why |
+| --- | --- |
+| Single column | Error association and speed |
+| 16px minimum input text | iOS zoom / readability |
+| Labels above fields | Stable layout |
+| Date/time inputs use appropriate mobile keyboards / pickers | Fewer typos |
+| Group with short section titles | Progressive completion |
+| Autosave status visible near the top or sticky | Anxiety reduction |
+
+---
+
+## 5. Sticky actions
+
+| Use when | Avoid when |
+| --- | --- |
+| Primary commit must remain available while scrolling long forms | Multiple sticky bars compete |
+| Door Mode primary scan/check-in action | Marketing pages with no commit |
+
+Sticky bars use elevation separation and safe-area insets. They must not cover error messages — scroll errors into view on submit.
+
+---
+
+## 6. Bottom actions
+
+| Pattern | Guidance |
+| --- | --- |
+| Single primary button full width | Default |
+| Primary + quiet text secondary | Acceptable |
+| Two equal primary buttons | Not allowed |
+| Destructive + primary | Destructive is secondary/outline; confirm in dialog |
+
+---
+
+## 7. Touch targets
+
+| Spec | Value |
+| --- | --- |
+| Minimum target | 44×44px |
+| Spacing between targets | ≥8px |
+| List rows | Comfortable height ≥48px where actionable |
+
+Icon-only controls need accessible names. Token home: [11](11-design-tokens.md).
+
+---
+
+## 8. Responsive priorities
+
+When space is scarce, preserve in this order:
+
+1. **Primary task CTA**
+2. **Blocking status / errors**
+3. **Core content for the job**
+4. Metrics that change the decision
+5. Secondary nav / help
+6. Decorative illustration / marketing modules
+
+Hide or relocate (5)–(6) before compromising (1)–(3).
+
+---
+
+## Door Mode (special case)
+
+- Maximise list/search; minimise shell chrome
+- Large check-in controls
+- Offline / failure messaging must be unmistakable
+- Prefer one-handed reach zones for primary action
+
+Full Door Mode philosophy: [13-event-workspace-philosophy.md](13-event-workspace-philosophy.md). Offline-first enhancements: [20](20-vendor-studio-v2-vision.md) / [A03](appendices/A03-future-ideas-parking-lot.md).
+
+---
+
+## Design implications
+
+- Mobile QA is mandatory for Door Mode, Dashboard attention, and sticky commit flows
+- Hover-only essential actions fail review
+
+## Future considerations
+
+- Bottom navigation is optional and must be validated against IA count; do not assume it replaces the drawer
+- Tablet landscape may keep compact rail; treat as tablet rules in [03](03-layout-system.md), not phone rules
+
+## Related references
+
+- [03](03-layout-system.md) · [07](07-interaction-guidelines.md) · [13](13-event-workspace-philosophy.md) · [DDR-005](decisions/DDR-005-mobile-first.md) · [19](19-anti-patterns.md)

--- a/docs/design/vendor-studio/09-drupal-mapping.md
+++ b/docs/design/vendor-studio/09-drupal-mapping.md
@@ -1,0 +1,196 @@
+# Vendor Studio — Drupal Mapping
+
+**Version:** RC1  
+**Status:** Design authority (documentation only)
+
+## Purpose
+
+Map Design Operating System concepts to the existing **Drupal 11 + Commerce 3** structure so implementation extends the right homes.
+
+## Scope
+
+Architecture mapping only — **no implementation in this pack**. Paths and plugin IDs below are **targets or confirmed homes** based on repository conventions. If a specific template name cannot be confirmed at implementation time, discover it in-repo — do not invent.
+
+## Audience
+
+Technical Authority, theme engineers, module developers.
+
+## Related documents
+
+- [02-information-architecture.md](02-information-architecture.md)
+- [03-layout-system.md](03-layout-system.md)
+- [05-component-library.md](05-component-library.md)
+- [11-design-tokens.md](11-design-tokens.md)
+- [10-roadmap.md](10-roadmap.md)
+- [README.md](README.md) — governance
+
+---
+
+## Why mapping matters
+
+Design without Drupal homes creates parallel Twig/SCSS trees. Mapping keeps Vendor Studio maintainable and Commerce-safe.
+
+---
+
+## 1. Runtime homes
+
+| Concern | Location |
+| --- | --- |
+| Organiser console theme | `web/themes/custom/myeventlane_vendor_theme` |
+| Public MEL theme (do not fork ops UI here) | `web/themes/custom/myeventlane_theme` |
+| Vendor domain / routing / builders | `web/modules/custom/myeventlane_vendor` (+ related `myeventlane_*` modules) |
+| Config sync | `config/sync` (export only when intentionally changing config) |
+| Brand tokens (docs) | `docs/brand/design-tokens.md` |
+| Studio tokens (docs) | [11-design-tokens.md](11-design-tokens.md) |
+| Layout convergence authority | `docs/implementation/vx2-02a-workspace-layout-convergence.md` |
+
+Theme base: `stable9`. Body/console scoping: `.mel-vendor`.
+
+---
+
+## 2. Theme regions → design chrome
+
+| Design region | Theme region (`myeventlane_vendor_theme.info.yml`) |
+| --- | --- |
+| Sidebar global nav | `sidebar` |
+| Header left / centre / right | `vendor_header_left`, `vendor_header_center`, `vendor_header_right` |
+| Main workspace | `content` |
+| Help panels | `sidebar_help` |
+| System messages | `highlighted` |
+| Footer zones | `vendor_footer_*` |
+
+---
+
+## 3. Layout intents → SCSS / classes
+
+| Design intent | Class (product) | Token / SCSS home |
+| --- | --- | --- |
+| Form | `.mel-layout--form` | `--mel-layout-form` · `layout/_container.scss` · tokens spacing |
+| Reading | `.mel-layout--reading` | `--mel-layout-reading` |
+| Workspace | `.mel-layout--workspace` | `--mel-layout-workspace` |
+| Dashboard | `.mel-layout--dashboard` | `--mel-layout-dashboard` |
+| Marketing / wide | `.mel-layout--wide` / `--marketing` | `--mel-layout-wide` |
+| Shell tokens | `.mel-vendor` | `_root-tokens.scss` |
+
+**Rule:** Twig applies classes; SCSS owns widths. No hardcoded max-widths in templates. Numbers: [11](11-design-tokens.md). Decision: [DDR-003](decisions/DDR-003-layout-intents.md).
+
+---
+
+## 4. Design language → tokens / partials
+
+| Design concept | Likely SCSS / token surfaces |
+| --- | --- |
+| Colour / surface | `tokens/_colors.scss`, `_root-tokens.scss` |
+| Typography | `tokens/_typography.scss` |
+| Shadows | `tokens/_shadows.scss` |
+| Spacing / gutters | `tokens/_spacing.scss` (and root layout vars) |
+| Buttons | `components/_buttons.scss` |
+| Forms | `base/_forms.scss`, `components/_forms.scss`, `components/_form.scss` |
+| Cards / panels | `components/_cards.scss` |
+| Badges | `components/_badges.scss` |
+| Alerts | `components/_vendor-alert.scss` |
+| Empty states | `components/_empty-states.scss` |
+| Navigation shell | `layout/_navigation.scss` |
+| Workspace sheets | `workspace.scss`, page partials under `pages/` |
+
+---
+
+## 5. Components → Drupal building blocks
+
+| Component | Twig / theme | Data / logic | Library (examples in `*.libraries.yml`) |
+| --- | --- | --- | --- |
+| Workspace Hero | Console / workspace header Twig | Preprocess / section view models | `vendor-workspace`, page libraries |
+| Metric Cards | Card Twig partials | Dashboard / analytics builders | `dashboard`, `analytics` |
+| Action Cards / Task Lists | List/alert Twig | `VendorActionQueueBuilder` (and successors) | `dashboard` |
+| Data Tables | Table Twig / Views templates | Views or custom builders | page-specific |
+| Forms / Inputs | Form API theme suggestions | Form classes / workspace section forms | `form-protection`, `event-form`, wizard libs |
+| Buttons | Shared btn partials | Render `#type` => link/submit | `global` |
+| Badges | Status partial | Field formatters / view model flags | `global` |
+| Charts | Analytics Twig | Analytics services | `chartjs`, `analytics` |
+| Notifications | Messenger + custom | JS behaviours | `mel_notifications` |
+| Help panels | `sidebar_help` + support Twig | Help Centre services (organiser audience) | support / help libraries |
+| Door Mode UI | Check-in templates | Attendee / check-in modules | `mel-checkin` related SCSS/JS |
+
+Exact template filenames vary by surface — locate via theme registry / module templates at implementation time.
+
+---
+
+## 6. IA destinations → routing patterns
+
+Product path patterns (from VX2 IA; confirm in `*.routing.yml` before changing):
+
+| IA item | Path pattern |
+| --- | --- |
+| Dashboard | `/vendor/dashboard` |
+| Events | `/vendor/events` |
+| Event Workspace | `/vendor/events/{id}` · `/vendor/events/{id}/{section}` |
+| Create | `/vendor/events/create` (and established create gateways) |
+| Orders / Attendees / Messages / Payments / Analytics / Marketing / Settings / Support | `/vendor/{area}` hubs |
+
+Nav assembly: `VendorNavBuilder` (or successor) → sidebar render array → theme.
+
+**Access:** Workspace ownership and permissions remain server-side. Design never treats UI absence as security.
+
+---
+
+## 7. Preprocess, theme hooks, render arrays
+
+| Design need | Drupal mechanism |
+| --- | --- |
+| Attach layout class per page | Preprocess `page` / specific controllers setting `#attributes` |
+| Primary CTA in header | Render array variables to header Twig |
+| Action queue | Builder service → page variable → Twig |
+| Section body in Event Workspace | Workspace section plugins / controllers → embed form or view |
+| Cache correctness | Cache contexts (user, route, vendor workspace) + tags on entities |
+| Assets | `#attached` libraries; avoid global JS on unrelated routes |
+
+Business rules stay in services/forms — **not** Twig.
+
+---
+
+## 8. Commerce boundaries
+
+| Organiser concept | Commerce reality (hidden) |
+| --- | --- |
+| Ticket | Product variation / `mel_ticket_type` abstractions |
+| Order | Commerce order |
+| Payment / payout | Payment gateway + Stripe Connect account state |
+| Refund | Commerce/Stripe refund flows |
+
+Design copy uses organiser language ([15](15-copywriting-guide.md)). Implementation keeps Commerce entities and states authoritative. UI must not claim paid/refunded until state confirms.
+
+---
+
+## 9. Libraries strategy
+
+| Principle | Practice |
+| --- | --- |
+| Global shell | `global` + `vendor-workspace` |
+| Heavy page JS | Attach only on routes that need it (`analytics`, `dashboard`, wizard, notifications) |
+| No exploit-laden “admin” scripts | Follow MEL security rules |
+| Build pipeline | Vendor theme Vite/SCSS via repo `npm run mel:lint` / `mel:build` when implementing |
+
+---
+
+## 10. What this pack must not change (until a coded phase)
+
+- Twig, SCSS, PHP, JS, YAML config — unchanged by documentation-only work
+- Checkout flows, payment gateways, order ownership
+- Role permissions (`user.role.vendor` etc.) without explicit access review
+- Help audience boundaries
+
+---
+
+## Design implications
+
+- Implementation PRs update an “Implemented mapping” note under the relevant phase when code lands
+- Prefer extending existing partials over parallel `vendor-studio-*` component trees ([DDR-004](decisions/DDR-004-component-philosophy.md))
+
+## Future considerations
+
+- Confirm template filenames in-repo at coding time — do not invent
+- Dark mode token remap homes at Phase 12
+
+## Related references
+
+- [02](02-information-architecture.md) · [03](03-layout-system.md) · [05](05-component-library.md) · [11](11-design-tokens.md) · [10](10-roadmap.md) · [16](16-design-review-checklist.md)

--- a/docs/design/vendor-studio/10-roadmap.md
+++ b/docs/design/vendor-studio/10-roadmap.md
@@ -1,0 +1,226 @@
+# Vendor Studio Design Operating System — Roadmap
+
+**Version:** RC1  
+**Status:** Design authority (documentation only)
+
+## Purpose
+
+Sequence how this Design Operating System is **applied** in implementation phases — without absorbing v2 vision scope.
+
+## Scope
+
+Phased rollout, dependencies, Drupal impact, risk, effort. **Not** a backlog of parked ideas ([20](20-vendor-studio-v2-vision.md), [A03](appendices/A03-future-ideas-parking-lot.md)). Metric targets should reference [18](18-product-success-metrics.md). Maturity targets: [17](17-design-maturity-model.md).
+
+## Audience
+
+Product Owner, Design Authority, Technical Authority, phase leads.
+
+## Related documents
+
+- [01-vendor-studio-vision.md](01-vendor-studio-vision.md)
+- [09-drupal-mapping.md](09-drupal-mapping.md)
+- [17-design-maturity-model.md](17-design-maturity-model.md)
+- [18-product-success-metrics.md](18-product-success-metrics.md)
+- [20-vendor-studio-v2-vision.md](20-vendor-studio-v2-vision.md)
+- [`docs/vendor-experience-convergence-roadmap.md`](../../vendor-experience-convergence-roadmap.md)
+- [README.md](README.md) — governance / versioning
+
+---
+
+## Why phased application
+
+Shipping everything at once recreates drift. One phase at a time keeps diffs reviewable and protects Commerce/access surfaces.
+
+**Phase exit bar:** lift touched surfaces to at least **maturity Level 2** ([17](17-design-maturity-model.md)) unless the brief states otherwise.
+
+```text
+Phase 1 Design system
+    → 2 Dashboard → 3 Events → 4 Workspace
+    → 5 Orders → 6 Attendees → 7 Messages → 8 Payments
+    → 9 Analytics → 10 Marketing → 11 Settings → 12 Dark mode
+```
+
+---
+
+## Phase 1 — Design system
+
+| | |
+| --- | --- |
+| **Objectives** | Adopt this OS as authority; align tokens, layout intents, component contracts; remove competing max-width patterns from new work |
+| **Dependencies** | VX2-02A layout tokens; brand tokens docs; this documentation pack (RC1 → v1.0 freeze) |
+| **Drupal impact** | Theme token/SCSS hygiene only when coding begins; no Commerce changes |
+| **Risk** | Low — documentation and token alignment; medium if partial restyles fork components |
+| **Metrics** | Consistency; checklist citation rate ([18](18-product-success-metrics.md)) |
+| **Estimated effort** | M |
+
+---
+
+## Phase 2 — Dashboard
+
+| | |
+| --- | --- |
+| **Objectives** | Action-queue-led Dashboard pattern; identity + today + upcoming composition |
+| **Dependencies** | Phase 1; existing `VendorActionQueueBuilder` / dashboard view models; [12](12-dashboard-philosophy.md) |
+| **Drupal impact** | Primarily `myeventlane_vendor_theme` Twig/SCSS; possible preprocess; prefer theme-only if payloads exist |
+| **Risk** | Medium — easy to restyle without fixing priority; must not invent new payment states |
+| **Metrics** | Dashboard clarity ([18](18-product-success-metrics.md)) |
+| **Estimated effort** | M |
+
+---
+
+## Phase 3 — Events
+
+| | |
+| --- | --- |
+| **Objectives** | Events list clarity; create gateway; obvious entry to Workspace |
+| **Dependencies** | Phase 1; Events routes `/vendor/events` |
+| **Drupal impact** | Events list templates, nav labels, empty states |
+| **Risk** | Low–medium — create/draft flows already sensitive; do not alter publish rules casually |
+| **Metrics** | Time to first published event (path clarity) |
+| **Estimated effort** | M |
+
+---
+
+## Phase 4 — Workspace
+
+| | |
+| --- | --- |
+| **Objectives** | Event Workspace shell + Overview pattern consistency; section nav clarity |
+| **Dependencies** | Phases 1–3; VX2 One Event Workspace runtime; [13](13-event-workspace-philosophy.md) |
+| **Drupal impact** | Workspace Twig/SCSS/JS libraries; section headers; readiness presentation |
+| **Risk** | High — autosave, draft lifecycle, publish readiness; regress carefully |
+| **Metrics** | Workspace completion; time to first ticket |
+| **Estimated effort** | XL |
+
+---
+
+## Phase 5 — Orders
+
+| | |
+| --- | --- |
+| **Objectives** | Global + event order list/detail patterns; deliberate refund entry UX |
+| **Dependencies** | Phases 1, 4 (event-scoped); Commerce order access rules understood |
+| **Drupal impact** | Order views/templates; vendor order view SCSS; **no** payment logic changes without review |
+| **Risk** | High — PII, ownership, refunds |
+| **Metrics** | Support reduction on order findability; money trust |
+| **Estimated effort** | L |
+
+---
+
+## Phase 6 — Attendees
+
+| | |
+| --- | --- |
+| **Objectives** | Attendee workspace + Door Mode mobile excellence |
+| **Dependencies** | Phase 4; VX2 Attendee Workspace; [08](08-mobile-guidelines.md) |
+| **Drupal impact** | Attendee templates, check-in UI, filters; access isolation |
+| **Risk** | High — door stress, offline edge cases, personal data |
+| **Metrics** | Mobile usability; Door Mode reliability |
+| **Estimated effort** | L |
+
+---
+
+## Phase 7 — Messages
+
+| | |
+| --- | --- |
+| **Objectives** | Hub for brand/templates/history + clear send path; event-scoped messaging alignment |
+| **Dependencies** | Phase 1; messaging modules/routes |
+| **Drupal impact** | Messaging forms/templates; ensure brand settings ≠ send confusion |
+| **Risk** | Medium — accidental sends; audience selection clarity |
+| **Metrics** | Feature adoption (send path); support reduction |
+| **Estimated effort** | L |
+
+---
+
+## Phase 8 — Payments
+
+| | |
+| --- | --- |
+| **Objectives** | Payments hub pattern unifying Stripe, payouts, refunds, tax entry points |
+| **Dependencies** | Phase 1; Stripe Connect safety rules |
+| **Drupal impact** | Hub Twig/nav; deep links to existing Stripe/payout UIs; **no** gateway secret or state invention |
+| **Risk** | Critical — money, Connect onboarding, payout readiness honesty |
+| **Metrics** | Time to connect Stripe; money trust |
+| **Estimated effort** | L |
+
+---
+
+## Phase 9 — Analytics
+
+| | |
+| --- | --- |
+| **Objectives** | Analytics hub pattern: KPIs + charts + text alternatives + empty honesty |
+| **Dependencies** | Phase 1; analytics services/data availability |
+| **Drupal impact** | Analytics templates, `chartjs` attachment scope, exports |
+| **Risk** | Medium — misleading charts; performance of heavy queries |
+| **Metrics** | Operational clarity without decorative metrics ([19](19-anti-patterns.md)) |
+| **Estimated effort** | L |
+
+---
+
+## Phase 10 — Marketing
+
+| | |
+| --- | --- |
+| **Objectives** | Marketing/Boost hub at wide layout intent; clear spend/state before purchase |
+| **Dependencies** | Phase 1; Boost product rules |
+| **Drupal impact** | Marketing templates/SCSS; Boost CTAs; do not weaken entitlements |
+| **Risk** | Medium — commercial actions; placement complexity |
+| **Metrics** | Feature adoption (when relevant); must not harm publish/check-in |
+| **Estimated effort** | L |
+
+---
+
+## Phase 11 — Settings
+
+| | |
+| --- | --- |
+| **Objectives** | Settings form pattern consistency; sectioned calm forms; payout-impact copy |
+| **Dependencies** | Phase 1; organiser settings forms; [15](15-copywriting-guide.md) |
+| **Drupal impact** | Settings Twig/SCSS/form sectioning; schema only if config changes are intentional |
+| **Risk** | Medium — team access, business identity fields |
+| **Metrics** | Support reduction; settings completion without staff rescue |
+| **Estimated effort** | M |
+
+---
+
+## Phase 12 — Dark mode
+
+| | |
+| --- | --- |
+| **Objectives** | Token-level dark theme under `.mel-vendor`; QA across tables, severity, money |
+| **Dependencies** | Phases 1–11 substantially complete on light theme; [11](11-design-tokens.md) dark strategy |
+| **Drupal impact** | Token maps / SCSS; no structural PHP required |
+| **Risk** | Medium–high — contrast regressions; partial adoption worse than none |
+| **Metrics** | Accessibility maintained under dark remap |
+| **Estimated effort** | L |
+
+---
+
+## Cross-phase rules
+
+1. **One phase ships at a time** for reviewable diffs.
+2. **Documentation-only phases** do not modify Twig/SCSS/PHP/JS/YAML.
+3. **Commerce / access / payments** changes require explicit risk callouts and human approval.
+4. Prefer convergence with VX2 epics over parallel redesigns.
+5. Validate theme work with `npm run mel:lint` / `npm run mel:build` and Drupal cache rebuild when code lands.
+6. Cite Design OS docs + complete [16](16-design-review-checklist.md) on every PR.
+7. Do not absorb [20](20-vendor-studio-v2-vision.md) ideas without Product Owner promotion.
+
+---
+
+## Design implications
+
+- Roadmap reordering is explicit (CHANGELOG + Product Owner) — never silent in a feature PR
+- v1.0 freeze of this OS precedes or accompanies Phase 1 coding authority
+
+## Future considerations
+
+- Support polish can track with Phase 11 or a small companion slice; it is not a blocker for Dashboard/Workspace
+- Level 4–5 programmes are separate initiatives after core Level 2–3 excellence
+- After v1.0 freeze: tag, cite in every implementation PR ([README](README.md))
+
+## Related references
+
+- [09](09-drupal-mapping.md) · [12](12-dashboard-philosophy.md) · [13](13-event-workspace-philosophy.md) · [17](17-design-maturity-model.md) · [18](18-product-success-metrics.md) · [20](20-vendor-studio-v2-vision.md) · [A03](appendices/A03-future-ideas-parking-lot.md)

--- a/docs/design/vendor-studio/11-design-tokens.md
+++ b/docs/design/vendor-studio/11-design-tokens.md
@@ -1,0 +1,368 @@
+# Vendor Studio — Design Tokens
+
+**Version:** RC1  
+**Status:** Design authority (documentation only)
+
+## Purpose
+
+The definitive source of truth for every **visual decision** in Vendor Studio.
+
+If a spacing step, type size, radius, elevation level, or semantic colour is disputed, this document wins for Studio. Brand strategy and public discovery tokens remain in `docs/brand/`; this pack **extends** them for operations and records Studio-specific contracts.
+
+## Scope
+
+- Design specification only — no SCSS, Twig, or PHP implementation in this pack
+- Covers typography, spacing, grid, containers, radius, elevation, colour, motion, focus, icons, touch, and surface-level component token intents
+- Does not redefine navigation IA ([02](02-information-architecture.md)) or component behaviour contracts ([05](05-component-library.md))
+
+## Audience
+
+Designers, theme architects, frontend engineers, accessibility reviewers.
+
+## Related documents
+
+- [04-design-language.md](04-design-language.md) — philosophy of MEL extension
+- [03-layout-system.md](03-layout-system.md) — structural use of containers
+- [14-visual-identity.md](14-visual-identity.md) — emotional use of tokens
+- [docs/brand/design-tokens.md](../../brand/design-tokens.md) — brand token source
+- [09-drupal-mapping.md](09-drupal-mapping.md) — future SCSS mapping homes
+- [DDR-003](decisions/DDR-003-layout-intents.md)
+
+---
+
+## Why tokens first
+
+Organisers spend long sessions in Studio. Inconsistent spacing, competing max-widths, and ad-hoc colours create cognitive tax and theme debt. A single token system:
+
+- Improves **organiser experience** through predictable rhythm
+- Protects **accessibility** (contrast, focus, targets)
+- Enables **long-term maintainability** (one remap for dark mode)
+- Aligns **Drupal theme** work under `.mel-vendor` without parallel hex forks
+
+---
+
+## 1. Naming conventions
+
+| Pattern | Example | Use |
+| --- | --- | --- |
+| `--mel-color-{role}` | `--mel-color-primary` | Brand-aligned colour |
+| `--mel-space-{n}` | `--mel-space-4` | Spacing scale (4px base) |
+| `--mel-radius-{size}` | `--mel-radius-md` | Corner radius |
+| `--mel-shadow-{level}` | `--mel-shadow-sm` | Elevation |
+| `--mel-font-size-{role}` | `--mel-font-size-body` | Type scale |
+| `--mel-duration-{band}` | `--mel-duration-base` | Motion |
+| `--mel-layout-{intent}` | `--mel-layout-workspace` | Container max-width |
+| `--mel-vendor-*` | Scoped under `.mel-vendor` | Console overrides |
+
+**Rules**
+
+- Prefer role names over raw values in documentation and future SCSS
+- Do not invent parallel systems (`studio-purple`, hardcoded `1120px` in Twig)
+- Semantic colour tokens (`danger`, `warning`, `success`, `info`) stay separate from brand accents
+
+---
+
+## 2. Typography
+
+Aligned with brand scale; Studio emphasises scanability over marketing display.
+
+| Role | Mobile | Desktop | Weight | Line-height | Use |
+| --- | --- | --- | --- | --- | --- |
+| Display | 32px | 44px | 700 | 1.2 | Rare — avoid in ops chrome |
+| H1 | 28px | 36px | 700 | 1.2 | One page title |
+| H2 | 24px | 30px | 600 | 1.25 | Section headings |
+| H3 | 20px | 24px | 600 | 1.3 | Panel / card titles |
+| Body | 16px | 16px | 400 | 1.5 | Default copy |
+| Body small | 14px | 14px | 400 | 1.45 | Meta, table secondary |
+| Label | 12–13px | 13px | 500 | 1.4 | Field labels, badges |
+
+**Rules**
+
+- Minimum **16px** body on mobile
+- Sentence case for UI labels
+- Tabular lining figures for KPIs where available
+- No novelty display faces in Door Mode or money surfaces
+
+---
+
+## 3. Spacing
+
+**Base unit:** 4px
+
+| Token | Value | Typical use |
+| --- | --- | --- |
+| space-1 | 4px | Icon padding, tight gaps |
+| space-2 | 8px | Compact stacks, target gaps |
+| space-3 | 12px | Form internals |
+| space-4 | 16px | Mobile card padding, gutters mobile |
+| space-5 | 20px | Between related elements |
+| space-6 | 24px | Tablet gutters, section gaps mobile |
+| space-8 | 32px | Desktop gutters, card padding desktop |
+| space-10 | 40px | Major section breaks |
+| space-12 | 48px | Large breaks |
+
+**Whitespace philosophy (summary):** Separate competing panels with space before borders/shadows. Full emotional guidance: [14](14-visual-identity.md).
+
+---
+
+## 4. Grid
+
+| Rule | Value |
+| --- | --- |
+| Conceptual columns | 12 inside active container |
+| Metric cards | 2 mobile · 2–3 tablet · ≤4 desktop |
+| Base alignment | Multiples of 4px |
+| Split layouts | Only documented split helpers (status / next / board) |
+
+Do not introduce a second grid alongside vendor theme layout partials.
+
+---
+
+## 5. Containers (layout intents)
+
+| Intent | Max width | Gutters | Use |
+| --- | --- | --- | --- |
+| Form | 800px | 16 / 24 / 32 | Settings, Stripe, wizards |
+| Reading | 800px | 16 / 24 / 32 | Help, readiness, next-action |
+| Workspace | 1200px | 16 / 24 / 32 | Event Workspace, tickets, lists |
+| Dashboard | 1280px | 16 / 24 / 32 | Home, global hubs |
+| Wide / Marketing | 1400px | 16 / 24 / 32 | Boost grids, boards |
+
+Shell remains full width. Next-action blocks inside wide workspaces still prefer **Reading** width.
+
+Authority for structural behaviour: [03-layout-system.md](03-layout-system.md) · [DDR-003](decisions/DDR-003-layout-intents.md).
+
+---
+
+## 6. Radius
+
+| Token | Intent | Typical use |
+| --- | --- | --- |
+| radius-sm | Small | Badges, chips |
+| radius-md | Medium | Inputs, buttons |
+| radius-lg | Large | Cards, panels, modals |
+| radius-pill | Pill | Sparse use — density of pills kills hierarchy |
+
+Runtime alignment examples: ~8 / 14 / 20 / pill. Prefer brand radius scale; avoid 0px admin sharpness.
+
+---
+
+## 7. Elevation
+
+| Level | Use |
+| --- | --- |
+| 0 Flat | Default on warm canvas |
+| 1 shadow-sm | Light cards, hover hint |
+| 2 shadow-md | Panels, dropdowns |
+| 3 shadow-lg | Modals, sticky mobile action bars |
+
+Restraint is mandatory — multi-layer fashion shadows fight calm ops UI ([19](19-anti-patterns.md)).
+
+---
+
+## 8. Colour philosophy
+
+Vendor Studio shares MEL DNA: warm cream canvas, purple primary, coral accent, soft supporting lavenders/skies.
+
+| Principle | Why |
+| --- | --- |
+| Warm, not clinical | Long sessions feel human |
+| Purple is scarce | Protects primary-action hierarchy |
+| Coral for focus / energy | Distinct from filled primary buttons |
+| Discovery gold is rare | Preserves semantic clarity; not a warning colour |
+| Neutrals carry reading | Body and borders stay sober |
+
+Organiser branding may tint **content previews**, never the whole shell.
+
+---
+
+## 9. Semantic colours
+
+| Meaning | Rule |
+| --- | --- |
+| Danger / error | Distinct danger token + text + icon |
+| Warning | Amber/warning + label |
+| Success | Green/success + label; use sparingly |
+| Info | Soft sky / info token |
+| Money caution | Precise copy + sober treatment; no playful colour on refunds |
+
+**Never** convey severity by colour alone.
+
+---
+
+## 10. Motion tokens
+
+| Band | Duration | Use |
+| --- | --- | --- |
+| Fast | ~120ms | Hover / focus colour |
+| Base | ~200ms | Panels, accordions, card lift |
+| Slow | ~320ms | Optional section reveal |
+| Enter max | ≤400ms | Dialog enter |
+
+Easing: ease-out for entrances; ease-in-out for toggles.  
+Always honour `prefers-reduced-motion` — instant state, no meaning that depends on motion.
+
+Behaviour detail: [07-interaction-guidelines.md](07-interaction-guidelines.md).
+
+---
+
+## 11. Focus styles
+
+| Spec | Rule |
+| --- | --- |
+| Visibility | Always visible on interactive elements |
+| Colour | Vendor focus token (coral/accent family) — distinct from purple fill |
+| Offset | Clear separation from control edge |
+| Never | Remove outlines for aesthetics |
+
+---
+
+## 12. Icon sizing
+
+| Context | Size |
+| --- | --- |
+| Inline with body | 16–20px |
+| Button / input adornment | 20px |
+| Nav item | 20–24px |
+| Empty state illustration container | Modest; not hero theatre |
+| Door Mode primary control icon | Larger, paired with text label |
+
+Icons require accessible names when standalone.
+
+---
+
+## 13. Touch targets
+
+| Spec | Value |
+| --- | --- |
+| Minimum | 44×44px |
+| Spacing between targets | ≥8px |
+| Actionable list rows | ≥48px height preferred |
+
+---
+
+## 14. Buttons (token intents)
+
+| Variant | Visual weight |
+| --- | --- |
+| Primary | Filled purple; one per region |
+| Secondary | Outline / soft surface |
+| Quiet | Text or ghost |
+| Destructive | Danger emphasis; confirm for irreversible |
+
+Min height meets touch target. Full-width primary on mobile when sticky.
+
+---
+
+## 15. Forms (token intents)
+
+| Spec | Value |
+| --- | --- |
+| Container | Form / Reading 800px |
+| Label | Visible, above field |
+| Input text | ≥16px |
+| Error text | Adjacent; danger semantic |
+| Section gap | space-6 to space-8 |
+
+---
+
+## 16. Tables (token intents)
+
+| Spec | Rule |
+| --- | --- |
+| Header | Distinct surface or weight; sticky optional |
+| Row padding | May tighten vs page chrome |
+| Mobile | Card-row **or** horizontal scroll — one pattern per surface |
+| Actions | Explicit control; not hover-only |
+
+---
+
+## 17. Charts (token intents)
+
+| Spec | Rule |
+| --- | --- |
+| Series colours | Colour-blind safe; not severity-critical alone |
+| Critical numbers | Always available as text/KPI |
+| Empty | Honest empty — no fake trend lines |
+| Mobile | Simplify series; prefer one chart per view |
+
+---
+
+## 18. Navigation (token intents)
+
+| Spec | Rule |
+| --- | --- |
+| Active state | Clear; not colour-only |
+| Badge counts | Sparse; attention not FOMO |
+| Support / Settings | Visually separated (footer zone of nav) |
+
+Structure authority: [02](02-information-architecture.md).
+
+---
+
+## 19. Empty states (token intents)
+
+| Spec | Rule |
+| --- | --- |
+| Composition | Heading + reason + primary CTA |
+| Width | Reading / form |
+| Illustration | Optional, quiet; never replaces copy |
+
+---
+
+## 20. Loading states (token intents)
+
+| Spec | Rule |
+| --- | --- |
+| Skeleton | Mirrors final layout; no fake metrics |
+| Busy buttons | Prevent double-submit |
+| `aria-busy` | On loading containers |
+
+---
+
+## 21. Dark mode token strategy
+
+**Phase 12** capability ([10-roadmap.md](10-roadmap.md)) — not a near-term default.
+
+| Principle | Detail |
+| --- | --- |
+| Tokens first | Remap under `.mel-vendor`; no per-component hex forks |
+| Re-QA | Tables, badges, severity, money surfaces |
+| Brand | Warm neutrals, not neon admin |
+| Opt-in | Product decision at Phase 12 |
+| Partial dark | Forbidden until the remap exists |
+
+---
+
+## 22. Future SCSS mapping
+
+Implementation homes (when coding begins) — confirm in repository:
+
+| Concern | Likely home under `myeventlane_vendor_theme` |
+| --- | --- |
+| Root / vendor vars | `_root-tokens.scss` · `.mel-vendor` |
+| Colour | `tokens/_colors.scss` |
+| Type | `tokens/_typography.scss` |
+| Space | `tokens/_spacing.scss` |
+| Shadow | `tokens/_shadows.scss` |
+| Layout intents | `layout/_container.scss` · `--mel-layout-*` |
+
+**Rule:** Twig applies intent classes; SCSS owns widths. See [09-drupal-mapping.md](09-drupal-mapping.md).
+
+---
+
+## Design implications
+
+- New visual values must be proposed as tokens here before appearing in theme PRs
+- Competing max-widths and one-off hex values are regressions ([19](19-anti-patterns.md))
+- Public discovery tokens remain brand-owned; Studio documents operational extension only
+
+## Future considerations
+
+- Dark mode remap table (Phase 12)
+- Optional density token (`comfortable` / `compact`) only if organiser research demands it
+- Chart palette formalisation when Analytics phase lands
+
+## Related references
+
+- [README.md](README.md) · [03](03-layout-system.md) · [04](04-design-language.md) · [07](07-interaction-guidelines.md) · [09](09-drupal-mapping.md) · [14](14-visual-identity.md) · [DDR-003](decisions/DDR-003-layout-intents.md) · [docs/brand/design-tokens.md](../../brand/design-tokens.md)

--- a/docs/design/vendor-studio/12-dashboard-philosophy.md
+++ b/docs/design/vendor-studio/12-dashboard-philosophy.md
@@ -1,0 +1,228 @@
+# Vendor Studio — Dashboard Philosophy
+
+**Version:** RC1  
+**Status:** Design authority (documentation only)
+
+## Purpose
+
+Define what the **Dashboard** exists to accomplish — and what it must never become.
+
+## Scope
+
+Philosophy and composition for the global organiser home (`/vendor/dashboard`). Page-level pattern summary remains in [06](06-workspace-patterns.md); this document owns mission, ranking, and experience variants.
+
+## Audience
+
+Product, design, dashboard implementers, accessibility reviewers.
+
+## Related documents
+
+- [01-vendor-studio-vision.md](01-vendor-studio-vision.md) — Golden Rule, Three Questions
+- [02-information-architecture.md](02-information-architecture.md) — why Dashboard is first
+- [06-workspace-patterns.md](06-workspace-patterns.md) — compositional pattern
+- [18-product-success-metrics.md](18-product-success-metrics.md)
+- [19-anti-patterns.md](19-anti-patterns.md)
+- [05-component-library.md](05-component-library.md)
+
+---
+
+## Mission
+
+The Dashboard answers one job:
+
+> **What needs me now so I can run my events successfully today?**
+
+It is the attention home — not a marketing homepage, not a wallpaper of charts, and not a second Event Workspace.
+
+---
+
+## Dashboard hierarchy
+
+```text
+1. Identity + Create event (chrome)
+2. Action Queue          ← strongest
+3. Today’s focus
+4. Upcoming events
+5. Business health (few KPIs)
+6. Recent activity
+7. Celebrations / milestones (quiet)
+8. Help / guidance (quietest)
+```
+
+If space is scarce, preserve **1 → 3** before metrics theatre.
+
+---
+
+## Information ranking
+
+| Rank | Content | Why |
+| --- | --- | --- |
+| P0 | Blocking actions (publish blockers, Stripe connect, failed sends) | Golden Rule |
+| P1 | Time-sensitive ops (door today, live event issues) | Stress states |
+| P2 | Near-term events | Planning |
+| P3 | Business health KPIs (≤4) | Decision support |
+| P4 | Activity feed | Context |
+| P5 | Celebrations | Motivation without FOMO |
+| — | Decorative hero, vanity charts, duplicate nav | Excluded |
+
+---
+
+## Action Queue philosophy
+
+- Backend severity ordering — Twig does not re-sort
+- Each item: **severity + title + reason + one CTA**
+- Dismiss only when safe
+- Empty queue = calm “You’re caught up” — not a void
+- Never hide the top item behind expanders on first paint
+
+**Why:** Prior dashboards failed when vanity content outranked the queue.
+
+---
+
+## Metrics philosophy
+
+- Metrics support decisions; they do not decorate
+- Maximum **four** KPIs in the health strip
+- Each KPI: label, value, optional meaningful delta
+- Click only when a real drill-down exists
+- No fabricated numbers while loading ([11](11-design-tokens.md) loading tokens)
+
+Decorative metrics are an anti-pattern ([19](19-anti-patterns.md)).
+
+---
+
+## Today’s focus
+
+Surface the event or task that matters **today** (live event, door soon, publish today). One clear entry into Event Workspace. Avoid multi-event boards that compete with the Action Queue.
+
+---
+
+## Upcoming events
+
+Short list of next events with status badges and open-workspace actions. This is a launcher, not a full Events catalogue (that is Events hub).
+
+---
+
+## Business health
+
+A sober pulse: e.g. sales period total, tickets sold, upcoming count, attention count. Exact KPI set is product-configurable; the **philosophy** is few, honest, and linked.
+
+---
+
+## Recent activity
+
+Chronological, scannable, low chrome. Prefer “Order received”, “Published”, “Refund completed” — organiser language. Not a Drupal watchdog.
+
+---
+
+## Celebrations
+
+Milestones feel earned (first publish, first paid order, successful door). Brief, dismissible, never gamified pressure or FOMO badges.
+
+---
+
+## Notifications
+
+- Success: polite, dismissible
+- Errors: persistent until addressed
+- Do not stack toast theatre over the Action Queue
+- Badge counts in chrome stay sparse
+
+Interaction detail: [07](07-interaction-guidelines.md).
+
+---
+
+## Loading
+
+Skeleton mirrors final layout. `aria-busy` on the container. Never show plausible fake revenue.
+
+---
+
+## Empty states
+
+| State | Response |
+| --- | --- |
+| No events yet | Welcome + Create event + short why |
+| Events but nothing needs attention | Calm caught-up + upcoming list |
+| Missing Stripe / payouts | Action Card with reason + connect path |
+
+Empty dashboards without a next step are forbidden ([19](19-anti-patterns.md)).
+
+---
+
+## First organiser experience
+
+- Short path to first draft and first publish
+- Action Queue teaches the system by listing real next steps
+- Help is contextual; no staff diagnostics
+- Metrics may be empty — honesty over vanity zeros dressed as insight
+
+---
+
+## Power organiser experience
+
+- Action Queue still wins over dense widgets
+- Cross-event Orders/Attendees reachable from nav, not duplicated as Dashboard chrome
+- Density may increase in tables elsewhere; Dashboard stays attention-led
+- No “customisable widget soup” in v1
+
+---
+
+## Accessibility
+
+- One H1
+- Queue items are real links/buttons with clear names
+- Severity not colour-only
+- Keyboard reaches Create event and top queue item without trap
+- WCAG AA
+
+---
+
+## Mobile dashboard
+
+- Baseline 390px
+- Action Queue first; metrics collapse to 2-column
+- Sticky Create event / primary only if it doesn’t obscure errors
+- Full rules: [08](08-mobile-guidelines.md)
+
+---
+
+## Future AI assistant panel
+
+Out of current roadmap. If introduced later:
+
+- Advisory only; never silent money/publish actions
+- Must not displace Action Queue as P0
+- Spec belongs in [20](20-vendor-studio-v2-vision.md) until promoted
+
+---
+
+## Success criteria
+
+Dashboard succeeds when:
+
+1. Organisers identify the top needed action within five seconds  
+2. Empty and full states both answer “what now?”  
+3. Metrics never outrank blockers  
+4. First and power organisers share one model  
+5. Mobile remains operable for today’s event  
+
+Metric definitions: [18-product-success-metrics.md](18-product-success-metrics.md).
+
+---
+
+## Design implications
+
+- Implementation phases must not “pretty up” the Dashboard by weakening Action Queue priority
+- New widgets require a job story and a rank slot — or they do not ship
+- Pattern checklist in [06](06-workspace-patterns.md) still applies
+
+## Future considerations
+
+- Optional AI panel (v2)
+- Research-gated nav compaction on small screens ([02](02-information-architecture.md))
+- Personalisation of KPI set without layout forks
+
+## Related references
+
+- [01](01-vendor-studio-vision.md) · [02](02-information-architecture.md) · [06](06-workspace-patterns.md) · [10](10-roadmap.md) Phase 2 · [18](18-product-success-metrics.md) · [19](19-anti-patterns.md)

--- a/docs/design/vendor-studio/13-event-workspace-philosophy.md
+++ b/docs/design/vendor-studio/13-event-workspace-philosophy.md
@@ -1,0 +1,258 @@
+# Vendor Studio — Event Workspace Philosophy
+
+**Version:** RC1  
+**Status:** Design authority (documentation only)
+
+## Purpose
+
+Become the definitive specification for **Event Workspace** — the per-event application where organisers build and run a single event.
+
+## Scope
+
+Philosophy, shell, sections, readiness, publishing, autosave, live ops, Door Mode, and lifecycle. Global IA remains in [02](02-information-architecture.md). Component contracts remain in [05](05-component-library.md).
+
+## Audience
+
+Product, design, Event Workspace implementers, Commerce-aware reviewers, accessibility lead.
+
+## Related documents
+
+- [02-information-architecture.md](02-information-architecture.md)
+- [06-workspace-patterns.md](06-workspace-patterns.md)
+- [07-interaction-guidelines.md](07-interaction-guidelines.md)
+- [08-mobile-guidelines.md](08-mobile-guidelines.md)
+- [DDR-002](decisions/DDR-002-event-workspace.md)
+- [09-drupal-mapping.md](09-drupal-mapping.md)
+- VX2 screen specs for field inventories (composition only here)
+
+---
+
+## Workspace philosophy
+
+Event Workspace is **one application per event** — builder and operations together.
+
+```text
+Global Studio  ←→  Event Workspace (this event)
+```
+
+There is no Studio vs Manager split. Organisers should never learn MEL’s internal history to edit tickets or check attendees.
+
+**Why:** Dual products recreate cognitive tax, duplicate navigation, and broken “where am I?” answers.
+
+---
+
+## Workspace shell
+
+```text
+┌──────────────────────────────────────────────────────────┐
+│ Global header (organiser · Create event · account)       │
+├──────────────┬───────────────────────────────────────────┤
+│ Global nav   │ Event chrome: name · status · primary CTA │
+│ (dimmed /    ├───────────────────────────────────────────┤
+│ context)     │ Section nav (Overview → … → Settings)     │
+│              ├───────────────────────────────────────────┤
+│              │ Section body (layout intent: Workspace;   │
+│              │ readiness/next-action prefer Reading)     │
+└──────────────┴───────────────────────────────────────────┘
+```
+
+| Shell rule | Why |
+| --- | --- |
+| Event name + status always visible | Answers “Where am I?” |
+| Section nav inside content, not a second CMS sidebar | Hide platform complexity |
+| One primary CTA in event chrome (context-sensitive) | One primary action |
+| View public page / share as secondary | Growth without displacing ops |
+
+---
+
+## Context switching
+
+| Switch | Meaning |
+| --- | --- |
+| Global → Event | Enter from Events list, Dashboard shortcut, or deep link |
+| Event → Global | Back to Events / Dashboard via shell |
+| Section → Section | Same event; preserve event chrome |
+
+Never require re-selecting the event for every section. Never open a parallel “manager” product for ops.
+
+---
+
+## Sections
+
+Canonical order (IA-aligned):
+
+```text
+Overview → Details → Schedule → Venue → Images → Tickets
+→ Orders → Attendees → Messages → Marketing → Analytics
+→ Publishing → Settings
+```
+
+### Overview
+
+Mission: readiness + next action + live pulse. Compositional Home — not a second Dashboard of the whole business.
+
+### Details
+
+Core event copy and facts organisers expect to edit. Progressive disclosure for advanced fields.
+
+### Schedule
+
+Dates/times clarity; timezone honesty; multi-session only when the product supports it without CMS jargon.
+
+### Venue
+
+Place and accessibility essentials; reuse organiser venues from Settings when helpful.
+
+### Images
+
+Media selection in organiser language (“Event image”), not media browser CMS vocabulary.
+
+### Tickets
+
+Sellable options. Advanced inventory tools nest here. Commerce products/variations stay backstage.
+
+### Orders
+
+Event-filtered sales. Deliberate refund entry. State matches Commerce truth.
+
+### Attendees
+
+Guest operations. **Door Mode** lives here as a mode — not a global product.
+
+### Messages
+
+Event-scoped send with clear audience. Brand/templates may link to global Messages hub.
+
+### Marketing
+
+Boost, share, embed for **this** event. Spend/state clear before purchase.
+
+### Analytics
+
+This event’s performance; text alternatives for critical figures.
+
+### Publishing
+
+Readiness, visibility, blockers with reasons and recovery. Honest publish.
+
+### Settings
+
+Event-level preferences (not global organiser Settings). Dangerous toggles confirmed.
+
+---
+
+## Readiness model
+
+| Principle | Detail |
+| --- | --- |
+| Honest | Green only when capability is real |
+| Actionable | Each blocker names fix + link |
+| Separated | Distinct from field validation |
+| Visible | Overview + Publishing surfaces |
+
+Fake readiness destroys trust ([01](01-vendor-studio-vision.md)).
+
+---
+
+## Publishing philosophy
+
+- Publish is deliberate, not accidental
+- Blockers explain **why** and **how to fix**
+- Unpublish / visibility changes state consequences clearly
+- UI never invents “live” when access or ticket capability is false
+- High risk: confirm against repository publish matrix before changing rules
+
+---
+
+## Autosave philosophy
+
+| Surface | Behaviour |
+| --- | --- |
+| Long builder sections (where established) | Autosave + Saving / Saved / Error |
+| Money, refunds, Stripe, publish | **Explicit confirm** — no silent commit |
+| Failure | Visible error + retry; never claim Saved |
+
+Detail: [07-interaction-guidelines.md](07-interaction-guidelines.md).
+
+---
+
+## Live event philosophy
+
+When an event is live or door-imminent:
+
+- Status is unmistakable
+- Attendees / Orders / Door Mode rise in practical priority
+- Avoid burying live ops under builder sections
+- Celebrations stay quiet; ops stay calm
+
+---
+
+## Door Mode philosophy
+
+Door Mode is **guest ops under stress**.
+
+| Rule | Why |
+| --- | --- |
+| Maximise list/search; minimise chrome | Speed |
+| Large targets; one-handed primary | Mobile stress |
+| Failure/offline messaging unmistakable | Trust |
+| Prefer controls over shortcut memorisation | Accessibility under pressure |
+| Remains under Attendees | IA integrity ([02](02-information-architecture.md)) |
+
+Offline-first enhancements are v2 ([20](20-vendor-studio-v2-vision.md)).
+
+---
+
+## Event lifecycle
+
+```text
+Draft → Ready → Published / Live → Door → Aftermath → Archive
+```
+
+| Stage | Design emphasis |
+| --- | --- |
+| Draft | Next step + readiness |
+| Ready | Publish confidence |
+| Live | Sales + guest pulse |
+| Door | Door Mode excellence |
+| Aftermath | Orders, refunds, analytics clarity |
+| Archive | Read-only calm; clear exit |
+
+---
+
+## Success criteria
+
+1. No Studio/Manager dual nav  
+2. Overview always shows next step  
+3. Publish blockers explained  
+4. Autosave never silently mutates money  
+5. Door Mode usable on phone under time pressure  
+6. Organiser language throughout  
+
+Metrics: [18](18-product-success-metrics.md).
+
+---
+
+## Future evolution
+
+- Predictive readiness and AI assistant: [20](20-vendor-studio-v2-vision.md)
+- Multi-event operations: parking lot [A03](appendices/A03-future-ideas-parking-lot.md)
+- Section order may gain research-driven compaction on mobile; default remains full clarity
+
+---
+
+## Design implications
+
+- New event tools nest under the correct section; they do not earn a global nav item by default
+- Implementation must preserve server-side ownership/access — UI is not security
+- Field inventories stay in VX2 screen specs; this file owns philosophy
+
+## Future considerations
+
+- Collaborative editing presence
+- Stronger offline Door Mode
+- Cross-event bulk ops (explicitly not v1)
+
+## Related references
+
+- [02](02-information-architecture.md) · [06](06-workspace-patterns.md) · [07](07-interaction-guidelines.md) · [08](08-mobile-guidelines.md) · [09](09-drupal-mapping.md) · [DDR-002](decisions/DDR-002-event-workspace.md) · [10](10-roadmap.md) Phase 4

--- a/docs/design/vendor-studio/14-visual-identity.md
+++ b/docs/design/vendor-studio/14-visual-identity.md
@@ -1,0 +1,183 @@
+# Vendor Studio — Visual Identity
+
+**Version:** RC1  
+**Status:** Design authority (documentation only)
+
+## Purpose
+
+Describe how Vendor Studio should **feel** — the emotional and visual character that makes it unmistakably MyEventLane while serving operations, not discovery.
+
+## Scope
+
+Emotional goals, hierarchy, whitespace, cards, type, colour usage, illustration, photography, iconography, motion, micro-interactions, premium feel, and differentiation. Numeric tokens live in [11](11-design-tokens.md). Brand strategy for public MEL lives in `docs/brand/`.
+
+## Audience
+
+Designers, brand contributors, theme architects, product leaders.
+
+## Related documents
+
+- [01-vendor-studio-vision.md](01-vendor-studio-vision.md)
+- [04-design-language.md](04-design-language.md)
+- [11-design-tokens.md](11-design-tokens.md)
+- [15-copywriting-guide.md](15-copywriting-guide.md)
+- [A02-design-principles-vs-humanitix.md](appendices/A02-design-principles-vs-humanitix.md)
+
+---
+
+## Emotional goals
+
+| Feel | Means |
+| --- | --- |
+| Calm confidence | Clear next step; no dashboard panic |
+| Warm competence | Human, local, precise with money |
+| Focused energy | Purple primary is scarce and meaningful |
+| Trustworthy | Honest states; sober refunds |
+| Light to return to | Organisers *want* to open it daily |
+
+Not: exclusive VIP theatre · clinical admin grey · neon “pro dark” by default · FOMO badge spam.
+
+---
+
+## Visual hierarchy
+
+1. Task title (H1)  
+2. Primary action  
+3. Attention / status  
+4. Supporting content  
+5. Help  
+
+If everything is bold, nothing is. Hierarchy is the product.
+
+---
+
+## Whitespace philosophy
+
+Whitespace is a **ranking tool**, not decoration.
+
+- Air around attention lists  
+- Compress empty marketing voids in ops heroes  
+- Dense tables may tighten rows; page chrome stays breathable  
+- Ultra-wide unused side space on forms is intentional calm  
+
+---
+
+## Card philosophy
+
+Cards earn their size ([01](01-vendor-studio-vision.md) principle 9).
+
+| Use a card when | Prefer flat when |
+| --- | --- |
+| The unit is interactive (action item, event row) | Grouping alone is enough |
+| Boundary aids scanning of distinct tasks | Nested cards would stack chrome |
+
+Card-inside-card is an anti-pattern ([19](19-anti-patterns.md)).
+
+---
+
+## Minimalism
+
+Minimalism here means **one job per region**, not emptiness. Remove chrome that does not answer the Three Questions. Keep the data organisers need.
+
+---
+
+## Typography hierarchy
+
+Readable sans; one H1; sentence case; marketing display faces stay on public MEL. Detail: [11](11-design-tokens.md).
+
+---
+
+## Colour usage
+
+Warm cream canvas, white surfaces, scarce purple, coral focus, rare gold. Semantic colours for severity. Full rules: [11](11-design-tokens.md).
+
+---
+
+## Illustration usage
+
+- Optional in empty/success states  
+- Guide presence is encouraging, **not a mascot in chrome**  
+- Never required to understand state  
+- Prefer clarity over character scenes in Door Mode  
+
+---
+
+## Photography
+
+- Event imagery belongs in content previews and public pages  
+- Ops heroes are operational, not full-bleed marketing theatres  
+- Do not paste public homepage hero patterns into console chrome  
+
+---
+
+## Iconography
+
+- Simple, consistent stroke/weight  
+- Paired with text for severity and nav  
+- Not a substitute for labels on primary actions  
+
+---
+
+## Animation philosophy
+
+Motion explains state (open, save, success). It does not entertain. Honour reduced motion. Tokens: [11](11-design-tokens.md). Behaviour: [07](07-interaction-guidelines.md).
+
+---
+
+## Micro-interactions
+
+| Allowed | Disallowed |
+| --- | --- |
+| Button busy, save status, subtle row hover | Confetti FOMO, parallax chrome |
+| Focus ring clarity | Hover-only essential info |
+| Dialog confirm for money | Playful treatment of refunds |
+
+---
+
+## Premium feel
+
+Premium in Vendor Studio means:
+
+- Precision with money and publish  
+- Coherent spacing and type  
+- Recoverable errors  
+- Speed under door stress  
+
+It does not mean glassmorphism, badge theatres, or imitating fintech dark dashboards.
+
+---
+
+## Compare against
+
+| Surface | Relationship | Why Vendor Studio differs |
+| --- | --- | --- |
+| **Public MEL** | Shared brand DNA | Discovery vs operations; different hero and card jobs |
+| **Drupal admin** | Implementation platform | Organiser language; no CMS IA; warmth over admin grey |
+| **Humanitix** | Competitor reference | Philosophy compare only ([A02](appendices/A02-design-principles-vs-humanitix.md)); do not copy chrome |
+| **Shopify** | Ops excellence reference | Commerce backstage; event lifecycle and Door Mode are MEL-specific |
+| **Stripe** | Money clarity reference | Sober payments UX inspiration; MEL remains community-warm, not pure fintech |
+| **Linear** | Focus and speed reference | Issue-tracker density is not the default; attention queues beat keyboard-first culture for door stress |
+
+### Why Vendor Studio is different
+
+Vendor Studio is built for **Australian community event operators** — warm like MEL public, precise like a payments console, structured like a modern ops tool — without becoming admin UI, marketplace FOMO, or a cloned competitor shell.
+
+We do not imitate. We **borrow principles** (clarity, scarcity of primary actions, honest money) and express them through MEL’s Hidden Gem + Guide soul applied to operations.
+
+---
+
+## Design implications
+
+- Visual PRs cite this file + [11](11-design-tokens.md)
+- “Make it pop” is not a requirement; “make the next step obvious” is
+- Public and Studio themes must not converge into one muddled aesthetic
+
+## Future considerations
+
+- Phase 12 dark mode must still feel MEL-warm  
+- Illustration library expansion only with empty-state jobs  
+- Organiser brand colour in previews, never shell re-skin  
+
+## Related references
+
+- [01](01-vendor-studio-vision.md) · [04](04-design-language.md) · [11](11-design-tokens.md) · [15](15-copywriting-guide.md) · [19](19-anti-patterns.md) · `docs/brand/`

--- a/docs/design/vendor-studio/15-copywriting-guide.md
+++ b/docs/design/vendor-studio/15-copywriting-guide.md
@@ -1,0 +1,231 @@
+# Vendor Studio — Copywriting Guide
+
+**Version:** RC1  
+**Status:** Design authority (documentation only)
+
+## Purpose
+
+Ensure every contributor writes with **one consistent voice** so organisers never feel like they entered a different product — or a CMS.
+
+## Scope
+
+Voice, tone, grammar, Australian English, UI labels, messages, payments/refunds wording, accessibility wording, preferred/avoided vocabulary, and Drupal/Commerce terminology translation. Brand consumer copy guidelines remain authoritative for public MEL; this guide owns **organiser console** copy.
+
+## Audience
+
+Product, design, content, engineers writing UI strings, support article authors for organiser audience.
+
+## Related documents
+
+- [01-vendor-studio-vision.md](01-vendor-studio-vision.md) — personality
+- [14-visual-identity.md](14-visual-identity.md)
+- [A01-glossary.md](appendices/A01-glossary.md)
+- [docs/brand/copy-guidelines.md](../../brand/copy-guidelines.md)
+- [docs/vendor-experience-convergence-language-guide.md](../../vendor-experience-convergence-language-guide.md)
+
+---
+
+## Voice
+
+Warm · Capable · Local · Calm · Honest
+
+We speak as a knowledgeable guide standing beside the organiser — never as a bureaucratic system, never as a hype machine.
+
+---
+
+## Tone
+
+| Context | Tone |
+| --- | --- |
+| Setup / readiness | Encouraging, specific |
+| Live ops / Door Mode | Brief, certain |
+| Payments / refunds | Sober, precise |
+| Errors | Clear, blame-free, recoverable |
+| Success | Brief celebration + next step |
+| Empty states | Honest + inviting action |
+
+---
+
+## Grammar
+
+- Sentence case for headings and buttons  
+- Prefer active voice  
+- Prefer second person (“your event”)  
+- Contractions OK when they sound natural  
+- Avoid exclamation overload  
+
+---
+
+## Australian English
+
+| Prefer | Avoid |
+| --- | --- |
+| Organiser | Organizer |
+| Cancelled | Canceled |
+| Colour (docs) | Color (except code tokens) |
+| Favourite | Favorite |
+
+Follow `docs/brand/copy-guidelines.md` for consumer-facing overlap.
+
+---
+
+## Button labels
+
+| Pattern | Example |
+| --- | --- |
+| Verb + object | Create event · Refund order · Connect Stripe |
+| Specific confirmations | Refund order — not OK / Confirm |
+| Avoid vagueness | Submit · Click here · Continue (unless step context is obvious) |
+
+One primary label per region.
+
+---
+
+## Headings
+
+- One H1 that names the task  
+- Headings describe organiser jobs, not modules  
+- Question headings sparingly (“Ready to publish?”) when they aid readiness  
+
+---
+
+## Success messages
+
+Structure: **What happened** + **What to do next**.
+
+> Event published. Share your event link or view orders.
+
+---
+
+## Errors
+
+Structure: **What went wrong** + **Why it matters** + **How to fix**.
+
+> We couldn’t save your ticket. Check capacity is a whole number and try again.
+
+Never: “An error has occurred.” alone.
+
+---
+
+## Warnings
+
+Explain risk before irreversible actions. Do not soften money consequences.
+
+> Refunding returns funds to the purchaser. This cannot be undone from Vendor Studio.
+
+---
+
+## Notifications
+
+Short. Organiser language. Coalesce duplicates. Errors persist; successes may dismiss.
+
+---
+
+## Payments
+
+- Use: payouts, Stripe connection, available balance (as product defines)  
+- State honesty: never claim paid/payout ready without confirmed state  
+- Prefer “Connect Stripe to receive payouts” over gateway jargon  
+
+---
+
+## Refunds
+
+- Name the object: “Refund this order”  
+- State partial vs full clearly when supported  
+- Confirm with consequence sentence  
+- UI does not invent refund success  
+
+---
+
+## Accessibility wording
+
+- Link text describes destination (“View order 1042”, not “Click here”)  
+- Icon-only controls need accessible names  
+- Severity in text, not colour alone  
+- Live regions: short status phrases (“Saved”, “Saving”, “Error saving”)  
+
+---
+
+## Preferred wording
+
+discover · explore · find · join · experience · community · publish · draft · live · attendees · orders · tickets · payouts · Door Mode · ready · next step · organiser
+
+Human labels: **Organiser**. Machine/URLs may say `vendor`.
+
+---
+
+## Avoided wording
+
+exclusive · VIP · members only · secret access · limited access · FOMO pressure · configuration detected · entity · node · taxonomy · paragraph · product variation · store · commerce (in UI) · CMS · submit (as default money CTA)
+
+---
+
+## Drupal terminology translation
+
+| Drupal / platform | Organiser copy |
+| --- | --- |
+| Node / content | Event (or the specific thing) |
+| Media | Image / event image |
+| Taxonomy | Category / tags (as product defines) |
+| Unpublished | Draft (or exact visibility label) |
+| User | Account / team member (context) |
+| Permission denied | You don’t have access — ask your organiser admin / support path |
+
+---
+
+## Commerce terminology translation
+
+| Commerce | Organiser copy |
+| --- | --- |
+| Product / variation | Ticket (or ticket type) |
+| Order | Order |
+| Order item | Line / ticket line (context) |
+| Payment gateway | Payment method / Stripe |
+| Completed / fulfilled states | Paid / confirmed — only when true |
+| Adjustment | Fee / discount (plain language) |
+| Store | (omit — not organiser-facing) |
+
+---
+
+## Examples of excellent copy
+
+> You’re almost ready to publish. Add at least one ticket to continue.
+
+> Payouts unavailable until Stripe is connected — here’s why.
+
+> You’re caught up. Nothing needs you right now.
+
+> Check in — large, certain, paired with attendee name.
+
+---
+
+## Examples of poor copy
+
+> Incomplete configuration detected in field_event_tickets.
+
+> VIP exclusive access unlocked!
+
+> Error 403.
+
+> OK
+
+> Please submit the form to persist entity values.
+
+---
+
+## Design implications
+
+- All new UI strings reviewed against this guide  
+- Money and publish copy gets extra scrutiny  
+- Staff-only help vocabulary never appears in organiser UI  
+
+## Future considerations
+
+- Locale expansion beyond en-AU must preserve organiser voice  
+- Tone samples library for support macros  
+- AI-generated copy must pass this guide before ship ([20](20-vendor-studio-v2-vision.md))  
+
+## Related references
+
+- [01](01-vendor-studio-vision.md) · [A01](appendices/A01-glossary.md) · [14](14-visual-identity.md) · [docs/brand/copy-guidelines.md](../../brand/copy-guidelines.md)

--- a/docs/design/vendor-studio/16-design-review-checklist.md
+++ b/docs/design/vendor-studio/16-design-review-checklist.md
@@ -1,0 +1,207 @@
+# Vendor Studio — Design Review Checklist
+
+**Version:** RC1.1  
+**Status:** Design authority (documentation only)
+
+## Purpose
+
+Mandatory **detailed** checklist for every Vendor Studio pull request that changes organiser-facing experience or this Design Operating System.
+
+## Scope
+
+YES / NO verification with rationale. Gate list ownership: [21-definition-of-done.md](21-definition-of-done.md). This file owns the expandable checklist. Not a substitute for code review, security review, or Commerce risk review.
+
+## Audience
+
+Authors and reviewers of Vendor Studio PRs (product, design, theme, module).
+
+## Related documents
+
+- [21-definition-of-done.md](21-definition-of-done.md) — mandatory gates (complete both)
+- [ADR-0001](decisions/ADR-0001-design-authority.md) — precedence
+- [README.md](README.md) — governance
+- [01](01-vendor-studio-vision.md) · [02](02-information-architecture.md) · [11](11-design-tokens.md) · [15](15-copywriting-guide.md) · [18](18-product-success-metrics.md) · [19](19-anti-patterns.md)
+- [09-drupal-mapping.md](09-drupal-mapping.md)
+
+### How to use
+
+1. Satisfy applicable gates in [21-definition-of-done.md](21-definition-of-done.md).  
+2. Copy this checklist into the PR. Mark **YES** or **NO**. Every **NO** requires a rationale and, if shipping anyway, Product Owner + Design Authority acknowledgement. **N/A** allowed only with rationale (e.g. docs-only PR).  
+3. Cite OS documents touched or followed.
+
+---
+
+## Information Architecture
+
+| # | Check | YES / NO | Rationale |
+| --- | --- | --- | --- |
+| IA1 | Fits the single global shell model (no Studio/Manager fork) | | |
+| IA2 | Labels use organiser jobs, not Drupal concepts | | |
+| IA3 | Event-scoped tools live in Event Workspace, not new global peers without DDR | | |
+| IA4 | Create event remains chrome primary, not a competing confusing destination | | |
+
+## Accessibility
+
+| # | Check | YES / NO | Rationale |
+| --- | --- | --- | --- |
+| A11Y1 | WCAG AA contrast for text and essential UI | | |
+| A11Y2 | Visible focus on all interactive elements | | |
+| A11Y3 | Keyboard path for primary task | | |
+| A11Y4 | Severity not colour-only | | |
+| A11Y5 | `prefers-reduced-motion` honoured | | |
+| A11Y6 | Form labels and errors programmatically associated | | |
+
+## Mobile
+
+| # | Check | YES / NO | Rationale |
+| --- | --- | --- | --- |
+| M1 | Usable at ~390px baseline | | |
+| M2 | One primary job preserved in first viewport | | |
+| M3 | Touch targets ≥44×44px | | |
+| M4 | No hover-only essential actions | | |
+| M5 | Table pattern chosen (card rows or x-scroll) and consistent | | |
+
+## Navigation
+
+| # | Check | YES / NO | Rationale |
+| --- | --- | --- | --- |
+| N1 | “Where am I?” is clear | | |
+| N2 | No duplicate nav systems on one surface | | |
+| N3 | Active state not colour-only | | |
+
+## Hierarchy
+
+| # | Check | YES / NO | Rationale |
+| --- | --- | --- | --- |
+| H1 | Passes Three Question Framework | | |
+| H2 | Passes Golden Rule (next step ≤5 seconds) | | |
+| H3 | Attention outranks vanity content | | |
+
+## Typography
+
+| # | Check | YES / NO | Rationale |
+| --- | --- | --- | --- |
+| T1 | One H1 | | |
+| T2 | Body ≥16px on mobile | | |
+| T3 | Sentence case UI labels | | |
+
+## Spacing
+
+| # | Check | YES / NO | Rationale |
+| --- | --- | --- | --- |
+| S1 | Uses spacing scale (4px base) — no ad-hoc systems | | |
+| S2 | Layout intent class used; no hardcoded content max-width in Twig | | |
+
+## Components
+
+| # | Check | YES / NO | Rationale |
+| --- | --- | --- | --- |
+| C1 | Extends existing MEL/vendor components before inventing new | | |
+| C2 | Cards earn their size; no card-in-card nesting | | |
+| C3 | One primary button per region | | |
+
+## Motion
+
+| # | Check | YES / NO | Rationale |
+| --- | --- | --- | --- |
+| MO1 | Motion explains state; not decorative chrome loops | | |
+| MO2 | Dialogs ≤400ms enter; no layout thrash required for meaning | | |
+
+## Performance
+
+| # | Check | YES / NO | Rationale |
+| --- | --- | --- | --- |
+| P1 | No heavy uncached queries introduced for vanity widgets | | |
+| P2 | Heavy JS attached only on routes that need it | | |
+
+## Loading
+
+| # | Check | YES / NO | Rationale |
+| --- | --- | --- | --- |
+| L1 | Skeleton/loading does not show fake metrics | | |
+| L2 | Busy/disabled submit prevents double-submit where needed | | |
+
+## Errors
+
+| # | Check | YES / NO | Rationale |
+| --- | --- | --- | --- |
+| E1 | Errors explain recovery | | |
+| E2 | No dead ends | | |
+
+## Success
+
+| # | Check | YES / NO | Rationale |
+| --- | --- | --- | --- |
+| SU1 | Success states include next step | | |
+
+## Help
+
+| # | Check | YES / NO | Rationale |
+| --- | --- | --- | --- |
+| HE1 | Help is organiser-audience only | | |
+| HE2 | Staff-only content does not leak | | |
+
+## Drupal
+
+| # | Check | YES / NO | Rationale |
+| --- | --- | --- | --- |
+| D1 | Business logic not in Twig | | |
+| D2 | Cache contexts/tags considered for personalised/attention data | | |
+| D3 | Mapping consistent with [09](09-drupal-mapping.md) | | |
+
+## Commerce
+
+| # | Check | YES / NO | Rationale |
+| --- | --- | --- | --- |
+| CO1 | Order/payment/ticket states not invented in UI | | |
+| CO2 | Refunds/payouts use deliberate confirmation patterns | | |
+| CO3 | Risk called out if touching checkout, payments, capacity, ownership | | |
+
+## Security
+
+| # | Check | YES / NO | Rationale |
+| --- | --- | --- | --- |
+| SE1 | Access enforced server-side (UI hide ≠ security) | | |
+| SE2 | No secrets, dumps, or PII leakage in UI/logs from this change | | |
+
+## Copywriting
+
+| # | Check | YES / NO | Rationale |
+| --- | --- | --- | --- |
+| CW1 | Follows [15](15-copywriting-guide.md) | | |
+| CW2 | No CMS/Commerce jargon in organiser UI | | |
+| CW3 | Australian English | | |
+
+## Documentation
+
+| # | Check | YES / NO | Rationale |
+| --- | --- | --- | --- |
+| DOC1 | PR cites relevant Design OS documents | | |
+| DOC2 | DDR added/updated if foundational decision changed | | |
+| DOC3 | Anti-patterns checked ([19](19-anti-patterns.md)) | | |
+| DOC4 | Success metrics impacted named ([18](18-product-success-metrics.md)) | | |
+
+---
+
+## Sign-off
+
+| Role | Name | Date |
+| --- | --- | --- |
+| Author | | |
+| Design Authority (if required) | | |
+| Technical Authority (if Drupal/Commerce risk) | | |
+
+---
+
+## Design implications
+
+PRs that skip this checklist are incomplete for Vendor Studio surfaces.
+
+## Future considerations
+
+- Automate citation hints in PR templates after v1.0 freeze  
+- Add phase-specific annexes (e.g. Payments) without forking this core list  
+
+## Related references
+
+- [README.md](README.md) · [19](19-anti-patterns.md) · [18](18-product-success-metrics.md) · [09](09-drupal-mapping.md)

--- a/docs/design/vendor-studio/17-design-maturity-model.md
+++ b/docs/design/vendor-studio/17-design-maturity-model.md
@@ -1,0 +1,97 @@
+# Vendor Studio — Design Maturity Model
+
+**Version:** RC1  
+**Status:** Design authority (documentation only)
+
+## Purpose
+
+Define how Vendor Studio evolves over time — a shared ladder for evaluating features, phases, and quality claims.
+
+## Scope
+
+Maturity levels, evaluation criteria, and how to use the model in planning. Not a scoreboard for individual engineers. Not an analytics implementation.
+
+## Audience
+
+Product Owner, Design Authority, Technical Authority, phase leads.
+
+## Related documents
+
+- [10-roadmap.md](10-roadmap.md)
+- [18-product-success-metrics.md](18-product-success-metrics.md)
+- [20-vendor-studio-v2-vision.md](20-vendor-studio-v2-vision.md)
+- [01-vendor-studio-vision.md](01-vendor-studio-vision.md)
+
+---
+
+## Why a maturity model
+
+Without a ladder, every feature claims to be “delightful” while core flows remain merely workable. The model keeps ambition honest: **reach Level 2 everywhere before celebrating Level 4 anywhere**.
+
+---
+
+## Levels
+
+| Level | Name | Meaning |
+| --- | --- | --- |
+| **1** | Functional | Organisers can complete the job. States exist. Access holds. Ugly or inconsistent is possible but not blocking. |
+| **2** | Consistent | Shell, layout intents, components, and copy follow this Design OS. Three Questions answered. Anti-patterns avoided. |
+| **3** | Delightful | Calm confidence: empty/success/error polish, mobile excellence for the job, celebrations that earn their place, Door Mode feels fast. |
+| **4** | Intelligent | System anticipates needs with honest recommendations (readiness insights, prioritisation). Still organiser-controlled. |
+| **5** | Predictive | Trusted forecasting and proactive ops (e.g. sales risk, staffing hints) with transparent confidence — never silent money/publish actions. |
+
+```text
+1 Functional → 2 Consistent → 3 Delightful → 4 Intelligent → 5 Predictive
+```
+
+---
+
+## Evaluation dimensions
+
+Rate a surface (e.g. Dashboard, Tickets, Door Mode) per dimension; the **surface level** is the minimum across critical dimensions.
+
+| Dimension | L1 | L2 | L3 | L4 | L5 |
+| --- | --- | --- | --- | --- | --- |
+| IA / nav | Reachable | OS IA | Effortless context | Suggests next hub | Anticipates cross-event needs |
+| Hierarchy | Usable | Golden Rule met | Scannable under stress | Prioritises for you | Predicts attention |
+| A11y | Basic | WCAG AA solid | Excellent AT paths | Adaptive assistance* | — |
+| Mobile | Possible | OS mobile rules | Door-grade | Context-aware layout | Offline-first ops |
+| Money honesty | Correct | Clear copy | Recoverable excellence | Risk hints | Forecast impacts |
+| Help | Exists | Contextual | Proactive tips | Assistant panel | Autonomous drafts* |
+
+\*Always human-confirm for money, publish, and sends.
+
+---
+
+## Using the model
+
+1. **Phase exit:** A roadmap phase should lift target surfaces to at least **Level 2**.  
+2. **Feature proposals:** State current level, target level, and which [18](18-product-success-metrics.md) metrics move.  
+3. **No level-skipping theatre:** Do not ship “AI delight” on a Level 1 refunds flow.  
+4. **v2 vision:** Levels 4–5 ideas live in [20](20-vendor-studio-v2-vision.md) until promoted.
+
+---
+
+## Current posture (RC1 documentation)
+
+| Surface | Honest target for near-term implementation |
+| --- | --- |
+| Design OS itself | Enables Level 2+ product-wide |
+| Dashboard / Workspace / Door Mode | Level 2 mandatory; Level 3 aspirational in phase polish |
+| Intelligent / Predictive | Out of current [10](10-roadmap.md) until Product Owner promotes |
+
+---
+
+## Design implications
+
+- “Done” means Level 2 unless the phase brief says otherwise  
+- Marketing language in release notes must not claim Level 4/5 without evidence  
+
+## Future considerations
+
+- Quarterly maturity review in governance cadence ([README](README.md))  
+- Per-surface scorecard living outside this pack once implementation lands  
+
+## Related references
+
+- [10](10-roadmap.md) · [18](18-product-success-metrics.md) · [20](20-vendor-studio-v2-vision.md) · [19](19-anti-patterns.md)

--- a/docs/design/vendor-studio/18-product-success-metrics.md
+++ b/docs/design/vendor-studio/18-product-success-metrics.md
@@ -1,0 +1,119 @@
+# Vendor Studio — Product Success Metrics
+
+**Version:** RC1  
+**Status:** Design authority (documentation only)
+
+## Purpose
+
+Define how we know Vendor Studio is succeeding for organisers, operations, and the business.
+
+This is **not** an analytics implementation spec. It is the product measurement philosophy every future feature should reference.
+
+## Scope
+
+Organiser success, operational success, and business success metrics; how features declare impact. Instrumentation details belong in delivery tickets, not here.
+
+## Audience
+
+Product Owner, design, engineering leads, anyone writing phase briefs or PRs.
+
+## Related documents
+
+- [01-vendor-studio-vision.md](01-vendor-studio-vision.md) — behavioural intent
+- [12-dashboard-philosophy.md](12-dashboard-philosophy.md)
+- [13-event-workspace-philosophy.md](13-event-workspace-philosophy.md)
+- [16-design-review-checklist.md](16-design-review-checklist.md) — DOC4
+- [17-design-maturity-model.md](17-design-maturity-model.md)
+
+---
+
+## Why metrics before features
+
+Features without a success metric become aesthetic churn. Every Vendor Studio initiative should name **which metrics it improves** and **which it must not harm** (especially money trust and accessibility).
+
+---
+
+## Organiser success
+
+Measures of time-to-value and confidence.
+
+| Metric | Intent |
+| --- | --- |
+| **Time to first published event** | New organisers reach publish without staff rescue |
+| **Time to connect Stripe** | Payout path is findable and honest |
+| **Time to create first ticket** | Ticket setup is progressive and clear |
+| **Time to first booking** | Public + Studio path yields a real order when demand exists |
+
+**Signals:** funnel timings, qualitative onboarding sessions, support “where do I…?” deflection on these jobs.
+
+---
+
+## Operational success
+
+Measures of daily operability.
+
+| Metric | Intent |
+| --- | --- |
+| **Dashboard clarity** | Top Action Queue item identified ≤5 seconds (Golden Rule) |
+| **Workspace completion** | Readiness blockers understood; sections finished without dual-nav confusion |
+| **Mobile usability** | Door Mode and today’s attention succeed on phone |
+| **Accessibility** | Primary tasks completable by keyboard / AT; AA maintained |
+
+**Signals:** task success tests, Door Mode field feedback, a11y audits, checklist compliance rate.
+
+---
+
+## Business success
+
+Measures of healthy platform growth (product outcomes, not vanity charts).
+
+| Metric | Intent |
+| --- | --- |
+| **Organiser retention** | Organisers return to run another event |
+| **Repeat event creation** | Studio is a habit, not a one-off struggle |
+| **Feature adoption** | Payments hub, Messages, Marketing used when relevant — not ignored due to findability |
+| **Support reduction** | Fewer tickets about navigation, publish confusion, payout location |
+
+**Signals:** retention cohorts, event creation frequency, feature use with honest denominators, support taxonomy tags.
+
+---
+
+## Feature impact statement (required pattern)
+
+For each material feature or phase:
+
+```text
+Improves: [metric names from this doc]
+Must not harm: [e.g. money state honesty, Door Mode speed, AA]
+Maturity: from Level X → Level Y ([17](17-design-maturity-model.md))
+OS refs: [documents cited]
+```
+
+---
+
+## Anti-vanity rules
+
+- Do not invent Dashboard charts solely to “have metrics”
+- Do not celebrate adoption of a confusing feature
+- Money metrics must reconcile with Commerce/Stripe truth
+- Empty states are allowed; fake success is not  
+
+See [19-anti-patterns.md](19-anti-patterns.md).
+
+---
+
+## Design implications
+
+- Vision ([01](01-vendor-studio-vision.md)) no longer owns metric definitions — it points here  
+- PRs name impacted metrics ([16](16-design-review-checklist.md) DOC4)  
+- Roadmap phases ([10](10-roadmap.md)) should declare metric targets at planning time  
+
+## Future considerations
+
+- Baseline measurement once instrumentation exists  
+- North-star selection is a Product Owner decision; this pack provides the menu  
+- Predictive metrics belong with Level 4–5 ([17](17-design-maturity-model.md), [20](20-vendor-studio-v2-vision.md))  
+
+## Related references
+
+- [01](01-vendor-studio-vision.md) · [12](12-dashboard-philosophy.md) · [13](13-event-workspace-philosophy.md) · [17](17-design-maturity-model.md) · [10](10-roadmap.md)

--- a/docs/design/vendor-studio/19-anti-patterns.md
+++ b/docs/design/vendor-studio/19-anti-patterns.md
@@ -1,0 +1,197 @@
+# Vendor Studio — Design Anti-Patterns
+
+**Version:** RC1  
+**Status:** Design authority (documentation only)
+
+## Purpose
+
+Prevent regression years from now by naming harmful patterns, why they hurt, and what to do instead.
+
+## Scope
+
+Experience anti-patterns for Vendor Studio. Not a code lint list. Not competitor mockery.
+
+## Audience
+
+Everyone shipping Vendor Studio UI or OS docs.
+
+## Related documents
+
+- [01-vendor-studio-vision.md](01-vendor-studio-vision.md)
+- [11-design-tokens.md](11-design-tokens.md)
+- [12-dashboard-philosophy.md](12-dashboard-philosophy.md)
+- [16-design-review-checklist.md](16-design-review-checklist.md)
+- [DDR-004](decisions/DDR-004-component-philosophy.md)
+
+---
+
+## How to use
+
+If a PR introduces an anti-pattern, it fails design review unless Design Authority accepts a documented exception with expiry.
+
+---
+
+### ❌ Card inside card inside card
+
+**Why harmful:** Hierarchy collapses; whitespace and borders multiply; mobile becomes a tunnel of chrome.
+
+**What to do instead:** One interactive card boundary. Nest content with spacing and headings, not nested surfaces.
+
+**Example:** Action item as a single Action Card — not a card wrapping a card wrapping a button bar.
+
+---
+
+### ❌ Three primary buttons
+
+**Why harmful:** Violates one primary action; organisers freeze; conversion and ops speed drop.
+
+**What to do instead:** One primary; secondary/quiet for alternatives; move tertiary into menus.
+
+**Example:** Publish (primary) · Preview (secondary) · Save draft (quiet) — not three filled purples.
+
+---
+
+### ❌ Hidden primary actions
+
+**Why harmful:** Fails Golden Rule; hover-only or overflow-buried CTAs punish mobile and keyboard users.
+
+**What to do instead:** Primary CTA in page header (sticky on mobile when needed); visible without hover.
+
+**Example:** Refund available as a clear row action or detail primary — not only in a hover pencil icon.
+
+---
+
+### ❌ CMS terminology
+
+**Why harmful:** Forces organisers to learn Drupal; destroys trust and increases support.
+
+**What to do instead:** Organiser language ([15](15-copywriting-guide.md), [A01](appendices/A01-glossary.md)).
+
+**Example:** “Event image” not “Add media entity”; “Ticket” not “Product variation”.
+
+---
+
+### ❌ Duplicate navigation
+
+**Why harmful:** Studio vs Manager déjà vu; “Where am I?” fails; maintenance forks forever.
+
+**What to do instead:** One global shell; Event Workspace as contextual app ([02](02-information-architecture.md), [DDR-002](decisions/DDR-002-event-workspace.md)).
+
+**Example:** Orders appear globally and event-filtered — same product, not two nav trees named differently.
+
+---
+
+### ❌ Empty dashboards
+
+**Why harmful:** Silence without a next step abandons first organisers.
+
+**What to do instead:** Honest empty + Create event / Connect Stripe / finish tickets ([12](12-dashboard-philosophy.md)).
+
+**Example:** “Create your first event” Action Card — not a blank warm cream void.
+
+---
+
+### ❌ Decorative metrics
+
+**Why harmful:** Pretty numbers that don’t change decisions slow scanning and invite fake precision.
+
+**What to do instead:** ≤4 decision-supporting KPIs; text truth; no charts without a question ([12](12-dashboard-philosophy.md)).
+
+**Example:** “Tickets sold this week” with drill-down — not a sparkline orchard with no labels.
+
+---
+
+### ❌ Dashboard wallpaper
+
+**Why harmful:** Marketing heroes, badge spam, and widget soup bury the Action Queue.
+
+**What to do instead:** Attention-led composition; operational hero only ([12](12-dashboard-philosophy.md), [03](03-layout-system.md)).
+
+**Example:** Action Queue first — not a full-bleed lifestyle photo with floating promo stickers.
+
+---
+
+### ❌ Overly dense forms
+
+**Why harmful:** Setup pressure skyrockets; errors multiply; mobile fails.
+
+**What to do instead:** Sectioned forms at 800px; progressive disclosure; autosave status where established ([13](13-event-workspace-philosophy.md)).
+
+**Example:** Tickets basics first; advanced capacity rules nested — not a single scrolling field avalanche.
+
+---
+
+### ❌ Multiple competing layouts
+
+**Why harmful:** Inconsistent max-widths teach organisers nothing and create theme debt.
+
+**What to do instead:** Layout intents only ([03](03-layout-system.md), [11](11-design-tokens.md), [DDR-003](decisions/DDR-003-layout-intents.md)).
+
+**Example:** `.mel-layout--workspace` — not hardcoded `1120px` in Twig beside `1080px` elsewhere.
+
+---
+
+### ❌ Different spacing systems
+
+**Why harmful:** Visual noise; “almost aligned” UI feels unfinished; hard to theme dark mode later.
+
+**What to do instead:** 4px spacing scale exclusively ([11](11-design-tokens.md)).
+
+**Example:** `space-4` / `space-6` — not `13px` and `27px` one-offs.
+
+---
+
+### ❌ Fake readiness
+
+**Why harmful:** Organisers publish into failure; trust collapses.
+
+**What to do instead:** Honest readiness with reasons and recovery ([13](13-event-workspace-philosophy.md)).
+
+**Example:** “Blocked: add a ticket” — not a green tick on an unsellable event.
+
+---
+
+### ❌ Playful money
+
+**Why harmful:** Refunds and payouts are high-stakes; whimsy reads as unsafe.
+
+**What to do instead:** Sober copy, confirmation dialogs, state honesty ([15](15-copywriting-guide.md)).
+
+**Example:** “Refund this order” + consequence — not confetti on refund success.
+
+---
+
+### ❌ Colour-only status
+
+**Why harmful:** Fails WCAG and colour-vision users; Door Mode mis-reads are costly.
+
+**What to do instead:** Colour + text + icon ([11](11-design-tokens.md)).
+
+**Example:** Red badge labelled “Failed” — not a lone red dot.
+
+---
+
+### ❌ Staff tools in organiser IA
+
+**Why harmful:** Security, confusion, and audience boundary violations.
+
+**What to do instead:** Diagnostics stay staff-only; organiser Support is Help Centre scoped ([02](02-information-architecture.md)).
+
+**Example:** No “Entity debug” in sidebar.
+
+---
+
+## Design implications
+
+- Checklist DOC3 points here  
+- New anti-patterns require a PR to this file (owning list)  
+- Exceptions need expiry and owner  
+
+## Future considerations
+
+- Add screenshots library of real regressions (docs-only)  
+- Theme lint rules may later encode a subset — design ownership stays here  
+
+## Related references
+
+- [01](01-vendor-studio-vision.md) · [12](12-dashboard-philosophy.md) · [13](13-event-workspace-philosophy.md) · [15](15-copywriting-guide.md) · [16](16-design-review-checklist.md)

--- a/docs/design/vendor-studio/20-vendor-studio-v2-vision.md
+++ b/docs/design/vendor-studio/20-vendor-studio-v2-vision.md
@@ -1,0 +1,114 @@
+# Vendor Studio — v2 Vision
+
+**Version:** RC1  
+**Status:** Design authority (documentation only) · **Not for implementation**
+
+## Purpose
+
+Preserve strategic thinking that aligns with long-term direction **without contaminating** the current implementation roadmap ([10](10-roadmap.md)).
+
+## Scope
+
+Ideas outside current sequencing. No delivery commitments. No Drupal tickets implied. Overlaps with [A03](appendices/A03-future-ideas-parking-lot.md): this file is narrative vision; A03 is the short parking list.
+
+## Audience
+
+Product leaders, Design Authority, future phase planners.
+
+## Related documents
+
+- [10-roadmap.md](10-roadmap.md) — current sequencing (authoritative for “now”)
+- [17-design-maturity-model.md](17-design-maturity-model.md) — Levels 4–5
+- [18-product-success-metrics.md](18-product-success-metrics.md)
+- [A03-future-ideas-parking-lot.md](appendices/A03-future-ideas-parking-lot.md)
+
+---
+
+## Why separate v2 vision
+
+If ambitious ideas sit inside Phase notes, teams either:
+
+1. Scope-creep current work, or  
+2. Lose the ideas entirely  
+
+This document keeps Vendor Studio’s north star visible while **RC1 / v1.0** stays shippable.
+
+---
+
+## North star (unchanged)
+
+Vendor Studio remains the event operating system organisers enjoy opening every day — calmer, clearer, and more capable over time — without exposing Drupal or Commerce complexity.
+
+v2 advances **maturity Levels 4–5** only after Level 2–3 excellence on core surfaces.
+
+---
+
+## Theme directions (non-binding)
+
+### AI event assistant
+
+Contextual guidance beside tasks: suggest next readiness fixes, draft message outlines, explain blockers in plain language.
+
+**Constraints:** Never silent publish, refund, payout, or send. Organiser confirms. Copy must pass [15](15-copywriting-guide.md).
+
+### Predictive readiness
+
+Anticipate blockers before organisers hit Publish (missing image, ticket, Stripe, schedule conflicts).
+
+### Sales forecasting
+
+Directional forecasts with transparent confidence — never presented as guaranteed revenue.
+
+### Command palette
+
+Fast navigation for power organisers (`⌘K` patterns). Optional accelerator — never the only path ([07](07-interaction-guidelines.md)).
+
+### Workflow automation
+
+Rules like “notify me when sold out” or “remind to publish checklist Friday”. Explicit opt-in; auditable.
+
+### Team collaboration
+
+Roles, comments, assignment on blockers — still workspace-ownership secure.
+
+### Offline-first Door Mode
+
+Stronger offline tolerance, clearer sync recovery, stress-proof conflict handling.
+
+### Cross-event operations
+
+Bulk actions and multi-event boards for promoters running many events — without destroying single-event clarity for everyone else.
+
+### Smart recommendations
+
+Boost / marketing / schedule suggestions grounded in organiser goals and policy — not FOMO dark patterns.
+
+---
+
+## Promotion rules
+
+An idea may leave this document into [10](10-roadmap.md) only when:
+
+1. Product Owner prioritises it  
+2. Core surfaces are at least **Level 2** consistent ([17](17-design-maturity-model.md))  
+3. A DDR covers any IA/shell change  
+4. Success metrics are named ([18](18-product-success-metrics.md))  
+5. Commerce/access risks are explicit  
+
+Until then: capture here or in [A03](appendices/A03-future-ideas-parking-lot.md) — do not sneak into Phase 2–11 scope.
+
+---
+
+## Design implications
+
+- Implementation PRs must not cite this file as permission to build  
+- Roadmap changes that absorb v2 ideas must update [10](10-roadmap.md) and CHANGELOG  
+
+## Future considerations
+
+- Annual vision refresh  
+- Split into theme briefs when a Level 4 program is funded  
+
+## Related references
+
+- [10](10-roadmap.md) · [17](17-design-maturity-model.md) · [18](18-product-success-metrics.md) · [A03](appendices/A03-future-ideas-parking-lot.md) · [README.md](README.md)

--- a/docs/design/vendor-studio/21-definition-of-done.md
+++ b/docs/design/vendor-studio/21-definition-of-done.md
@@ -1,0 +1,114 @@
+# Vendor Studio — Definition of Done
+
+**Version:** RC1.1  
+**Status:** Design authority (documentation only)
+
+## Purpose
+
+Define **completion criteria** for every Vendor Studio feature. A feature is not done when it “looks finished” — it is done when every applicable gate below is satisfied.
+
+## Scope
+
+Mandatory review gates for organiser-facing Vendor Studio work and for Design OS documentation changes that affect those surfaces. Detailed YES/NO items live in [16-design-review-checklist.md](16-design-review-checklist.md). This document owns the **gate list and done rule**.
+
+## Audience
+
+Authors, reviewers, Product Owner, Design Authority, Technical Authority.
+
+## Related documents
+
+- [16-design-review-checklist.md](16-design-review-checklist.md) — detailed checklist
+- [ADR-0001](decisions/ADR-0001-design-authority.md) — constitution
+- [23-governance-lifecycle.md](23-governance-lifecycle.md)
+- [01-vendor-studio-vision.md](01-vendor-studio-vision.md)
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+
+---
+
+## Why a Definition of Done
+
+Without a shared done bar, teams ship inconsistent surfaces and call them complete. This gate list protects organiser experience, accessibility, Drupal/Commerce integrity, and long-term maintainability.
+
+**Rule:** Only features satisfying every **applicable** criterion are considered complete. Mark N/A only with rationale (e.g. docs-only PR, no Commerce touch).
+
+---
+
+## Mandatory review gates
+
+Copy into the PR. Check each applicable gate.
+
+### Design and product
+
+- [ ] **Design review** — Design Authority (or delegate) reviewed experience against OS docs cited in the PR
+- [ ] **Information Architecture** — Fits [02](02-information-architecture.md); no Studio/Manager fork; organiser labels
+- [ ] **Three Question Framework** — Where am I? What needs me? What is the next useful action? ([01](01-vendor-studio-vision.md))
+- [ ] **Golden Rule** — Next step clear within five seconds ([01](01-vendor-studio-vision.md))
+- [ ] **Component Library compliance** — Extends [05](05-component-library.md); no parallel component names ([DDR-004](decisions/DDR-004-component-philosophy.md))
+- [ ] **Design Tokens compliance** — Spacing, type, colour, intents per [11](11-design-tokens.md) / [03](03-layout-system.md)
+
+### Accessibility and interaction
+
+- [ ] **Accessibility (WCAG AA)** — Contrast, semantics, severity not colour-only
+- [ ] **Mobile** — Usable at ~390px; [08](08-mobile-guidelines.md) / [DDR-005](decisions/DDR-005-mobile-first.md)
+- [ ] **Keyboard** — Primary task completable; focus visible ([07](07-interaction-guidelines.md))
+
+### Content and states
+
+- [ ] **Copywriting** — [15](15-copywriting-guide.md); no CMS/Commerce jargon in UI
+- [ ] **Loading states** — No fake metrics; appropriate busy/skeleton patterns
+- [ ] **Empty states** — Honest reason + next step
+- [ ] **Error states** — Reason + recovery; no dead ends
+- [ ] **Success states** — Confirmation + next useful action
+
+### Platform integrity
+
+- [ ] **Security** — Access server-side; no PII/secrets leakage; UI hide ≠ security
+- [ ] **Drupal architecture** — Logic not in Twig; cache considered; mapping per [09](09-drupal-mapping.md)
+- [ ] **Commerce architecture** — States not invented; refunds/payouts deliberate; risk called out
+- [ ] **Performance** — No vanity heavy queries; JS scoped to routes that need it
+
+### Documentation and process
+
+- [ ] **Documentation updated** — OS mapping notes / CHANGELOG / cross-refs as needed; PR cites OS docs
+- [ ] **Design Review Checklist completed** — [16-design-review-checklist.md](16-design-review-checklist.md) filled (YES/NO/N/A + rationale)
+
+---
+
+## Applicability guide
+
+| Work type | Typical N/A |
+| --- | --- |
+| Docs-only OS change | Commerce runtime, performance runtime |
+| Pure SCSS token alignment | Commerce, if no state UI |
+| Refunds / payouts UI | None — all money gates apply |
+| Door Mode | None for mobile/a11y/security |
+
+When unsure, **do not mark N/A** — ask Technical Authority or Design Authority.
+
+---
+
+## Relationship to checklist and lifecycle
+
+```text
+Governance lifecycle (23)
+    → Implementation
+        → Definition of Done gates (this file)
+            → Detailed YES/NO (16)
+                → Merge / release
+```
+
+---
+
+## Design implications
+
+- “LGTM” without gates is insufficient for Vendor Studio
+- Incomplete DoD blocks merge for organiser-facing surfaces
+
+## Future considerations
+
+- PR template may embed this gate list after v1.0 freeze
+- Phase-specific annexes (e.g. Payments) must not weaken core gates
+
+## Related references
+
+- [16](16-design-review-checklist.md) · [ADR-0001](decisions/ADR-0001-design-authority.md) · [23](23-governance-lifecycle.md) · [18](18-product-success-metrics.md) · [19](19-anti-patterns.md)

--- a/docs/design/vendor-studio/22-design-system-health.md
+++ b/docs/design/vendor-studio/22-design-system-health.md
@@ -1,0 +1,122 @@
+# Vendor Studio — Design System Health Report
+
+**Version:** RC1.1  
+**Status:** Design authority (documentation only)
+
+## Purpose
+
+Provide an **executive assessment** of the Design Operating System itself — strengths, risks, technical debt avoided, and how to keep the standard healthy.
+
+## Scope
+
+Assessment of the documentation product standard (not runtime UI health). Companion to the publication readiness findings below. Recommendation for freeze: see final section and sprint report.
+
+## Audience
+
+Product Owner, Design Authority, Technical Authority, executives sponsoring Vendor Studio.
+
+## Related documents
+
+- [ADR-0001](decisions/ADR-0001-design-authority.md)
+- [23-governance-lifecycle.md](23-governance-lifecycle.md)
+- [INDEX.md](INDEX.md)
+- [CHANGELOG.md](CHANGELOG.md)
+
+---
+
+## Strengths
+
+| Strength | Evidence |
+| --- | --- |
+| **Consistent IA** | Single shell; Workspace contextual; job-based nav ([02](02-information-architecture.md), DDR-001/002) |
+| **Strong governance** | Constitution (ADR-0001), lifecycle (23), DoD (21), checklist (16), CONTRIBUTING |
+| **Clear precedence** | Higher docs win; implementation may not contradict ([ADR-0001](decisions/ADR-0001-design-authority.md)) |
+| **Drupal alignment** | Mapping homes, regions, libraries, no-logic-in-Twig ([09](09-drupal-mapping.md)) |
+| **Commerce alignment** | Organiser language vs Commerce truth; money honesty; risk callouts ([09](09-drupal-mapping.md), [15](15-copywriting-guide.md)) |
+| **Mobile-first thinking** | 390px baseline, Door Mode, DDR-005 ([08](08-mobile-guidelines.md)) |
+| **One concept, one home** | Authority rules in README; tokens in 11; metrics in 18; anti-patterns in 19 |
+| **Traceable decisions** | DDR-001–007 + ADR-0001 |
+| **Future safely parked** | v2 vision and parking lot do not contaminate roadmap ([20](20-vendor-studio-v2-vision.md), [A03](appendices/A03-future-ideas-parking-lot.md)) |
+| **Contributor onboarding path** | Poster → Vision → Quick Ref → Glossary → INDEX |
+
+---
+
+## Risks
+
+| Risk | Why it matters | Mitigation |
+| --- | --- | --- |
+| **Areas still theoretical** | OS is documentation-first; runtime may diverge until phases land | Cite OS in every PR; update [09](09-drupal-mapping.md) when code lands |
+| **Implementation validation pending** | Tokens, intents, Door Mode excellence unproven in production UI | Phase exit at maturity Level 2 ([17](17-design-maturity-model.md)) |
+| **Assumptions not yet proven** | e.g. Orders-before-Attendees nav; Action Queue severity UX | Organiser testing; quarterly review cadence |
+| **Role seats unnamed** | Governance fails if no humans fill PO / Design / Technical Authority | Assign names in ops docs (does not block freeze of the standard) |
+| **VX2 / historical doc drift** | Contributors may follow obsolete convergence notes | README: OS wins on design philosophy; confirm runtime in repo |
+| **Scope creep from v2** | AI / command palette temptation during early phases | Lifecycle promotion rules; A03 parking |
+
+---
+
+## Technical debt avoided
+
+This Design OS intentionally prevents historical MEL problems:
+
+| Historical problem | Prevention in OS |
+| --- | --- |
+| Studio vs Manager dual products | DDR-002; single Event Workspace |
+| Competing Event Editor vs Events | DDR-001; Create event as chrome |
+| Scattered money links | DDR-006; Payments hub |
+| Insights vs Analytics naming confusion | IA future labels + copy guide |
+| Competing max-widths / layout forks | DDR-003; tokens in 11 |
+| Parallel component trees | DDR-004; extend `.mel-*` |
+| Desktop-only door/ops thinking | DDR-005; mobile guidelines |
+| CMS/Commerce jargon in UI | [15](15-copywriting-guide.md), glossary |
+| Dashboard wallpaper / vanity metrics | [12](12-dashboard-philosophy.md), [19](19-anti-patterns.md) |
+| Fake readiness / playful money | Principles + Workspace + copy rules |
+| Staff tools leaking to organisers | IA exclusions; help audience rules |
+| Silent redesign via PRs | ADR-0001 precedence; DoD; DDR triggers |
+
+---
+
+## Future maintenance guidance
+
+Keep the Design System healthy by:
+
+1. **Cite before code** — Implementation PRs name OS documents first  
+2. **One home** — Never fork guidance; update the owner doc and reference elsewhere  
+3. **DDR for foundations** — Shell, workspace, intents, components, mobile, hubs  
+4. **Lifecycle always** — Follow [23](23-governance-lifecycle.md); no shortcut “while we’re here”  
+5. **DoD every time** — [21](21-definition-of-done.md) + [16](16-design-review-checklist.md)  
+6. **CHANGELOG honesty** — Record OS changes; don’t silently rewrite history  
+7. **Park ambition** — v2 ideas stay in 20/A03 until promoted  
+8. **Quarterly health** — Re-read anti-patterns, parking lot, maturity claims  
+9. **Mapping feedback loop** — When runtime differs, update 09 — don’t invent a second truth  
+10. **Protect higher docs** — Implementation never “fixes” Vision by ignoring it  
+
+---
+
+## Publication readiness (executive)
+
+| Question | Assessment |
+| --- | --- |
+| Philosophy consistent? | **Yes** — operator tool, event centre of gravity, Golden Rule throughout |
+| Terminology consistent? | **Yes** — Organiser/vendor split; glossary; copy guide |
+| New contributor onboarding? | **Yes** — Poster, reading order, CONTRIBUTING, INDEX, ARCHITECTURE |
+| Major decisions traceable? | **Yes** — ADR-0001 + DDR-001–007 |
+| Contradictions? | **None material found** after RC1.1 consolidation; precedence resolves future conflicts |
+| Concepts needing DDRs? | Hub decisions captured as DDR-006/007 in RC1.1 |
+
+**Freeze recommendation:** see sprint closing declaration (Option A/B/C).
+
+---
+
+## Design implications
+
+- Health is measured by contributor behaviour (citation, DoD) not page count
+- Growing the pack without governance is a regression
+
+## Future considerations
+
+- After v1.0, prefer 1.x clarifications over new parallel manuals
+- Runtime design-debt register can live outside this pack once implementation starts
+
+## Related references
+
+- [ADR-0001](decisions/ADR-0001-design-authority.md) · [23](23-governance-lifecycle.md) · [21](21-definition-of-done.md) · [INDEX.md](INDEX.md) · [README.md](README.md)

--- a/docs/design/vendor-studio/23-governance-lifecycle.md
+++ b/docs/design/vendor-studio/23-governance-lifecycle.md
@@ -1,0 +1,165 @@
+# Vendor Studio — Design Governance Lifecycle
+
+**Version:** RC1.1  
+**Status:** Design authority (documentation only)
+
+## Purpose
+
+Explain **how the Design Operating System evolves** — the official lifecycle for all future Vendor Studio design work.
+
+## Scope
+
+Process from idea through release. Does not replace Drupal release engineering. Constitution: [ADR-0001](decisions/ADR-0001-design-authority.md). Contributor how-to: [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Audience
+
+Everyone proposing or reviewing Vendor Studio design or OS changes.
+
+## Related documents
+
+- [ADR-0001](decisions/ADR-0001-design-authority.md)
+- [21-definition-of-done.md](21-definition-of-done.md)
+- [16-design-review-checklist.md](16-design-review-checklist.md)
+- [10-roadmap.md](10-roadmap.md)
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+
+---
+
+## Why a lifecycle
+
+Ad-hoc redesign recreates the problems this OS was written to prevent. A single lifecycle keeps philosophy, IA, tokens, and implementation aligned as the product grows.
+
+---
+
+## Official lifecycle
+
+```text
+Idea
+  ↓
+Proposal
+  ↓
+Design Decision Record (when required)
+  ↓
+Review
+  ↓
+Approval
+  ↓
+Implementation
+  ↓
+Validation
+  ↓
+Documentation update
+  ↓
+Release
+```
+
+---
+
+### 1. Idea
+
+A need appears: organiser pain, phase work, support theme, or strategic opportunity.
+
+| Do | Don’t |
+| --- | --- |
+| Capture briefly | Silently start a parallel UI pattern |
+| Check [19](19-anti-patterns.md) and [20](20-vendor-studio-v2-vision.md) | Treat competitor chrome as a brief |
+
+Large out-of-roadmap ideas → [A03](appendices/A03-future-ideas-parking-lot.md) or [20](20-vendor-studio-v2-vision.md).
+
+---
+
+### 2. Proposal
+
+Open a documentation (and/or product) proposal that states:
+
+- Problem and organiser outcome
+- Authoritative OS document(s) affected
+- Metrics impacted ([18](18-product-success-metrics.md))
+- Maturity intent ([17](17-design-maturity-model.md))
+
+---
+
+### 3. Design Decision Record
+
+Create or update a **DDR** when the change is foundational (shell, workspace, intents, components, mobile, hubs, money UX philosophy, a11y relaxation). See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+Lightweight clarifications may skip a new DDR but must update the owning document + CHANGELOG.
+
+---
+
+### 4. Review
+
+| Reviewer | Focus |
+| --- | --- |
+| Design Authority | Experience, consistency, copy, a11y intent |
+| Technical Authority | Drupal/Commerce feasibility, access, payments, cache |
+| Product Owner | Scope, roadmap fit, organiser priority |
+
+Use precedence in [ADR-0001](decisions/ADR-0001-design-authority.md) when docs conflict.
+
+---
+
+### 5. Approval
+
+DDR status → Accepted (or proposal approved in PR).  
+No silent “we’ll document later” for foundational changes.
+
+---
+
+### 6. Implementation
+
+- Feature branch; cite OS docs in PR  
+- Extend existing theme/module homes ([09](09-drupal-mapping.md))  
+- **No implementation may contradict higher-order documents** ([ADR-0001](decisions/ADR-0001-design-authority.md))
+
+---
+
+### 7. Validation
+
+- [21-definition-of-done.md](21-definition-of-done.md) gates  
+- [16-design-review-checklist.md](16-design-review-checklist.md)  
+- Theme lint/build and Drupal checks when code changes  
+- Commerce/access risk explicit when applicable  
+
+---
+
+### 8. Documentation update
+
+- Update authoritative homes and cross-refs  
+- Add “Implemented mapping” notes under [09](09-drupal-mapping.md) when useful  
+- [CHANGELOG.md](CHANGELOG.md) for OS changes  
+- Bump version per [README](README.md) versioning policy when the standard changes  
+
+---
+
+### 9. Release
+
+- Ship the phase/feature per engineering release process  
+- Roadmap phase exit targets maturity Level 2+ ([17](17-design-maturity-model.md))  
+- Do not promote parked v2 ideas in the same release without Product Owner approval  
+
+---
+
+## Fast path (non-foundational)
+
+```text
+Idea → Proposal (doc PR) → Review → Approval → Implementation* → Validation → Docs → Release
+```
+
+\*Implementation may be absent for docs-only clarifications.
+
+---
+
+## Design implications
+
+- Skipping DDR/Approval for foundational change is a process defect
+- Lifecycle applies to design OS edits and to product UI work
+
+## Future considerations
+
+- Automate citation reminders in PR templates after v1.0
+- Record cycle time from Proposal → Release for governance health (optional ops metric)
+
+## Related references
+
+- [ADR-0001](decisions/ADR-0001-design-authority.md) · [21](21-definition-of-done.md) · [CONTRIBUTING.md](CONTRIBUTING.md) · [10](10-roadmap.md) · [22](22-design-system-health.md)

--- a/docs/design/vendor-studio/ARCHITECTURE.md
+++ b/docs/design/vendor-studio/ARCHITECTURE.md
@@ -1,0 +1,158 @@
+# Vendor Studio — Product Architecture
+
+**Product Design System (PDS) v1.0 — FROZEN**  
+**Also known as:** Design Operating System
+
+## Purpose
+
+Provide a **visual overview** of Vendor Studio — how the Design Operating System layers relate, and how the product is structured for organisers.
+
+## Scope
+
+ASCII architecture diagrams and short explanations. Detail lives in linked authoritative documents. Not a Drupal module dependency graph.
+
+## Audience
+
+New contributors, product and engineering leads, reviewers.
+
+## Related documents
+
+- [01-vendor-studio-vision.md](01-vendor-studio-vision.md)
+- [02-information-architecture.md](02-information-architecture.md)
+- [INDEX.md](INDEX.md)
+- [ADR-0001](decisions/ADR-0001-design-authority.md)
+
+---
+
+## Why diagrams
+
+A contributor should see the whole system in one page before reading forty documents. Diagrams encode precedence and product shape without replacing the owning specs.
+
+---
+
+## 1. Design Operating System stack
+
+```text
+Vision (01) + Constitution (ADR-0001)
+        ↓
+Information Architecture (02)
+        ↓
+Layout System (03)
+        ↓
+Design Tokens (11)
+        ↓
+Components (05)  ←  Design Language (04) · Visual Identity (14) · Copy (15)
+        ↓
+Patterns (06)  ←  Dashboard (12) · Event Workspace (13)
+        ↓
+Interaction (07) · Mobile (08)
+        ↓
+Drupal Mapping (09)
+        ↓
+Implementation (theme + modules — outside this pack)
+        ↓
+Runtime (.mel-vendor console)
+```
+
+**Roadmap (10)** sequences implementation. **v2 / parking (20, A03)** sit beside the stack — not inside current delivery.
+
+Governance wraps the stack: Lifecycle (23) · DoD (21) · Checklist (16) · Health (22).
+
+---
+
+## 2. Document precedence (constitutional)
+
+```text
+ADR-0001
+  → Mission / Vision / Principles
+    → Information Architecture
+      → Layout System
+        → Design Tokens
+          → Component Library
+            → Workspace Patterns
+              → Implementation Mapping
+                → Roadmap
+```
+
+No implementation may contradict a higher layer. Full rules: [ADR-0001](decisions/ADR-0001-design-authority.md).
+
+---
+
+## 3. Organiser product shape (global)
+
+```text
+Global Vendor Studio (shell)
+│
+├── Dashboard          Attention home
+├── Events             Catalogue → enter Workspace
+│     └── Event Workspace   Per-event application
+├── Orders             Cross-event sales
+├── Attendees          Cross-event guest work
+├── Messages           Brand · templates · history · send
+├── Payments           Stripe · payouts · refunds · tax
+├── Analytics          Business pulse
+├── Marketing          Boost · share · growth
+├── Settings           Organiser defaults
+└── Support            Help · escalations
+```
+
+Authoritative IA: [02-information-architecture.md](02-information-architecture.md).
+
+---
+
+## 4. Context switch
+
+```text
+┌─────────────────────┐         ┌──────────────────────────┐
+│  Global Studio      │  open   │  Event Workspace         │
+│  Dashboard, Events, │ ──────► │  Overview … Settings     │
+│  Orders, Payments…  │ ◄────── │  (this event only)       │
+└─────────────────────┘  leave  └──────────────────────────┘
+```
+
+Only one context switch: **Global ↔ Event**. Never Studio vs Manager.
+
+---
+
+## 5. Event Workspace sections
+
+```text
+Overview → Details → Schedule → Venue → Images → Tickets
+→ Orders → Attendees (incl. Door Mode) → Messages → Marketing
+→ Analytics → Publishing → Settings
+```
+
+Philosophy: [13-event-workspace-philosophy.md](13-event-workspace-philosophy.md).
+
+---
+
+## 6. Runtime mapping (summary)
+
+```text
+Design concept          Runtime home (typical)
+─────────────────────   ─────────────────────────────────
+Shell / nav             myeventlane_vendor_theme + VendorNavBuilder
+Layout intents          .mel-layout--* under .mel-vendor
+Components              vendor theme partials / .mel-* 
+Action Queue            builders in myeventlane_vendor*
+Event Workspace         vendor + event studio related modules
+Orders / payments       Commerce entities (truth) + vendor UI
+```
+
+Confirm in repository at implementation time: [09-drupal-mapping.md](09-drupal-mapping.md).
+
+---
+
+## Design implications
+
+- New features must declare where they sit in diagrams 1 and 3  
+- If it does not fit, that is an IA/DDR question — not a one-off page  
+
+## Future considerations
+
+- Add a module dependency diagram only when Technical Authority needs it for onboarding  
+- Keep ASCII stable; avoid tool-specific diagram formats as source of truth  
+
+## Related references
+
+- [02](02-information-architecture.md) · [09](09-drupal-mapping.md) · [ADR-0001](decisions/ADR-0001-design-authority.md) · [INDEX.md](INDEX.md)

--- a/docs/design/vendor-studio/CHANGELOG.md
+++ b/docs/design/vendor-studio/CHANGELOG.md
@@ -1,0 +1,89 @@
+# Vendor Studio Product Design System (PDS) — Changelog
+
+Also known as: Vendor Studio Design Operating System.
+
+All notable changes to this Product Design System are recorded here.
+
+Versioning follows the Versioning Policy in [README.md](README.md#versioning-policy).
+
+---
+
+## [1.0] — 2026-07-25 — FROZEN
+
+### Declared
+
+**Vendor Studio Product Design System (PDS) v1.0** is frozen as the governing product standard for all Vendor Studio implementation work.
+
+| Field | Value |
+| --- | --- |
+| **Product name** | Vendor Studio Product Design System (PDS) |
+| **Also known as** | Vendor Studio Design Operating System |
+| **Version** | 1.0 |
+| **Status** | **FROZEN** |
+| **Released** | 2026 |
+| **Authority** | Required for all Vendor Studio implementation work |
+
+### Freeze rules
+
+- No continual ad-hoc edits to the frozen standard
+- Future changes follow: DDR → Review → Approval → Version update ([23](23-governance-lifecycle.md))
+- Every Vendor Studio implementation PR must cite PDS documents (see [CONTRIBUTING.md](CONTRIBUTING.md) and repository PR template)
+- Prefer label `design-system` on Vendor Studio PRs
+
+### Includes
+
+- Full RC1 content (vision through v2 parking)
+- RC1.1 governance completion (ADR-0001, DoD, lifecycle, CONTRIBUTING, ARCHITECTURE, INDEX, health, DDR-006/007)
+- Canonical naming: **Product Design System (PDS)**
+
+---
+
+## [RC1.1] — 2026-07-25
+
+### Added — governance completion
+
+- ADR-0001 — constitutional design authority and document precedence
+- 21-definition-of-done.md — mandatory feature completion gates
+- 22-design-system-health.md — executive health and publication readiness
+- 23-governance-lifecycle.md — Idea → Release lifecycle
+- CONTRIBUTING.md — contributor and reviewer guide
+- ARCHITECTURE.md — visual OS and product overview
+- INDEX.md — contributor landing page
+- DDR-006 — Payments hub
+- DDR-007 — Marketing ≠ Analytics
+
+### Changed
+
+- README Versioning Policy and Document Governance expanded
+- Pack positioned as publishable product standard
+
+---
+
+## [RC1] — 2026-07-25
+
+### Added
+
+- README, QUICK_REFERENCE, DESIGN_PRINCIPLES_POSTER
+- Documents 11–20
+- DDR-001 through DDR-005
+- Appendices A01–A03
+- RC1 updates to documents 01–10
+
+---
+
+## [0.9] — 2026-07 (initial draft)
+
+### Added
+
+- Documents 01–10 initial set
+
+---
+
+## Future revisions
+
+| Version | Trigger examples |
+| --- | --- |
+| 1.x | Compatible clarifications, examples, non-breaking token additions, mapping updates after implementation |
+| 2.0 | Breaking IA or philosophy change; new DDR set; Product Owner approval |
+
+Out of current scope: [20-vendor-studio-v2-vision.md](20-vendor-studio-v2-vision.md) · [appendices/A03-future-ideas-parking-lot.md](appendices/A03-future-ideas-parking-lot.md).

--- a/docs/design/vendor-studio/CONTRIBUTING.md
+++ b/docs/design/vendor-studio/CONTRIBUTING.md
@@ -1,0 +1,168 @@
+# Contributing to the Vendor Studio Product Design System (PDS)
+
+**Also known as:** Vendor Studio Design Operating System  
+**Version:** 1.0  
+**Status:** **FROZEN**
+
+## Purpose
+
+Help future contributors read, change, and apply this Product Design System correctly.
+
+## Scope
+
+How humans work with the pack. Constitution: [ADR-0001](decisions/ADR-0001-design-authority.md). Lifecycle: [23](23-governance-lifecycle.md).
+
+## Audience
+
+Designers, engineers, product managers, reviewers.
+
+## Related documents
+
+- [INDEX.md](INDEX.md) — navigation landing page
+- [README.md](README.md) — purpose and governance summary
+- [21-definition-of-done.md](21-definition-of-done.md)
+- [16-design-review-checklist.md](16-design-review-checklist.md)
+
+---
+
+## How to read the Product Design System
+
+Start at [INDEX.md](INDEX.md) or follow this order:
+
+1. [DESIGN_PRINCIPLES_POSTER.md](DESIGN_PRINCIPLES_POSTER.md) — culture  
+2. [01-vendor-studio-vision.md](01-vendor-studio-vision.md) — mission, principles, Golden Rule  
+3. [ARCHITECTURE.md](ARCHITECTURE.md) — product shape  
+4. [QUICK_REFERENCE.md](QUICK_REFERENCE.md) — day-to-day aid  
+5. [appendices/A01-glossary.md](appendices/A01-glossary.md) — vocabulary  
+6. Then deep-dive by role (IA, tokens, Drupal mapping, etc.)
+
+You do **not** need prior MEL tribal knowledge if you follow this path and the glossary.
+
+---
+
+## Reading order (by role)
+
+| Role | Read next |
+| --- | --- |
+| Designer / Product | 02, 12, 13, 14, 15, 11, 19 |
+| Theme / Frontend | 03, 05, 07, 08, 11, 09, 21, 16 |
+| Drupal / Commerce | 09, 02, 13, ADR-0001, 21 |
+| Reviewer | 21, 16, ADR-0001, 19, cited docs in the PR |
+
+---
+
+## How to propose changes
+
+1. Branch from the appropriate base (never commit OS changes straight to `main` without review).  
+2. Identify the **authoritative home** for the concept ([README](README.md) document map).  
+3. Edit that home; replace duplicates elsewhere with references.  
+4. Update cross-links and [CHANGELOG.md](CHANGELOG.md).  
+5. Open a PR describing why (organiser outcome), not only what.  
+6. Follow [23-governance-lifecycle.md](23-governance-lifecycle.md).
+
+Documentation-only work must not modify PHP, Twig, SCSS, JS, YAML, or Drupal config unless a separate implementation sprint explicitly allows it.
+
+---
+
+## When to create a DDR
+
+Create a **Design Decision Record** when the change:
+
+- Alters global navigation or Event Workspace structure  
+- Adds/removes a layout intent or breaks max-width contracts  
+- Introduces a new component family duplicating MEL patterns  
+- Changes mobile navigation or Door Mode philosophy  
+- Establishes or moves a global hub (e.g. Payments, Marketing)  
+- Relaxes accessibility, money honesty, or publish honesty  
+- Conflicts with a locked runtime safety contract  
+
+Template shape: Decision · Problem · Alternatives · Reason · Consequences · Future review triggers (see existing `decisions/DDR-*.md`).
+
+Constitutional changes to ownership or precedence require amending [ADR-0001](decisions/ADR-0001-design-authority.md).
+
+---
+
+## When to update existing documents
+
+| Change type | Update |
+| --- | --- |
+| Clarification / example | Owning doc + CHANGELOG |
+| Token value addition (compatible) | [11](11-design-tokens.md) + CHANGELOG |
+| New anti-pattern observed | [19](19-anti-patterns.md) |
+| Runtime mapping discovered | [09](09-drupal-mapping.md) |
+| Phase reorder | [10](10-roadmap.md) + Product Owner |
+| Parked idea | [A03](appendices/A03-future-ideas-parking-lot.md) or [20](20-vendor-studio-v2-vision.md) |
+
+Do not copy principles into every file — link to [01](01-vendor-studio-vision.md).
+
+---
+
+## When to bump versions
+
+Follow [README.md](README.md) Versioning Policy:
+
+| Bump | When |
+| --- | --- |
+| Draft / RC | Pre-freeze iteration (e.g. RC1 → RC1.1) |
+| Freeze v1.0 | Product Owner + Design Authority declare freeze; tag |
+| Minor (1.x) | Compatible clarifications, examples, non-breaking tokens |
+| Major (2.0) | Breaking philosophy or IA; DDR set; Product Owner approval |
+
+---
+
+## How implementation teams should reference documents
+
+In every Vendor Studio implementation PR:
+
+```markdown
+## Vendor Studio Design System References
+This implementation follows:
+- 02-information-architecture.md
+- 05-component-library.md
+- 11-design-tokens.md
+- 16-design-review-checklist.md
+- 21-definition-of-done.md
+- ADR-0001
+- DDR-<n> (if applicable)
+```
+
+Also apply GitHub label **`design-system`**. Repository template: `.github/PULL_REQUEST_TEMPLATE.md`.
+
+Start from the PDS — do not invent patterns and document afterward.
+
+---
+
+## How reviewers should review Design PRs
+
+### Documentation PRs
+
+1. Is the authoritative home correct?  
+2. Are duplicates removed in favour of references?  
+3. Does precedence still hold ([ADR-0001](decisions/ADR-0001-design-authority.md))?  
+4. Is a DDR required but missing?  
+5. Is CHANGELOG updated?  
+6. Australian English; glossary terms respected?
+
+### Implementation PRs
+
+1. Citations present and accurate  
+2. [21](21-definition-of-done.md) gates + [16](16-design-review-checklist.md)  
+3. No contradiction of higher docs  
+4. Commerce/access/money risk explicit when applicable  
+5. Anti-patterns avoided ([19](19-anti-patterns.md))
+
+---
+
+## Design implications
+
+- Contribution quality is part of product quality  
+- Uncited Vendor Studio PRs are incomplete  
+
+## Future considerations
+
+- Link this file from repository root contributing docs if desired (separate decision)  
+- PR templates after v1.0 freeze  
+
+## Related references
+
+- [INDEX.md](INDEX.md) · [README.md](README.md) · [ADR-0001](decisions/ADR-0001-design-authority.md) · [23](23-governance-lifecycle.md) · [21](21-definition-of-done.md)

--- a/docs/design/vendor-studio/DESIGN_PRINCIPLES_POSTER.md
+++ b/docs/design/vendor-studio/DESIGN_PRINCIPLES_POSTER.md
@@ -1,0 +1,78 @@
+# Vendor Studio — Design Principles Poster
+
+**Product Design System (PDS) v1.0 — FROZEN**  
+**Also known as:** Design Operating System  
+**Purpose:** A one-page culture document. Not technical. Read this before any specification.
+
+---
+
+## Mission
+
+Help organisers create successful events with calm confidence — from first draft to door check-in to payout.
+
+Vendor Studio is the event operating system organisers enjoy opening every day.
+
+---
+
+## Product Philosophy
+
+Vendor Studio is a **tool for operators**, not a marketing site and not a CMS admin.
+
+- The **event** is the centre of gravity  
+- Attention is scarce — lead with what needs action  
+- Trust is earned through clarity — especially with money and publishing  
+- Complexity belongs backstage  
+- Warmth never replaces precision when money, access, or publishing is involved  
+
+---
+
+## Ten Design Principles
+
+1. **One primary action**  
+2. **Guide, don’t overwhelm**  
+3. **Always show the next step**  
+4. **Always explain why**  
+5. **Hide platform complexity**  
+6. **Celebrate progress**  
+7. **Mobile-capable operations**  
+8. **Accessible by default**  
+9. **Cards earn their size**  
+10. **Consistency over novelty**  
+
+*(Full rationale: [01-vendor-studio-vision.md](01-vendor-studio-vision.md))*
+
+---
+
+## Golden Rule
+
+If the organiser cannot answer **“What should I do next?”** within five seconds of landing on a screen, the screen has failed.
+
+---
+
+## Three Question Framework
+
+1. Where am I?  
+2. What needs me?  
+3. What is the next useful action?  
+
+---
+
+## Product Personality
+
+**Warm · Capable · Local · Calm · Honest**
+
+Sounds like: “You’re almost ready to publish.”  
+Does not sound like: “Incomplete configuration detected.”
+
+---
+
+## Organiser Promise
+
+We will never make you learn Drupal to run your event.  
+We will always tell you what needs you, why it matters, and what to do next.  
+We will treat your money, your guests, and your live event with sober care.  
+We will keep Vendor Studio coherent as it grows — one shell, one language, one standard of quality.
+
+---
+
+Every screen should help organisers confidently create, promote and run successful events.

--- a/docs/design/vendor-studio/INDEX.md
+++ b/docs/design/vendor-studio/INDEX.md
@@ -1,0 +1,131 @@
+# Vendor Studio Product Design System (PDS) — Index
+
+**Also known as:** Vendor Studio Design Operating System  
+**Version:** 1.0  
+**Status:** **FROZEN**  
+**Authority:** Required for all Vendor Studio implementation work  
+**Landing page for contributors**
+
+---
+
+## Mission
+
+Help organisers create successful events with calm confidence — from first draft to door check-in to payout.
+
+Vendor Studio is the event operating system organisers enjoy opening every day.
+
+---
+
+## Start here
+
+| Step | Document |
+| --- | --- |
+| 1 | [DESIGN_PRINCIPLES_POSTER.md](DESIGN_PRINCIPLES_POSTER.md) |
+| 2 | [01-vendor-studio-vision.md](01-vendor-studio-vision.md) |
+| 3 | [ARCHITECTURE.md](ARCHITECTURE.md) |
+| 4 | [QUICK_REFERENCE.md](QUICK_REFERENCE.md) |
+| 5 | [CONTRIBUTING.md](CONTRIBUTING.md) |
+| 6 | [appendices/A01-glossary.md](appendices/A01-glossary.md) |
+
+Full reading paths: [README.md](README.md) · [CONTRIBUTING.md](CONTRIBUTING.md)
+
+---
+
+## Document categories
+
+### Governance
+
+| Document | Role |
+| --- | --- |
+| [ADR-0001 Design Authority](decisions/ADR-0001-design-authority.md) | Constitution · precedence |
+| [README.md](README.md) | Purpose · map · versioning · governance summary |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | How to contribute and review |
+| [23-governance-lifecycle.md](23-governance-lifecycle.md) | Idea → Release lifecycle |
+| [21-definition-of-done.md](21-definition-of-done.md) | Completion gates |
+| [16-design-review-checklist.md](16-design-review-checklist.md) | Mandatory PR checklist |
+| [22-design-system-health.md](22-design-system-health.md) | Executive health assessment |
+| [CHANGELOG.md](CHANGELOG.md) | Version history |
+
+### Core design
+
+| Document | Owns |
+| --- | --- |
+| [01 Vision](01-vendor-studio-vision.md) | Mission · principles · Golden Rule · Three Questions |
+| [02 Information architecture](02-information-architecture.md) | Navigation · hierarchy |
+| [03 Layout system](03-layout-system.md) | Shell · intents structure |
+| [04 Design language](04-design-language.md) | MEL extension philosophy |
+| [11 Design tokens](11-design-tokens.md) | Visual token source of truth |
+| [14 Visual identity](14-visual-identity.md) | Feel · differentiation |
+| [15 Copywriting guide](15-copywriting-guide.md) | Voice · terminology |
+
+### Product surfaces
+
+| Document | Owns |
+| --- | --- |
+| [12 Dashboard philosophy](12-dashboard-philosophy.md) | Dashboard mission |
+| [13 Event Workspace philosophy](13-event-workspace-philosophy.md) | Workspace specification |
+| [06 Workspace patterns](06-workspace-patterns.md) | Hub composition patterns |
+| [05 Component library](05-component-library.md) | Component contracts |
+| [07 Interaction guidelines](07-interaction-guidelines.md) | Behaviour |
+| [08 Mobile guidelines](08-mobile-guidelines.md) | Mobile ops |
+| [19 Anti-patterns](19-anti-patterns.md) | What not to do |
+
+### Implementation guidance
+
+| Document | Owns |
+| --- | --- |
+| [09 Drupal mapping](09-drupal-mapping.md) | Theme · routes · Commerce boundaries |
+| [ARCHITECTURE.md](ARCHITECTURE.md) | Visual overview |
+| [10 Roadmap](10-roadmap.md) | Phased application |
+| [17 Design maturity model](17-design-maturity-model.md) | Levels 1–5 |
+| [18 Product success metrics](18-product-success-metrics.md) | Success measures |
+
+### Decision Records
+
+| Record | Decision |
+| --- | --- |
+| [ADR-0001](decisions/ADR-0001-design-authority.md) | Design authority constitution |
+| [DDR-001](decisions/DDR-001-shell-navigation.md) | Single global shell |
+| [DDR-002](decisions/DDR-002-event-workspace.md) | One Event Workspace |
+| [DDR-003](decisions/DDR-003-layout-intents.md) | Layout intents |
+| [DDR-004](decisions/DDR-004-component-philosophy.md) | Component philosophy |
+| [DDR-005](decisions/DDR-005-mobile-first.md) | Mobile-first ops |
+| [DDR-006](decisions/DDR-006-payments-hub.md) | Payments hub |
+| [DDR-007](decisions/DDR-007-marketing-analytics-separation.md) | Marketing ≠ Analytics |
+
+### Appendices
+
+| Document | Role |
+| --- | --- |
+| [A01 Glossary](appendices/A01-glossary.md) | Vocabulary |
+| [A02 vs Humanitix](appendices/A02-design-principles-vs-humanitix.md) | Philosophy contrast |
+| [A03 Parking lot](appendices/A03-future-ideas-parking-lot.md) | Excluded-from-v1 ideas |
+| [20 v2 vision](20-vendor-studio-v2-vision.md) | Long-term non-binding vision |
+
+### Culture and quick aids
+
+| Document | Role |
+| --- | --- |
+| [DESIGN_PRINCIPLES_POSTER.md](DESIGN_PRINCIPLES_POSTER.md) | One-page culture |
+| [QUICK_REFERENCE.md](QUICK_REFERENCE.md) | One-/two-page implementation aid |
+
+### Definition of Done · Roadmap
+
+| Document | Role |
+| --- | --- |
+| [21-definition-of-done.md](21-definition-of-done.md) | Feature completion gates |
+| [10-roadmap.md](10-roadmap.md) | Implementation sequencing |
+
+---
+
+## Golden Rule (reminder)
+
+If the organiser cannot answer “What should I do next?” within five seconds, the screen has failed.
+
+---
+
+## Pack home
+
+[README.md](README.md) — full purpose, freeze policy, versioning, governance.
+
+Every Vendor Studio PR: cite PDS docs · complete DoD (`21`) + checklist (`16`) · prefer label `design-system`.

--- a/docs/design/vendor-studio/QUICK_REFERENCE.md
+++ b/docs/design/vendor-studio/QUICK_REFERENCE.md
@@ -1,0 +1,153 @@
+# Vendor Studio — Quick Reference
+
+**Product Design System (PDS) v1.0 — FROZEN**  
+**Audience:** Designers and developers implementing Vendor Studio  
+**Authority:** Summaries only — full ownership in linked docs  
+**Landing:** [INDEX.md](INDEX.md) · **Done:** [21-definition-of-done.md](21-definition-of-done.md)  
+**Max length:** Keep to two pages when printed
+
+---
+
+## Ten Design Principles
+
+Full text and rationale: [01-vendor-studio-vision.md](01-vendor-studio-vision.md)
+
+1. One primary action  
+2. Guide, don’t overwhelm  
+3. Always show the next step  
+4. Always explain why  
+5. Hide platform complexity  
+6. Celebrate progress  
+7. Mobile-capable operations  
+8. Accessible by default  
+9. Cards earn their size  
+10. Consistency over novelty  
+
+---
+
+## Three Question Framework
+
+Every screen, in order:
+
+1. **Where am I?**  
+2. **What needs me?**  
+3. **What is the next useful action?**  
+
+---
+
+## Golden Rule
+
+> If the organiser cannot answer “What should I do next?” within five seconds of landing on a screen, the screen has failed.
+
+---
+
+## Layout Intents
+
+Shell is full width. Content chooses an intent ([03](03-layout-system.md), [11](11-design-tokens.md)):
+
+| Intent | Max width | Use |
+| --- | --- | --- |
+| Form | 800px | Settings, Stripe, wizards |
+| Reading | 800px | Help, readiness, next-action |
+| Workspace | 1200px | Event Workspace, lists, tickets |
+| Dashboard | 1280px | Organiser home, hubs |
+| Wide / Marketing | 1400px | Boost grids, boards |
+
+Gutters: 16 / 24 / 32px (mobile / tablet / desktop).
+
+---
+
+## Navigation Hierarchy
+
+```text
+Dashboard → Events → (Event Workspace) → Orders → Attendees
+→ Messages → Payments → Analytics → Marketing → Settings → Support
+```
+
+- One global shell; Workspace is entered from Events (not a permanent sidebar twin)  
+- Copy says **Organiser**; URLs may say `/vendor/*`  
+- Full IA: [02-information-architecture.md](02-information-architecture.md)
+
+---
+
+## Component Hierarchy
+
+Prefer in this order:
+
+1. Action / attention (Task List, Action Cards)  
+2. Status / KPIs (Metric Cards)  
+3. Data board (Tables, lists)  
+4. Help / guidance (quiet)
+
+Contracts: [05-component-library.md](05-component-library.md)  
+Avoid: [19-anti-patterns.md](19-anti-patterns.md)
+
+---
+
+## Typography Scale
+
+| Role | Mobile | Notes |
+| --- | --- | --- |
+| H1 | 28px | One per view |
+| H2 | 24px | Sections |
+| H3 | 20px | Subsections / card titles |
+| Body | 16px min | Line-height ~1.5 |
+| Small / meta | 14px | Sentence case |
+| Label | 12–13px | Prefer sentence case |
+
+Full tokens: [11-design-tokens.md](11-design-tokens.md)
+
+---
+
+## Colour Hierarchy
+
+1. Warm cream canvas · white surfaces  
+2. Purple = **one** primary action / active nav  
+3. Coral = focus / warm accent (not a second primary)  
+4. Semantic: error / warning / success / info (+ text/icon, never colour alone)  
+5. Discovery gold = rare; not Studio warnings  
+
+---
+
+## Mobile Rules
+
+- Baseline **390px**; enhance upward  
+- One primary job per viewport  
+- Nav: drawer / sheet; Create event always reachable  
+- Targets ≥ **44×44px**  
+- Tables: card rows **or** x-scroll — one pattern per surface  
+- Door Mode: max content, min chrome  
+
+Full: [08-mobile-guidelines.md](08-mobile-guidelines.md)
+
+---
+
+## Accessibility Rules
+
+- WCAG AA contrast  
+- Visible focus (vendor focus token)  
+- Keyboard paths for primary tasks  
+- Severity = colour + text + icon  
+- Labels on inputs; placeholders never replace labels  
+- Honour `prefers-reduced-motion`  
+- UI hiding is never security  
+
+---
+
+## Primary Action Rule
+
+- **One** primary CTA per screen region  
+- Desktop: page header top-right  
+- Mobile: sticky when commit is required  
+- Destructive actions are never styled as the sole primary without confirmation  
+- Chrome primary: **Create event** (does not compete with page primary inside Workspace)
+
+---
+
+## Before you ship
+
+- [21-definition-of-done.md](21-definition-of-done.md) gates  
+- [16-design-review-checklist.md](16-design-review-checklist.md) detail  
+- Cite the OS docs you followed in the PR ([CONTRIBUTING.md](CONTRIBUTING.md))  
+- Money / publish / access: Technical Authority + risk callout  
+- Precedence: [ADR-0001](decisions/ADR-0001-design-authority.md)  

--- a/docs/design/vendor-studio/README.md
+++ b/docs/design/vendor-studio/README.md
@@ -1,0 +1,275 @@
+# Vendor Studio Product Design System (PDS)
+
+**Also known as:** Vendor Studio Design Operating System  
+
+| Field | Value |
+| --- | --- |
+| **Version** | **1.0** |
+| **Status** | **FROZEN** |
+| **Released** | 2026 |
+| **Authority** | Required for all Vendor Studio implementation work |
+| **Language** | Australian English |
+| **Landing index** | [INDEX.md](INDEX.md) |
+
+---
+
+## Purpose
+
+This **Product Design System (PDS)** is the permanent product standard for **Vendor Studio** — MyEventLane’s organiser console.
+
+It exists so Vendor Studio can grow for years without losing its identity.
+
+Every redesign of Dashboard, Events, Event Workspace, Orders, Attendees, Messages, Payments, Analytics, Marketing, and Settings must begin by citing the relevant documents in this pack — not by inventing new patterns.
+
+**Constitution:** [decisions/ADR-0001-design-authority.md](decisions/ADR-0001-design-authority.md)  
+**Contributor guide:** [CONTRIBUTING.md](CONTRIBUTING.md)  
+**Architecture overview:** [ARCHITECTURE.md](ARCHITECTURE.md)
+
+---
+
+## Vision
+
+Vendor Studio is the event operating system organisers enjoy opening every day.
+
+It helps organisers create, promote, and run successful events with calm confidence — from first draft to door check-in to payout — without ever forcing them to think about Drupal, Commerce stores, products, variations, or CMS vocabulary.
+
+**Success criterion:** Contributors ship coherent Vendor Studio surfaces by following this PDS, Decision Records, Definition of Done, and the review checklist.
+
+---
+
+## Freeze policy (v1.0)
+
+This standard is **frozen**.
+
+- No continual ad-hoc edits
+- Changes require: **DDR → Review → Approval → Version update** ([23-governance-lifecycle.md](23-governance-lifecycle.md))
+- Compatible clarifications may ship as **1.x** with Design Authority approval
+- Breaking philosophy/IA changes require **2.0** and Product Owner approval
+
+---
+
+## Mandatory PR references
+
+Every Vendor Studio implementation PR must include:
+
+```markdown
+## Vendor Studio Design System References
+This implementation follows:
+- 02-information-architecture.md
+- 05-component-library.md
+- 11-design-tokens.md
+- 16-design-review-checklist.md
+- 21-definition-of-done.md
+- ADR-0001
+- DDR-003
+```
+
+(Adjust the list to the documents actually followed.)
+
+Repository aids:
+
+- [`.github/PULL_REQUEST_TEMPLATE.md`](../../../.github/PULL_REQUEST_TEMPLATE.md)
+- Prefer GitHub label: **`design-system`**
+
+---
+
+## Reading order
+
+### For every new contributor
+
+1. [INDEX.md](INDEX.md) — one-page map  
+2. [DESIGN_PRINCIPLES_POSTER.md](DESIGN_PRINCIPLES_POSTER.md) — culture  
+3. [01-vendor-studio-vision.md](01-vendor-studio-vision.md) — mission, principles, Golden Rule  
+4. [ARCHITECTURE.md](ARCHITECTURE.md) — product shape  
+5. [QUICK_REFERENCE.md](QUICK_REFERENCE.md) — day-to-day aid  
+6. [appendices/A01-glossary.md](appendices/A01-glossary.md) — vocabulary  
+7. [CONTRIBUTING.md](CONTRIBUTING.md) — how to change and cite  
+
+Role-based paths: [CONTRIBUTING.md](CONTRIBUTING.md).
+
+---
+
+## Document map
+
+### Governance
+
+| Doc | Owns |
+| --- | --- |
+| [ADR-0001](decisions/ADR-0001-design-authority.md) | Constitution, precedence, ownership |
+| [23 Governance lifecycle](23-governance-lifecycle.md) | Idea → Release process |
+| [21 Definition of Done](21-definition-of-done.md) | Completion gates |
+| [16 Design review checklist](16-design-review-checklist.md) | Detailed YES/NO PR checklist |
+| [22 Design system health](22-design-system-health.md) | Executive assessment |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Contributor & reviewer practice |
+| [CHANGELOG.md](CHANGELOG.md) | Version history |
+
+### Core authority (01–10)
+
+| Doc | Owns (authoritative home) |
+| --- | --- |
+| [01 Vision](01-vendor-studio-vision.md) | Mission, Ten Design Principles, Golden Rule, Three Question Framework, personality |
+| [02 Information architecture](02-information-architecture.md) | Navigation philosophy, global shell IA, workspace hierarchy |
+| [03 Layout system](03-layout-system.md) | Shell structure, breakpoints, layout intents (structure) |
+| [04 Design language](04-design-language.md) | Relationship to public MEL; high-level visual rules |
+| [05 Component library](05-component-library.md) | Component contracts |
+| [06 Workspace patterns](06-workspace-patterns.md) | Page-level composition patterns per hub |
+| [07 Interaction guidelines](07-interaction-guidelines.md) | Hover, focus, autosave, loading, validation, keyboard |
+| [08 Mobile guidelines](08-mobile-guidelines.md) | Mobile-first ops rules, Door Mode mobile |
+| [09 Drupal mapping](09-drupal-mapping.md) | Theme regions, classes, Commerce boundaries, libraries |
+| [10 Roadmap](10-roadmap.md) | Phased application of this PDS |
+
+### Product philosophy & standards (11–23)
+
+| Doc | Owns (authoritative home) |
+| --- | --- |
+| [11 Design tokens](11-design-tokens.md) | Definitive visual token specification |
+| [12 Dashboard philosophy](12-dashboard-philosophy.md) | What Dashboard exists to accomplish |
+| [13 Event Workspace philosophy](13-event-workspace-philosophy.md) | Per-event application specification |
+| [14 Visual identity](14-visual-identity.md) | How Vendor Studio should feel |
+| [15 Copywriting guide](15-copywriting-guide.md) | Voice, tone, terminology translation |
+| [17 Design maturity model](17-design-maturity-model.md) | Levels 1–5 |
+| [18 Product success metrics](18-product-success-metrics.md) | Success measures |
+| [19 Anti-patterns](19-anti-patterns.md) | Harmful patterns and replacements |
+| [20 Vendor Studio v2 vision](20-vendor-studio-v2-vision.md) | Non-binding long-term ideas |
+| [21 Definition of Done](21-definition-of-done.md) | Completion gates |
+| [22 Design system health](22-design-system-health.md) | Health assessment |
+| [23 Governance lifecycle](23-governance-lifecycle.md) | Evolution process |
+
+### Culture and navigation aids
+
+| Doc | Role |
+| --- | --- |
+| [INDEX.md](INDEX.md) | Contributor landing page |
+| [ARCHITECTURE.md](ARCHITECTURE.md) | Visual product / PDS overview |
+| [DESIGN_PRINCIPLES_POSTER.md](DESIGN_PRINCIPLES_POSTER.md) | One-page culture document |
+| [QUICK_REFERENCE.md](QUICK_REFERENCE.md) | One-/two-page implementation guide |
+
+### Decision Records
+
+| Record | Decision |
+| --- | --- |
+| [ADR-0001](decisions/ADR-0001-design-authority.md) | Design authority constitution |
+| [DDR-001](decisions/DDR-001-shell-navigation.md) | Single global shell navigation |
+| [DDR-002](decisions/DDR-002-event-workspace.md) | One Event Workspace |
+| [DDR-003](decisions/DDR-003-layout-intents.md) | Intent-based content containers |
+| [DDR-004](decisions/DDR-004-component-philosophy.md) | Extend MEL components; cards earn their size |
+| [DDR-005](decisions/DDR-005-mobile-first.md) | Mobile as first-class ops surface |
+| [DDR-006](decisions/DDR-006-payments-hub.md) | Payments hub |
+| [DDR-007](decisions/DDR-007-marketing-analytics-separation.md) | Marketing separate from Analytics |
+
+### Appendices
+
+| Doc | Role |
+| --- | --- |
+| [A01 Glossary](appendices/A01-glossary.md) | Shared vocabulary |
+| [A02 vs Humanitix](appendices/A02-design-principles-vs-humanitix.md) | Philosophy comparison (not imitation) |
+| [A03 Parking lot](appendices/A03-future-ideas-parking-lot.md) | Ideas excluded from current roadmap |
+
+---
+
+## Authority rules
+
+1. **One authoritative home per concept.**
+2. **Precedence is constitutional** ([ADR-0001](decisions/ADR-0001-design-authority.md)). No implementation may contradict higher-order documents.
+3. **Principles live in Vision (01).**
+4. **Tokens live in 11.**
+5. **Dashboard depth in 12; Workspace depth in 13.**
+6. **Success metrics in 18.**
+7. **Anti-patterns in 19.**
+8. **DoD gates in 21; checklist detail in 16.**
+9. **v2 / parking in 20 and A03** — must not contaminate [10-roadmap.md](10-roadmap.md).
+
+---
+
+## Versioning Policy
+
+```text
+Draft
+  ↓
+RC (Release Candidate)
+  ↓
+Frozen v1.0   ← current
+  ↓
+Minor revision (1.x)
+  ↓
+Major revision (2.0)
+```
+
+| Stage | Meaning | Who decides |
+| --- | --- | --- |
+| **Draft** | Early incomplete pack | Design Authority |
+| **RC** | Complete candidate for freeze | Design Authority + Product Owner |
+| **Frozen v1.0** | Published product standard; tagged; cited by every implementation PR | Product Owner + Design Authority (+ Technical Authority for platform contracts) |
+| **Minor revision (1.x)** | Compatible clarifications, examples, non-breaking tokens | Design Authority; Technical Authority if mapping/contracts |
+| **Major revision (2.0)** | Breaking philosophy or IA; new DDR set | Product Owner + Design Authority + Technical Authority |
+
+---
+
+## Document Governance
+
+### Roles
+
+| Role | Responsibility |
+| --- | --- |
+| **Product Owner** | Organiser outcomes; roadmap; scope; major bumps; freeze declaration |
+| **Design Authority** | Experience consistency; DDR approval; pack integrity |
+| **Technical Authority** | Drupal/Commerce feasibility; mapping honesty; access, payments, cache, security |
+
+### Review cadence
+
+| Cadence | Activity |
+| --- | --- |
+| Every Vendor Studio PR | Cite PDS docs; complete [21](21-definition-of-done.md) + [16](16-design-review-checklist.md); label `design-system` |
+| Each delivery phase | Confirm phase matches PDS; update [09](09-drupal-mapping.md) |
+| Quarterly | Health review ([22](22-design-system-health.md)) |
+| On major product shift | Re-open DDRs; version bump deliberately |
+
+### How DDRs are approved
+
+1. Draft DDR → 2. Design Authority review → 3. Technical Authority if platform risk → 4. Product Owner if scope/IA weight → 5. Status **Accepted** + CHANGELOG → 6. Implementation may proceed.
+
+Constitutional changes amend [ADR-0001](decisions/ADR-0001-design-authority.md).
+
+### How future documents are added
+
+Confirm missing home → lifecycle ([23](23-governance-lifecycle.md)) → standard front/closing matter → INDEX + README map → avoid duplicates.
+
+---
+
+## Relationship with other systems
+
+| System | Relationship |
+| --- | --- |
+| **Drupal 11** | Maps via [09](09-drupal-mapping.md). Business logic stays out of Twig. |
+| **Drupal Commerce 3** | Commerce-authoritative states; organiser-facing language; honesty mandatory. |
+| **MEL Brand** (`docs/brand/`) | Public brand; PDS extends for operations. |
+| **Vendor theme** | Runtime under `.mel-vendor`; implements PDS; does not redefine it. |
+| **Public theme** + `DESIGN_SYSTEM.md` | Discovery UI; do not fork into ops chrome. |
+| **VX2 docs** | Delivery history; **PDS wins** on design philosophy; confirm runtime in repository. |
+
+---
+
+## Roadmap stance
+
+- **Now:** PDS **v1.0 FROZEN** — governing authority.  
+- **Next:** Implementation against the standard, starting with Dashboard (wireframes before code).  
+- **Measure:** [18](18-product-success-metrics.md) · [17](17-design-maturity-model.md) · phases in [10](10-roadmap.md).
+
+---
+
+## Naming
+
+| Prefer in new writing | Accepted alias |
+| --- | --- |
+| **Vendor Studio Product Design System (PDS)** | Vendor Studio Design Operating System |
+
+“Operating System” describes what Vendor Studio *does* for organisers.  
+“Product Design System” describes what *this pack* is.
+
+---
+
+## Explicit non-goals of documentation-only work
+
+- No PHP, Twig, SCSS, JavaScript, YAML config, or theme implementation in docs-only sprints  
+- No imitation of competitor chrome  
+- No staff-only tooling in organiser IA  

--- a/docs/design/vendor-studio/appendices/A01-glossary.md
+++ b/docs/design/vendor-studio/appendices/A01-glossary.md
@@ -1,0 +1,117 @@
+# Appendix A01 — Glossary
+
+**Version:** RC1.1  
+**Status:** Design authority (documentation only)
+
+## Purpose
+
+Define shared vocabulary for the Vendor Studio Design Operating System so every document means the same thing by the same words.
+
+## Scope
+
+Organiser-facing terms, MEL product terms, and translations from Drupal/Commerce. Not a full platform dictionary.
+
+## Audience
+
+All contributors.
+
+## Related documents
+
+- [15-copywriting-guide.md](../15-copywriting-guide.md)
+- [02-information-architecture.md](../02-information-architecture.md)
+- [README.md](../README.md)
+
+---
+
+## Organiser terms
+
+| Term | Meaning |
+| --- | --- |
+| **Organiser** | Human who runs events on MEL. Preferred in UI. Machine/URLs may say `vendor`. |
+| **Vendor Studio** | The organiser console product (global shell + Event Workspace). |
+| **Dashboard** | Global attention home — what needs me now. |
+| **Events** | Catalogue of the organiser’s events; gateway into Workspace. |
+| **Event** | A single dated experience the organiser builds and runs. |
+| **Event Workspace** | Per-event application for build + ops. |
+| **Attendee** | Guest associated with an event (order, RSVP, waitlist, comp — as product defines). |
+| **Order** | A purchase record organisers reconcile and may refund (Commerce-backed). |
+| **Ticket** | Sellable admission option (Commerce variation backstage). |
+| **Payment / payouts** | Money movement and Stripe connection states — always honesty-bound. |
+| **Marketing** | Growth tools (Boost, share, embeds). |
+| **Messages** | Brand, templates, history, and sending to audiences. |
+| **Door Mode** | High-speed check-in mode under Attendees. |
+| **Readiness** | Honest publish/capability checklist with blockers and recovery. |
+| **Action Queue** | Ranked attention list on Dashboard (and similar surfaces). |
+| **Publishing** | Making an event live/visible per product rules — deliberate, not accidental. |
+
+---
+
+## MEL terminology
+
+| Term | Meaning |
+| --- | --- |
+| **MEL** | MyEventLane. |
+| **Hidden Gem** | Public brand discovery idea — high-value local experiences; not VIP theatre in Studio. |
+| **Guide** | Warm encouraging presence at decision points — not a mascot in console chrome. |
+| **Boost** | Paid/promoted growth capability (as product defines). |
+| **VX2** | Vendor Experience convergence programme docs (delivery history; OS wins on design philosophy). |
+
+---
+
+## Drupal terminology (backstage)
+
+| Term | Organiser-facing translation |
+| --- | --- |
+| Node / content entity | Event (or specific content type name only if already organiser-facing) |
+| Media | Image / file as labelled in UI |
+| Taxonomy | Category / tags |
+| Permission | Access (plain language) |
+| Theme region | (omit in UI) |
+| Config | (omit in UI) |
+
+---
+
+## Commerce terminology (backstage)
+
+| Term | Organiser-facing translation |
+| --- | --- |
+| Store | (omit) |
+| Product / variation | Ticket / ticket type |
+| Order | Order |
+| Order item | Line item / ticket line |
+| Payment gateway | Stripe / payment method |
+| Adjustment | Fee / discount (plain) |
+| Checkout | Checkout (public); organisers see orders/payments aftermath |
+
+---
+
+## Design OS terms
+
+| Term | Meaning |
+| --- | --- |
+| **Product Design System (PDS)** | Canonical name for this pack — permanent product design standard (v1.0 FROZEN). |
+| **Design Operating System** | Accepted alias for the PDS (describes what Vendor Studio does for organisers). |
+| **ADR** | Architecture/authority decision record; [ADR-0001](../decisions/ADR-0001-design-authority.md) is the constitution. |
+| **DDR** | Design Decision Record in `decisions/`. |
+| **Definition of Done** | Mandatory completion gates ([21](../21-definition-of-done.md)). |
+| **Layout intent** | Named content max-width contract (Form, Reading, Workspace, Dashboard, Wide). |
+| **Golden Rule** | Next-step clarity within five seconds ([01](../01-vendor-studio-vision.md)). |
+| **Three Questions** | Where am I? What needs me? What’s next? |
+| **Maturity level** | Functional → Predictive ladder ([17](../17-design-maturity-model.md)). |
+| **Precedence** | Higher documents win when guidance conflicts ([ADR-0001](../decisions/ADR-0001-design-authority.md)). |
+
+---
+
+## Design implications
+
+- New terms require an entry here before widespread use in OS docs  
+- UI copy must prefer organiser column, not backstage column  
+
+## Future considerations
+
+- Expand with role names when team collaboration ships  
+- Sync with VX2 language guide without duplicating full essays  
+
+## Related references
+
+- [15](../15-copywriting-guide.md) · [02](../02-information-architecture.md) · [docs/vendor-experience-convergence-language-guide.md](../../../vendor-experience-convergence-language-guide.md)

--- a/docs/design/vendor-studio/appendices/A02-design-principles-vs-humanitix.md
+++ b/docs/design/vendor-studio/appendices/A02-design-principles-vs-humanitix.md
@@ -1,0 +1,84 @@
+# Appendix A02 — Design principles vs Humanitix
+
+**Version:** RC1  
+**Status:** Design authority (documentation only)
+
+## Purpose
+
+Compare **philosophies only** with Humanitix as a category reference. Identify where MyEventLane Vendor Studio **intentionally differs**.
+
+## Scope
+
+Strategic differentiation. **Do not copy Humanitix** UI, IA, copy, or visual language. No screenshots inventory required for RC1.
+
+## Audience
+
+Product and design leaders setting differentiation.
+
+## Related documents
+
+- [01-vendor-studio-vision.md](../01-vendor-studio-vision.md)
+- [14-visual-identity.md](../14-visual-identity.md)
+- [15-copywriting-guide.md](../15-copywriting-guide.md)
+
+---
+
+## Why compare at all
+
+Organisers will mentally benchmark ticketing consoles. Differentiation must be deliberate — not accidental divergence or accidental imitation.
+
+---
+
+## Shared industry expectations (not imitation)
+
+Both categories succeed when organisers can:
+
+- Create and publish events  
+- Sell tickets and reconcile orders  
+- Check in guests  
+- Understand payouts  
+
+Meeting baseline expectations is table stakes — not a reason to clone chrome.
+
+---
+
+## Where MEL Vendor Studio intentionally differs
+
+| Dimension | MEL Vendor Studio stance | Intentional difference |
+| --- | --- | --- |
+| Brand soul | Hidden Gem + Guide; warm local community | Ops UI stays warm; not cold “enterprise admin” |
+| Language | Australian English; organiser not CMS | Community vocabulary over marketplace FOMO |
+| Dashboard | Action Queue first | Attention over wallpaper analytics |
+| Navigation | One shell; Event Workspace contextual | Reject dual build/manage products as a feature |
+| Discovery vs ops | Public MEL owns discovery patterns | Console does not paste public heroes/cards |
+| Money UX | Stripe-level sobriety with MEL warmth | Precise without becoming pure fintech theatre |
+| Door Mode | Mobile stress design first-class | Phone ops as core, not afterthought |
+| Exclusivity | Avoid VIP / members-only pressure | Community over scarcity marketing in Studio |
+| Platform honesty | Hide Drupal/Commerce; never fake readiness | Trust through clarity |
+
+---
+
+## What we refuse to copy
+
+- Competitor visual skins  
+- Competitor information architecture wholesale  
+- FOMO / exclusivity patterns that conflict with MEL brand  
+- Feature parity checklists as design rationale  
+
+If a proposal’s best argument is “Humanitix does it”, the proposal is incomplete. Argue from organiser jobs, accessibility, Commerce truth, and MEL brand.
+
+---
+
+## Design implications
+
+- Competitive reviews use this appendix for *difference*, [01](../01-vendor-studio-vision.md) for *decision*  
+- Implementation must not introduce “parity” forks that violate DDRs  
+
+## Future considerations
+
+- Periodic category review without importing UI patterns  
+- Add other competitors only as philosophy contrasts, never as template libraries  
+
+## Related references
+
+- [01](../01-vendor-studio-vision.md) · [14](../14-visual-identity.md) · [19](../19-anti-patterns.md)

--- a/docs/design/vendor-studio/appendices/A03-future-ideas-parking-lot.md
+++ b/docs/design/vendor-studio/appendices/A03-future-ideas-parking-lot.md
@@ -1,0 +1,67 @@
+# Appendix A03 — Future ideas parking lot
+
+**Version:** RC1  
+**Status:** Design authority (documentation only)
+
+## Purpose
+
+Capture ideas **intentionally excluded** from v1 / current roadmap so the Design System stays clean while strategic thoughts are preserved.
+
+## Scope
+
+Short inventory. Narrative vision lives in [20-vendor-studio-v2-vision.md](../20-vendor-studio-v2-vision.md). Current sequencing lives in [10-roadmap.md](../10-roadmap.md) only.
+
+## Audience
+
+Product and design; phase planners resisting scope creep.
+
+## Related documents
+
+- [20-vendor-studio-v2-vision.md](../20-vendor-studio-v2-vision.md)
+- [10-roadmap.md](../10-roadmap.md)
+- [17-design-maturity-model.md](../17-design-maturity-model.md)
+
+---
+
+## Parking rules
+
+1. Parking an idea is not rejecting it forever  
+2. Parked ideas must not appear as Phase 1–12 scope without promotion  
+3. Promotion follows rules in [20](../20-vendor-studio-v2-vision.md)  
+
+---
+
+## Parked ideas
+
+| Idea | Why parked (v1) | Revisit when |
+| --- | --- | --- |
+| AI event assistant | Requires Level 2–3 core excellence first; high trust risk | Level 4 programme funded |
+| Command palette | Power-user accelerator; not Door Mode critical path | After shell consistency |
+| Keyboard shortcut maps | Optional; need organiser testing | After primary keyboard a11y solid |
+| Advanced analytics suites | Risk of decorative metrics | After Analytics phase honesty |
+| Multi-event bulk operations | Can dilute single-event clarity | Promoter segment prioritised |
+| Offline-first Door Mode enhancements | Complexity; sync/conflict risk | Door Mode Level 3 done |
+| Team collaboration / comments | Access model expansion | After ownership model stable |
+| Predictive readiness / forecasting | Level 5; confidence UX hard | After honest readiness trusted |
+| Workflow automation rules | Silent action risk | Explicit opt-in design ready |
+| Customisable Dashboard widgets | Wallpaper risk | Action Queue culture entrenched |
+| Dark mode before Phase 12 | Partial dark is worse than none | Phases 1–11 substantially done |
+| `/organiser/*` URL rename | Continuity cost | Product Owner migration programme |
+| Density themes (compact/comfortable) | Token complexity | Research evidence |
+| Cross-event command centre | Second product risk | Clear IA DDR |
+
+---
+
+## Design implications
+
+- PRs must not implement parked ideas “while we’re here”  
+- Move rows to [10](../10-roadmap.md) only with Product Owner approval  
+
+## Future considerations
+
+- Quarterly prune: promote, keep, or archive  
+- Link each promoted idea to metrics in [18](../18-product-success-metrics.md)  
+
+## Related references
+
+- [20](../20-vendor-studio-v2-vision.md) · [10](../10-roadmap.md) · [17](../17-design-maturity-model.md) · [README.md](../README.md)

--- a/docs/design/vendor-studio/decisions/ADR-0001-design-authority.md
+++ b/docs/design/vendor-studio/decisions/ADR-0001-design-authority.md
@@ -1,0 +1,145 @@
+# ADR-0001 — Design Authority (Constitution)
+
+**Status:** Accepted  
+**Date:** 2026-07-25  
+**Pack version:** 1.0 (FROZEN)  
+**Owners:** Product Owner · Design Authority · Technical Authority
+
+---
+
+## Purpose
+
+This is the **constitutional document** for the **Vendor Studio Product Design System (PDS)** (also known as the Vendor Studio Design Operating System).
+
+It establishes why the PDS exists, who owns it, how decisions are made, and what happens when documents disagree.
+
+All other documents in this pack are subordinate to this constitution and to the precedence hierarchy below.
+
+---
+
+## Why the Product Design System exists
+
+Vendor Studio must grow for years without losing its identity.
+
+Without a governed product standard:
+
+- Screens are designed in isolation
+- Navigation forks reappear (Studio vs Manager)
+- Tokens and max-widths multiply
+- Drupal/Commerce vocabulary leaks into organiser UI
+- Accessibility and money honesty become optional
+
+The PDS exists so every feature is built against a **clear product standard**, not against the last screen someone liked.
+
+It is a long-lived product asset — comparable in intent to mature design systems (Polaris, Atlassian Design System, Material) — expressed uniquely for MyEventLane’s organiser operations.
+
+---
+
+## Who owns it
+
+| Role | Owns |
+| --- | --- |
+| **Product Owner** | Organiser outcomes; roadmap priority; whether a change is in scope; major version bumps |
+| **Design Authority** | Experience consistency (IA, visual, interaction, copy); DDR approval for design decisions; pack integrity |
+| **Technical Authority** | Drupal 11 / Commerce 3 feasibility; mapping honesty in [09](../09-drupal-mapping.md); access, payments, cache, and security risk |
+
+Roles are seats that must be filled on material reviews. Named individuals may be recorded in project ops docs without rewriting this constitution.
+
+Lifecycle of changes: [23-governance-lifecycle.md](../23-governance-lifecycle.md).  
+Contributor practice: [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+---
+
+## How design decisions are made
+
+1. **Idea** — captured; large ideas may park in [A03](../appendices/A03-future-ideas-parking-lot.md) or [20](../20-vendor-studio-v2-vision.md)
+2. **Proposal** — documentation PR states the authoritative home being changed
+3. **Design Decision Record (DDR)** — required for foundational experience decisions (see [README](../README.md) / [CONTRIBUTING](../CONTRIBUTING.md))
+4. **Review** — Design Authority; Technical Authority when Drupal/Commerce contracts change; Product Owner for scope/roadmap
+5. **Approval** — explicit acceptance in PR / DDR status
+6. **Implementation** — cites OS docs; never invents contradicting patterns
+7. **Validation** — [21-definition-of-done.md](../21-definition-of-done.md) and [16-design-review-checklist.md](../16-design-review-checklist.md)
+8. **Documentation update** — mapping notes, CHANGELOG, cross-refs
+9. **Release** — phase ship per [10](../10-roadmap.md); OS version bump when the standard itself changes
+
+---
+
+## Document precedence
+
+When two documents disagree, **higher wins**. Lower documents must be amended to restore alignment — never the reverse by silent implementation.
+
+```text
+ADR-0001 Design Authority (this constitution)
+    ↓
+Mission / Vision / Design Principles          → 01, Poster
+    ↓
+Information Architecture                      → 02 (+ DDR-001, DDR-002, …)
+    ↓
+Layout System                                 → 03 (+ DDR-003)
+    ↓
+Design Tokens                                 → 11
+    ↓
+Design Language / Visual Identity / Copy      → 04, 14, 15
+    ↓
+Component Library                             → 05 (+ DDR-004)
+    ↓
+Interaction / Mobile                          → 07, 08 (+ DDR-005)
+    ↓
+Workspace Patterns / Hub Philosophies         → 06, 12, 13
+    ↓
+Anti-patterns / Maturity / Metrics / DoD      → 19, 17, 18, 21
+    ↓
+Implementation Mapping                        → 09
+    ↓
+Roadmap                                       → 10
+    ↓
+v2 Vision / Parking lot                       → 20, A03  (non-binding on current work)
+```
+
+### Precedence rules
+
+1. **No implementation may contradict higher-order documents.**
+2. Runtime code and VX2 historical docs do not outrank this OS on **design philosophy**. Runtime **facts** (routes, fields, states) must still be confirmed in the repository before coding.
+3. Public MEL brand (`docs/brand/`, `DESIGN_SYSTEM.md`) outranks Studio for **public discovery** surfaces; Studio outranks brand docs for **organiser console** chrome and ops patterns, while still extending brand tokens rather than forking them.
+4. Commerce/payment/access safety rules in MEL engineering governance outrank UI convenience — honesty and security are non-negotiable even if a lower design doc is silent.
+5. [20](../20-vendor-studio-v2-vision.md) and [A03](../appendices/A03-future-ideas-parking-lot.md) never override [10](../10-roadmap.md) or higher docs until promoted through the lifecycle.
+
+---
+
+## What happens if two documents disagree
+
+| Situation | Action |
+| --- | --- |
+| Lower doc contradicts higher | Fix the lower doc; do not “split the difference” in code |
+| Two peers conflict (same level) | Design Authority decides; update both; add DDR if foundational |
+| OS contradicts confirmed runtime safety (payments/access) | Stop; Technical Authority + Product Owner; amend OS or halt the feature |
+| OS contradicts VX2 delivery note on philosophy | **OS wins** for design; update VX2 references or note obsolescence |
+| Implementation contradicts OS | Defect — not an implicit redesign |
+
+---
+
+## Relationship to DDRs
+
+| Record type | Role |
+| --- | --- |
+| **ADR-0001** | Constitution — authority, precedence, ownership |
+| **DDR-nnn** | Product design decisions (shell, workspace, intents, components, mobile, hubs) |
+
+DDRs must not violate this ADR. Changing precedence or ownership requires amending **ADR-0001** with Product Owner + Design Authority + Technical Authority approval.
+
+---
+
+## Consequences
+
+- Every Vendor Studio implementation PR cites relevant OS documents
+- Checklists and Definition of Done are gates, not suggestions
+- Ambiguity is resolved upward, then documented downward
+- The pack can freeze as v1.0 and evolve via governed revisions
+
+---
+
+## Future review triggers
+
+- Reorganisation of Product / Design / Technical authority seats
+- Proposal to split Vendor Studio into multiple products
+- Conflict with a new locked platform contract that cannot be reconciled without precedence change

--- a/docs/design/vendor-studio/decisions/DDR-001-shell-navigation.md
+++ b/docs/design/vendor-studio/decisions/DDR-001-shell-navigation.md
@@ -1,0 +1,57 @@
+# DDR-001 — Single global shell navigation
+
+**Status:** Accepted  
+**Date:** 2026-07-25  
+**Version:** RC1  
+**Owners:** Design Authority · Product Owner · Technical Authority
+
+---
+
+## Decision
+
+Vendor Studio uses **one global organiser shell** with a single job-based navigation. There is no parallel “Studio nav” vs “Manager nav”. Visible copy says **Organiser**; URL namespace may remain `/vendor/*`.
+
+---
+
+## Problem
+
+Historical MEL surfaces taught organisers two mental models for one business. Duplicate entries (e.g. Event Editor vs Events) and ops tools promoted to global peers inflated the shell and failed the Golden Rule.
+
+---
+
+## Alternatives considered
+
+| Alternative | Why not |
+| --- | --- |
+| Dual products (Studio + Manager) | Permanent cognitive tax; duplicate IA |
+| CMS-style toolbar of Drupal tools | Exposes platform complexity |
+| Flat mega-list of every feature | Exceeds ≤10 top-level guidance; poor mobile |
+| Rename URLs immediately to `/organiser/*` | Breaks continuity; copy change suffices for v1 |
+
+---
+
+## Reason
+
+- Better organiser experience: one place to learn  
+- Product clarity: jobs not modules  
+- Mobile usability: fewer top-level destinations  
+- Maintainability: one nav builder and theme shell  
+- Drupal-aware: paths can stay stable while UX converges  
+
+Authoritative detail: [02-information-architecture.md](../02-information-architecture.md).
+
+---
+
+## Consequences
+
+- New features must justify global nav weight or nest in Event Workspace / hubs  
+- Convergence work retires competing entries rather than adding “temporary” twins  
+- Support and Settings stay visually separated at the end of nav  
+
+---
+
+## Future review triggers
+
+- Research shows small-screen overload requiring nested hubs  
+- Product Owner approves `/organiser/*` URL migration  
+- Team collaboration requires a new top-level “Team” job with sustained frequency  

--- a/docs/design/vendor-studio/decisions/DDR-002-event-workspace.md
+++ b/docs/design/vendor-studio/decisions/DDR-002-event-workspace.md
@@ -1,0 +1,57 @@
+# DDR-002 — One Event Workspace (contextual application)
+
+**Status:** Accepted  
+**Date:** 2026-07-25  
+**Version:** RC1  
+**Owners:** Design Authority · Product Owner · Technical Authority
+
+---
+
+## Decision
+
+Per-event work happens in a **single Event Workspace** entered from Events (or Dashboard shortcuts). Workspace is **not** a permanent global sidebar twin of Events. Builder and operations share one sectioned application.
+
+---
+
+## Problem
+
+Splitting “build” and “manage” into separate products forced organisers to reorient, duplicated navigation, and hid the next step behind product history rather than event lifecycle.
+
+---
+
+## Alternatives considered
+
+| Alternative | Why not |
+| --- | --- |
+| Permanent “Workspace” global nav item | Empty context; requires constant event picking; recreates dual product |
+| Separate Builder and Manager apps | Fails IA philosophy; doubles maintenance |
+| Drupal node edit as primary UX | CMS terminology and admin patterns |
+| Global Check-in as peer product | Inflates shell; Door Mode is event guest ops |
+
+---
+
+## Reason
+
+- Organiser experience: one event application  
+- Clarity: Global ↔ Event is the only context switch  
+- Commerce-aware: tickets/orders/attendees stay event-scoped when operating an event  
+- Long-term maintainability: one shell to evolve  
+
+Authoritative detail: [13-event-workspace-philosophy.md](../13-event-workspace-philosophy.md) · [02](../02-information-architecture.md).
+
+---
+
+## Consequences
+
+- Door Mode lives under Attendees  
+- Advanced tools nest under sections (e.g. Tickets)  
+- Overview owns readiness + next action  
+- Canonical paths: `/vendor/events/{id}` and `/vendor/events/{id}/{section}`  
+
+---
+
+## Future review triggers
+
+- Multi-event bulk operations productisation ([20](../20-vendor-studio-v2-vision.md))  
+- Evidence that section count requires a new IA pattern on mobile  
+- Publish/autosave architecture changes that alter section boundaries  

--- a/docs/design/vendor-studio/decisions/DDR-003-layout-intents.md
+++ b/docs/design/vendor-studio/decisions/DDR-003-layout-intents.md
@@ -1,0 +1,56 @@
+# DDR-003 — Intent-based content containers
+
+**Status:** Accepted  
+**Date:** 2026-07-25  
+**Version:** RC1  
+**Owners:** Design Authority · Technical Authority
+
+---
+
+## Decision
+
+The Vendor Studio **shell may be full width**; **content uses named layout intents** with tokenised max-widths (Form/Reading 800, Workspace 1200, Dashboard 1280, Wide/Marketing 1400). Twig applies classes; SCSS owns widths. No hardcoded content max-widths in templates.
+
+---
+
+## Problem
+
+Competing max-width contracts (`1080`, `1120`, dual page containers) created inconsistent reading lengths, form strain on ultra-wide monitors, and theme debt.
+
+---
+
+## Alternatives considered
+
+| Alternative | Why not |
+| --- | --- |
+| Always fluid full-bleed content | Forms become unreadable; line length fails |
+| Single max-width for all pages | Dashboard boards and settings forms have different jobs |
+| Hardcode widths in Twig per page | Unmaintainable; breaks token remaps (dark mode, density) |
+| Marketing full-bleed heroes in ops | Wrong emotional model for console |
+
+---
+
+## Reason
+
+- Product clarity: width signals job type  
+- Accessibility / readability: form/reading lengths stay sane  
+- Maintainability: one token remap  
+- Aligns with VX2-02A layout convergence direction  
+
+Authoritative numbers: [11-design-tokens.md](../11-design-tokens.md) · structure: [03-layout-system.md](../03-layout-system.md).
+
+---
+
+## Consequences
+
+- New pages must declare an intent  
+- Next-action blocks inside wide workspaces prefer Reading width  
+- Ultra-wide side space on forms is intentional  
+
+---
+
+## Future review triggers
+
+- Evidence for a new intent (must not be a one-off pixel value)  
+- Density themes (comfortable/compact) requiring paired intent tokens  
+- Conflict with a locked runtime contract — document, don’t silently fork  

--- a/docs/design/vendor-studio/decisions/DDR-004-component-philosophy.md
+++ b/docs/design/vendor-studio/decisions/DDR-004-component-philosophy.md
@@ -1,0 +1,56 @@
+# DDR-004 — Component philosophy (extend MEL; cards earn their size)
+
+**Status:** Accepted  
+**Date:** 2026-07-25  
+**Version:** RC1  
+**Owners:** Design Authority · Technical Authority
+
+---
+
+## Decision
+
+Vendor Studio **extends existing MEL / vendor components** (`.mel-btn`, `.mel-card`, alerts, forms, etc.) under `.mel-vendor`. New component names for the same job are forbidden. **Cards earn their size** — if removing border/shadow/radius does not hurt understanding or interaction, it should not be a card.
+
+---
+
+## Problem
+
+Parallel component trees (`vendor-studio-*` forks), nested cards, and decorative panels create drift from public MEL DNA while failing ops clarity.
+
+---
+
+## Alternatives considered
+
+| Alternative | Why not |
+| --- | --- |
+| Brand-new Studio-only kit | Duplicates maintenance; splits brand |
+| Card everything for “premium” | Hierarchy collapse; mobile chrome heaviness |
+| Raw Drupal admin components | Wrong language and aesthetics |
+| Copy public event-card system into console | Wrong job (discovery vs ops) |
+
+---
+
+## Reason
+
+- Consistency over novelty ([01](../01-vendor-studio-vision.md))  
+- Maintainability in `myeventlane_vendor_theme`  
+- Accessibility: fewer one-off patterns to QA  
+- Aligns with brand governance: reuse before invent  
+
+Contracts: [05-component-library.md](../05-component-library.md) · anti-patterns: [19](../19-anti-patterns.md).
+
+---
+
+## Consequences
+
+- Component additions require purpose, a11y, responsive, Drupal mapping stubs in [05](../05-component-library.md)  
+- Dashboard prefers Task List + Metric Cards over novel widgets  
+- Nested cards are a review failure  
+
+---
+
+## Future review triggers
+
+- Genuine new interaction model with no MEL analogue (must still document in 05)  
+- Design system package extraction (if productised later)  
+- Dark mode requiring component token audits (Phase 12)  

--- a/docs/design/vendor-studio/decisions/DDR-005-mobile-first.md
+++ b/docs/design/vendor-studio/decisions/DDR-005-mobile-first.md
@@ -1,0 +1,57 @@
+# DDR-005 — Mobile as a first-class operating surface
+
+**Status:** Accepted  
+**Date:** 2026-07-25  
+**Version:** RC1  
+**Owners:** Design Authority · Product Owner
+
+---
+
+## Decision
+
+Vendor Studio is designed **mobile-first for urgent organiser jobs** (Door Mode, today’s attention, quick sales checks). Baseline composition is **390px**, enhance upward. Mobile is not a shrunk desktop.
+
+---
+
+## Problem
+
+Desktop-only console thinking fails at the door, on-site, and for organisers who manage events from a phone. Hover-only actions and miniature sidebars destroy operability.
+
+---
+
+## Alternatives considered
+
+| Alternative | Why not |
+| --- | --- |
+| Desktop-only “pro” console | Abandons live event reality |
+| Separate mobile app as the only fix | Delays web excellence; dual systems |
+| Bottom nav replacing IA entirely without research | Risks hiding money/support jobs |
+| Shortcut-first Door Mode | Stress + accessibility failure |
+
+---
+
+## Reason
+
+- Organiser experience under stress  
+- Accessibility and touch targets  
+- Product clarity: one responsive system  
+- Aligns with MEL brand mobile-first rule  
+
+Authoritative detail: [08-mobile-guidelines.md](../08-mobile-guidelines.md) · Door Mode: [13](../13-event-workspace-philosophy.md).
+
+---
+
+## Consequences
+
+- Hover never holds essential info  
+- Tables pick one mobile pattern per surface  
+- Sticky primary actions when commit requires it  
+- Offline-first Door Mode enhancements remain v2 unless promoted  
+
+---
+
+## Future review triggers
+
+- Validated bottom-nav information architecture study  
+- Offline-first Door Mode program ([20](../20-vendor-studio-v2-vision.md))  
+- PWA / installable console product decision  

--- a/docs/design/vendor-studio/decisions/DDR-006-payments-hub.md
+++ b/docs/design/vendor-studio/decisions/DDR-006-payments-hub.md
@@ -1,0 +1,57 @@
+# DDR-006 — Payments hub
+
+**Status:** Accepted  
+**Date:** 2026-07-25  
+**Pack version:** RC1.1  
+**Owners:** Design Authority · Product Owner · Technical Authority
+
+---
+
+## Decision
+
+Vendor Studio provides a single global **Payments** hub for Stripe connection, payouts, refunds entry points, and tax-related organiser tasks — rather than scattering money links across the shell.
+
+---
+
+## Problem
+
+When payouts, Stripe, and refunds appear as disconnected nav items, organisers cannot answer “Where is money?” in five seconds. Trust erodes; support tickets rise; Commerce reality feels fragmented.
+
+---
+
+## Alternatives considered
+
+| Alternative | Why not |
+| --- | --- |
+| Keep Payouts / Stripe / Refunds as separate global peers | Inflates nav; duplicates money anxiety |
+| Bury all money under Settings | Hides high-trust jobs; fails findability |
+| Put all refunds only under Orders | Misses account-level Stripe/payout readiness |
+| Expose Commerce payment gateway UI vocabulary | Violates hide-complexity principle |
+
+---
+
+## Reason
+
+- Organiser experience: one money home  
+- Product clarity: Orders = records; Payments = account money apparatus  
+- Commerce-aware: UI hubs must not invent state; deep links to truthful flows  
+- IA weight: high trust, moderate frequency → hub after Messages, before Analytics  
+
+Authoritative IA: [02-information-architecture.md](../02-information-architecture.md).
+
+---
+
+## Consequences
+
+- Shell shows **Payments**, not a cluster of money synonyms  
+- Refund *actions* remain deliberate from Orders; Payments hub provides orientation + account setup  
+- Copy stays sober ([15](../15-copywriting-guide.md)); no playful money ([19](../19-anti-patterns.md))  
+- Implementation must not weaken Stripe Connect / access rules  
+
+---
+
+## Future review triggers
+
+- Tax product expansion requiring IA weight change  
+- Evidence that refunds need a top-level peer again (unlikely — prefer Orders + Payments)  
+- Multi-entity payout structures for teams/collaboration  

--- a/docs/design/vendor-studio/decisions/DDR-007-marketing-analytics-separation.md
+++ b/docs/design/vendor-studio/decisions/DDR-007-marketing-analytics-separation.md
@@ -1,0 +1,54 @@
+# DDR-007 — Marketing separate from Analytics
+
+**Status:** Accepted  
+**Date:** 2026-07-25  
+**Pack version:** RC1.1  
+**Owners:** Design Authority · Product Owner
+
+---
+
+## Decision
+
+**Marketing** (Boost, share, growth actions) and **Analytics** (understand performance) are separate global hubs with separate jobs. They must not be merged into a single “Insights/Grow” chimera.
+
+---
+
+## Problem
+
+Collapsing growth actions and reporting into one nav item forces organisers to learn MEL’s internal naming (e.g. Insights vs Analytics) and buries spend decisions inside charts — or buries truth inside promotional chrome.
+
+---
+
+## Alternatives considered
+
+| Alternative | Why not |
+| --- | --- |
+| Single “Insights” hub for both | Job confusion; naming debt |
+| Marketing only inside Event Workspace | Cross-event growth tools still need a global home; event-scoped marketing remains in Workspace |
+| Analytics under Dashboard only | Dilutes Dashboard Action Queue; reporting needs a dedicated pulse |
+| Competitor-parity mega growth suite | Scope and FOMO risk; violates MEL brand |
+
+---
+
+## Reason
+
+- Product clarity: **grow** vs **understand**  
+- Dashboard stays attention-led ([12](../12-dashboard-philosophy.md))  
+- Marketing uses Wide layout intent; Analytics uses honest KPIs/charts ([11](../11-design-tokens.md), [06](../06-workspace-patterns.md))  
+- Avoids decorative metrics dressed as growth ([19](../19-anti-patterns.md))  
+
+---
+
+## Consequences
+
+- Global nav includes both Marketing and Analytics  
+- Event Workspace retains event-scoped Marketing and Analytics sections  
+- Labels prefer Analytics over ambiguous Insights in future IA  
+- Small-screen nesting only with research ([02](../02-information-architecture.md) future notes)  
+
+---
+
+## Future review triggers
+
+- Research-proven need to nest Marketing under Analytics on small screens  
+- New growth products that change job frequency enough to warrant IA redesign (requires new DDR)  


### PR DESCRIPTION
## Summary

- Freeze **Vendor Studio Product Design System (PDS) v1.0** (also known as Design Operating System) as the governing product standard for all Vendor Studio work.
- Full pack under `docs/design/vendor-studio/` (vision, IA, tokens, patterns, governance, DDRs, DoD, architecture, index).
- Add `.github/PULL_REQUEST_TEMPLATE.md` requiring **Vendor Studio Design System References** on relevant PRs.
- Prefer GitHub label `design-system` for Vendor Studio changes.

## Vendor Studio Design System References

This implementation follows:

- README.md / INDEX.md (PDS v1.0 FROZEN)
- ADR-0001
- 21-definition-of-done.md
- 23-governance-lifecycle.md
- CONTRIBUTING.md

## Test plan

- [x] Documentation only — no PHP/Twig/SCSS/JS/YAML runtime changes
- [x] Pre-commit hooks passed
- [ ] Confirm merge to `main` and optional git tag `vendor-studio-pds-v1.0`

## Risk

None for runtime. Establishes mandatory PDS citation for future Vendor Studio work.


Made with [Cursor](https://cursor.com)