### PR TITLE
Vendor Workspace Foundation (Mission Control + DDR-008/009)

### DIFF
--- a/docs/design/vendor-studio/CHANGELOG.md
+++ b/docs/design/vendor-studio/CHANGELOG.md
@@ -8,6 +8,20 @@ Versioning follows the Versioning Policy in [README.md](README.md#versioning-pol
 
 ---
 
+## [1.0.1] — 2026-07-25 — Foundation governance
+
+### Accepted
+
+- **DDR-008** — Canonical Event Workspace (path & shell): organiser product on `mel_event_studio_workspace`; transitional `/studio` paths; path unification deferred; Mission Control + Hero CTA contract documented against shipped Foundation.
+- **DDR-009** — Workspace Navigation: `EventStudioSectionManager` sole organiser nav source; Attendees before Orders; Door Mode under Attendees (direction); Home/Details/Images labels match runtime.
+
+### Notes
+
+- PDS design philosophy remains **1.0 FROZEN**; this entry records accepted DDRs for Vendor Workspace Foundation merge preparation.
+- Path rename (`/vendor/events/{id}` without `/studio`) and Door Mode chrome nesting remain post-Foundation work.
+
+---
+
 ## [1.0] — 2026-07-25 — FROZEN
 
 ### Declared

--- a/docs/design/vendor-studio/INDEX.md
+++ b/docs/design/vendor-studio/INDEX.md
@@ -92,6 +92,8 @@ Full reading paths: [README.md](README.md) · [CONTRIBUTING.md](CONTRIBUTING.md)
 | [DDR-005](decisions/DDR-005-mobile-first.md) | Mobile-first ops |
 | [DDR-006](decisions/DDR-006-payments-hub.md) | Payments hub |
 | [DDR-007](decisions/DDR-007-marketing-analytics-separation.md) | Marketing ≠ Analytics |
+| [DDR-008](decisions/DDR-008-canonical-event-workspace.md) | Canonical Event Workspace shell · transitional `/studio` |
+| [DDR-009](decisions/DDR-009-workspace-navigation.md) | Workspace section nav · Attendees before Orders |
 
 ### Appendices
 

--- a/docs/design/vendor-studio/README.md
+++ b/docs/design/vendor-studio/README.md
@@ -156,6 +156,8 @@ Role-based paths: [CONTRIBUTING.md](CONTRIBUTING.md).
 | [DDR-005](decisions/DDR-005-mobile-first.md) | Mobile as first-class ops surface |
 | [DDR-006](decisions/DDR-006-payments-hub.md) | Payments hub |
 | [DDR-007](decisions/DDR-007-marketing-analytics-separation.md) | Marketing separate from Analytics |
+| [DDR-008](decisions/DDR-008-canonical-event-workspace.md) | Canonical Event Workspace shell · transitional `/studio` |
+| [DDR-009](decisions/DDR-009-workspace-navigation.md) | Workspace section nav · Attendees before Orders |
 
 ### Appendices
 

--- a/docs/design/vendor-studio/decisions/DDR-008-canonical-event-workspace.md
+++ b/docs/design/vendor-studio/decisions/DDR-008-canonical-event-workspace.md
@@ -1,0 +1,93 @@
+# DDR-008 — Canonical Event Workspace (path & shell)
+
+**Status:** Accepted  
+**Date accepted:** 2026-07-25  
+**Version:** 1.0  
+**Owners:** Design Authority · Product Owner · Technical Authority  
+**Sprint origin:** Vendor Workspace v2 — Foundation (Phase A / Phase 2A)  
+**Related:** [DDR-002](DDR-002-event-workspace.md) · [DDR-009](DDR-009-workspace-navigation.md) · [13](../13-event-workspace-philosophy.md) · [07-workspace-unification.md](../../vendor-workspace-v2/07-workspace-unification.md)
+
+---
+
+## Decision (accepted)
+
+1. **Organiser Event Workspace** is a single application implemented by `myeventlane_event_studio` (`mel_event_studio_workspace`).
+2. **Shipped organiser runtime paths (Foundation):** `/vendor/events/{node}/studio` and `/vendor/events/{node}/studio/{section}`.
+3. **Canonical target paths (path-unification phase):** `/vendor/events/{id}` and `/vendor/events/{id}/{section}` — aligns DDR-002; not renamed in Foundation.
+4. **`/studio` prefix** is transitional product truth until path unification ships; permanent redirects will preserve bookmarks and help links.
+5. **`mel_event_workspace` (Manager)** is **Staff Operations** intent — organisers must not land there for ordinary event work (staff-gate remains phased work).
+6. **Door Mode** remains an event-scoped capability; chrome continuity with Event Workspace is mandatory even if the route path migrates later.
+7. **Home Mission Control** is the shared operational card for Home and non-Home chrome (`mel_event_studio_mission_control`), fed by `EventWorkspaceOverviewBuilder` / `EventReadinessFacade` — not a second readiness engine.
+
+---
+
+## Shipped Foundation runtime (authority)
+
+| Surface | Runtime truth |
+| --- | --- |
+| Organiser shell theme | `mel_event_studio_workspace` |
+| Controller | `EventStudioController` |
+| Routes | `myeventlane_event_studio.routing.yml` — `/vendor/events/{node}/studio*` |
+| Workspace Hero | `mel-event-studio-topbar.html.twig` — identity · status · one primary CTA |
+| Mission Control | `mel-event-studio-mission-control.html.twig` — next step · improvements · Event Quality |
+| Primary CTA contract | `EventWorkspaceOverviewBuilder::resolveAuthoritativePrimaryCta()` — Hero + Mission Control share lifecycle CTA; Stripe Connect is the only Mission Control exception |
+| Readiness authority | `EventReadinessFacade` (unchanged) |
+| Homepage quality score | Existing `FeaturedEventReadinessService` presentation `score` — Event Quality section only |
+
+Foundation does **not** invent a third shell or a parallel scoring system.
+
+---
+
+## Problem (historical)
+
+Accepted **DDR-002** decided “one Event Workspace” and listed paths without `/studio`. Pre-Foundation runtime used `/studio` and dual Studio/Manager themes. Organisers were mostly protected by `VendorLegacyWizardRedirectSubscriber`, but dual shells created support confusion and Door Mode chrome breaks.
+
+---
+
+## Migration remaining (post-Foundation)
+
+| Phase | Work | Foundation status |
+| --- | --- | --- |
+| **1 — Product clarity** | Organiser UI says **Event Workspace**; Manager = Staff Operations | **Shipped** (organiser chrome/copy) |
+| **2 — Path unification** | Routes → `/vendor/events/{id}[/{section}]`; redirects from `/studio` | **Not started** |
+| **3 — Staff Operations** | Staff-gate Manager organiser entry; Door Mode chrome continuity | **Not started** |
+
+---
+
+## Alternatives considered
+
+| Alternative | Assessment |
+| --- | --- |
+| **A. Path-unify to DDR-002** (accepted direction) | Rename organiser routes after Foundation; keep Studio theme; redirect `/studio/*`; staff-gate Manager |
+| **B. Amend DDR-002 to `/studio` forever** | Rejected as permanent product history in URLs |
+| **C. Keep dual shells indefinitely** | Rejected — fails PDS 13 / DDR-001 spirit |
+| **D. Rebuild on Manager theme** | Rejected — abandons Studio section/plugin stack |
+| **E. New third theme for v2** | Forbidden |
+
+---
+
+## Consequences
+
+- Organiser product extension point is `mel_event_studio_workspace` only.
+- Implementation and help may cite `/studio` until Phase 2 completes; docs must call it transitional.
+- Path rename, redirect inventory, and Door Mode chrome continuity remain explicit follow-on work — not Foundation blockers.
+- Publishing Experience (Phase 3) proceeds only after this Foundation merge.
+
+---
+
+## Future review triggers
+
+- Multi-event bulk ops requiring different URL shapes
+- Evidence that `/vendor/events/{id}` collides with non-Workspace console routes
+- Door Mode offline / PWA productisation
+- Staff Operations surfaces needing a dedicated staff theme
+
+---
+
+## Approval checklist
+
+- [x] Design Authority — product clarity & IA (Foundation merge preparation)
+- [x] Technical Authority — shell, routes (transitional), access, cache, no third readiness engine
+- [x] Product Owner — Foundation merge approved; path unification deferred
+- [x] Status **Accepted** + CHANGELOG entry
+- [x] INDEX decision table updated

--- a/docs/design/vendor-studio/decisions/DDR-009-workspace-navigation.md
+++ b/docs/design/vendor-studio/decisions/DDR-009-workspace-navigation.md
@@ -1,0 +1,131 @@
+# DDR-009 — Workspace Navigation
+
+**Status:** Accepted  
+**Date accepted:** 2026-07-25  
+**Version:** 1.0  
+**Owners:** Design Authority · Product Owner · Technical Authority  
+**Sprint origin:** Vendor Workspace v2 — Foundation (Phase A / Phase 2A)  
+**Related:** [DDR-001](DDR-001-shell-navigation.md) · [DDR-002](DDR-002-event-workspace.md) · [DDR-008](DDR-008-canonical-event-workspace.md) · [02](../02-information-architecture.md) · [13](../13-event-workspace-philosophy.md) · [07-workspace-unification.md](../../vendor-workspace-v2/07-workspace-unification.md)
+
+---
+
+## Decision (accepted)
+
+1. **Single nav source** for Event Workspace section membership and order: `EventStudioSectionManager` + `Plugin/EventStudioSection/*`.
+2. **Event Workspace section order** (organiser product — labels as shipped):
+
+```text
+Home → Details → Schedule → Venue → Images → Tickets
+→ Attendees → Messages → Marketing → Orders
+→ Analytics → Publishing → Settings
+```
+
+3. **Door Mode** is presented as a mode/entry under **Attendees**, not as a global shell peer and not as a competing top-level Workspace product. (Entry UX nesting remains follow-on; route may stay stable initially.)
+4. **Global shell order is unchanged by this DDR:** global Orders may remain before global Attendees (PDS 02). Workspace order may differ because live ops are event-primary.
+5. **PDS 13** section order text should be amended under governance to match this accepted order (queued — not a silent edit outside CHANGELOG/INDEX).
+6. Duplicate authorities (`VendorEventTabsService`, shortened console preprocess lists, Manager local tasks for organisers) are retired or staff-gated over time — they must not redefine organiser IA.
+
+---
+
+## Shipped Foundation navigation (authority)
+
+### Studio section weights (organiser truth)
+
+| Weight | Machine id | Organiser label | Route pattern |
+| --- | --- | --- | --- |
+| 0 | `overview` | Home | `…/studio` |
+| 10 | `information` | Details | `…/studio/information` |
+| 20 | `schedule` | Schedule | `…/studio/schedule` |
+| 30 | `venue` | Venue | `…/studio/venue` |
+| 40 | `branding` | Images | `…/studio/branding` |
+| 50 | `tickets` | Tickets | `…/studio/tickets` |
+| 60 | `attendees` | Attendees | `…/studio/attendees` |
+| 70 | `messaging` | Messages | `…/studio/messaging` |
+| 80 | `marketing` | Marketing | `…/studio/marketing` |
+| 90 | `orders` | Orders | `…/studio/orders` |
+| 100 | `analytics` | Analytics | `…/studio/analytics` |
+| 110 | `publishing` | Publishing | `…/studio/publishing` |
+| 120 | `settings` | Settings | `…/studio/settings` |
+
+Hidden / nested plugins (examples): Questions, Capacity, Extras, Content, Fulfilment — `navigationVisible: FALSE`.
+
+Paths remain on transitional `/studio` per [DDR-008](DDR-008-canonical-event-workspace.md).
+
+### Event chrome (constant)
+
+```text
+[← Events]  Event name · Status badge · Primary CTA · Secondary (View / Share)
+```
+
+Hero owns the visual primary CTA. Mission Control mirrors the same authoritative next action (`resolveAuthoritativePrimaryCta`), except the approved Stripe Connect exception.
+
+### Door Mode (accepted direction)
+
+```text
+Attendees
+  └── Door Mode  (mode / full-stress UI)
+```
+
+- ≤2 taps from Home when state is Live / door-imminent (product target).
+- Same event identity visible; no “you left Workspace” feeling.
+- Check-in access and mutations remain server-authoritative.
+
+### Lifecycle emphasis (not membership)
+
+Nav membership is stable. Visual emphasis may highlight Attendees/Door when Live, Publishing when Ready, Orders when Completed — see `08-event-lifecycle-model.md` and `11-operational-state-model.md`.
+
+---
+
+## Operational reasoning
+
+| Choice | Why |
+| --- | --- |
+| Attendees before Orders in Workspace | Door and guest prep dominate live stress; money trail remains one tap away; matches shipped weights |
+| Orders before Attendees in **global** nav | Cross-event reconciliation is a business job (PDS 02) — unchanged |
+| Marketing before Orders | Growth actions often precede deep order inspection while Selling |
+| Publishing near end | Deliberate gate after build/ops sections; Hero still surfaces publish CTA when Ready |
+| Single nav source | Stops triple-definition drift; one place for a11y labels and mobile priority |
+
+---
+
+## Migration remaining
+
+| Phase | Work | Foundation status |
+| --- | --- | --- |
+| **1** | Declare `EventStudioSectionManager` sole organiser nav authority | **Shipped** (runtime + this DDR) |
+| **2** | Align / retire `VendorEventTabsService` + console preprocess organiser use | **Not started** |
+| **3** | Door Mode entry UX under Attendees (presentation); keep route stable initially | **Not started** |
+| **4** | Staff-gate Manager tabs for organisers | **Not started** |
+
+---
+
+## Risks
+
+| Risk | Severity | Mitigation |
+| --- | --- | --- |
+| Help/docs still teach Orders-before-Attendees inside Workspace | Medium | Update copy with PDS 13 amendment |
+| Reordering visible nav without weight/tests | Medium | Keep weights; snapshot tests on section order |
+| Door Mode access regression | High | No permission changes in nav-only / Foundation PRs |
+| Mobile drawer hiding Orders | Medium | Preserve mobile_priority metadata; audit 390px |
+| Global vs Workspace order confusion for support | Low | Document in glossary / staff playbook |
+
+---
+
+## Alternatives considered
+
+| Alternative | Why not |
+| --- | --- |
+| Force PDS 13 Orders-before-Attendees in runtime | Fights live-ops priority and shipped weights |
+| Make Door Mode a Workspace top-level section | Inflates nav; contradicts DDR-002 |
+| Keep multiple nav builders forever | Permanent drift |
+| Different section sets per lifecycle | Breaks shell constancy |
+
+---
+
+## Approval checklist
+
+- [x] Design Authority
+- [x] Product Owner (IA weight — Attendees before Orders)
+- [x] Technical Authority (nav builders, Door Mode access adjacency)
+- [x] PDS 13 amendment queued under governance
+- [x] Status **Accepted** + CHANGELOG

--- a/docs/design/vendor-workspace-v2/00-runtime-discovery.md
+++ b/docs/design/vendor-workspace-v2/00-runtime-discovery.md
@@ -1,0 +1,396 @@
+# Vendor Workspace v2 — Runtime Discovery
+
+**Status:** Discovery only (no runtime changes)  
+**Branch:** `feature/vendor-workspace-v2-discovery`  
+**Commit:** `37fcdc4494b4c841b55eb01fbde59cbd0f7aaba9` (`origin/main` — PR #716 Dashboard Foundation merged)  
+**Date:** 2026-07-25  
+**Authority:** Vendor Studio PDS v1.0 (pack) · cursor rule claims v1.0.1 — see conflicts below
+
+No Twig, SCSS, PHP, JS, YAML, routes, builders, or view models were modified for this document.
+
+---
+
+## Stage 1 — Repository health
+
+| Check | Result |
+| --- | --- |
+| Working tree | Clean at branch creation |
+| Branch | `feature/vendor-workspace-v2-discovery` from latest `origin/main` |
+| Dashboard Foundation | **Merged** — `37fcdc449` Merge PR #716 (`feature/vendor-dashboard-v2-slice2`) |
+| Config drift | **Present** — see §1.1 |
+| Runtime safety | Bootstrap OK (DDEV Drupal 11.4.4); Workspace dual-shell remains (see §2) |
+
+### 1.1 Config drift affecting Workspace
+
+`ddev drush config:status` shows local active ≠ sync. Workspace-relevant diffs:
+
+| Config | Drift | Workspace impact |
+| --- | --- | --- |
+| `user.role.vendor` | Active **missing** permission `resend ticket emails` that exists in sync | Ticket/attendee ops capability may differ from exported intent |
+| `views.view.myeventlane_vendor_rsvps` | Active **missing** `organiser_owned` filter present in sync | RSVP list isolation weaker in active DB than in repo sync — **access-adjacent** |
+
+Other drift (Klaro apps, payment gateways, checkout flow, help content, `field_product_target`) is **not** Event Workspace chrome, but payment/checkout items remain high risk for any later publish/Stripe work.
+
+**Stage 1 verdict:** Discovery may proceed (docs only). **Implementation must not start** until Workspace-relevant config is reconciled (especially RSVP organiser ownership filter and vendor role perms).
+
+---
+
+## Stage 2 — PDS governance map (why each doc governs Event Workspace)
+
+| Document | Why it governs Event Workspace |
+| --- | --- |
+| **01 Vision** | Golden Rule / Three Questions / Ten Principles apply to every Workspace screen (next step, honesty, hide Commerce language). |
+| **02 Information Architecture** | Defines Workspace as contextual app under Events; forbids dual Studio/Manager products; section nesting rules. |
+| **03 Layout System** | Event chrome + Workspace/Reading intents for Overview next-action vs wide ops boards. |
+| **05 Component Library** | Contracts for Workspace Hero, readiness, metrics, alerts, tables used inside the event app. |
+| **06 Workspace Patterns** | Page composition for Event Workspace (readiness + next action + KPIs + activity). |
+| **07 Interaction Guidelines** | Autosave vs explicit publish/money confirm; focus, loading, keyboard under ops stress. |
+| **08 Mobile Guidelines** | Door Mode, sticky CTAs, 390px baseline for live event phone use. |
+| **09 Drupal Mapping** | Homes for theme, routes, builders, Commerce boundaries — prevents parallel trees. |
+| **11 Design Tokens** | Spacing, intents, severity colours for Workspace chrome consistency. |
+| **13 Event Workspace Philosophy** | **Primary** Workspace specification: shell, sections, readiness, publish, lifecycle, Door Mode. |
+| **15 Copywriting Guide** | Organiser language for status, blockers, publish, refunds — no CMS vocabulary. |
+| **16 Design Review Checklist** | PR gate (IA1 no dual nav, readiness honesty, a11y, mobile). |
+| **18 Product Success Metrics** | Time-to-publish, next-step clarity, Door Mode usability targets for Workspace work. |
+| **19 Anti-patterns** | Dual nav, fake readiness, nested cards, CMS chrome — common Workspace failure modes. |
+| **21 Definition of Done** | Completion gates before calling Workspace slices “done”. |
+| **ADR-0001** | Constitution / precedence — Workspace design cannot silently override higher docs. |
+| **ADR-0002** | **MISSING from repository** — referenced by `.cursor/rules/mel-vendor-studio-pds.mdc` as `ADR-0002-implementation-follows-pds.md`. Pack README is v1.0 FROZEN without ADR-0002. |
+| **DDR-001** | One global shell — Workspace must not reintroduce parallel global nav. |
+| **DDR-002** | One Event Workspace; canonical paths `/vendor/events/{id}` · `/{section}`. |
+| **DDR-003** | Layout intents for Workspace content widths. |
+| **DDR-004** | Extend MEL components; no parallel `vendor-studio-*` kit. |
+| **DDR-005** | Mobile-first ops including Door Mode. |
+
+### PDS ↔ runtime conflicts (STOP / DDR)
+
+| Conflict | PDS / DDR claim | Runtime evidence | Recommendation |
+| --- | --- | --- | --- |
+| **C1 Dual shells** | DDR-002 / 13: one Event Workspace | Organisers redirected into Studio (`mel_event_studio_workspace`); Manager (`mel_event_workspace`) remains for staff / uid 1 / deep links | **DDR** (or DDR-002 amendment): declare Studio-under-`/studio` as transitional canonical **or** path-unify to `/vendor/events/{id}/{section}` |
+| **C2 Path shape** | DDR-002: `/vendor/events/{id}` and `/{section}` | Product path is `/vendor/events/{node}/studio` (+ `/studio/{section}`) | Same DDR as C1 |
+| **C3 Section order** | 13: … Tickets → **Orders** → Attendees → … | Studio nav + `VendorEventTabsService`: Tickets → **Attendees** → Messages → Marketing → **Orders** | Clarify in DDR: live-ops priority vs money trail; amend 13 if Attendees-before-Orders is intentional |
+| **C4 ADR-0002 missing** | Cursor rule requires ADR-0002 | No `docs/design/vendor-studio/decisions/ADR-0002-*.md` | Author ADR-0002 (implementation follows PDS) or remove rule reference |
+| **C5 Version label** | Rule: PDS v1.0.1 | Pack README/INDEX: **1.0 FROZEN** | Align CHANGELOG / README via governance lifecycle |
+
+These are **design authority conflicts**. Discovery documents them; it does **not** invent a new architecture.
+
+---
+
+## 2. Executive runtime verdict
+
+At this commit, **organiser product truth** for per-event work is **Event Studio Workspace**:
+
+- Theme: `mel_event_studio_workspace`
+- Entry: `/vendor/events/{node}/studio`
+- Redirect: `VendorLegacyWizardRedirectSubscriber` sends trusted organisers away from most Manager routes
+
+**Manager Event Workspace** (`mel_event_workspace`, `/vendor/events/{event}`) remains in code for staff (`administer nodes` / uid 1) and some surfaces (notably **Door Mode** still renders Manager shell).
+
+Dashboard v2 Foundation (merged) is the **global** attention home; Event Workspace Home is the **per-event** mission control — they must not duplicate business-wide queues.
+
+---
+
+## 3. Routes
+
+### 3.1 Manager console (`myeventlane_vendor.routing.yml`)
+
+| Route | Path | Notes |
+| --- | --- | --- |
+| `myeventlane_vendor.console.event_workspace` | `/vendor/events/{event}` | `EventWorkspaceController::workspace` → redirected for organisers |
+| `…event_overview` | `…/overview` | Overview controller |
+| `…event_tickets` | `…/tickets` | Ticket manager form |
+| `…event_orders` | `…/orders` | Orders list |
+| `…event_order_view` | `…/orders/{order}` | Order detail |
+| `…event_operational_addon_orders` | `…/addons` | Add-on orders |
+| `…event_rsvps` | `…/rsvps` | RSVPs |
+| `…event_analytics` | `…/analytics` | Analytics (Pro-gated in places) |
+| `…event_settings` | `…/settings` | Settings |
+| `…event_publish` | `…/publish` | Redirect toward Studio |
+| `…event_unpublish` | `…/unpublish` | Unpublish form |
+| `…event_promotion` | `…/promotion` | Legacy comms |
+| `myeventlane_event_attendees.vendor_list` | `/vendor/events/{node}/attendees` | Attendees |
+| `myeventlane_event_attendees.vendor_operations_door` | `/vendor/events/{node}/operations/door` | **Door Mode** (kept) |
+
+### 3.2 Event Studio (`myeventlane_event_studio.routing.yml`)
+
+| Route | Path | Section |
+| --- | --- | --- |
+| `myeventlane_event_studio.workspace` | `/vendor/events/{node}/studio` | overview (Home) |
+| `…workspace_information` / `details` | `…/studio/information` | information |
+| `…workspace_schedule` | `…/studio/schedule` | schedule |
+| `…workspace_venue` | `…/studio/venue` | venue |
+| `…workspace_branding` / `images` | `…/studio/branding` | branding |
+| `…workspace_tickets` | `…/studio/tickets` | tickets |
+| `…workspace_attendees` | `…/studio/attendees` | attendees |
+| `…workspace_messaging` | `…/studio/messaging` | messaging |
+| `…workspace_marketing` | `…/studio/marketing` | marketing |
+| `…workspace_orders` | `…/studio/orders` | orders |
+| `…workspace_analytics` | `…/studio/analytics` | analytics |
+| `…workspace_publishing` | `…/studio/publishing` | publishing |
+| `…workspace_settings` | `…/studio/settings` | settings |
+| Hidden/nested | questions, capacity, extras, fulfilment, content | `navigationVisible: FALSE` on several plugins |
+| `myeventlane_event_studio.autosave` | `/vendor/events/autosave` | POST + CSRF header |
+| `myeventlane_event_studio.publish` | `/vendor/events/{node}/studio/publish` | POST + CSRF header |
+
+---
+
+## 4. Controllers
+
+| Controller | Theme / response |
+| --- | --- |
+| `EventStudioController::workspace` | `#theme => mel_event_studio_workspace` |
+| `EventStudioAutosaveController` | JSON |
+| `EventStudioPublishController` | JSON (+ Home guide AJAX refresh) |
+| `EventWorkspaceController::workspace` | `mel_event_workspace` via `buildVendorPage` |
+| Vendor event Orders / Overview / Analytics / Settings / RSVP / Attendees / Addon | `mel_event_workspace` |
+| Door Mode ops | `mel_event_workspace` + venue ops library |
+
+---
+
+## 5. Builders & view models
+
+| Service / class | Module | Role |
+| --- | --- | --- |
+| `EventWorkspaceOverviewBuilder` | `myeventlane_event_studio` | Studio **Home** render (`mel_event_studio_overview`) — readiness, next action, ops cards |
+| `VendorEventWorkspaceViewModelBuilder` | `myeventlane_vendor` | Mission-control payload; **reused** by Home guide state |
+| `EventStudioSectionManager` + `Plugin/EventStudioSection/*` | `myeventlane_event_studio` | Section nav + metadata |
+| `EventStudioSectionRenderer` | `myeventlane_event_studio` | Section bodies (Home → overview builder) |
+| `EventStudioWorkspacePresentation` | `myeventlane_event_studio` | Readiness strip / event health |
+| `EventReadinessFacade` / `EventReadinessService` | `myeventlane_event_studio` | Publish readiness evaluation |
+| `PublishEligibilityEvaluator` | `myeventlane_event_studio` | Publish gating |
+| `PaidPublishStripeGate` | (Studio stack) | Stripe health on Home |
+| `VendorEventTabsService` | `myeventlane_vendor` | Tab rows (mostly Studio route targets) |
+| `EventStudioSaveService` / `EventStudioAutosaveService` | `myeventlane_event_studio` | Persist + draft autosave |
+| Sales / extras summary builders | `myeventlane_event_studio` | Compact panels on Manager root |
+
+---
+
+## 6. Twig templates
+
+### Studio shell
+
+| Hook / file |
+| --- |
+| `mel-event-studio-workspace.html.twig` |
+| `mel-event-studio-overview.html.twig` (Home) |
+| `mel-event-studio-sidebar.html.twig` |
+| `mel-event-studio-topbar.html.twig` |
+| `mel-event-studio-section.html.twig` |
+| `mel-event-studio-attendees-workspace.html.twig` |
+
+Registered in `myeventlane_event_studio.module` `hook_theme()`.
+
+### Manager shell
+
+| File |
+| --- |
+| `web/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig` |
+| `…/components/workspace/workspace-tabs.html.twig` |
+| `…/components/workspace/workspace-header.html.twig` |
+| `…/event/mel-event-overview-page.html.twig` |
+| `…/event/mel-event-settings-page.html.twig` |
+
+---
+
+## 7. Theme suggestions & preprocess
+
+| Mechanism | Evidence |
+| --- | --- |
+| Studio preprocess | `template_preprocess_mel_event_studio()` → `EventStudioPreprocess` |
+| Studio HTML markers | `myeventlane_event_studio_preprocess_html` |
+| Manager workspace preprocess | `myeventlane_vendor_theme_preprocess_mel_event_workspace()` |
+| Console page tabs | `VendorConsolePagePreprocess` (shorter Studio URL list) |
+| Vendor theme negotiator | `VendorThemeNegotiator` → `myeventlane_vendor_theme` for `/vendor/*` |
+
+---
+
+## 8. Libraries & SCSS
+
+| Library | Role |
+| --- | --- |
+| `myeventlane_event_studio/mel_event_studio_shell_only` | Studio workspace shell CSS/JS |
+| `myeventlane_event_studio/mel_event_studio_tickets_app` / `attendees_app` | Section apps |
+| `myeventlane_vendor_theme/vendor-workspace` | Manager shell grid (`workspace.scss`) |
+| `myeventlane_vendor_theme/event_mission_control` | Mission-control SCSS |
+| `myeventlane_vendor_theme/event_overview` | Overview / charts |
+| Panel libs | Ticket/extras sales panel CSS from Event Studio |
+
+SCSS homes: `mel-event-studio-shell.css`, `mel-event-studio-nav.css`, vendor `_event-mission-control.scss`, `_workspace.scss`, `workspace.scss`.
+
+---
+
+## 9. Cache
+
+| Surface | Evidence |
+| --- | --- |
+| Studio workspace | `#cache` tags = `$node->getCacheTags()`; contexts `route`, `user`, `user.permissions`, `url.query_args:mel_celebrate` |
+| Studio access | Cacheable deps on event/vendor + user contexts |
+| Manager `EventWorkspaceController` | **No** `#cache` on workspace root render array |
+| Manager overview body | Tags/contexts from `$event` |
+| `VendorEventWorkspaceViewModelBuilder` | No builder-level `#cache` metadata |
+
+---
+
+## 10. Workspace shell
+
+| Concern | Studio (organiser) | Manager (staff / residual) |
+| --- | --- | --- |
+| Theme | `mel_event_studio_workspace` | `mel_event_workspace` |
+| Event chrome | Topbar (name, status, publish) | Workspace header + tabs |
+| Section nav | Sidebar plugins (`EventStudioSectionManager`) | Tabs Twig + local tasks + `VendorEventTabsService` |
+| Global shell | Same vendor theme sidebar (DDR-001) | Same |
+
+**Triple nav sources (debt):** Studio sidebar plugins ≠ `VendorEventTabsService` ≠ `VendorConsolePagePreprocess` ≠ Drupal local tasks.
+
+---
+
+## 11. Per-surface inventory
+
+| Surface | Exists | Primary organiser home | Reusable? | Never change casually |
+| --- | --- | --- | --- | --- |
+| **Overview / Home** | Yes | Studio `workspace` + `EventWorkspaceOverviewBuilder` | Yes — extend Home, don’t fork | Next-action resolution order |
+| **Publishing** | Yes | `workspace_publishing` | Yes | `PublishEligibilityEvaluator` + CSRF publish |
+| **Readiness** | Yes | Home + strip + Publishing | Yes — facade | Honesty of green/ready |
+| **Tickets** | Yes | `workspace_tickets` | Yes | Commerce variation modelling |
+| **Orders** | Yes | `workspace_orders` (readonly section) | Yes | Order ownership / payment state |
+| **Attendees** | Yes | `workspace_attendees` | Yes | Access / PII |
+| **Messages** | Yes | `workspace_messaging` | Yes | Audience boundaries |
+| **Marketing** | Yes | `workspace_marketing` | Yes | Boost spend honesty |
+| **Analytics** | Yes | `workspace_analytics` | Yes | Pro gating if present |
+| **Door Mode** | Yes | `/operations/door` (Manager theme) | Yes — keep under Attendees IA | Check-in mutation access |
+| **Settings** | Yes | `workspace_settings` | Yes | Dangerous toggles + ownership |
+
+---
+
+## 12. Current event payload
+
+### Studio Home (`EventWorkspaceOverviewBuilder::build`)
+
+```text
+#theme mel_event_studio_overview
+#event_ready, #next_action, #readiness
+#tickets, #attendees, #sales, #marketing, #boost, #analytics, #activity
+```
+
+### Shared VM (`VendorEventWorkspaceViewModelBuilder`) — confirmed top-level keys
+
+```text
+event { nid, title, status, status_label, status_severity, date_label,
+        event_type, event_type_label, public_url, image }
+readiness, operational_readiness, todays_focus, sales_snapshot
+action_grid { sales[], setup[], growth[] }
+readiness_summary, lifecycle_guidance, next_action, metrics, tabs
+actions { edit, advanced_tickets, edit_tickets, extras, promote, rsvps,
+          orders, addon_orders, attendees, checkin, analytics, settings, preview }
+presentation_alerts, empty_state
+```
+
+### Studio shell variables
+
+```text
+node, sections, sidebar_guidance, current_section*, section_content,
+topbar, event_health, readiness, homepage_readiness, boost*, publish_handoff
+```
+
+---
+
+## 13. CTA hierarchy (Studio Home — organiser truth)
+
+From `resolveNextRecommendedAction()` + overview Twig:
+
+1. **Primary:** Next recommended action (`next_action`) — booking/setup error from VM → publish blockers → Stripe connect → “Go to publishing” → “Share” (marketing)
+2. **Event Ready** card + expandable checklist
+3. **Ops cards** (Tickets, Attendees, Sales, Marketing, Boost, Analytics) with ghost CTAs
+4. **Topbar publish** (shell) — separate from Home next-action
+5. Mobile: Next Action `order: -1` below 720px (`mel-event-studio-shell.css`)
+
+Manager hero (if reached): Edit event → Preview → Advanced ticket tools + Today’s focus + action grid.
+
+---
+
+## 14. Save / autosave / publish
+
+| Flow | Runtime |
+| --- | --- |
+| Explicit section save | `EventStudioBaseForm` → `EventStudioSaveService::save` |
+| Autosave | POST `myeventlane_event_studio.autosave`; JS delay **12000ms**; only if section `supports_autosave`; draft-oriented |
+| Publish | POST `myeventlane_event_studio.publish`; dirty/stale/draft conflict checks; eligibility + Stripe gate; AJAX refreshes Home guide |
+| Money / refunds | Explicit confirm paths — do not silent-commit via autosave |
+
+---
+
+## 15. Navigation (Studio section order — weights)
+
+```text
+Home(0) → Details(10) → Schedule(20) → Venue(30) → Images(40) → Tickets(50)
+→ Attendees(60) → Messages(70) → Marketing(80) → Orders(90)
+→ Analytics(100) → Publishing(110) → Settings(120)
+```
+
+PDS 13 places **Orders before Attendees**. Runtime places **Attendees before Orders** (live-ops bias). Documented as conflict C3.
+
+---
+
+## 16. Mobile behaviour
+
+- Studio shell JS: mobile priority sidebar filtering (`data-mobile-priority`)
+- Home next-action promoted on small screens
+- Door Mode: separate stress UI; large targets expected by PDS 08/13
+- Breakpoints dense in shell CSS (480–900+)
+
+---
+
+## 17. What already exists / reusable / must not change
+
+### Already exists
+
+- Full Studio section plugin architecture
+- Home mission-control builder + readiness facade
+- Autosave + publish JSON APIs with CSRF
+- Manager mission-control VM + Twig (staff / residual)
+- Door Mode route and check-in stack
+- Legacy redirect funnel (organisers → Studio)
+
+### Reusable for Workspace v2
+
+- `EventWorkspaceOverviewBuilder` + overview Twig
+- `VendorEventWorkspaceViewModelBuilder` (shared next_action / focus)
+- Section plugins / `EventStudioSectionManager`
+- Readiness facade + publish eligibility
+- Vendor theme layout intents / tokens (DDR-003/11)
+- Shell libraries (`mel_event_studio_shell_only`)
+
+### Should never change without explicit risk review
+
+- `EventVendorAccessChecker` / `EventStudioAccess` / `accountHasWorkspaceParityForEvent`
+- Commerce order/payment state truth on Orders
+- Publish eligibility + Stripe paid-publish gate
+- Autosave dirty/stale vs publish conflict rules
+- CSRF on autosave/publish
+- Door Mode check-in access / mutations
+- Help audience boundaries
+
+---
+
+## 18. Redirect map (organiser funnel)
+
+Evidence: `VendorLegacyWizardRedirectSubscriber.php`
+
+Most Manager console event routes → Studio destinations. Door Mode routes handled separately (canonical door ops). Staff with `administer nodes` / uid 1 skip redirect.
+
+---
+
+## Cannot confirm from repository alone
+
+- Production hit rates for Manager vs Studio after redirect
+- Full page-cache HIT/MISS for Manager workspace without `#cache`
+- Whether every deep link (Boost wizards, diagnostics) is on the redirect list
+- Exact visual Door Mode class inventory beyond theme hook + library attach
+
+---
+
+## Related packs
+
+- Dashboard Foundation discovery: `docs/design/vendor-dashboard-v2/`
+- PDS home: `docs/design/vendor-studio/`
+- Prior VX2 notes: `docs/implementation/vx2-event-workspace-home-redesign.md`, `docs/vendor-console-v2-audit.md`

--- a/docs/design/vendor-workspace-v2/01-product-experience-audit.md
+++ b/docs/design/vendor-workspace-v2/01-product-experience-audit.md
@@ -1,0 +1,139 @@
+# Vendor Workspace v2 — Product Experience Audit
+
+**Status:** Discovery only  
+**Branch:** `feature/vendor-workspace-v2-discovery` @ `37fcdc449`  
+**Surface under review:** Organiser Event Studio Workspace (`/vendor/events/{node}/studio*`) — product truth after legacy redirects  
+**Date:** 2026-07-25  
+
+Ratings: **Excellent · Good · Average · Poor**  
+Evidence from repository only (builders, Twig, routes, PDS). No redesign in this document.
+
+---
+
+## Golden Rule probe
+
+Can an organiser opening **this event** quickly answer:
+
+| Question | Rating | Why |
+| --- | --- | --- |
+| **Where am I?** | **Good** | Studio topbar + sidebar section + event title/status exist (`mel-event-studio-topbar`, section plugins). Path still includes `/studio`, and Overview is labelled **Home** in nav vs **Overview** in PDS — mild orientation tax. Dual shell still in codebase (staff Manager) risks support confusion. |
+| **How is my event performing?** | **Good** | Home cards for sales, tickets, attendees, analytics, activity (`EventWorkspaceOverviewBuilder`). Not a second business Dashboard (correct per 13). Depth depends on sales summary / Pro analytics routes. |
+| **What needs my attention?** | **Good** | `next_action` + readiness checklist + Stripe attention + presentation alerts. Priority order in `resolveNextRecommendedAction()` is explicit (setup errors → blockers → Stripe → publish → share). Risk: Manager “Today’s focus” + Studio next-action are parallel mental models if staff/docs mix shells. |
+| **What should I do next?** | **Good → Excellent** on Home | Dedicated next-action CTA; mobile promotes it (`order: -1` &lt; 720px). Weaker on non-Home sections if strip/guidance is secondary to forms. |
+
+**Overall confidence to run an event from Workspace today:** **Average → Good** — strong Home + publish/autosave stack; weakened by dual-shell debt, Door Mode shell split, nav order vs PDS, and config drift on RSVP isolation.
+
+---
+
+## Dimension scores
+
+### Navigation — **Average**
+
+**Why**
+
+- Studio sidebar is coherent and weighted (Home → … → Settings).
+- **Triple tab sources** still exist (`EventStudioSectionManager`, `VendorEventTabsService`, `VendorConsolePagePreprocess`, Manager local tasks).
+- Section order **Attendees before Orders** conflicts with PDS 13 (Orders before Attendees).
+- Door Mode is a peer tab/link, not nested visually under Attendees as strongly as DDR-002/13 imply.
+- Organisers never “see” Manager nav (redirected), but URLs and support docs may still say `/vendor/events/{id}` without `/studio`.
+
+### Hierarchy — **Good**
+
+**Why**
+
+- Home leads with next action + Event Ready, then ops cards — matches 06 Workspace pattern intent.
+- Topbar publish vs Home next-action can compete (two primary-looking affordances).
+- Builder sections (Details → Images) correctly precede ops for draft lifecycle; live ops emphasis is only partial (nav order helps Attendees; Home cards still equal-weight).
+
+### Cognitive load — **Average**
+
+**Why**
+
+- Progressive disclosure via hidden plugins (questions, capacity, extras) is good.
+- Home can still feel dense (ready + next + six cards + activity + boost).
+- Historical Studio vs Manager vocabulary may leak in help/docs (`docs/product-language-inventory.md` notes past “Event workspace” naming).
+- `/studio` path encodes internal product history.
+
+### Readiness — **Good**
+
+**Why**
+
+- Facade + checklist + humanised labels; green gated through eligibility patterns.
+- Publishing section + Home share readiness story.
+- Anti-pattern risk remains if any surface marks “ready” without capability (must keep PublishEligibility / Stripe gate authoritative).
+
+### Publishing — **Good**
+
+**Why**
+
+- Dedicated Publishing section; deliberate POST publish with dirty/stale/draft checks.
+- Next-action routes unfinished organisers to Publishing.
+- Residual: Manager `event_publish` redirects to Studio settings/edit paths — confusing if bookmarks survive.
+
+### Workflow (draft → live) — **Good**
+
+**Why**
+
+- Create → Studio workspace; edit redirects into sections; autosave on capable sections; publish API.
+- Lifecycle guidance exists on VM (`lifecycle_guidance`).
+- Gap: no single lifecycle “mode” that reweights shell emphasis automatically (see `03-workspace-state-model.md` proposal — design only).
+
+### Trust (money / capacity / status) — **Good**
+
+**Why**
+
+- Autosave does not publish; publish is explicit; Stripe gate on paid paths.
+- Orders section marked readonly in Studio metadata — correct caution.
+- Config drift: active RSVP view missing `organiser_owned` vs sync — **trust risk** for guest list isolation until reconciled.
+
+### Accessibility — **Average** (cannot fully score without runtime a11y pass)
+
+**Why (repo)**
+
+- Focus/keyboard rules live in PDS 07/08; shell JS has mobile patterns.
+- Cannot confirm WCAG AA contrast or Door Mode focus order from code alone without audit run.
+- Multiple competing nav implementations increase a11y regression risk.
+
+### Mobile — **Good**
+
+**Why**
+
+- Next-action priority on small screens; mobile_priority metadata on sections; drawer patterns in guidelines.
+- Door Mode is the critical stress path — separate route/theme still Manager shell (split experience on phone).
+
+### Operational awareness — **Good**
+
+**Why**
+
+- Today’s focus / next_action / activity feed / sales snapshot.
+- Weaker: live/door-imminent “unmistakable status” (13) depends on status badges + organiser noticing Attendees — not a dedicated Live Ops mode yet.
+
+---
+
+## Three Questions Framework (01) on Home
+
+| Question | Present? | Quality |
+| --- | --- | --- |
+| What needs my attention? | Yes — `next_action`, readiness errors | Good |
+| What’s happening with my events? | Partial — **this** event pulse, not portfolio | Good (correct scope) |
+| What should I do next? | Yes — primary CTA | Good / Excellent on Home |
+
+---
+
+## Anti-pattern scan (19)
+
+| Anti-pattern | Present? |
+| --- | --- |
+| Studio/Manager dual product | **Yes in code**; organisers funnelled to one |
+| Fake readiness | Not evidenced as intentional; protect via eligibility |
+| Nested card chrome | Risk on dense Home — watch card boundaries |
+| CMS vocabulary | Mostly avoided in Home copy; monitor forms |
+| Global Check-in peer | Door Mode global history mitigated; still separate path |
+
+---
+
+## Summary verdict
+
+Event Workspace Home is already a credible **mission-control seed**. The largest experience debts are **architectural duality** (two shells / path shapes), **nav source fragmentation**, **Door Mode shell split**, and **config drift** on RSVP ownership — not a blank-canvas redesign need.
+
+**Proceed to wireframes only after** DDR resolution on path/shell unity (see `06-implementation-readiness.md`) so wireframes target the correct URL and shell.

--- a/docs/design/vendor-workspace-v2/02-organiser-journey.md
+++ b/docs/design/vendor-workspace-v2/02-organiser-journey.md
@@ -1,0 +1,140 @@
+# Vendor Workspace v2 — Organiser Journey
+
+**Status:** Discovery / product model (no implementation)  
+**Date:** 2026-07-25  
+**Aligned to:** PDS 13 lifecycle · runtime Studio Home next-action rules  
+**Lifecycle used (sprint):** Draft → Ready → Published → Selling → Upcoming → Live → Completed  
+
+PDS 13 uses Draft → Ready → Published/Live → Door → Aftermath → Archive. This map expands selling/upcoming for operational clarity; Archive remains the calm end-state of Completed.
+
+---
+
+## Journey overview
+
+```text
+Draft → Ready → Published → Selling → Upcoming → Live → Completed
+  ↑ setup/readiness          ↑ growth/sales     ↑ door ops   ↑ aftermath
+```
+
+Shell stays constant (DDR-002). Emphasis and primary CTA change by state.
+
+---
+
+## 1. Draft
+
+| | |
+| --- | --- |
+| **Goals** | Capture the event’s identity; leave every session knowing the next setup step |
+| **Questions** | What is still missing? Can I come back later without losing work? |
+| **Stress** | Blank-page anxiety; fear of “doing Drupal wrong” |
+| **Primary task** | Complete the next readiness blocker |
+| **Information required** | Checklist with reasons + deep links; autosave status; draft badge |
+| **Primary CTA** | Continue setup → first failing checklist item / Publishing review |
+| **Ideal Workspace response** | Home next-action = setup error or “Continue setup”; builder sections emphasised; sales cards quiet |
+
+**Runtime today:** `resolveNextRecommendedAction()` elevates readiness errors and “Continue setup” / Publishing when not ready. Autosave on capable sections. **Good fit.**
+
+---
+
+## 2. Ready
+
+| | |
+| --- | --- |
+| **Goals** | Gain confidence to publish; verify payments if paid tickets |
+| **Questions** | Am I truly ready? Will guests find this? Is Stripe connected? |
+| **Stress** | Publish regret; public visibility fear |
+| **Primary task** | Review Publishing and publish deliberately |
+| **Information required** | Green readiness only when real; Stripe attention; preview public page |
+| **Primary CTA** | Go to publishing / Publish |
+| **Ideal Workspace response** | Home celebrates readiness calmly; primary CTA = Publishing; share secondary |
+
+**Runtime today:** When readiness OK and unpublished → “Ready when you are” + “Go to publishing”; Stripe attention can precede publish CTA. **Good fit** (Stripe vs publish priority is intentional in code comments).
+
+---
+
+## 3. Published
+
+| | |
+| --- | --- |
+| **Goals** | Confirm the event is findable; first share |
+| **Questions** | Is it live on MEL? What’s the link? |
+| **Stress** | “Did publish actually work?” |
+| **Primary task** | Share / verify public page |
+| **Information required** | Published status unmistakable; public URL; early sales zero-state that is calm |
+| **Primary CTA** | Share (Marketing) |
+| **Ideal Workspace response** | Status = Published; next-action = Share; sales cards show empty-but-ready |
+
+**Runtime today:** Published + ready → Share → `workspace_marketing`. **Good fit.**
+
+---
+
+## 4. Selling
+
+| | |
+| --- | --- |
+| **Goals** | Watch tickets move; fix capacity/pricing issues; light promotion |
+| **Questions** | Are tickets selling? Which type? Any refunds? |
+| **Stress** | Slow sales; inventory mistakes |
+| **Primary task** | Monitor sales + adjust tickets/marketing |
+| **Information required** | Sales snapshot, ticket breakdown, orders entry, Boost/share state |
+| **Primary CTA** | Context: View orders / Adjust tickets / Share |
+| **Ideal Workspace response** | Sales + Orders rise in hierarchy; Marketing available; setup chrome quieter |
+
+**Runtime today:** Home sales/tickets/analytics cards exist; next-action still defaults to Share when published unless VM injects error/info. **Average** — selling emphasis is card-level, not shell reweight.
+
+---
+
+## 5. Upcoming (near-term, not yet door)
+
+| | |
+| --- | --- |
+| **Goals** | Prep guest list, messages, door plan |
+| **Questions** | Who’s coming? What do I message? Is check-in ready? |
+| **Stress** | Last-minute incomplete guest data |
+| **Primary task** | Attendee readiness + message plan |
+| **Information required** | Attendee counts, RSVPs if used, message entry, Door Mode entry |
+| **Primary CTA** | Review attendees / Send message |
+| **Ideal Workspace response** | Attendees + Messages emphasised; Door Mode promoted but not yet full-screen stress mode |
+
+**Runtime today:** Attendees before Orders in Studio nav helps. Dedicated “upcoming mode” not confirmed as automated shell emphasis. **Average.**
+
+---
+
+## 6. Live (door / in-progress)
+
+| | |
+| --- | --- |
+| **Goals** | Check guests in quickly; handle exceptions calmly |
+| **Questions** | Who is next? Did that scan work? What if offline? |
+| **Stress** | Queue pressure; lighting; one-handed phone use |
+| **Primary task** | Door Mode check-in |
+| **Information required** | Searchable list, large targets, failure messaging, event identity |
+| **Primary CTA** | Open Door Mode / Check in |
+| **Ideal Workspace response** | Status unmistakable Live; Attendees/Door Mode dominate; builder sections de-emphasised |
+
+**Runtime today:** Door Mode at `/vendor/events/{node}/operations/door` on **Manager** theme shell — split from Studio. PDS wants Door under Attendees. **Average / Poor for continuity** (capability exists; shell continuity weak).
+
+---
+
+## 7. Completed (aftermath → archive)
+
+| | |
+| --- | --- |
+| **Goals** | Reconcile orders/refunds; learn from analytics; archive calmly |
+| **Questions** | What sold? What’s owed? Can I close this out? |
+| **Stress** | Refund disputes; payout timing |
+| **Primary task** | Orders / refunds / analytics review |
+| **Information required** | Order truth, refund entry, payout links to Payments hub, archive affordance |
+| **Primary CTA** | Review orders / View analytics |
+| **Ideal Workspace response** | Builder quiet; Orders + Analytics + Settings/archive calm; no fake “boost now” pressure |
+
+**Runtime today:** Orders/analytics sections exist; archive routes on Manager remain. Lifecycle “aftermath mode” not automated. **Average.**
+
+---
+
+## Cross-state constants
+
+- One Workspace application (DDR-002) — **product intent**; runtime still dual-shell.
+- Honest money and publish (01, 07, 13).
+- Help copy Australian English, organiser voice (15).
+- Global Dashboard answers portfolio attention; Workspace answers **this event**.

--- a/docs/design/vendor-workspace-v2/03-workspace-state-model.md
+++ b/docs/design/vendor-workspace-v2/03-workspace-state-model.md
@@ -1,0 +1,142 @@
+# Vendor Workspace v2 — Workspace State Model
+
+**Status:** Discovery / design model (no implementation)  
+**Date:** 2026-07-25  
+**Principle:** The shell remains consistent. Only emphasis changes. (DDR-002 · 13)
+
+---
+
+## Shell invariants (all states)
+
+| Element | Always present |
+| --- | --- |
+| Global organiser shell | Sidebar + header (DDR-001) |
+| Event chrome | Event name · status · one primary CTA slot · secondary view/share |
+| Section nav | Same section set / order (pending DDR on Orders vs Attendees) |
+| Help | Context help available, not blocking ops |
+
+**Do not** swap to a second product, second sidebar taxonomy, or CMS node-edit chrome by state.
+
+---
+
+## State matrix
+
+### Draft
+
+| Slot | Emphasis |
+| --- | --- |
+| **Hero** | Event name + Draft badge; subtitle = next incomplete step |
+| **Status** | Draft |
+| **Readiness** | Dominant — checklist open or summary with issue count |
+| **Operational focus** | Setup |
+| **Metrics** | Quiet / empty-state calm |
+| **Primary actions** | Continue setup |
+| **Secondary actions** | Preview (if meaningful), Save status |
+| **Help** | “What makes an event ready?” |
+| **Warnings** | Blockers with fix links |
+| **Success** | Soft progress (“3 of 8 complete”) — not fireworks |
+
+### Ready
+
+| Slot | Emphasis |
+| --- | --- |
+| **Hero** | Ready to publish |
+| **Status** | Ready (unpublished) |
+| **Readiness** | Green + Stripe attention if needed |
+| **Operational focus** | Publish confidence |
+| **Metrics** | Still quiet |
+| **Primary actions** | Go to Publishing / Publish |
+| **Secondary actions** | Preview public page |
+| **Help** | What guests will see |
+| **Warnings** | Stripe / visibility consequences |
+| **Success** | Calm “ready when you are” |
+
+### Published
+
+| Slot | Emphasis |
+| --- | --- |
+| **Hero** | Published confirmation |
+| **Status** | Published |
+| **Readiness** | Collapsed unless regressions |
+| **Operational focus** | First share |
+| **Metrics** | Zero sales OK — empty success |
+| **Primary actions** | Share |
+| **Secondary actions** | View public page, Marketing |
+| **Help** | Sharing tips |
+| **Warnings** | None unless capability regresses |
+| **Success** | Quiet published confirmation |
+
+### Selling
+
+| Slot | Emphasis |
+| --- | --- |
+| **Hero** | Sales pulse headline |
+| **Status** | Published · On sale |
+| **Readiness** | Background |
+| **Operational focus** | Revenue + inventory |
+| **Metrics** | Sales, tickets sold, conversion cues |
+| **Primary actions** | View orders / Manage tickets (context) |
+| **Secondary actions** | Boost, Messages |
+| **Help** | Pricing / capacity tips (non-blocking) |
+| **Warnings** | Low capacity, Stripe issues |
+| **Success** | Milestone sales (quiet) |
+
+### Upcoming
+
+| Slot | Emphasis |
+| --- | --- |
+| **Hero** | Countdown / date clarity |
+| **Status** | Published · Upcoming |
+| **Readiness** | Guest-ops readiness (questions, door) |
+| **Operational focus** | Attendees + Messages |
+| **Metrics** | Attendee / RSVP counts |
+| **Primary actions** | Review attendees |
+| **Secondary actions** | Message guests, open Door Mode preview |
+| **Help** | Door prep checklist |
+| **Warnings** | Incomplete guest data |
+| **Success** | Prep complete |
+
+### Live
+
+| Slot | Emphasis |
+| --- | --- |
+| **Hero** | Unmistakable Live / Door status |
+| **Status** | Live |
+| **Readiness** | Hidden unless blocking check-in |
+| **Operational focus** | Door Mode + exceptions |
+| **Metrics** | Checked-in / remaining |
+| **Primary actions** | Door Mode |
+| **Secondary actions** | Orders exceptions, Messages |
+| **Help** | Minimal chrome |
+| **Warnings** | Scan failures, offline (v2) |
+| **Success** | Check-in confirmations — brief |
+
+### Completed
+
+| Slot | Emphasis |
+| --- | --- |
+| **Hero** | Completed / thank-you tone |
+| **Status** | Completed / Archived |
+| **Readiness** | N/A or historical |
+| **Operational focus** | Aftermath money + learning |
+| **Metrics** | Final sales, attendance |
+| **Primary actions** | Review orders / Analytics |
+| **Secondary actions** | Refunds via deliberate path, Archive |
+| **Help** | Payouts → Payments hub |
+| **Warnings** | Open refunds |
+| **Success** | Calm closure — no growth pressure |
+
+---
+
+## Mapping to runtime today
+
+| State model slot | Runtime seed |
+| --- | --- |
+| Hero / status | Studio topbar + `event.status*` on VM |
+| Readiness | Facade + Home Event Ready |
+| Operational focus | Partially via next_action + nav order — **not** full state machine |
+| Metrics | Home cards / sales snapshot |
+| Primary actions | `resolveNextRecommendedAction()` |
+| Door Live mode | Separate Door Mode route (shell split) |
+
+**Gap:** Emphasis changes are mostly **content-level** (next_action + cards), not a formal Workspace state presentation layer. Future slices should extend builders/presentation — not invent a second shell.

--- a/docs/design/vendor-workspace-v2/04-mission-control-model.md
+++ b/docs/design/vendor-workspace-v2/04-mission-control-model.md
@@ -1,0 +1,144 @@
+# Vendor Workspace v2 — Mission Control Model
+
+**Status:** Discovery / philosophy (no implementation)  
+**Date:** 2026-07-25  
+**Role:** Product philosophy for Event Workspace Home and chrome  
+**Authority chain:** ADR-0001 → 01 → 02 → DDR-002 → 13 → this model (composition detail)
+
+---
+
+## How should organisers feel when opening an event?
+
+**Calm confidence.**  
+They should feel: “I know where I am, I know what matters for *this* event, and I know the next useful move — without learning MEL’s internal history.”
+
+Not: a CMS, a second Dashboard of the whole business, or a marketing landing page.
+
+---
+
+## Mission Control definition
+
+Event Workspace **Home** is Mission Control for **one event**.
+
+| It is | It is not |
+| --- | --- |
+| Readiness + next action + live pulse | Global action queue (that is Dashboard) |
+| Builder + operations in one app | Studio vs Manager fork |
+| Status-honest | Decorative green |
+| Lifecycle-aware emphasis | A different shell per lifecycle |
+
+Dashboard Foundation (merged) owns portfolio attention. Workspace owns event attention. Cross-link; do not duplicate.
+
+---
+
+## Composition blocks
+
+### 1. Workspace Hero
+
+- Event name, date clarity, status badge, primary CTA slot, secondary view public page / share
+- One primary action (01 Principle 1)
+- Component contract: PDS 05 Workspace Hero
+
+### 2. Readiness
+
+- Honest score/checklist with reasons and recovery links
+- Visible on Home; detailed on Publishing
+- Never green without capability (13)
+
+### 3. Publishing
+
+- Deliberate publish/unpublish
+- Blockers explained
+- Explicit confirm — not autosave (07, 13)
+
+### 4. Today’s Focus
+
+- Single narrative of “what matters now” for this event
+- Runtime seed: `todays_focus` on VM + Studio `next_action` (prefer one presented story on Home)
+
+### 5. Operational status
+
+- Tickets capability, capacity signals, door readiness near live
+- Presentation alerts for recoverable issues
+
+### 6. Business health (event-scoped)
+
+- Sales snapshot, orders pulse, refund attention when present
+- Money truth from Commerce — UI never invents paid
+
+### 7. Communications
+
+- Event-scoped Messages entry; brand/templates link out to global Messages hub
+- Audience clarity before send
+
+### 8. Attendees
+
+- Guest list ops; **Door Mode** nests here (DDR-002)
+- Counts + exceptions on Home near live
+
+### 9. Tickets
+
+- Sellable options in organiser language
+- Advanced inventory nested — Commerce backstage
+
+### 10. Orders
+
+- Event-filtered sales; deliberate refund entry
+- Readonly Studio section today — preserve caution
+
+### 11. Marketing
+
+- Share, embed, Boost for **this** event
+- Spend/state clear before purchase (DDR-007 separation from Analytics)
+
+### 12. Analytics
+
+- This event’s performance; text alternatives for critical figures
+- Not a replacement for global Analytics hub
+
+### 13. Quick actions
+
+- Grouped shortcuts (runtime `action_grid`: sales / setup / growth)
+- Never outrank the single primary CTA
+
+### 14. Workspace navigation
+
+- Stable section list; lifecycle changes **emphasis**, not membership
+- Resolve Orders↔Attendees order via DDR before wireframes freeze
+
+### 15. Progress
+
+- Event Ready complete_count / total; autosave Saving/Saved/Error
+- Celebrate quietly (01 Principle 6)
+
+### 16. Success criteria (Mission Control)
+
+1. Organiser answers Three Questions within one viewport on Home  
+2. No dual-product navigation  
+3. Publish blockers always explain recovery  
+4. Live/Door stress path reachable in ≤2 taps from Home when Live  
+5. Dashboard and Workspace do not show competing “what needs me” systems for the same item without clear scope  
+
+---
+
+## Emotional design notes (14 / 15)
+
+- Warm, capable, local, calm, honest
+- Severity not colour-only
+- Australian English
+- Avoid FOMO, VIP, exclusive pressure on Boost/share
+
+---
+
+## Runtime seeds to extend (not replace)
+
+| Philosophy block | Runtime seed |
+| --- | --- |
+| Hero | Studio topbar + VM `event` |
+| Readiness | Facade + `#event_ready` / `#readiness` |
+| Next / Today’s focus | `resolveNextRecommendedAction` + VM `todays_focus` / `next_action` |
+| Ops cards | tickets, attendees, sales, marketing, boost, analytics, activity |
+| Publish | `workspace_publishing` + publish POST |
+| Door | `vendor_operations_door` (shell continuity debt) |
+
+Wireframes (next sprint, pending human approval) should compose these seeds against the state model — not invent parallel builders.

--- a/docs/design/vendor-workspace-v2/05-drupal-mapping.md
+++ b/docs/design/vendor-workspace-v2/05-drupal-mapping.md
@@ -1,0 +1,147 @@
+# Vendor Workspace v2 — Drupal Mapping
+
+**Status:** Discovery mapping (no new architecture)  
+**Date:** 2026-07-25  
+**Commit:** `37fcdc449`  
+**Rule:** Reuse existing homes. Do not invent parallel modules, themes, or route trees.
+
+Companion: PDS [09-drupal-mapping.md](../vendor-studio/09-drupal-mapping.md).
+
+---
+
+## 1. Concept → runtime home
+
+| Workspace concept | Runtime home |
+| --- | --- |
+| Organiser theme | `web/themes/custom/myeventlane_vendor_theme` |
+| Global shell / nav | `VendorNavBuilder` + vendor theme layout regions |
+| Event Studio Workspace (organiser product) | `myeventlane_event_studio` — theme `mel_event_studio_workspace` |
+| Manager Workspace (staff / residual) | `myeventlane_vendor` — theme `mel_event_workspace` |
+| Home / Mission Control body | `EventWorkspaceOverviewBuilder` → `mel_event_studio_overview` |
+| Shared event VM | `VendorEventWorkspaceViewModelBuilder` |
+| Section nav | `EventStudioSectionManager` + `Plugin/EventStudioSection/*` |
+| Section bodies | `EventStudioSectionRenderer` + section forms |
+| Readiness | `EventReadinessFacade` / `EventReadinessService` |
+| Publish eligibility | `PublishEligibilityEvaluator` (+ Stripe gate) |
+| Autosave | `EventStudioAutosaveController` + `EventStudioAutosaveService` |
+| Publish API | `EventStudioPublishController` |
+| Organiser redirect funnel | `VendorLegacyWizardRedirectSubscriber` |
+| Door Mode | `myeventlane_event_attendees` — `vendor_operations_door` |
+| Access / ownership | `EventStudioAccess`, `VendorConsoleAccess`, `accountHasWorkspaceParityForEvent` |
+| Config sync | `config/sync` — reconcile before implementation |
+
+---
+
+## 2. Twig
+
+| Concept | Template / hook |
+| --- | --- |
+| Studio shell | `mel-event-studio-workspace.html.twig` |
+| Home | `mel-event-studio-overview.html.twig` |
+| Sidebar / topbar / section | `mel-event-studio-sidebar|topbar|section.html.twig` |
+| Attendees stack | `mel-event-studio-attendees-workspace.html.twig` |
+| Manager shell | `mel-event/mel-event-workspace.html.twig` |
+| Manager tabs / header | `components/workspace/workspace-*.html.twig` |
+
+---
+
+## 3. Preprocess & theme hooks
+
+| Need | Mechanism |
+| --- | --- |
+| Studio variables | `EventStudioPreprocess` / `template_preprocess_mel_event_studio` |
+| Manager workspace vars | `myeventlane_vendor_theme_preprocess_mel_event_workspace` |
+| Console tab shortening | `VendorConsolePagePreprocess` |
+| Theme negotiation | `VendorThemeNegotiator` → `myeventlane_vendor_theme` |
+| Hook registration | `myeventlane_event_studio.module` `hook_theme`; vendor theme `hook_theme` for `mel_event_workspace` |
+
+---
+
+## 4. Builders & view models
+
+| Concept | Builder |
+| --- | --- |
+| Home cards + next action | `EventWorkspaceOverviewBuilder` |
+| Event mission VM | `VendorEventWorkspaceViewModelBuilder` |
+| Tabs (legacy/alternate) | `VendorEventTabsService` |
+| Presentation strip | `EventStudioWorkspacePresentation` |
+| Sales panels | `EventStudioCommerceSalesSummaryBuilder`, extras builders |
+| Dashboard (do not merge) | `VendorDashboardViewModelBuilder` — portfolio only |
+
+---
+
+## 5. Libraries & SCSS
+
+| Concept | Library / SCSS |
+| --- | --- |
+| Studio shell | `myeventlane_event_studio/mel_event_studio_shell_only` |
+| Home styles | `css/mel-event-studio-shell.css` (`.mel-event-workspace-home*`) |
+| Manager workspace | `myeventlane_vendor_theme/vendor-workspace`, `event_mission_control` |
+| Layout intents | `.mel-layout--*` + tokens (DDR-003 · 11) |
+| Section apps | tickets_app, attendees_app, branding, extras libs as attached today |
+
+Extend existing partials (DDR-004). Do not create `vendor-workspace-v2-*` parallel kits.
+
+---
+
+## 6. Routes & access
+
+| Concept | Route pattern | Access |
+| --- | --- | --- |
+| Studio Home | `myeventlane_event_studio.workspace` | `EventStudioAccess` |
+| Studio sections | `…workspace_*` | same |
+| Autosave / publish | POST autosave / publish | CSRF header + access |
+| Manager event root | `myeventlane_vendor.console.event_workspace` | Vendor console access + ownership; redirected for organisers |
+| Door Mode | `…vendor_operations_door` | Check-in capability |
+
+**Entity ownership:** Always server-side workspace parity / vendor ownership. UI absence is not security.
+
+---
+
+## 7. Cache
+
+| Surface | Tags / contexts (confirmed) |
+| --- | --- |
+| Studio workspace render | Node tags; `route`, `user`, `user.permissions`, `url.query_args:mel_celebrate` |
+| Access results | Event/vendor deps + user contexts |
+| Manager workspace root | Incomplete `#cache` — risk if still rendered |
+| Home builder | Inherits parent; no separate `#cache` array |
+
+Future slices must preserve/improve cache metadata — especially if Manager surfaces remain.
+
+---
+
+## 8. Commerce boundaries
+
+| Organiser language | Backstage |
+| --- | --- |
+| Ticket | Product variation / MEL ticket type abstractions |
+| Order | Commerce order |
+| Payment / payout | Gateway + Stripe Connect |
+| Refund | Deliberate Commerce/Stripe flows |
+
+Workspace mapping must not collapse event node and ticket products into one unclear model.
+
+---
+
+## 9. What mapping forbids
+
+- New theme for Workspace v2
+- New global nav item “Workspace”
+- Parallel overview builder that ignores readiness facade
+- Client-only publish/ready flags
+- Moving Door Mode to a global shell peer
+- Dashboard action-queue duplication inside event Home
+
+---
+
+## 10. Preferred extension points for later slices
+
+1. `EventWorkspaceOverviewBuilder` + overview Twig — Home composition  
+2. `EventStudioWorkspacePresentation` — state emphasis / strips  
+3. Section plugin weights/titles — nav order after DDR  
+4. Topbar variables — primary CTA slot by state  
+5. Door Mode entry presentation under Attendees — path may stay; chrome should feel same app  
+6. Retire or staff-gate Manager shell after path DDR  
+
+Path unification (`/studio` removal) is a **DDR + Technical Authority** change — not a silent Twig edit.

--- a/docs/design/vendor-workspace-v2/06-implementation-readiness.md
+++ b/docs/design/vendor-workspace-v2/06-implementation-readiness.md
@@ -1,0 +1,150 @@
+# Vendor Workspace v2 — Implementation Readiness
+
+**Status:** Discovery readiness (no implementation)  
+**Date:** 2026-07-25  
+**Branch:** `feature/vendor-workspace-v2-discovery` @ `37fcdc449`
+
+---
+
+## Strengths
+
+- Studio Workspace is a real per-event application with section plugins, Home builder, readiness facade, autosave, and publish APIs.
+- Home already encodes next-action priority (setup → blockers → Stripe → publish → share).
+- Shared `VendorEventWorkspaceViewModelBuilder` gives Mission Control seeds (focus, metrics, actions).
+- Organiser funnel via `VendorLegacyWizardRedirectSubscriber` reduces dual-nav exposure in practice.
+- Dashboard Foundation merged — clear split: portfolio vs event.
+- Door Mode and Commerce-aware Orders surfaces exist.
+- PDS pack (01–21 + DDR-001–005) gives design authority for Workspace.
+
+---
+
+## Weaknesses
+
+- Dual shells remain (`mel_event_studio_workspace` vs `mel_event_workspace`).
+- DDR-002 canonical paths omit `/studio`; runtime requires it for organisers.
+- Triple/quadruple nav sources drift.
+- PDS 13 Orders-before-Attendees vs runtime Attendees-before-Orders.
+- Door Mode still on Manager theme — continuity break at highest stress moment.
+- Manager workspace root cache metadata weak.
+- Local config drift: vendor role permission + RSVP `organiser_owned` filter.
+- ADR-0002 referenced by Cursor rule but **absent** from pack; version label 1.0 vs 1.0.1 mismatch.
+
+---
+
+## Architecture opportunities
+
+1. **Declare one canonical shell** (Studio) and staff-gate or delete Manager event chrome after path strategy DDR.  
+2. **Unify nav assembly** — one builder feeding sidebar/tabs.  
+3. **State-aware presentation layer** on existing builders (03 state model) without new modules.  
+4. **Door Mode chrome continuity** — same app feeling under Attendees.  
+5. **Align Home “Today’s focus” and `next_action`** into one narrative.  
+6. **Harden cache** on any remaining Manager surfaces.
+
+---
+
+## Reusable inventory
+
+| Kind | Assets |
+| --- | --- |
+| **Components** | Workspace hero/topbar patterns, readiness checklist, ops cards, empty states, alerts, metric patterns from vendor theme + Studio Home |
+| **Builders** | `EventWorkspaceOverviewBuilder`, `VendorEventWorkspaceViewModelBuilder`, readiness facade, section manager/renderer, sales summaries |
+| **Twig** | `mel-event-studio-workspace|overview|sidebar|topbar|section`, manager workspace partials for reference/staff |
+| **SCSS/CSS** | `mel-event-studio-shell.css`, nav CSS, mission-control / workspace SCSS, layout intent classes |
+| **APIs** | Autosave + publish POST endpoints with CSRF |
+
+---
+
+## Potential risks
+
+| Risk | Severity |
+| --- | --- |
+| Path/shell change without redirect map | High — bookmarks, emails, help links |
+| Touching publish/eligibility/Stripe gate | High — money + trust |
+| Orders/refunds UX changes | High — Commerce state |
+| RSVP view / vendor role config drift ignored | High — access/isolation |
+| Door Mode access/mutation changes | High — live ops |
+| Cache regressions on workspace | Medium |
+| Duplicating Dashboard queues on Home | Medium — product confusion |
+
+---
+
+## Technical debt
+
+- Dual Workspace themes and route trees  
+- Legacy Manager local tasks vs Studio plugin nav  
+- `VendorEventTabsService` vs section manager duplication  
+- Manager `EventWorkspaceController` without solid `#cache`  
+- `/studio` prefix as permanent product history leak  
+- Hidden section plugins still routable — document IA carefully  
+
+---
+
+## Product debt
+
+- Organisers may still learn “Studio” as a word (path, old docs)  
+- Home density vs One primary action tension (topbar publish + next-action)  
+- Lifecycle emphasis not formalised — Selling/Live feel under-weighted  
+- Door Mode IA promise (under Attendees) vs peer-tab presentation  
+- Section order conflict with frozen PDS 13  
+
+---
+
+## Potential DDRs
+
+| ID (proposed) | Topic |
+| --- | --- |
+| **DDR-008** (recommended) | Canonical Event Workspace path & shell — resolve `/studio` vs DDR-002 paths; retirement plan for Manager `mel_event_workspace` organiser entry |
+| **DDR-009** (recommended) | Workspace section order — Attendees vs Orders; Door Mode placement in nav chrome |
+| **ADR-0002** (missing) | Author “implementation follows PDS” or remove rule reference |
+| **PDS 1.0.1 patch** | Version label alignment + CHANGELOG if governance docs added |
+| Amend **13** | Only after DDR-009 if runtime order is intentional |
+
+Do **not** silently redesign paths in a theme PR.
+
+---
+
+## Recommended implementation slices (after wireframes + DDRs)
+
+Order assumes DDRs accepted first.
+
+0. **Hygiene (blocker):** Reconcile `user.role.vendor` + `views.view.myeventlane_vendor_rsvps` active vs sync; document payment/Klaro drift ownership.  
+1. **DDR-008/009 + ADR-0002** documentation PRs (no UX code).  
+2. **Wireframes** — Home + chrome by lifecycle state (this pack’s models).  
+3. **Slice A — Home Mission Control composition** — extend `EventWorkspaceOverviewBuilder` + overview Twig only; no route renames.  
+4. **Slice B — State emphasis** — presentation/topbar primary CTA by lifecycle; reuse VM.  
+5. **Slice C — Nav single source** — section manager as sole nav; retire duplicate tab builders gradually.  
+6. **Slice D — Door Mode continuity** — Attendees entry + shared chrome; keep check-in access logic.  
+7. **Slice E — Path unification** (if DDR-008 requires) — redirects, tests, help URL updates; highest risk last.
+
+---
+
+## Stage 10 — Success criteria answers
+
+| Question | Answer |
+| --- | --- |
+| **What already exists?** | Full Studio Workspace app, Home mission-control builder, readiness/publish/autosave, Manager residual shell, Door Mode, shared VM, Dashboard Foundation. |
+| **What should stay?** | Studio section architecture, readiness facade, publish/autosave safety, ownership access, Commerce order truth, Door Mode capability, layout intents/tokens. |
+| **What should change?** | Dual-shell story → one organiser shell; nav single source; lifecycle emphasis; Home primary CTA clarity; Door Mode continuity; path strategy per DDR. |
+| **What should be removed?** | Organiser-facing Manager event chrome (after DDR); duplicate tab builders; competing “Studio vs Manager” language in product UI. |
+| **What should become more prominent?** | Next action, honest status, Live/Door entry when relevant, sales pulse while Selling. |
+| **What should become quieter?** | Builder density when Live; Boost pressure after Completed; governance panels; duplicate metrics. |
+| **Can organisers confidently run an event from this Workspace?** | **Partially yes** for setup → publish → share; **weaker** for Live door continuity and IA purity. |
+| **If not, why not?** | Shell/path duality, Door Mode theme split, nav fragmentation, config drift on RSVP isolation, incomplete lifecycle emphasis. |
+
+---
+
+## Recommendation: Proceed to Workspace Wireframes?
+
+### **YES — conditional**
+
+**YES** to wireframes **provided**:
+
+1. Wireframes target **Studio Workspace** as organiser truth (`/vendor/events/{node}/studio*` until DDR-008).  
+2. Open **DDR-008** (path/shell) and **DDR-009** (section order / Door chrome) before freezing IA in pixels.  
+3. Author or drop **ADR-0002** reference.  
+4. Treat config drift reconciliation as a **parallel blocker** before any implementation slice.  
+5. Do **not** wireframe a greenfield shell or new Drupal architecture.
+
+**NO** if Product Owner insists wireframes must show DDR-002 literal paths `/vendor/events/{id}/{section}` without an accepted transition DDR — that would invent a runtime that does not exist yet.
+
+**Repository evidence:** PR #716 on `main`; Studio routes + overview builder; legacy redirect subscriber; DDR-002 path text vs `/studio` prefix; missing ADR-0002 file under `docs/design/vendor-studio/decisions/`.

--- a/docs/design/vendor-workspace-v2/07-workspace-unification.md
+++ b/docs/design/vendor-workspace-v2/07-workspace-unification.md
@@ -1,0 +1,237 @@
+# Vendor Workspace v2 — Workspace Unification Architecture
+
+**Status:** Architecture (Sprint 1B) — documentation only  
+**Date:** 2026-07-25  
+**Branch:** `feature/vendor-workspace-v2-discovery`  
+**Base commit:** `37fcdc449` (Dashboard Foundation merged via PR #716)  
+**Authority:** Vendor Studio PDS v1.0 · ADR-0001 · DDR-001 · DDR-002 (amendment pending DDR-008/009)  
+**Depends on:** Sprint 1A — `00`–`06` in this pack  
+
+No Twig, SCSS, PHP, JS, YAML, routes, builders, or view models were modified for this document.
+
+---
+
+## Stage 1 — Discovery review (confirmed)
+
+### Confirmations
+
+| Claim | Status | Evidence |
+| --- | --- | --- |
+| **Studio is organiser truth** | **Confirmed** | `EventStudioController` → `#theme => mel_event_studio_workspace`; entry `/vendor/events/{node}/studio`; `VendorLegacyWizardRedirectSubscriber` funnels trusted organisers from most Manager routes |
+| **Manager remains staff/operational** | **Confirmed** | Staff with `administer nodes` / uid 1 skip redirect; many controllers still render `mel_event_workspace`; Door Mode still uses Manager shell |
+| **Dashboard Foundation assumptions remain valid** | **Confirmed** | PR #716 on `main` @ `37fcdc449`; Dashboard = portfolio attention; Workspace = per-event attention; do not duplicate action queues (`04-mission-control-model.md`, dashboard pack `09-merge-readiness.md`) |
+
+### Current architecture (as-is)
+
+```text
+Vendor Studio (global shell — DDR-001)
+├── Dashboard          ← portfolio attention (Foundation merged)
+├── Events             ← catalogue
+│     └── Event Studio Workspace   ← organiser product truth
+│           path: /vendor/events/{node}/studio[/{section}]
+│           theme: mel_event_studio_workspace
+│           Home: EventWorkspaceOverviewBuilder
+└── … Orders, Attendees, Messages, Payments, …
+
+Parallel residual:
+Manager Event Workspace
+  path: /vendor/events/{event}[/{section}]
+  theme: mel_event_workspace
+  users: staff / uid 1 / deep links / Door Mode / some Boost & refund surfaces
+```
+
+### Current problems
+
+1. **Dual shells** — organisers redirected to Studio; Manager chrome remains for staff, Door Mode, and residual controllers (conflict C1 in `00-runtime-discovery.md`).
+2. **Path shape vs DDR-002** — Accepted DDR-002 claims `/vendor/events/{id}/{section}`; runtime requires `/studio` (conflict C2).
+3. **Nav source fragmentation** — `EventStudioSectionManager` ≠ `VendorEventTabsService` ≠ `VendorConsolePagePreprocess` ≠ local tasks.
+4. **Section order vs PDS 13** — Runtime: Attendees (60) before Orders (90); PDS 13: Orders before Attendees (conflict C3).
+5. **Door Mode shell split** — Highest-stress path leaves Studio chrome.
+6. **Config drift** — Active DB vs sync on `user.role.vendor` and RSVP `organiser_owned` filter (access-adjacent).
+7. **Governance gaps** — ADR-0002 referenced by cursor rule but missing; PDS version label 1.0 vs 1.0.1.
+
+### Current strengths
+
+1. Real per-event application with section plugins, autosave, publish CSRF APIs.
+2. Home mission-control seed: readiness + `resolveNextRecommendedAction()` + ops cards.
+3. Shared `VendorEventWorkspaceViewModelBuilder` for focus/metrics/actions.
+4. Organiser funnel already reduces dual-nav exposure in practice.
+5. Clear Dashboard ↔ Workspace scope split after Foundation merge.
+6. PDS pack (01–21, DDR-001–007) provides design authority.
+
+### Discovery contradiction check
+
+**No repository evidence contradicts Sprint 1A Discovery.** Spot-checks on this branch still show:
+
+- Studio workspace theme + `/studio` routes
+- Legacy redirect subscriber + staff skip
+- Attendees weight 60 / Orders weight 90
+- Door Mode on Manager-themed controllers
+- Dashboard Foundation commit on `main`
+
+Conflicts C1–C5 remain **design authority vs runtime** gaps — not discovery errors.
+
+---
+
+## Stage 2 — Future architecture (to-be)
+
+### Definitions
+
+| Term | Definition | Who uses it |
+| --- | --- | --- |
+| **Vendor Studio** | The organiser console product: one global shell (Dashboard, Events, hubs). Not a CMS. Not staff Manager. | Organisers (vendors) and their authorised team roles with console trust |
+| **Event Workspace** | The **single contextual application** for one event — builder + operations. Entered from Events (or Dashboard shortcuts). Shell constant; emphasis changes by lifecycle. | Organisers operating **this** event |
+| **Manager (future: Staff Operations)** | Staff / platform operational surfaces for support, diagnostics, and privileged overrides. **Not** an organiser product twin. | Staff (`administer nodes` / uid 1) and explicitly staff-gated tools |
+
+### Navigation flow (canonical product)
+
+```text
+Dashboard
+  ↓ (attention item / “Open event”)
+Events
+  ↓ (select event / Create event → land in Workspace)
+Event Workspace (Home = Mission Control)
+  ↓
+Operational sections (same app)
+  Overview · Details · Schedule · Venue · Images · Tickets
+  · Attendees (+ Door Mode) · Messages · Marketing · Orders
+  · Analytics · Publishing · Settings
+```
+
+**Context rules**
+
+- Global → Event is the only major context switch (PDS 13).
+- Section → Section never re-asks “which event?”.
+- Global Orders / Attendees remain cross-event hubs; Workspace sections are event-filtered (PDS 02).
+- Workspace is **never** a permanent global sidebar peer of Events (DDR-002).
+
+### Manager → Staff Operations
+
+| Dimension | Decision |
+| --- | --- |
+| Organiser-facing name | **Do not** say “Manager” in product UI |
+| Staff product name | **Staff Operations** (internal/docs) |
+| Theme | May retain `mel_event_workspace` temporarily for staff-only routes |
+| Organiser entry | **Forbidden** — redirects remain until path unification retires Manager organiser entry |
+| Door Mode | Capability stays; chrome must feel like Event Workspace (continuity), even if route path migrates later |
+
+---
+
+## What remains / disappears / redirects / becomes contextual
+
+### Remains (organiser product)
+
+| Asset | Why |
+| --- | --- |
+| `myeventlane_event_studio` Workspace app | Organiser truth |
+| Section plugin architecture | Extensible IA without new route trees |
+| `EventWorkspaceOverviewBuilder` + overview Twig | Mission Control body |
+| `VendorEventWorkspaceViewModelBuilder` | Shared next-action / focus / metrics |
+| Readiness facade + `PublishEligibilityEvaluator` + Stripe gate | Trust |
+| Autosave + publish POST + CSRF | Safety |
+| Door Mode check-in capability | Live ops |
+| Vendor theme + layout intents / tokens | PDS 09 / DDR-003 / 11 |
+| Dashboard Foundation | Portfolio attention home |
+
+### Disappears (from organiser product story)
+
+| Asset | Disposition |
+| --- | --- |
+| Organiser-facing “Studio vs Manager” language | Retire from UI, help, onboarding |
+| Competing Manager event chrome as organiser destination | Staff-gate then retire |
+| Duplicate tab builders as equal authorities | Collapse to `EventStudioSectionManager` as sole nav source |
+| Topbar publish **competing** with Home primary CTA as two primaries | One primary CTA slot by state (publish may occupy it when Ready) |
+
+### Redirects
+
+| From | To | Notes |
+| --- | --- | --- |
+| Most `/vendor/events/{id}/*` Manager organiser routes | Workspace destinations | Already: `VendorLegacyWizardRedirectSubscriber` |
+| Future (if DDR-008 Option A): `/…/studio[/{section}]` | `/vendor/events/{id}[/{section}]` | Requires accepted DDR + redirect map + help URL updates |
+| Legacy publish Manager routes | Publishing / Workspace | Keep bookmark safety |
+
+### Becomes contextual
+
+| Capability | Global hub | Event Workspace |
+| --- | --- | --- |
+| Orders | Cross-event money trail | This event’s orders |
+| Attendees | Cross-event guest search | This event’s list + Door Mode |
+| Messages | Brand, templates, history | Event-scoped send |
+| Marketing | Boost / growth hubs | This event share / Boost |
+| Analytics | Business pulse | This event performance |
+| Settings | Organiser defaults | This event settings / archive |
+
+---
+
+## Target information architecture (Workspace)
+
+**Recommended section order for Event Workspace** (live-ops bias; amends PDS 13 via prepared **DDR-009**):
+
+```text
+Overview (Home)
+→ Details → Schedule → Venue → Images
+→ Tickets
+→ Attendees   ← Door Mode nests here
+→ Messages
+→ Marketing
+→ Orders
+→ Analytics
+→ Publishing
+→ Settings
+```
+
+**Rationale:** Matches runtime weights today (Attendees 60, Orders 90); aligns with live-ops priority and PDS 02 note that Workspace may lead with Attendees while **global** nav keeps Orders before Attendees. Frozen PDS 13 text requires DDR-009 before amending.
+
+**Transitional paths (until DDR-008 Accepted):**
+
+```text
+/vendor/events/{node}/studio
+/vendor/events/{node}/studio/{section}
+```
+
+**Target paths (DDR-008 recommendation):**
+
+```text
+/vendor/events/{id}
+/vendor/events/{id}/{section}
+```
+
+---
+
+## Shell architecture (constant)
+
+```text
+┌────────────────────────────────────────────────────────────┐
+│ Global header — Organiser · Create event · account         │
+├────────────┬───────────────────────────────────────────────┤
+│ Global nav │ Event chrome: name · status · 1° CTA · 2°    │
+│ (context)  ├───────────────────────────────────────────────┤
+│            │ Section nav (stable membership)               │
+│            ├───────────────────────────────────────────────┤
+│            │ Section body — Mission Control or section UI  │
+│            │ Sticky action bar (mobile) when needed        │
+└────────────┴───────────────────────────────────────────────┘
+```
+
+Lifecycle changes **emphasis and CTA content**, not shell membership (see `08`, `11`).
+
+---
+
+## Relationship to prepared DDRs
+
+| Record | Topic | Status |
+| --- | --- | --- |
+| [DDR-008](../vendor-studio/decisions/DDR-008-canonical-event-workspace.md) | Canonical Event Workspace path & shell | **Prepared — not accepted** |
+| [DDR-009](../vendor-studio/decisions/DDR-009-workspace-navigation.md) | Workspace navigation & section order | **Prepared — not accepted** |
+
+Implementation must not rename paths or reorder nav until these are Accepted (or Product Owner issues an explicit waiver for composition-only slices).
+
+---
+
+## Explicit non-goals of this architecture doc
+
+- No runtime changes
+- No new Drupal module or theme
+- No greenfield shell
+- No collapsing event nodes with Commerce products
+- No staff tools in organiser IA

--- a/docs/design/vendor-workspace-v2/08-event-lifecycle-model.md
+++ b/docs/design/vendor-workspace-v2/08-event-lifecycle-model.md
@@ -1,0 +1,200 @@
+# Vendor Workspace v2 — Event Lifecycle Model
+
+**Status:** Architecture / product design (Sprint 1B) — documentation only  
+**Date:** 2026-07-25  
+**Authority:** PDS 01 · 13 · 15 · DDR-002 · prepared DDR-008/009  
+**Extends:** `02-organiser-journey.md` · `03-workspace-state-model.md`  
+
+Shell membership is constant. Only emphasis, CTA content, warnings, and metrics prominence change.
+
+Lifecycle used:
+
+```text
+Draft → Ready → Published → Selling → Upcoming → Live → Completed
+```
+
+PDS 13’s Draft → Ready → Published/Live → Door → Aftermath → Archive maps here: Door ⊂ Live; Aftermath/Archive ⊂ Completed.
+
+---
+
+## Cross-state invariants
+
+| Invariant | Rule |
+| --- | --- |
+| Shell | Global nav + event chrome + section nav always present |
+| One primary CTA | Event chrome holds exactly one primary action |
+| Honesty | Readiness never green without publish capability; money never invented |
+| Scope | Workspace = this event; Dashboard = portfolio |
+| Language | Australian English; no Commerce/CMS vocabulary in organiser UI |
+| Help | Available, non-blocking; audience boundaries preserved |
+| Autosave | Never publishes; never money-commits |
+
+---
+
+## 1. Draft
+
+| Dimension | Specification |
+| --- | --- |
+| **Primary goal** | Capture identity and close every session knowing the next setup step |
+| **Hero** | Event name · **Draft** badge · subtitle = first incomplete readiness item |
+| **Workspace emphasis** | Readiness checklist + builder sections (Details → Images → Tickets) |
+| **Primary CTA** | Continue setup → deep link to first blocker |
+| **Secondary CTA** | Preview (if meaningful) · Save status (“Saved”) |
+| **Warnings** | Blockers with reasons + recovery links; never shame |
+| **Metrics** | Quiet / calm empty states (no fake sales) |
+| **Help** | “What makes an event ready?” · progressive field guidance |
+| **Navigation emphasis** | Details, Schedule, Venue, Images, Tickets highlighted; ops quieter |
+| **Operational tools** | Autosave on capable sections; Publishing review available but not primary |
+| **Success criteria** | Organiser can answer “what’s missing?” in &lt;5s; work resumes without CMS fear |
+
+**Runtime seed:** `resolveNextRecommendedAction()` elevates setup errors / Continue setup.
+
+---
+
+## 2. Ready
+
+| Dimension | Specification |
+| --- | --- |
+| **Primary goal** | Confidence to publish deliberately (including Stripe if paid) |
+| **Hero** | Event name · **Ready** · calm “Ready when you are” |
+| **Workspace emphasis** | Readiness green (honest) + Publishing confidence + Stripe attention if needed |
+| **Primary CTA** | Go to Publishing / Publish |
+| **Secondary CTA** | Preview public page |
+| **Warnings** | Stripe connect / payout readiness; visibility consequences of publish |
+| **Metrics** | Still quiet |
+| **Help** | What guests will see after publish |
+| **Navigation emphasis** | Publishing elevated; builder complete-state |
+| **Operational tools** | Publish eligibility + Stripe gate; explicit confirm |
+| **Success criteria** | No false green; publish path obvious; regret risk acknowledged calmly |
+
+**Runtime seed:** Unpublished + ready → “Go to publishing”; Stripe may precede publish CTA.
+
+---
+
+## 3. Published
+
+| Dimension | Specification |
+| --- | --- |
+| **Primary goal** | Confirm findability; complete first share |
+| **Hero** | Event name · **Published** · public URL affordance |
+| **Workspace emphasis** | Share / Marketing; readiness collapsed unless regression |
+| **Primary CTA** | Share |
+| **Secondary CTA** | View public page · Open Marketing |
+| **Warnings** | Only if capability regresses (tickets broken, unpublished accidentally) |
+| **Metrics** | Zero sales OK — empty-success copy, not failure |
+| **Help** | Sharing tips; embed if available |
+| **Navigation emphasis** | Marketing; soft pulse on Tickets/Orders |
+| **Operational tools** | Public link copy; Boost available but not pressuring |
+| **Success criteria** | Organiser trusts “it’s live”; can share in one action |
+
+**Runtime seed:** Published + ready → Share → `workspace_marketing`.
+
+---
+
+## 4. Selling
+
+| Dimension | Specification |
+| --- | --- |
+| **Primary goal** | Watch inventory and revenue; fix issues; light promotion |
+| **Hero** | Event name · **On sale** / Published · sales pulse headline |
+| **Workspace emphasis** | Sales snapshot · Tickets · Orders · Marketing |
+| **Primary CTA** | Context-sensitive: View orders **or** Adjust tickets **or** Share (from next-action / alerts) |
+| **Secondary CTA** | Boost · Messages · Analytics |
+| **Warnings** | Low capacity · Stripe issues · refund spikes |
+| **Metrics** | Tickets sold, revenue (Commerce-truth), conversion cues if honest |
+| **Help** | Capacity / pricing tips — non-blocking |
+| **Navigation emphasis** | Tickets, Orders, Marketing; builder quieter |
+| **Operational tools** | Ticket manager; readonly-safe order inspection; Boost with spend clarity |
+| **Success criteria** | Organiser sees movement or calm zero; knows which lever to pull |
+
+**Runtime gap:** Emphasis is card-level today, not formal shell reweight — target for presentation layer.
+
+---
+
+## 5. Upcoming
+
+| Dimension | Specification |
+| --- | --- |
+| **Primary goal** | Guest-list readiness, messaging plan, door prep |
+| **Hero** | Event name · **Upcoming** · date/countdown clarity |
+| **Workspace emphasis** | Attendees · Messages · door prep checklist |
+| **Primary CTA** | Review attendees |
+| **Secondary CTA** | Message guests · Preview Door Mode |
+| **Warnings** | Incomplete guest questions · missing door staff plan |
+| **Metrics** | Attendee / RSVP counts; checked-in = 0 expected |
+| **Help** | Door prep checklist |
+| **Navigation emphasis** | Attendees, Messages; Door entry visible |
+| **Operational tools** | Guest list; messaging; Door Mode preview (not full stress mode) |
+| **Success criteria** | Organiser knows who’s coming and how door will run |
+
+**Runtime gap:** No automated “upcoming mode” shell emphasis yet.
+
+---
+
+## 6. Live
+
+| Dimension | Specification |
+| --- | --- |
+| **Primary goal** | Check guests in quickly; handle exceptions calmly |
+| **Hero** | Unmistakable **Live** / Door status · event identity always visible |
+| **Workspace emphasis** | Door Mode + Attendees exceptions; builder de-emphasised |
+| **Primary CTA** | Open Door Mode / Check in |
+| **Secondary CTA** | Order exceptions · Message · View orders |
+| **Warnings** | Scan failure · access issues · (future) offline |
+| **Metrics** | Checked-in / remaining; exceptions count |
+| **Help** | Minimal chrome; large targets; reduced motion respected |
+| **Navigation emphasis** | Attendees (+ Door); everything else secondary |
+| **Operational tools** | Door Mode stress UI; searchable list; server-side check-in |
+| **Success criteria** | ≤2 taps from Home to Door; one-handed usable at 390px; confirmation brief |
+
+**Runtime debt:** Door Mode on Manager shell — continuity must be fixed (DDR-008/009).
+
+---
+
+## 7. Completed
+
+| Dimension | Specification |
+| --- | --- |
+| **Primary goal** | Reconcile money; learn; close calmly |
+| **Hero** | Event name · **Completed** · thank-you / closure tone |
+| **Workspace emphasis** | Orders · Analytics · Settings/archive; no growth pressure |
+| **Primary CTA** | Review orders **or** View analytics (context) |
+| **Secondary CTA** | Refunds (deliberate) · Archive · Duplicate event (if product supports later) |
+| **Warnings** | Open refunds · payout holds — link to Payments hub |
+| **Metrics** | Final sales, attendance, (honest) outcomes |
+| **Help** | Payouts → Payments; refund expectations |
+| **Navigation emphasis** | Orders, Analytics, Settings; Marketing demoted |
+| **Operational tools** | Order truth; refund entry; archive affordance |
+| **Success criteria** | Organiser can close the loop without FOMO “boost now” |
+
+**Runtime gap:** Aftermath mode not automated; archive routes residual on Manager — map via DDR-008 Phase 3.
+
+---
+
+## State detection (design contract — not inventing fields)
+
+Presentation layer should derive emphasis from **existing** signals already used by builders/VM where possible:
+
+| Signal class | Examples already in stack |
+| --- | --- |
+| Publish state | Node published flag / status labels on VM |
+| Readiness | `EventReadinessFacade` / eligibility |
+| Sales activity | Sales snapshot / Home cards |
+| Temporal | Event date/time fields already feeding VM date labels |
+| Door proximity | Dashboard Foundation patterns for “today / doors open”; reuse carefully for Workspace |
+| Completion | Past end + published/unpublished archive patterns |
+
+**Do not invent** new entity fields in this sprint. If a signal cannot be confirmed in repository at implementation time — **stop and ask**.
+
+---
+
+## CTA conflict resolution
+
+When multiple CTAs could apply:
+
+1. Safety / setup errors  
+2. Publish blockers / Stripe gate  
+3. Lifecycle primary (table above)  
+4. Growth (Share / Boost)  
+
+Event chrome shows **one** primary. Home may explain why. Topbar must not permanently compete with Home next-action as a second primary of equal weight.

--- a/docs/design/vendor-workspace-v2/09-workspace-wireframes.md
+++ b/docs/design/vendor-workspace-v2/09-workspace-wireframes.md
@@ -1,0 +1,386 @@
+# Vendor Workspace v2 — High-Fidelity Wireframes
+
+**Status:** High-fidelity product design (Sprint 1B) — documentation only  
+**Date:** 2026-07-25  
+**Surface:** Event Workspace Home (Mission Control) + chrome behaviours  
+**Authority:** PDS 03 · 05 · 06 · 08 · 11 · 13 · 14 · prepared DDR-008/009  
+**Transitional URL shown:** `/vendor/events/{id}/studio` until DDR-008 Accepted  
+
+These wireframes **redesign composition and hierarchy**. They do not rearrange today’s dense cards into a prettier admin page.
+
+---
+
+## Design intent
+
+| Feel | Means |
+| --- | --- |
+| Calm | Generous whitespace; one story per band |
+| Professional | Clear type hierarchy; no novelty chrome |
+| Fast | Next action above the fold; ≤1 primary |
+| Reliable | Status + readiness honesty |
+| Focused | Lifecycle emphasis, not equal-weight dashboard tiles |
+| Helpful | Plain-language recovery |
+| Premium | Restraint; quality empty states |
+
+**Avoid:** Nested cards, equal-weight KPI walls, dual primaries, CMS forms as Home, decorative charts.
+
+---
+
+## Shared chrome (all breakpoints)
+
+### Event chrome
+
+```text
+← Events    {Event name}                    [Status]    [ Primary CTA ]  [ View ]
+            {Date · Venue short}                        (one only)       [ Share ]
+```
+
+### Section nav membership (DDR-009 proposed)
+
+```text
+Overview · Details · Schedule · Venue · Images · Tickets
+Attendees · Messages · Marketing · Orders · Analytics · Publishing · Settings
+```
+
+Lifecycle changes **emphasis** (e.g. Live pins Attendees), not membership.
+
+### Drawer (tablet / mobile)
+
+- Section nav in left drawer (tablet) or full-height drawer (mobile)
+- Focus trap + Esc + return focus (PDS 07)
+- Mobile priority items first; builder sections grouped under “Setup”
+
+### Sticky actions
+
+| Breakpoint | Behaviour |
+| --- | --- |
+| Desktop | Primary CTA in event chrome; no duplicate sticky unless destructive confirm |
+| Tablet | Chrome CTA remains; drawer for nav |
+| 390px | Sticky bottom bar: Primary CTA + optional overflow (⋯) for Share/View |
+
+---
+
+## A. Desktop (≥1200px) — Workspace Home
+
+### Selling state (canonical “run my event” composition)
+
+```text
+┌─ GLOBAL HEADER ─────────────────────────────────────────────────────────────┐
+│ MyEventLane  Organiser    [Create event]              Help   Account        │
+├─ GLOBAL NAV ─┬─ EVENT WORKSPACE ────────────────────────────────────────────┤
+│ Dashboard    │ ← Events   Summer Night Market          On sale   [Orders] [View]
+│ Events ●     │            Sat 18 Oct · Fitzroy                   primary  [Share]
+│ Orders       ├─ SECTIONS ───────────────────────────────────────────────────┤
+│ Attendees    │ Overview● Details Schedule Venue Images Tickets Attendees … │
+│ Messages     ├─ MAIN (Reading intent — calm column) ────────────────────────┤
+│ Payments     │                                                              │
+│ Analytics    │  ┌─ TODAY’S FOCUS ─────────────────────────────────────────┐ │
+│ Marketing    │  │ Tickets are moving — 42 sold. Two types nearly full.  │ │
+│ Settings     │  │                                          [ View orders ]│ │
+│ Support      │  └──────────────────────────────────────────────────────────┘ │
+│              │                                                              │
+│              │  Health · On sale · Ready · Stripe connected                 │
+│              │  ─────────────────────────────────────────────────────────   │
+│              │                                                              │
+│              │  OPERATIONAL PULSE                          (not a card wall)│
+│              │  Tickets        42 sold · 18 left     →                      │
+│              │  Attendees      40 expected           →                      │
+│              │  Orders         $1,280 · 2 refunds    →                      │
+│              │  Messages       1 draft               →                      │
+│              │                                                              │
+│              │  GROWTH (quiet)                                              │
+│              │  Marketing · last shared 2d ago              [ Share ]       │
+│              │  Analytics · views this week                  →              │
+│              │                                                              │
+│              │  Activity (grouped, scannable)                               │
+│              │  · Order #1842 paid · 2h ago                                 │
+│              │  · Ticket “Early” 90% sold · 5h ago                          │
+│              │                                                              │
+│              │  Setup complete · Publishing · Settings          (muted)     │
+└──────────────┴──────────────────────────────────────────────────────────────┘
+```
+
+### Whitespace hierarchy (desktop)
+
+1. **Band 0** — Event chrome (identity + one CTA)  
+2. **Band 1** — Today’s Focus (single narrative + primary)  
+3. **Band 2** — Health strip (status · readiness · payments) — one line  
+4. **Band 3** — Operational pulse (list rows, not nested cards)  
+5. **Band 4** — Growth quiet + activity  
+6. **Band 5** — Setup/Publishing/Settings muted footer links  
+
+### Draft state differences (desktop)
+
+- Today’s Focus = next readiness blocker + **Continue setup**
+- Operational pulse muted / collapsed
+- Health strip shows “Draft · 3 of 8 ready”
+- Primary CTA in chrome = Continue setup
+
+### Live state differences (desktop)
+
+- Status unmistakable **Live**
+- Today’s Focus = Door readiness + **Open Door Mode**
+- Operational pulse leads with Attendees checked-in/remaining
+- Builder links hidden under “Setup” disclosure
+
+### Completed state differences (desktop)
+
+- Tone closure; Marketing demoted
+- Primary = Review orders / Analytics
+- No Boost pressure
+
+---
+
+## B. Tablet (768–1199px)
+
+```text
+┌─ GLOBAL HEADER (compact) ──────────────────────────────────────────┐
+│ ☰  MEL Organiser          [Create]              Account            │
+├────────────────────────────────────────────────────────────────────┤
+│ ← Events   Summer Night Market     On sale    [ Orders ]  [ ⋯ ]   │
+│            Sat 18 Oct                                             │
+├─ SECTION CHIP ROW (scroll) ────────────────────────────────────────┤
+│ Overview●  Tickets  Attendees  Orders  More…                      │
+├────────────────────────────────────────────────────────────────────┤
+│ TODAY’S FOCUS                                                     │
+│ Tickets are moving — 42 sold.                                     │
+│                                              [ View orders ]      │
+├────────────────────────────────────────────────────────────────────┤
+│ Health · On sale · Ready · Stripe OK                              │
+├────────────────────────────────────────────────────────────────────┤
+│ Pulse rows (full width)                                           │
+│ Tickets →   Attendees →   Orders →   Messages →                   │
+├────────────────────────────────────────────────────────────────────┤
+│ Activity                                                          │
+└────────────────────────────────────────────────────────────────────┘
+
+☰ opens global nav drawer
+⋯ opens Share / View / Publishing shortcuts
+“More…” opens Workspace section drawer (full section list)
+```
+
+**Tablet rules**
+
+- Chip row shows lifecycle-priority sections; full list in drawer  
+- Today’s Focus remains above pulse  
+- No dual sidebars visible simultaneously  
+- Touch targets ≥44px  
+
+---
+
+## C. 390px Mobile — Workspace Home (Selling)
+
+```text
+┌────────────────────────────┐
+│ ☰  MEL        [Create]  👤 │
+├────────────────────────────┤
+│ ← Events                   │
+│ Summer Night Market        │
+│ On sale · Sat 18 Oct       │
+├────────────────────────────┤
+│ TODAY’S FOCUS              │
+│ Tickets moving · 42 sold   │
+│                            │
+│ [ View orders ]            │  ← promoted (order: -1 pattern preserved)
+├────────────────────────────┤
+│ On sale · Ready · Stripe OK│
+├────────────────────────────┤
+│ Tickets          42 sold › │
+│ Attendees      40 expect › │
+│ Orders           $1,280 ›  │
+│ Messages        1 draft ›  │
+├────────────────────────────┤
+│ Share event              › │
+│ Activity                   │
+│ · Order paid · 2h          │
+├────────────────────────────┤
+│                            │
+│                            │
+├─ STICKY ───────────────────┤
+│ [ View orders ]      [ ⋯ ] │
+└────────────────────────────┘
+```
+
+### 390px Live
+
+```text
+┌────────────────────────────┐
+│ Summer Night Market        │
+│ ● LIVE · Door open         │
+├────────────────────────────┤
+│ TODAY’S FOCUS              │
+│ Check guests in as they    │
+│ arrive.                    │
+│ [ Open Door Mode ]         │
+├────────────────────────────┤
+│ Checked in  28 / 40        │
+│ Exceptions             2 › │
+├────────────────────────────┤
+│ Messages · Orders (muted)  │
+├─ STICKY ───────────────────┤
+│ [ Open Door Mode ]         │
+└────────────────────────────┘
+```
+
+### Mobile drawer — sections
+
+```text
+┌─ Workspace ───────────────┐
+│ Overview                  │
+│ ── Run event ──           │
+│ Tickets                   │
+│ Attendees                 │
+│   Door Mode               │
+│ Messages                  │
+│ Orders                    │
+│ Marketing                 │
+│ Analytics                 │
+│ ── Setup ──               │
+│ Details · Schedule · …    │
+│ Publishing · Settings     │
+│                     Close │
+└───────────────────────────┘
+```
+
+---
+
+## Section body wireframes (not Home)
+
+Home is Mission Control. Other sections use Workspace layout intent with a **section header** (title · short purpose · secondary tools) — not a second hero stack.
+
+### Tickets
+
+```text
+Tickets
+Sellable options for this event
+
+[ Add ticket type ]
+
+Early bird     $25 · 90% sold · On sale     [ Edit ]
+GA             $35 · On sale                [ Edit ]
+Comp           Free · Hidden                [ Edit ]
+
+Advanced inventory (disclosure) → Commerce backstage tools
+```
+
+### Attendees
+
+```text
+Attendees                         [ Open Door Mode ]
+40 expected · 2 exceptions
+
+[ Search guests ]
+
+Name · Ticket · Status · Actions
+…
+```
+
+### Orders
+
+```text
+Orders                            (Commerce truth)
+$1,280 · 36 orders · 2 refunds
+
+Filters · Export (if permitted)
+
+Order · Buyer · Total · State · →
+```
+
+### Messages
+
+```text
+Messages for this event
+Audience: ticket holders (clarify before send)
+
+[ New message ]
+
+Drafts · Sent history (event-scoped)
+Brand/templates → global Messages hub (link out)
+```
+
+### Marketing
+
+```text
+Marketing
+Share · Embed · Boost
+
+Public link                    [ Copy ]
+Boost status · spend clear     [ Boost ]
+```
+
+### Analytics
+
+```text
+Analytics (this event)
+Views · Sales over time · Top tickets
+Text alternatives for critical figures
+Pro-gated depth if product requires — honest about limits
+```
+
+### Publishing
+
+```text
+Publishing
+Status: Ready / Published
+Checklist with recovery links
+[ Publish ] or [ Unpublish ] — explicit confirm
+Stripe attention if paid path blocked
+```
+
+### Settings
+
+```text
+Settings
+Event-level preferences · danger zone (archive/unpublish)
+Ownership-sensitive toggles · confirm patterns
+```
+
+### Help (contextual)
+
+Inline “Need help?” near blockers; links to Help Centre articles with **organiser** audience only — never staff playbooks.
+
+---
+
+## Primary / secondary CTA matrix (chrome)
+
+| State | Primary | Secondary |
+| --- | --- | --- |
+| Draft | Continue setup | Preview |
+| Ready | Publish / Go to Publishing | Preview |
+| Published | Share | View public |
+| Selling | View orders *or* Adjust tickets | Share |
+| Upcoming | Review attendees | Message |
+| Live | Open Door Mode | Exceptions |
+| Completed | Review orders | Analytics |
+
+\* Resolved by attention rules (errors → lifecycle primary → growth).
+
+---
+
+## What we deliberately did **not** wireframe
+
+- A second global “Workspace” nav item  
+- Nested card grids of six equal ops tiles as the hero  
+- Manager dual product  
+- CMS node-edit as Home  
+- Decorative “mission control” gauges without action  
+
+---
+
+## Traceability to runtime seeds
+
+| Wireframe band | Extend (do not replace) |
+| --- | --- |
+| Event chrome | Studio topbar + VM `event` |
+| Today’s Focus | Unify `todays_focus` + `next_action` presentation |
+| Health strip | Readiness facade + Stripe gate signals |
+| Pulse rows | Home cards flattened to rows |
+| Activity | Overview activity feed |
+| Door entry | Attendees + `vendor_operations_door` |
+| Sticky mobile CTA | Existing `<720px` next-action priority pattern |
+
+---
+
+## Acceptance notes for future implementation
+
+Wireframes are approved for composition **only after** human review of this sprint. Path labels may show DDR-002 target URLs in mock copy once DDR-008 Accepted; until then engineering uses `/studio`.

--- a/docs/design/vendor-workspace-v2/10-workspace-mission-control.md
+++ b/docs/design/vendor-workspace-v2/10-workspace-mission-control.md
@@ -1,0 +1,165 @@
+# Vendor Workspace v2 — Mission Control (Ideal Workspace)
+
+**Status:** Product design philosophy (Sprint 1B) — documentation only  
+**Date:** 2026-07-25  
+**Authority:** PDS 01 · 12 · 13 · 14 · 18 · `04-mission-control-model.md` · wireframes `09`  
+**Role:** Ideal experience definition for Event Workspace Home  
+
+This document describes the **ideal** Workspace organisers should feel. It does not invent a parallel builder. Runtime seeds remain in `EventWorkspaceOverviewBuilder` and `VendorEventWorkspaceViewModelBuilder`.
+
+---
+
+## The five-second test
+
+An organiser opens an event. Within **five seconds**, without scrolling past the first meaningful band, they can answer:
+
+| Question | Ideal answer source |
+| --- | --- |
+| **Where am I?** | Event name · status · “Event Workspace” context (not Drupal, not “Studio vs Manager”) |
+| **How healthy is my event?** | Health strip: status · readiness · payments/Stripe honesty |
+| **What needs attention?** | Today’s Focus narrative (one story) |
+| **What should I do next?** | Single primary CTA (chrome + Focus aligned) |
+| **How close am I to success?** | Lifecycle-appropriate progress (setup % **or** sales/door pulse **or** closure metrics) |
+| **How do I run this event?** | Obvious path to Tickets · Attendees/Door · Orders · Messages |
+
+If any answer requires hunting through equal-weight cards, Mission Control has failed.
+
+---
+
+## Design around confidence — not administration
+
+| Confidence looks like | Administration looks like |
+| --- | --- |
+| “You’re ready — publish when you are” | Form dump of every field |
+| “42 sold — Early nearly full” | Raw Commerce variation tables on Home |
+| “Open Door Mode” | Nested local tasks and dual shells |
+| Calm empty sales | Red error empty states for zero |
+| One next step | Toolbars of peer actions |
+
+**Emotional target (PDS 14):** warm, capable, local, calm, honest — premium through restraint.
+
+---
+
+## Ideal Workspace anatomy
+
+```text
+Identity (chrome)
+    ↓
+Today’s Focus (narrative + primary)
+    ↓
+Health (status · readiness · money capability)
+    ↓
+Run this event (pulse rows)
+    ↓
+Quiet growth + activity
+    ↓
+Setup / publishing / settings (muted unless Draft/Ready)
+```
+
+### Block contracts
+
+#### 1. Identity
+
+- Event name, date clarity, venue short, status badge  
+- One primary CTA slot; Share/View secondary  
+- Answers **Where am I?**
+
+#### 2. Today’s Focus
+
+- Single sentence in organiser language  
+- One button matching chrome primary (or explaining why chrome differs briefly)  
+- Unifies today’s dual mental models: VM `todays_focus` + Studio `next_action`  
+- Answers **What needs attention?** and **What next?**
+
+#### 3. Health
+
+- Status · Readiness (honest) · Stripe/payments signal when relevant  
+- Never decorative green  
+- Answers **How healthy?**
+
+#### 4. Success proximity
+
+| Lifecycle | Proximity cue |
+| --- | --- |
+| Draft / Ready | “3 of 8 ready” |
+| Published / Selling | Sales / capacity pulse |
+| Upcoming | Guest prep completeness |
+| Live | Checked-in / remaining |
+| Completed | Final totals + open refunds |
+
+#### 5. Run this event
+
+Operational pulse rows — Tickets, Attendees, Orders, Messages — depth on click. Not six nested marketing cards.
+
+#### 6. Growth (quiet)
+
+Marketing/Analytics present but visually secondary while Selling; demoted when Completed; primary only when Published (first share).
+
+#### 7. Activity
+
+Grouped, factual, scannable — not a social feed.
+
+#### 8. Help
+
+Contextual, Australian English, organiser audience — appears beside blockers, not as a tour modal wall.
+
+---
+
+## Relationship to Dashboard
+
+| Dashboard Foundation | Event Mission Control |
+| --- | --- |
+| Portfolio attention | This event attention |
+| Action queue across events | Today’s Focus for one event |
+| Business health strip | Event health strip |
+| “Today’s event / Next up” | Deep link **into** Workspace Focus |
+
+**Rule:** Never clone the Dashboard queue onto Workspace Home. Cross-link with clear scope labels (“Across your events” vs “This event”).
+
+---
+
+## Confidence principles (normative for Home PRs)
+
+1. **One story above the fold** — Focus band owns the narrative.  
+2. **One primary action** — Chrome and Focus agree.  
+3. **Honesty over cheerleading** — Readiness and money tell the truth.  
+4. **Lifecycle reweight, don’t rebuild** — Same shell.  
+5. **Stress path privilege** — Live/Door gets ruthlessly simple UI.  
+6. **Empty is success when appropriate** — Zero sales after publish is calm, not failure.  
+7. **Hide MEL history** — No Studio/Manager fork in copy or chrome.  
+8. **Accessibility is confidence** — Focus order, contrast, non-colour severity, reduced motion (PDS 07/08).
+
+---
+
+## Success criteria (Mission Control)
+
+Measurable intent (aligns PDS 18; exact instrumentation later):
+
+1. Time-to-identify next step on Home &lt; 5s (moderated usability).  
+2. Publish blockers always show recovery.  
+3. Live → Door Mode ≤ 2 taps.  
+4. No dual-product navigation in organiser path.  
+5. Dashboard item and Workspace Focus never contradict without scoped explanation.
+
+---
+
+## Runtime extension map
+
+| Ideal block | Extend |
+| --- | --- |
+| Identity | Topbar + VM `event` |
+| Focus | Presentation unify `todays_focus` + `resolveNextRecommendedAction()` |
+| Health | Readiness facade + Stripe gate + status |
+| Pulse | Flatten overview cards to rows |
+| Activity | Overview activity |
+| Door | Attendees entry + Door Mode route (chrome continuity) |
+
+**Do not** create `VendorWorkspaceV2MissionControlBuilder` as a parallel system.
+
+---
+
+## Ideal day-in-the-life vignette
+
+> Jordan opens **Summer Night Market**. In one glance: On sale, Ready, Stripe OK. Focus says tickets are moving and Early is nearly full. Primary: View orders. Pulse shows attendees expected and a message draft. Jordan adjusts capacity in Tickets, shares once from Marketing, and on the night taps Open Door Mode from the same Workspace — never learning that MEL once had two products.
+
+That vignette is the design bar for Foundation implementation.

--- a/docs/design/vendor-workspace-v2/11-operational-state-model.md
+++ b/docs/design/vendor-workspace-v2/11-operational-state-model.md
@@ -1,0 +1,179 @@
+# Vendor Workspace v2 — Operational State Model
+
+**Status:** Architecture / product design (Sprint 1B) — documentation only  
+**Date:** 2026-07-25  
+**Principle:** The shell remains constant. Only emphasis changes.  
+**Extends:** `03-workspace-state-model.md` · `08-event-lifecycle-model.md`  
+
+States covered:
+
+```text
+No Event · Draft · Ready · Published · Upcoming · Live · Completed
+```
+
+**Note on Selling:** Selling is a **sub-emphasis of Published** (active sales signals). It does not add/remove panels; it raises Orders/Tickets/Marketing prominence. See matrices below.
+
+---
+
+## Shell constants (all states)
+
+Always present:
+
+- Global organiser shell (DDR-001)  
+- Event chrome (when an event context exists)  
+- Section nav membership (DDR-009 proposed order)  
+- Help entry  
+- One primary CTA slot in chrome (content varies)
+
+Never by state:
+
+- Second product shell  
+- CMS node-edit takeover  
+- Removing Orders/Attendees from membership (only mute emphasis)
+
+---
+
+## No Event
+
+*Context: Events catalogue empty, or user lands with no selectable event — Workspace not entered.*
+
+| Dimension | Spec |
+| --- | --- |
+| **Visible panels** | Events empty state · Create event · optional Dashboard “get started” |
+| **Hidden panels** | All Workspace sections, Door Mode, event metrics |
+| **CTA priority** | **Create event** |
+| **Messages** | Warm, capable: “Create your first event — we’ll guide the rest” |
+| **Metrics** | None |
+| **Warnings** | None (unless account/Stripe setup blocks creation — rare; be honest) |
+| **Suggested actions** | Create event · Browse help “Hosting on MEL” |
+
+Workspace shell is **not** shown empty with dead section nav.
+
+---
+
+## Draft
+
+| Dimension | Spec |
+| --- | --- |
+| **Visible panels** | Focus (setup) · Health (draft progress) · Readiness · Setup sections · muted ops |
+| **Hidden / muted** | Sales charts, Boost pressure, Door Mode stress UI |
+| **CTA priority** | Continue setup |
+| **Messages** | Next blocker in plain language |
+| **Metrics** | Readiness complete_count / total |
+| **Warnings** | Blockers with fix links |
+| **Suggested actions** | Fix first blocker · Preview if meaningful · Save confidence |
+
+---
+
+## Ready
+
+| Dimension | Spec |
+| --- | --- |
+| **Visible panels** | Focus (publish confidence) · Health green + Stripe · Publishing · Preview |
+| **Hidden / muted** | Door Mode, dense sales analytics |
+| **CTA priority** | Publish / Go to Publishing |
+| **Messages** | “Ready when you are” · visibility consequences |
+| **Metrics** | Readiness complete; sales still quiet |
+| **Warnings** | Stripe / paid-path gates |
+| **Suggested actions** | Publish · Preview public page |
+
+---
+
+## Published
+
+*Includes early Published (pre-sales) and **Selling** emphasis.*
+
+### Published (pre-sales / first share)
+
+| Dimension | Spec |
+| --- | --- |
+| **Visible panels** | Focus (Share) · Health Published · Marketing · calm zero sales |
+| **Hidden / muted** | Setup density, Door Mode |
+| **CTA priority** | Share |
+| **Messages** | “Your event is live on MEL” |
+| **Metrics** | Views if honest; sales zero-success |
+| **Warnings** | Regressions only |
+| **Suggested actions** | Share · Copy link · light Boost optional |
+
+### Selling emphasis (Published + sales activity)
+
+| Dimension | Spec |
+| --- | --- |
+| **Visible panels** | Focus (sales/inventory) · Pulse: Tickets · Orders · Attendees · Marketing |
+| **Hidden / muted** | Builder sections collapsed under Setup |
+| **CTA priority** | View orders / Adjust tickets / Share (attention rules) |
+| **Messages** | Capacity and refund attention when present |
+| **Metrics** | Sold, remaining, revenue (Commerce truth) |
+| **Warnings** | Low capacity · Stripe · refund spikes |
+| **Suggested actions** | Orders · Tickets · Message · Boost with spend clarity |
+
+---
+
+## Upcoming
+
+| Dimension | Spec |
+| --- | --- |
+| **Visible panels** | Focus (guest prep) · Attendees · Messages · Door preview · date clarity |
+| **Hidden / muted** | Heavy builder; Boost pressure reduced |
+| **CTA priority** | Review attendees |
+| **Messages** | Door prep checklist items |
+| **Metrics** | Expected guests · RSVPs · message draft count |
+| **Warnings** | Incomplete guest data / questions |
+| **Suggested actions** | Attendees · Message · Preview Door Mode |
+
+---
+
+## Live
+
+| Dimension | Spec |
+| --- | --- |
+| **Visible panels** | Focus (Door) · Live status · checked-in metrics · exceptions · Attendees/Door |
+| **Hidden / muted** | Setup, Marketing/Boost, Analytics deep dives, Publishing (unless emergency unpublish) |
+| **CTA priority** | Open Door Mode |
+| **Messages** | Minimal; failure messages large and clear |
+| **Metrics** | Checked-in / remaining · exceptions |
+| **Warnings** | Scan/access failures |
+| **Suggested actions** | Door Mode · Exceptions · Orders (edge) · Message (edge) |
+
+---
+
+## Completed
+
+| Dimension | Spec |
+| --- | --- |
+| **Visible panels** | Focus (closure) · Orders · Analytics · Settings/archive · final metrics |
+| **Hidden / muted** | Door Mode, Boost, setup checklists, “share now” pressure |
+| **CTA priority** | Review orders / View analytics |
+| **Messages** | Thank-you / closure; payouts → Payments hub |
+| **Metrics** | Final sales · attendance |
+| **Warnings** | Open refunds · payout holds |
+| **Suggested actions** | Orders · Refunds (deliberate) · Analytics · Archive |
+
+---
+
+## Panel emphasis legend
+
+| Label | Meaning |
+| --- | --- |
+| **Visible** | On Home or one tap; visually primary |
+| **Muted** | Reachable via nav; de-emphasised on Home |
+| **Hidden** | Not appropriate for state (e.g. Door stress UI in Draft) — capability may still exist via nav with calm entry |
+
+---
+
+## CTA priority algorithm (normative)
+
+```text
+1. Safety / setup errors (VM / readiness)
+2. Publish blockers / Stripe gate
+3. State primary (tables above)
+4. Growth (Share / Boost)
+```
+
+Chrome primary **equals** Focus primary unless a transient confirm dialog is open.
+
+---
+
+## Mapping note for implementers
+
+This model is a **presentation contract** for `EventStudioWorkspacePresentation` + Home builder — not a new state-machine entity. Derive from existing publish/readiness/date/sales signals; if a signal is missing in repository, stop and ask (do not invent fields).

--- a/docs/design/vendor-workspace-v2/12-workspace-implementation-strategy.md
+++ b/docs/design/vendor-workspace-v2/12-workspace-implementation-strategy.md
@@ -1,0 +1,197 @@
+# Vendor Workspace v2 — Implementation Strategy
+
+**Status:** Implementation readiness (Sprint 1B) — documentation only  
+**Date:** 2026-07-25  
+**Branch:** `feature/vendor-workspace-v2-discovery`  
+**Base:** `37fcdc449`  
+**Authority:** PDS 09 · 10 · 21 · 16 · ADR-0001 · prepared DDR-008/009  
+
+**Do not implement from this document until human approval.** No PHP/Twig/SCSS/JS/YAML changes in Sprint 1B.
+
+---
+
+## Preconditions (blockers)
+
+| Gate | Why |
+| --- | --- |
+| Human approval of Sprint 1B pack | Wireframes + architecture accepted |
+| **DDR-008 / DDR-009** Accepted **or** explicit PO waiver for composition-only slices on `/studio` | Avoid building against undecided IA/paths |
+| Config hygiene: `user.role.vendor` + `views.view.myeventlane_vendor_rsvps` active vs sync | Access-adjacent trust |
+| Author or remove **ADR-0002** reference in cursor rule | Governance honesty |
+| Feature branch from latest `main` | Dashboard Foundation already merged |
+
+---
+
+## Slice overview
+
+```text
+Slice 1  Workspace shell (presentation constancy)
+Slice 2  Workspace Hero (event chrome / identity)
+Slice 3  Readiness (honest health)
+Slice 4  Publishing (deliberate gate UX)
+Slice 5  Tickets
+Slice 6  Operations (Attendees/Door, Orders, Messages, Marketing/Analytics emphasis)
+Slice 7  Polish (a11y, mobile sticky, density, copy)
+```
+
+**Parallel / later (not Foundation):** Path unification (DDR-008 Phase 2), nav single-source collapse, Manager staff-gate.
+
+---
+
+## Slice 1 — Workspace shell
+
+| | |
+| --- | --- |
+| **Scope** | Establish constant shell composition: global context + event chrome region + section nav + main band structure matching wireframes (`09`). No route renames. Clarify organiser copy: “Event Workspace”. |
+| **Risk** | Low–Medium — theme/Twig structure; must not break section plugin rendering or libraries |
+| **Reusable components** | Layout intents (DDR-003), existing Studio workspace Twig, vendor tokens (11) |
+| **Reusable builders** | `EventStudioSectionManager`, `EventStudioPreprocess` |
+| **Twig impact** | `mel-event-studio-workspace.html.twig`, sidebar/topbar wrappers — structure only |
+| **SCSS impact** | `mel-event-studio-shell.css` / nav CSS — spacing hierarchy, not new kit |
+| **Validation** | Visual: Desktop/tablet/390px shell; `ddev drush cr`; keyboard to section nav; no dual global nav; `npm run mel:lint` / `mel:build` if theme assets touched |
+
+---
+
+## Slice 2 — Workspace Hero
+
+| | |
+| --- | --- |
+| **Scope** | Event chrome: name, status, date clarity, **one** primary CTA slot, secondary View/Share. Align CTA with lifecycle tables (`08`). Remove competing dual-primary (topbar publish vs Home) by slot rules. |
+| **Risk** | Medium — publish affordance must remain reachable when Ready; do not hide money gates |
+| **Reusable components** | PDS 05 Workspace Hero patterns; existing topbar |
+| **Reusable builders** | VM `event` + `next_action`; presentation layer |
+| **Twig impact** | `mel-event-studio-topbar.html.twig` (+ Home header if split) |
+| **SCSS impact** | Hero/chrome spacing; sticky mobile CTA prep |
+| **Validation** | CTA matrix spot-check Draft/Ready/Published/Live; focus visible; SR status not colour-only |
+
+---
+
+## Slice 3 — Readiness
+
+| | |
+| --- | --- |
+| **Scope** | Health strip + Event Ready presentation: honest checklist, counts, recovery links. Never green without eligibility. Unify messaging with Publishing section. |
+| **Risk** | High if readiness cosmetics diverge from `PublishEligibilityEvaluator` / Stripe gate |
+| **Reusable components** | Readiness checklist patterns; alerts (severity) |
+| **Reusable builders** | `EventReadinessFacade` / `EventReadinessService`; `EventStudioWorkspacePresentation` |
+| **Twig impact** | Overview readiness regions; strip partials |
+| **SCSS impact** | Health strip; checklist density |
+| **Validation** | Fixture events: blocked / ready / Stripe-blocked; confirm no false ready; cache tags preserved |
+
+---
+
+## Slice 4 — Publishing
+
+| | |
+| --- | --- |
+| **Scope** | Publishing section + Home Focus alignment for Ready state; explicit publish/unpublish UX; dirty/stale/draft conflict messaging clarity. **No** autosave publish. |
+| **Risk** | **High** — CSRF publish API, eligibility, Stripe paid-publish gate |
+| **Reusable components** | Confirm patterns (07); Publishing section form |
+| **Reusable builders** | `PublishEligibilityEvaluator`, `EventStudioPublishController`, PaidPublishStripeGate |
+| **Twig impact** | Publishing section + Focus CTA labels |
+| **SCSS impact** | Minimal — confirm dialog clarity |
+| **Validation** | Publish happy path + blocked path + stale conflict; Network CSRF header; staff vs organiser access unchanged |
+
+---
+
+## Slice 5 — Tickets
+
+| | |
+| --- | --- |
+| **Scope** | Tickets section body composition per wireframes: organiser language list, progressive disclosure for advanced inventory. Home pulse row links here. |
+| **Risk** | **High** — Commerce variations, capacity, stock; do not collapse event≠product model |
+| **Reusable components** | Tickets app library; MEL list/row patterns |
+| **Reusable builders** | Tickets section plugin + existing ticket services |
+| **Twig impact** | Tickets section templates / app mount |
+| **SCSS impact** | Section header + row list |
+| **Validation** | Create/edit ticket type; capacity display honesty; no product/variation jargon in UI |
+
+---
+
+## Slice 6 — Operations
+
+| | |
+| --- | --- |
+| **Scope** | Home operational pulse rows; Attendees entry + **Door Mode continuity** (same-app feel); Orders readonly-safe presentation; Messages/Marketing/Analytics emphasis by state (`11`). |
+| **Risk** | **High** — Door Mode access/mutations; order ownership; PII; messaging audience; Boost spend honesty |
+| **Reusable components** | Attendees workspace Twig; Door Mode route (keep access logic); Orders section |
+| **Reusable builders** | Overview builder pulse; attendees controllers; sales summaries |
+| **Twig impact** | Overview pulse; attendees header Door CTA; avoid new Manager shell features for organisers |
+| **SCSS impact** | Pulse rows; Live emphasis; Door entry |
+| **Validation** | Live ≤2 taps to Door; order list scoped to event; no PII leakage; mobile Door targets ≥44px |
+
+---
+
+## Slice 7 — Polish
+
+| | |
+| --- | --- |
+| **Scope** | Density reduction; empty states; activity grouping; sticky mobile CTA; focus order; `prefers-reduced-motion`; copy pass (PDS 15); Help links audience check. |
+| **Risk** | Low–Medium — regressions in spacing/a11y |
+| **Reusable components** | Empty states; skeletons if Dashboard patterns apply lightly |
+| **Reusable builders** | None new |
+| **Twig impact** | Copy + empty partials |
+| **SCSS impact** | Whitespace hierarchy; sticky bar; reduced motion |
+| **Validation** | `16` checklist + `21` DoD; axe/keyboard pass on Home; 390px Live sticky; `mel:lint` / `mel:build` |
+
+---
+
+## Out-of-slice (explicit)
+
+| Work | When |
+| --- | --- |
+| Path unify `/studio` → `/vendor/events/{id}` | After DDR-008 Accepted — own PR train |
+| Collapse `VendorEventTabsService` / console preprocess | After DDR-009 Accepted |
+| Staff-gate / retire Manager organiser entry | DDR-008 Phase 3 |
+| New entity fields for lifecycle state machine | Only if repository gap confirmed + asked |
+| Dashboard queue duplication on Home | Never |
+
+---
+
+## Recommended delivery order
+
+```text
+Hygiene (config) → DDR acceptances → Slice 1 → 2 → 3 → 4 → 5 → 6 → 7
+                         ↘ path unification (parallel track, later)
+```
+
+Each slice: feature branch · cite PDS + DDRs in PR · stop after slice · human review.
+
+---
+
+## Validation command set (per runtime slice)
+
+```bash
+ddev drush cr
+ddev drush config:status
+ddev composer validate
+npm run mel:lint
+npm run mel:build
+git status --short
+git diff
+```
+
+Add targeted tests for publish/autosave/Door/access when those slices touch them.
+
+---
+
+## Residual risks after full slice train
+
+- Dual shell until DDR-008 Phase 3  
+- Door Mode route may still be `/operations/door` even with chrome continuity  
+- Config drift if hygiene skipped  
+- Lifecycle detection imperfect without confirmed temporal signals — ask before inventing  
+
+---
+
+## Definition of “Workspace Foundation done”
+
+Slices **1–3** (+ Publishing Focus alignment from Slice 4 labels) ship with:
+
+- Wireframe hierarchy on Home  
+- One primary CTA  
+- Honest readiness  
+- No path rename required  
+- PDS citations + DoD gates  
+
+Operations depth (5–6) and polish (7) may follow as Workspace Ops train.

--- a/docs/design/vendor-workspace-v2/13-workspace-foundation-review.md
+++ b/docs/design/vendor-workspace-v2/13-workspace-foundation-review.md
@@ -1,0 +1,164 @@
+# Vendor Workspace v2 — Foundation Review (Slices 1–3)
+
+**Status:** Implementation complete — awaiting Product Owner review  
+**Date:** 2026-07-25  
+**Branch:** `feature/vendor-workspace-foundation`  
+**Base:** `origin/main` @ `37fcdc449` (Dashboard Foundation PR #716)  
+**Scope:** Slice 1 Shell · Slice 2 Hero · Slice 3 Readiness presentation only  
+
+No commit / push in this sprint.
+
+---
+
+## Repository summary
+
+| Check | Result |
+| --- | --- |
+| Branch | `feature/vendor-workspace-foundation` tracking `origin/main` |
+| Dashboard Foundation | Merged (`37fcdc449`) |
+| Discovery + Architecture docs | Present under `docs/design/vendor-workspace-v2/` (untracked from Sprint 1A/1B) |
+| Runtime health | Drupal 11.4.4 bootstrap OK |
+| Config drift | **Known** (Klaro, payments, `user.role.vendor`, RSVP view) — unchanged by this sprint |
+| DDR-008 / DDR-009 | Still **Prepared** (not Accepted) — composition used transitional `/studio` |
+
+---
+
+## Files changed
+
+### Runtime
+
+| Path | Slice | Why |
+| --- | --- | --- |
+| `…/templates/mel-event-studio-workspace.html.twig` | 1 | Shell comment / Home ownership clarity |
+| `…/templates/mel-event-studio-sidebar.html.twig` | 1 | “Event Workspace” labelling |
+| `…/templates/mel-event-studio-topbar.html.twig` | 2 | Workspace Hero: identity, status, date/venue, one primary CTA, View/Share |
+| `…/templates/mel-event-studio-overview.html.twig` | 1–3 | Mission Control hierarchy: Focus → Health → Readiness → quieter ops |
+| `…/css/mel-event-studio-shell.css` | 1–3 | Calmer hero + Home spacing; Reading-width Focus; mobile sticky primary |
+| `…/js/mel-event-studio-shell.js` | 2–3 | Hero primary sync after publish AJAX; health class sync |
+| `…/src/Controller/EventStudioController.php` | 2 | Topbar date/venue/share + `resolveHeroPrimaryCta()` from readiness |
+| `…/src/Controller/EventStudioPublishController.php` | 2 | AJAX topbar carries `primary_cta` + date/venue |
+| `…/src/Service/EventStudioWorkspacePresentation.php` | 2–3 | `buildTopbarDateLabel` / `buildTopbarVenueLabel`; clearer strip copy |
+
+### Tests
+
+| Path | Why |
+| --- | --- |
+| `EventStudioWorkspacePresentationContractTest.php` | Hero contract assertions |
+| `EventStudioWorkspaceStateMatrixTest.php` | Strip title expectations |
+| `EventStudioWorkspaceUxConsolidationTest.php` | JS fallback copy |
+
+### Docs
+
+| Path | Why |
+| --- | --- |
+| `13-workspace-foundation-review.md` | This review |
+
+---
+
+## Architecture followed
+
+- Studio remains organiser truth (`mel_event_studio_workspace`, `/studio`)
+- No route rename, no Manager retirement, no nav collapse, no path unification
+- Dashboard vs Workspace scope unchanged
+- Mission Control: one narrative above the fold; one primary action
+- Lifecycle CTA rules from Sprint 1B (Continue setup → Publish → Share) using existing readiness/published signals
+- Stripe Connect attention remains Home Focus authority (not duplicated in Hero)
+
+---
+
+## Reused
+
+| Kind | Assets |
+| --- | --- |
+| **Components / patterns** | `.mel-btn`, existing Studio shell BEM, readiness checklist marks |
+| **Builders** | `EventWorkspaceOverviewBuilder` (unchanged business logic), `EventStudioSectionManager` |
+| **ViewModels** | `VendorEventWorkspaceViewModelBuilder` still feeds Home next-action; Hero date uses same `field_event_start` as VM |
+| **Readiness** | `EventReadinessFacade`, `PublishEligibilityEvaluator` (via facade), presentation-only strip/Home |
+| **Libraries** | `mel_event_studio_shell_only` |
+
+**Not created:** new builders, new themes, parallel kits, new routes.
+
+---
+
+## Accessibility review
+
+| Requirement | Status |
+| --- | --- |
+| Status not colour-only | Health strip + text headlines + SR labels on checklist |
+| Focus / keyboard | Existing shell drawer + focus patterns preserved; primary CTAs `min-height: 44px` |
+| ARIA | Hero banner; health labelled heading; checklist SR prefixes |
+| Reduced motion | No new motion introduced |
+| 390px | Topbar stacks; sticky primary action band; Focus first |
+
+Residual: full axe pass in browser not run in this sprint — recommend Product visual + keyboard pass.
+
+---
+
+## Performance review
+
+| Concern | Status |
+| --- | --- |
+| Duplicate ViewModel on every section | **Avoided** — Hero date/venue from presentation field reads, not full VM |
+| Duplicate builders | None |
+| Cache | Workspace `#cache` tags/contexts unchanged on controller return |
+| Extra queries | Date/venue use fields already loaded on `$node` |
+
+---
+
+## Validation run
+
+| Command | Result |
+| --- | --- |
+| `ddev drush cr` | Success |
+| `ddev drush config:status` | Known drift only (pre-existing) |
+| `composer validate` | Valid |
+| `npm run mel:lint` | Passed |
+| `npm run mel:build` | Passed |
+| PHPUnit (presentation, state matrix, UX, next-action) | 36 tests OK |
+| Smoke: readiness + date/venue on event 1094 | Published+ready; strip “Live and ready” |
+| Smoke: render `mel_event_studio_topbar` | Hero labels + primary key OK |
+
+---
+
+## Known limitations
+
+1. DDR-008/009 not Accepted — `/studio` remains transitional.
+2. Config drift (`user.role.vendor`, RSVP ownership) still open — not touched here.
+3. Ops/business cards still present (muted) — Slice 6 will redesign pulse rows.
+4. Hero primary does not re-run Stripe evaluation (by design — Home Focus owns Connect).
+5. After in-place publish, Share becomes primary via JS; full page refresh remains authoritative.
+
+---
+
+## Technical debt (unchanged / residual)
+
+- Dual Manager shell still in codebase  
+- Triple nav sources  
+- Door Mode chrome split  
+- ADR-0002 missing  
+
+---
+
+## Future slices
+
+4 Publishing · 5 Tickets · 6 Operations (Door continuity) · 7 Polish · later path unification (DDR-008)
+
+---
+
+## Design compliance
+
+| Mission Control question | Foundation answer |
+| --- | --- |
+| Where am I? | Hero identity + Event Workspace eyebrow + status |
+| How healthy? | Health strip + readiness progress |
+| What needs attention? | Today’s Focus |
+| What next? | One primary (Hero + Focus) |
+| How close to success? | `@done of @total complete` |
+
+Avoided: KPI walls as hero, nested card competition above fold, dual primary Publish+Focus of equal weight when setup incomplete.
+
+---
+
+## Recommendation
+
+**Ready for Product Review?** → see sprint final report.

--- a/docs/design/vendor-workspace-v2/14-phase-a-product-review.md
+++ b/docs/design/vendor-workspace-v2/14-phase-a-product-review.md
@@ -1,0 +1,374 @@
+# Vendor Workspace Foundation — Phase A Product Review
+
+**Status:** Phase A.5 product coherence fixes complete — awaiting Product Owner approval  
+**Date:** 2026-07-25  
+**Branch:** `feature/vendor-workspace-foundation`  
+**Base:** `37fcdc449`  
+**Reviewer role:** Product / Architecture / UX / A11y / Performance validation  
+**Scope:** Validate Slices 1–3; Phase A.5 resolves Product Review findings only. No DDR acceptance. No commit/push.
+
+Runtime pages inspected (authenticated organiser/staff session):
+
+| Event | Path | State sample |
+| --- | --- | --- |
+| 1756 Untitled event | `/vendor/events/1756/studio` | Draft · blockers · Continue setup |
+| 1755 Anna Live at the Hall | `/vendor/events/1755/studio` | Published paid · Share · Boost active |
+| 1381 The Event Two | `/vendor/events/1381/studio` | Published · past-ish · Share · View RSVPs |
+
+Viewports measured via CDP: **390**, **430** (via 390+observation), **768**, ~**1024+** desktop.
+
+---
+
+## 1. Repository health
+
+| Check | Result |
+| --- | --- |
+| Branch | `feature/vendor-workspace-foundation` |
+| Status | 12 modified runtime/test files; untracked Sprint 1A/1B docs + DDRs + this pack |
+| Diff stat | +574 / −193 across Studio module only |
+| DDEV | OK — `https://myeventlane.ddev.site` Drupal 11.4.4 |
+| `ddev drush status` | Bootstrap successful |
+| `config:status` | **Known drift** (Klaro, payments, `user.role.vendor`, RSVP view, etc.) — not introduced by Foundation |
+| `composer validate` | Valid |
+| Services / routes | **No** `.services.yml` / `.routing.yml` changes |
+| Unit tests (presentation + state matrix) | 23 OK |
+
+**Finding:** Repository is healthy for review. Config drift remains a pre-existing parallel risk (not Foundation chrome).
+
+---
+
+## 2. Architecture review
+
+| Requirement | Evidence | Verdict |
+| --- | --- | --- |
+| `EventReadinessFacade` single authority | `EventStudioController` + `EventWorkspaceOverviewBuilder` + `EventStudioPublishController` call `readinessFacade->evaluate` | **PASS** |
+| No new readiness calculator | Diff adds presentation helpers + CTA mapping from `$readiness->ready` / published only | **PASS** |
+| Twig presentation-only | Overview/topbar consume precomputed props; no eligibility math | **PASS** |
+| Controllers remain thin | `buildTopbar` enrichment + small `resolveHeroPrimaryCta` using facade result | **PASS** (minor: CTA mapping lives in controller, not presentation — acceptable) |
+| Builders/VMs reused | Overview builder unchanged for business evaluation; VM still feeds next-action | **PASS** |
+| Cache metadata unchanged | Identical `#cache` tags/contexts vs HEAD | **PASS** |
+| No new services | No services.yml changes | **PASS** |
+
+### Architectural concerns (non-blocking for Foundation intent)
+
+1. **Hero CTA vs Home Focus can diverge** — Hero uses readiness/published only; Focus uses `resolveNextRecommendedAction()` (includes Stripe / VM severity). Draft sample: Hero **Continue setup** vs Focus **Edit event**.
+2. **Pre-existing parallel readiness** in `VendorEventWorkspaceViewModelBuilder::buildReadinessItems` still exists for Manager/VM paths — Foundation did not add a third source; Studio Home remains facade-backed.
+3. **Staff chrome in review session** (`Staff Overview`, admin toolbar) pollutes organiser-fidelity review — not a Foundation defect.
+
+---
+
+## 3. Product Design System review
+
+| Area | Verdict | Notes |
+| --- | --- | --- |
+| Workspace Shell | **PASS** | Event Workspace identity; section drawer; global shell preserved |
+| Workspace Hero | **PASS** with **MINOR** | Identity, status, date/venue, primary slot present; disabled Published still occupies action row |
+| Mission Control hierarchy | **PASS** | DOM order: Focus → Health → Readiness → Secondary |
+| Readiness presentation | **PASS** | Facade-backed; checklist opens when attention; legend present |
+| Spacing | **MINOR ISSUE** | Calmer than before; not fully audited to 12/16/24/32 token grid |
+| Typography | **PASS** | Clear H1/H2 hierarchy; eyebrow present |
+| Component consistency | **MINOR ISSUE** | Secondary ops cards still denser than Focus; intentional Slice-6 deferral |
+| Button hierarchy | **MAJOR ISSUE** | Multiple visible `.mel-btn--primary` in one viewport (Hero + Focus + global Create ± Boost) |
+| Visual weight | **PASS** | Focus/Health dominate; secondary muted |
+| Whitespace | **PASS** | Reading-width Home (`max-width` ~42–52rem) |
+| Navigation clarity | **PASS** | Sections usable; `/studio` transitional (DDR unaccepted — correct) |
+
+---
+
+## 4. Visual review (desktop)
+
+Observed on published + draft Home:
+
+| Check | Result |
+| --- | --- |
+| Hero hierarchy | Strong — title + Live/Draft badge + context line |
+| Readiness placement | Correct band under Focus |
+| CTA prominence | Coral primary readable |
+| Card consistency | Secondary cards quieter; still card-ish (deferred) |
+| Alignment | Acceptable |
+| Status indicators | Text + tone classes (not colour-only) |
+| Empty / loading | Not fully exercised this pass |
+| Boost banner | Can sit between Hero and Focus — competes with Mission Control (**MINOR**, pre-existing) |
+
+**Locations needing refinement (no fix this sprint):**
+
+1. Align Hero primary with Focus primary (same label/destination when both show).  
+2. Past events: Hero badge **Live** while health meta shows **Past**.  
+3. Disabled **Published** control still reads as a large button in the action cluster.  
+4. Hidden `[data-mel-hero-primary-link]` still `display:flex` (CSS leak; small width but incorrect).
+
+---
+
+## 5. Mobile review
+
+| Viewport | Overflow-X | Hierarchy | Touch ≥44px | Notes |
+| --- | --- | --- | --- | --- |
+| **390** | None | Focus above Health above Secondary | Yes (measured 44) | Hero tall when address long; Sections toggle visible |
+| **430** | None (same shell) | Same | Yes | Same patterns |
+| **768** | None | Order OK | Yes | Hybrid: global sidebar + Sections toggle still visible |
+| **1024+** | None | Order OK | Yes | Sections toggle hidden; workspace sidebar present |
+
+**Issues**
+
+- **MINOR:** Long venue strings inflate Hero height on 390.  
+- **MINOR:** Sticky action band stacks many controls (Staff Overview / View / Share / Published).  
+- **MAJOR:** Dual/triple primary CTAs remain on small screens (Share + Focus CTA + Create event).
+
+---
+
+## 6. Accessibility review
+
+| Check | Result |
+| --- | --- |
+| Skip link | Present |
+| Keyboard | Focusable controls abundant; full keyboard-only walkthrough **not completed** end-to-end |
+| Visible focus | Existing MEL focus styles assumed; dedicated focus-ring audit incomplete |
+| Heading hierarchy | H1 event title in Hero; Focus/Health as H2 — good. Publish feedback H2s exist in DOM (hidden panels) |
+| Landmarks | Hero `role=banner`; workspace `main`; organiser `aside` — good. Admin toolbar adds many `nav` landmarks in staff sessions |
+| Screen reader | Spot check via accessibility tree / snapshot only — **no VoiceOver/NVDA run** |
+| Colour contrast (sampled) | Title 17.4:1; context 7.58:1; detail 5.87:1; eyebrow 4.76:1 — AA for sampled text |
+| Status not colour-only | **PASS** — text badges + headlines |
+| Button names | Share / Continue setup / View / Published named; empty hidden primary link is inert when `hidden` |
+| Axe scan | **Not run** (tooling not available in session) |
+
+**Findings**
+
+1. **MAJOR (process):** Axe + SR walkthrough still required before merge per PO gate.  
+2. **MINOR:** Staff toolbar landmark noise during staff-impersonation review.  
+3. **MINOR:** Hidden primary link should not retain flex display.
+
+---
+
+## 7. Organiser journey review
+
+| Step | Where am I? | Next action obvious? | First-time clear? | Friction |
+| --- | --- | --- | --- | --- |
+| Create event | Global Create | N/A | Yes | — |
+| Land in Workspace (draft) | Event Workspace / Draft | Continue setup + Focus “Add RSVP…” | Mostly | **Two primaries diverge** |
+| Continue setup | Publishing section (link target) | Checklist | Yes | Hero may send to Publishing while Focus sends to Edit |
+| Add tickets | Tickets section (out of Foundation UX redesign) | Section exists | OK | Not Foundation-redesigned |
+| Publish | Explicit publish control when Ready | Yes when `publish_is_primary` | Yes | Not fully walked this pass |
+| Return to Workspace | Home Mission Control | Share / ops Focus | Yes | Boost / Create also primary |
+| Edit | Sections | Yes | Yes | — |
+| Share | Marketing via Hero Share | Yes when published | Yes | Competes with Focus CTA |
+| Unpublish | Not validated this pass | Unknown | — | Needs explicit PO walk |
+
+**Friction summary:** Mission Control structure works; **CTA alignment between Hero and Focus is the main journey risk.**
+
+---
+
+## 8. Regression review
+
+| Scenario | Observed | Regression? |
+| --- | --- | --- |
+| Draft event | Draft badge, Needs Attention, readiness open, Continue setup | No |
+| Published event | Live badge, Share primary, Health “Live and healthy” | No |
+| Past-ish published | Health shows Past; Hero still Live | **Product inconsistency** (pre-existing status model exposed more clearly) |
+| Free RSVP | View RSVPs in Focus | No |
+| Paid event | View orders in Focus; tickets/sales cards present | No |
+| Without tickets (draft) | Focus asks for RSVP/tickets | No |
+| With blockers | Attention tone + open checklist | No |
+| Ready unpublished | Not isolated in this pass | Incomplete |
+| Manager surfaces | Not entered | Out of scope — untouched |
+
+---
+
+## 9. Performance review
+
+| Check | Result |
+| --- | --- |
+| Duplicate ViewModels | No full VM call added to topbar |
+| Duplicate builders | None |
+| Duplicate queries | Date/venue from loaded node fields |
+| Unnecessary JS | +~78 lines for Hero primary sync — justified |
+| Cache regressions | None — metadata identical |
+| CSS growth | +~174 / −29 lines in shell CSS — acceptable for Foundation |
+
+---
+
+## 10. Documentation review
+
+`13-workspace-foundation-review.md` **accurately** reflects shipped Slices 1–3, facade authority, transitional `/studio`, and known limitations.
+
+### DDR-008 / DDR-009 — do **not** accept yet
+
+Still **Prepared**. Before acceptance they must be updated to match shipped reality:
+
+| DDR | Must update before Accept |
+| --- | --- |
+| **DDR-008** | Confirm transitional `/studio` remains until path phase; document Foundation composition ships on Studio shell; Staff Operations language |
+| **DDR-009** | Confirm runtime Attendees-before-Orders unchanged; Door Mode still not chrome-nested; nav single-source still future work |
+
+Accepting now would freeze docs ahead of runtime path/nav truth.
+
+---
+
+## 11. Issues found
+
+### Critical
+
+*None observed that break publish safety, access, or readiness truth.*
+
+### Major
+
+1. **Multiple primary CTAs** in one viewport (Hero + Focus + global Create ± Boost). Violates PDS “one primary action” for the event context.  
+2. **Hero vs Focus CTA mismatch** on draft (Continue setup vs Edit event).  
+3. **Accessibility gate incomplete** — no Axe run, no VoiceOver/NVDA, incomplete keyboard walkthrough.  
+4. **Live vs Past status conflict** on past published events (Hero Live / health Past).
+
+### Minor
+
+1. Disabled **Published** button still visually heavy in action row.  
+2. Hidden primary link CSS (`display:flex` despite `hidden`).  
+3. Long venue strings → tall Hero on 390.  
+4. Boost banner competes with Mission Control above Focus.  
+5. Spacing not fully token-audited to 12/16/24/32.  
+6. Ready-unpublished and Unpublish paths not fully walked.  
+7. Staff Overview visible in staff sessions (expected; muddy organiser QA).
+
+### Nice-to-have
+
+1. Collapse “Published” to a status chip rather than a disabled button.  
+2. Unify Create event visual weight when inside an event (global chrome).  
+3. Past events: Hero badge “Completed” / “Past” when applicable.
+
+---
+
+## 12. Scores ( / 10 )
+
+| Dimension | Score | Rationale |
+| --- | --- | --- |
+| Architecture | **9** | Facade preserved; no parallel readiness; cache/routes untouched |
+| UX | **7** | Mission Control hierarchy clear; dual/mismatched primaries hurt confidence |
+| Visual Design | **7.5** | Calmer shell/Hero; secondary density and Published button weight remain |
+| Accessibility | **6** | Structure + contrast samples good; required SR/Axe/keyboard gates incomplete |
+| Mobile | **7.5** | No overflow; 44px targets; Hero height + multi-CTA clutter |
+| Launch Readiness | **6.5** | Architecturally mergeable after small CTA/status fixes + completing a11y gates |
+
+---
+
+## 13. Final recommendation
+
+### NOT READY
+
+**for Foundation merge to `main` today.**
+
+**Evidence**
+
+- Architecture and scope discipline are strong (`EventReadinessFacade` remains canonical; no out-of-scope features).  
+- Product review gates set by PO are **not fully cleared**: dual/mismatched primaries, Live/Past inconsistency, incomplete a11y tooling pass, incomplete unpublish/ready-unpublished walk.  
+- These are **validation findings**, not a call for a new feature sprint.
+
+**Recommended path to READY**
+
+1. Fix or explicitly waive: Hero↔Focus primary alignment; Past/Live badge honesty; hidden-link CSS.  
+2. Complete Axe + keyboard + SR spot check; record results.  
+3. Walk Ready→Publish→Share→Unpublish on a clean fixture.  
+4. Keep DDR-008/009 Prepared until updated to shipped runtime.  
+5. Then Phase B: Accept DDRs (updated) → commit → push → PR.
+
+**Do not start Publishing Experience until Phase A clears.**
+
+---
+
+## Explicit non-actions taken
+
+- No code changes for fixes  
+- No DDR acceptance  
+- No commit / push  
+- No Phase 2 implementation
+
+---
+
+## Phase A.5 Resolution
+
+**Status:** Product coherence fixes implemented — awaiting Product Owner approval  
+**Date:** 2026-07-25  
+**Scope:** Product Review findings only. Architecture preserved. No DDR acceptance. No commit/push.
+
+### Issue 1 — Hero and Focus disagree (P0)
+
+| | |
+| --- | --- |
+| **Root cause** | Focus `resolveNextRecommendedAction()` early-returned ViewModel next-actions (`Edit event`, `View attendees`) while Hero used readiness lifecycle CTA (`Continue setup` / `Publish` / `Share`). |
+| **CTA ownership** | **Hero owns the one primary CTA.** Focus reflects Hero label + destination. Stripe Connect attention remains the only Focus exception (Home Focus authority for Connect). |
+| **Implementation** | `EventWorkspaceOverviewBuilder::resolveNextRecommendedAction()` — remove VM override; align CTA labels with Hero (`Continue setup` / `Publish` / `Share`); keep specific VM blocker *title/message* when severity is error. Overview Focus button → `mel-btn--secondary`. |
+| **Validation** | Draft 1756: Hero + Focus both `Continue setup` → `/studio/publishing`. Live 1755 + Past 1381: both `Share`. Unit: `EventWorkspaceOverviewNextActionTest` updated (44 targeted OK). |
+| **Remaining risk** | Stripe-attention Focus can still narrate Connect while Hero keeps Share/Publish — intentional; Focus CTA stays secondary visually. |
+
+### Issue 2 — Multiple primary actions (P0)
+
+| | |
+| --- | --- |
+| **Root cause** | Hero, Focus, global Create, and Boost CTAs all used coral `mel-btn--primary` weight in one viewport. |
+| **Implementation** | Focus → secondary; Create demoted inside workspace via higher-specificity shell CSS (`:has(.mel-event-studio--workspace)`); Boost extension / publish-success Boost CTAs demoted in workspace; Hero retains sole coral primary. |
+| **Validation** | CDP: one coral primary per sample (Continue setup / Share). Create renders outline/tertiary. Functionality retained. |
+| **Remaining risk** | Create still carries `mel-btn--primary` class (visual demotion only). Staff toolbar chrome still noisy. |
+
+### Issue 3 — Accessibility gate (P0)
+
+| Check | Result |
+| --- | --- |
+| Keyboard / focus order | Workspace focusables: breadcrumb → Hero actions (View/Share/primary/Publish) → section nav → Focus/Health — logical |
+| Visible focus | `:focus-visible` outline added for Hero/Focus/sidebar controls |
+| Heading hierarchy | Hero H1 event title present; shell still exposes “Event Studio” H1 (pre-existing console chrome) |
+| ARIA landmarks | Hero `role=banner`; Home sections labelled; topbar meta `role=group` + `aria-label` (fixed prohibited attr) |
+| Screen reader spot check | Accessibility tree: named Share/Continue setup/Published; status not colour-only |
+| Axe (workspace root) | **0 violations** after fixes (axe-core 4.10.2, WCAG 2 A/AA) on past + live samples |
+| Colour contrast | Hero primary darkened to `#c24132` on white (~5.13:1); readiness hint `#4349a8` |
+| **Remaining risk** | Dual H1 with vendor shell title; admin toolbar landmark noise in staff sessions; no VoiceOver/NVDA device run |
+
+### Issue 4 — Hero “Live” vs Health “Past” (P1)
+
+| | |
+| --- | --- |
+| **Root cause** | Hero hardcoded `published ? Live : Draft`. Health used ViewModel `resolvePublicationStatus()` (Past when `field_event_end` &lt; now). |
+| **Status ownership** | **Operational status presentation** uses the same end-date rule as the workspace VM (`Draft` / `Live` / `Past`) via `EventStudioWorkspacePresentation::buildTopbarStatus()` — display only. Does **not** alter `EventReadinessFacade` or lifecycle logic. |
+| **Implementation** | Controller + publish AJAX topbar consume `buildTopbarStatus()`; Health headline uses `Event completed` when `status_key === past`. |
+| **Validation** | Event 1381: Hero badge **Past**, Health pill **Past**, headline **Event completed**. Event 1755: both **Live**. |
+| **Remaining risk** | Past detection uses PHP `time()` (same field as VM; not injected clock) — acceptable for presentation. |
+
+### Issue 5 — Minor visual fixes (P2)
+
+| | |
+| --- | --- |
+| **Heavy Published** | Published control uses quiet chip class `mel-event-studio-topbar__status-action` (no primary/ghost weight). |
+| **Hidden primary link** | Stub no longer uses `mel-btn`; `[hidden]` forced `display: none !important`. CDP: `display:none` when Share primary. |
+
+### Architecture preserved
+
+- `EventReadinessFacade` sole readiness authority — unchanged  
+- No new builders / ViewModels / readiness calculators / lifecycle models  
+- Routes, cache metadata, services.yml — unchanged  
+- DDR-008 / DDR-009 — still **Prepared** (not accepted)
+
+### Validation commands
+
+| Command | Result |
+| --- | --- |
+| `composer validate` | Valid |
+| `ddev drush cr` | Success |
+| `ddev drush config:status` | Known pre-existing drift only |
+| `npm run mel:lint` | Passed |
+| `npm run mel:build` | Passed |
+| PHPUnit (presentation / next-action / state matrix / UX / checklist) | 44 OK |
+| Runtime smoke 1756 / 1755 / 1381 | One narrative CTA; status agreement; axe 0 on workspace |
+
+### Updated scores (post A.5)
+
+| Dimension | Score | Rationale |
+| --- | --- | --- |
+| Architecture | **9** | Unchanged — facade/cache/routes intact |
+| UX | **8.5** | Hero↔Focus aligned; one dominant primary |
+| Visual Design | **8** | Published chip quieter; Create/Boost demoted |
+| Accessibility | **8.5** | Axe 0 on workspace; contrast + ARIA fixes; residual dual H1 / no AT |
+| Mobile | **8** | Multi-primary clutter reduced; sticky band quieter |
+| Launch Readiness | **8.5** | Product Review P0/P1/P2 addressed |
+
+### Phase A.5 recommendation
+
+**READY FOR FOUNDATION MERGE** — pending Product Owner approval.
+
+Evidence: one Hero-owned primary CTA; Focus reflects Hero; Past/Live/Draft status agrees; a11y axe gate cleared on workspace; architecture constraints held; no DDR acceptance; no commit/push in this phase.
+
+**Do not start Publishing Experience until PO approves.**

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -2038,6 +2038,22 @@
   letter-spacing: 0.01em;
 }
 
+/* Workspace Hero primary: darken coral so white label meets WCAG AA (~4.5:1).
+   Specificity must beat vendor shell `.mel-vendor … .mel-btn--primary`. */
+.mel-vendor .mel-vendor-console.mel-vendor-shell .mel-event-studio--workspace .mel-btn.mel-btn--primary {
+  background-color: #c24132;
+  border-color: #c24132;
+  color: #fff;
+  font-weight: 700;
+}
+
+.mel-vendor .mel-vendor-console.mel-vendor-shell .mel-event-studio--workspace .mel-btn.mel-btn--primary:hover,
+.mel-vendor .mel-vendor-console.mel-vendor-shell .mel-event-studio--workspace .mel-btn.mel-btn--primary:focus-visible {
+  background-color: #a8362a;
+  border-color: #a8362a;
+  color: #fff;
+}
+
 .mel-event-studio .mel-btn.mel-btn--secondary {
   font-weight: 600;
 }
@@ -2075,18 +2091,15 @@
   top: 0;
   z-index: 20;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: 18px;
+  gap: 1.25rem 1.5rem;
   min-height: 76px;
-  padding: 14px 20px;
-  border: 1px solid rgba(236, 72, 153, 0.16);
-  border-radius: 22px;
-  background:
-    linear-gradient(135deg, rgba(255, 247, 237, 0.92) 0%, rgba(250, 245, 255, 0.88) 100%),
-    rgba(255, 255, 255, 0.96);
-  box-shadow: 0 18px 42px rgba(91, 33, 182, 0.09);
-  backdrop-filter: blur(12px);
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.98);
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.05);
 }
 
 .mel-event-studio-topbar__eyebrow,
@@ -2111,13 +2124,28 @@
   flex: 1 1 auto;
 }
 
+.mel-event-studio-topbar__identity {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.75rem;
+}
+
 .mel-event-studio-topbar__title {
   margin: 0;
   color: #0f172a;
-  font-size: 1.25rem;
+  font-size: 1.35rem;
   font-weight: 700;
   letter-spacing: -0.03em;
   overflow-wrap: anywhere;
+  line-height: 1.25;
+}
+
+.mel-event-studio-topbar__context {
+  margin: 0.35rem 0 0;
+  color: #475569;
+  font-size: 0.9375rem;
+  line-height: 1.4;
 }
 
 .mel-event-studio-topbar__location {
@@ -2170,7 +2198,10 @@
 
 .mel-event-studio-topbar__actions {
   flex: 0 0 auto;
-  align-self: center;
+  align-self: flex-start;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  max-width: 100%;
 }
 
 .mel-event-studio-topbar__badge {
@@ -2182,6 +2213,7 @@
   background: #f1f5f9;
   color: #0f172a;
   font-weight: 700;
+  font-size: 0.8125rem;
 }
 
 .mel-event-studio-topbar__state,
@@ -2221,14 +2253,52 @@
   min-height: 44px;
 }
 
+.mel-event-studio-topbar__actions .mel-btn:focus-visible,
+.mel-event-workspace-home__focus .mel-btn:focus-visible,
+.mel-event-workspace-home__secondary .mel-btn:focus-visible,
+.mel-event-studio-sidebar__toggle:focus-visible {
+  outline: 2px solid #0f766e;
+  outline-offset: 2px;
+}
+
+/* Hidden Hero primary stub must not keep .mel-btn flex display. */
+.mel-event-studio-topbar__actions .mel-btn[hidden],
+.mel-event-studio-topbar__primary-link[hidden],
+.mel-event-workspace-home__focus .mel-btn[hidden] {
+  display: none !important;
+}
+
+/* Published control is a quiet status chip — not a competing primary. */
 .mel-event-studio-topbar__status-action {
-  font-weight: 700;
-  opacity: 0.88;
+  min-height: 32px;
+  padding: 0.25rem 0.65rem;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: #f1f5f9;
+  box-shadow: none;
+  color: #64748b;
+  font-size: 0.8125rem;
+  font-weight: 650;
+  letter-spacing: 0.01em;
+  opacity: 1;
   pointer-events: none;
+  cursor: default;
+}
+
+.mel-event-studio-topbar__status-action:disabled,
+.mel-event-studio-topbar__status-action[aria-disabled='true'] {
+  opacity: 1;
+  color: #64748b;
+}
+
+.mel-event-studio-topbar__badge--past {
+  background: #e2e8f0;
+  color: #475569;
 }
 
 .mel-event-studio--workspace > .mel-event-studio-readiness-strip,
 .mel-event-studio--workspace > .mel-event-studio-homepage-readiness,
+.mel-event-studio--workspace > .mel-event-studio-mission-control-shell,
 .mel-event-studio--workspace > .mel-boost-active-banner,
 .mel-event-studio--workspace > .mel-event-studio-event-health {
   margin-bottom: 16px;
@@ -5511,28 +5581,376 @@
 .mel-event-workspace-home {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1.75rem;
   width: 100%;
-  max-width: 1280px;
-  margin-inline: auto;
+  max-width: 42rem;
+  margin-inline: 0;
   min-width: 0;
   box-sizing: border-box;
 }
 
+.mel-event-workspace-home__focus {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  padding: 1.35rem 1.4rem;
+  border-radius: 16px;
+  border: 1px solid rgba(36, 48, 58, 0.1);
+  background: var(--mel-surface, #fff);
+  box-shadow: 0 8px 24px rgba(36, 48, 58, 0.04);
+}
+
+/* Phase 2A — shared Mission Control (Home + Information chrome) */
+.mel-event-studio-mission-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem 1.1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(36, 48, 58, 0.1);
+  background: var(--mel-surface, #fff);
+  box-shadow: 0 8px 24px rgba(36, 48, 58, 0.04);
+}
+
+.mel-event-studio-mission-control--attention {
+  border-color: rgba(180, 83, 9, 0.28);
+}
+
+.mel-event-studio-mission-control__header {
+  margin: 0;
+}
+
+.mel-event-studio-mission-control__title {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--mel-text-muted, #64748b);
+}
+
+.mel-event-studio-mission-control__next {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.mel-event-studio-mission-control__eyebrow {
+  margin: 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--mel-text-muted, #64748b);
+}
+
+.mel-event-studio-mission-control__next-title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: 1.25;
+  color: var(--mel-text, #24303a);
+}
+
+.mel-event-studio-mission-control__why-label {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--mel-text-muted, #64748b);
+}
+
+.mel-event-studio-mission-control__why-text {
+  margin: 0.15rem 0 0;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  color: var(--mel-text, #24303a);
+}
+
+.mel-event-studio-mission-control__cta {
+  align-self: flex-start;
+  min-height: 44px;
+  margin-top: 0.35rem;
+}
+
+.mel-event-studio-mission-control__publish-hint {
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  color: var(--mel-text-muted, #64748b);
+}
+
+.mel-event-studio-mission-control__improvements {
+  border-top: 1px solid rgba(36, 48, 58, 0.08);
+  padding-top: 0.65rem;
+}
+
+.mel-event-studio-mission-control__improvements-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  cursor: pointer;
+  list-style: none;
+  min-height: 44px;
+}
+
+.mel-event-studio-mission-control__improvements-summary::-webkit-details-marker {
+  display: none;
+}
+
+.mel-event-studio-mission-control__improvements-main {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.mel-event-studio-mission-control__improvements-count,
+.mel-event-studio-mission-control__improvements-hint {
+  font-size: 0.85rem;
+  color: var(--mel-text-muted, #64748b);
+}
+
+.mel-event-studio-mission-control__improvements-headline {
+  margin: 0 0 0.5rem;
+  font-size: 0.9rem;
+  color: var(--mel-text-muted, #64748b);
+}
+
+.mel-event-studio-mission-control__checklist {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.mel-event-studio-mission-control__check {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.45rem;
+  font-size: 0.9rem;
+  line-height: 1.35;
+  color: var(--mel-text, #24303a);
+}
+
+.mel-event-studio-mission-control__check-mark {
+  flex: 0 0 auto;
+  width: 1.1rem;
+  text-align: center;
+  color: var(--mel-text-muted, #64748b);
+}
+
+.mel-event-studio-mission-control__check--attention .mel-event-studio-mission-control__check-mark {
+  color: #b45309;
+}
+
+.mel-event-studio-mission-control__check--success .mel-event-studio-mission-control__check-mark {
+  color: #15803d;
+}
+
+.mel-event-studio-mission-control__quality {
+  border-top: 1px solid rgba(36, 48, 58, 0.08);
+  padding-top: 0.65rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.mel-event-studio-mission-control__quality-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.mel-event-studio-mission-control__quality-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--mel-text, #24303a);
+}
+
+.mel-event-studio-mission-control__quality-score {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.mel-event-studio-mission-control__quality-bar {
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(36, 48, 58, 0.08);
+  overflow: hidden;
+}
+
+.mel-event-studio-mission-control__quality-bar-fill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--mel-coral, #e07a5f);
+  min-width: 0;
+}
+
+.mel-event-studio-mission-control__quality.is-ready .mel-event-studio-mission-control__quality-bar-fill {
+  background: #15803d;
+}
+
+.mel-event-studio-mission-control__quality-status,
+.mel-event-studio-mission-control__quality-explain {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.35;
+  color: var(--mel-text-muted, #64748b);
+}
+
+.mel-event-studio-mission-control-shell .mel-event-studio-mission-control {
+  margin: 0;
+}
+
+@media (max-width: 47.99em) {
+  .mel-event-studio-mission-control {
+    padding: 0.9rem 1rem;
+    gap: 0.65rem;
+  }
+
+  .mel-event-studio-mission-control__next-title {
+    font-size: 1.15rem;
+  }
+}
+
+.mel-event-workspace-home__focus-title {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 700;
+  line-height: 1.25;
+  color: var(--mel-text, #24303a);
+}
+
+.mel-event-workspace-home__focus .mel-btn--primary {
+  align-self: flex-start;
+  min-height: 44px;
+  margin-top: 0.25rem;
+}
+
+.mel-event-workspace-home__focus .mel-btn--secondary {
+  align-self: flex-start;
+  min-height: 44px;
+  margin-top: 0.25rem;
+}
+
+/* Inside Event Workspace: global Create + Boost CTAs are tertiary to Hero primary.
+   Specificity must beat vendor shell `.mel-vendor .mel-vendor-console… .mel-btn--primary`. */
+.mel-vendor .mel-vendor-console.mel-vendor-shell:has(.mel-event-studio--workspace) .mel-vendor-console__primary-action.mel-btn--primary,
+body.mel-vendor:has(.mel-event-studio--workspace) .mel-vendor-console.mel-vendor-shell .mel-vendor-console__primary-action.mel-btn--primary {
+  background: transparent;
+  border: 1px solid rgba(15, 23, 42, 0.14);
+  color: #334155;
+  box-shadow: none;
+  font-weight: 600;
+}
+
+.mel-vendor .mel-vendor-console.mel-vendor-shell:has(.mel-event-studio--workspace) .mel-boost-extension-card__cta.mel-btn--primary,
+.mel-event-studio--workspace .mel-boost-extension-card__cta.mel-btn--primary,
+.mel-event-studio--workspace .mel-publish-boost-cta__actions .mel-btn--primary {
+  background: transparent;
+  border: 1px solid rgba(15, 23, 42, 0.14);
+  color: #334155;
+  box-shadow: none;
+  font-weight: 600;
+}
+
+.mel-event-workspace-home__health {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem 1.15rem;
+  border-radius: 14px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(248, 250, 252, 0.9);
+}
+
+.mel-event-workspace-home__health--attention {
+  border-color: rgba(245, 166, 35, 0.45);
+  background: rgba(255, 248, 235, 0.85);
+}
+
+.mel-event-workspace-home__health--success {
+  border-color: rgba(92, 201, 139, 0.35);
+}
+
+.mel-event-workspace-home__health-main {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.65rem;
+}
+
+.mel-event-workspace-home__health-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 650;
+  line-height: 1.3;
+  color: var(--mel-text, #24303a);
+}
+
+.mel-event-workspace-home__ready-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.06);
+  font-weight: 700;
+  flex: 0 0 auto;
+}
+
+.mel-event-workspace-home__health--attention .mel-event-workspace-home__ready-mark {
+  background: rgba(245, 166, 35, 0.2);
+}
+
+.mel-event-workspace-home__health--success .mel-event-workspace-home__ready-mark {
+  background: rgba(92, 201, 139, 0.2);
+}
+
+.mel-event-workspace-home__health-meta {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.85rem;
+  font-size: 0.875rem;
+  color: var(--mel-muted, #5b6670);
+}
+
+.mel-event-workspace-home__readiness-legend {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  margin: 0.35rem 0 0;
+  font-size: 0.8125rem;
+  color: var(--mel-muted, #5b6670);
+}
+
+.mel-event-workspace-home__secondary {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  opacity: 0.96;
+}
+
+.mel-event-workspace-home__secondary .mel-event-workspace-home__card {
+  box-shadow: none;
+  background: rgba(255, 255, 255, 0.72);
+}
+
 .mel-event-workspace-home__row {
   display: grid;
-  gap: 1rem;
+  gap: 0.85rem;
   width: 100%;
   min-width: 0;
   grid-template-columns: 1fr;
-}
-
-.mel-event-workspace-home__row--guide {
-  align-items: stretch;
-}
-
-.mel-event-workspace-home__row--guide .mel-event-workspace-home__card--next {
-  order: -1;
 }
 
 .mel-event-workspace-home__row--business {
@@ -5540,23 +5958,50 @@
 }
 
 @media (min-width: 720px) {
-  .mel-event-workspace-home__row--guide,
+  .mel-event-workspace-home {
+    max-width: 52rem;
+    gap: 2rem;
+  }
+
   .mel-event-workspace-home__row--ops {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .mel-event-workspace-home__row--guide .mel-event-workspace-home__card--next {
-    order: 0;
-  }
-
   .mel-event-workspace-home__row--business {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .mel-event-workspace-home__health {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
   }
 }
 
 @media (min-width: 1100px) {
   .mel-event-workspace-home__row--business {
     grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+/* Foundation: promote Today's Focus above the fold on small screens */
+@media (max-width: 719px) {
+  .mel-event-workspace-home__focus {
+    order: -1;
+  }
+
+  .mel-event-studio-topbar__actions {
+    position: sticky;
+    bottom: 0;
+    z-index: 15;
+    width: 100%;
+    margin-top: 0.5rem;
+    padding: 0.65rem 0 0.15rem;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, #fff 28%);
+  }
+
+  .mel-event-studio-topbar__actions .mel-btn--primary {
+    flex: 1 1 auto;
   }
 }
 
@@ -5737,7 +6182,8 @@
 
 .mel-event-workspace-home__readiness-hint {
   font-weight: 600;
-  color: var(--mel-accent, #7c83fd);
+  /* Darker than brand accent so checklist hint meets WCAG AA on cream Home surface. */
+  color: #4349a8;
 }
 
 .mel-event-workspace-home__readiness-body {

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
@@ -208,182 +208,7 @@
     ));
   }
 
-  function ensureReadinessStrip(shell) {
-    let strip = shell.querySelector('[data-mel-readiness-strip]');
-    if (strip) {
-      return strip;
-    }
-    // Do not invent a strip on Home — prepend would land above the topbar.
-    if (isHomeShell(shell)) {
-      return null;
-    }
-    strip = document.createElement('section');
-    strip.className = 'mel-event-studio-readiness-strip needs-attention';
-    strip.setAttribute('aria-label', Drupal.t('Publish readiness'));
-    strip.setAttribute('data-mel-readiness-strip', '');
-    strip.innerHTML = [
-      '<div class="mel-event-studio-readiness-strip__summary">',
-      '<strong data-mel-readiness-title></strong>',
-      '<span data-mel-readiness-state></span>',
-      '<p class="mel-event-studio-readiness-strip__explain" data-mel-readiness-explain hidden></p>',
-      '</div>',
-      '<ul class="mel-event-studio-readiness-strip__checklist" data-mel-readiness-checklist hidden></ul>',
-      '<div class="mel-event-studio-readiness-strip__counts" data-mel-readiness-counts>',
-      '<span data-mel-readiness-errors-count></span>',
-      '<span data-mel-readiness-warnings-count></span>',
-      '<span data-mel-readiness-recommendations-count></span>',
-      '<span data-mel-readiness-completed-count></span>',
-      '</div>',
-    ].join('');
-    const health = shell.querySelector('[data-mel-event-health]');
-    if (health) {
-      health.insertAdjacentElement('afterend', strip);
-    }
-    else {
-      const topbar = shell.querySelector('.mel-event-studio-topbar, [data-mel-studio-topbar]');
-      if (topbar) {
-        topbar.insertAdjacentElement('afterend', strip);
-      }
-      else {
-        shell.prepend(strip);
-      }
-    }
-    return strip;
-  }
-
-  function ensureReadinessExplain(strip) {
-    let explain = strip.querySelector('[data-mel-readiness-explain]');
-    if (explain) {
-      return explain;
-    }
-    const summary = strip.querySelector('.mel-event-studio-readiness-strip__summary');
-    if (!summary) {
-      return null;
-    }
-    explain = document.createElement('p');
-    explain.className = 'mel-event-studio-readiness-strip__explain';
-    explain.setAttribute('data-mel-readiness-explain', '');
-    summary.appendChild(explain);
-    return explain;
-  }
-
-  function ensureReadinessChecklist(strip) {
-    let list = strip.querySelector('[data-mel-readiness-checklist]');
-    if (list) {
-      return list;
-    }
-    list = document.createElement('ul');
-    list.className = 'mel-event-studio-readiness-strip__checklist';
-    list.setAttribute('data-mel-readiness-checklist', '');
-    const counts = strip.querySelector('[data-mel-readiness-counts], .mel-event-studio-readiness-strip__counts');
-    if (counts) {
-      counts.insertAdjacentElement('beforebegin', list);
-    }
-    else {
-      strip.appendChild(list);
-    }
-    return list;
-  }
-
-  function ensureReadinessCounts(strip) {
-    let counts = strip.querySelector('[data-mel-readiness-counts], .mel-event-studio-readiness-strip__counts');
-    if (counts) {
-      return counts;
-    }
-    counts = document.createElement('div');
-    counts.className = 'mel-event-studio-readiness-strip__counts';
-    counts.setAttribute('data-mel-readiness-counts', '');
-    counts.innerHTML = [
-      '<span data-mel-readiness-errors-count></span>',
-      '<span data-mel-readiness-warnings-count></span>',
-      '<span data-mel-readiness-recommendations-count></span>',
-      '<span data-mel-readiness-completed-count></span>',
-    ].join('');
-    strip.appendChild(counts);
-    return counts;
-  }
-
-  function updateReadinessChecklist(strip, checklist) {
-    const list = ensureReadinessChecklist(strip);
-    const counts = ensureReadinessCounts(strip);
-    const items = Array.isArray(checklist) ? checklist : [];
-    if (items.length === 0) {
-      list.hidden = true;
-      list.replaceChildren();
-      counts.hidden = false;
-      return;
-    }
-    counts.hidden = true;
-    list.hidden = false;
-    list.replaceChildren();
-    items.forEach((item) => {
-      if (!item || typeof item.label !== 'string') {
-        return;
-      }
-      const complete = !!item.complete;
-      const tone = typeof item.tone === 'string' ? item.tone : '';
-      const li = document.createElement('li');
-      li.className = 'mel-event-studio-readiness-strip__check'
-        + (complete ? ' is-complete' : '')
-        + (tone ? ` mel-event-studio-readiness-strip__check--${tone}` : '');
-      const mark = document.createElement('span');
-      mark.setAttribute('aria-hidden', 'true');
-      mark.textContent = complete ? '✔' : ((tone === 'warning' || tone === 'idea') ? '◇' : '○');
-      const sr = document.createElement('span');
-      sr.className = 'visually-hidden';
-      if (complete) {
-        sr.textContent = Drupal.t('Complete');
-      }
-      else if (tone === 'warning') {
-        sr.textContent = Drupal.t('Suggested review');
-      }
-      else if (tone === 'idea') {
-        sr.textContent = Drupal.t('Idea');
-      }
-      else {
-        sr.textContent = Drupal.t('Outstanding');
-      }
-      const label = document.createTextNode(' ' + item.label);
-      li.appendChild(mark);
-      li.appendChild(sr);
-      li.appendChild(label);
-      list.appendChild(li);
-    });
-  }
-
-  function ensureHomepageReadinessWrapper(shell) {
-    let wrapper = shell.querySelector('.mel-event-studio-homepage-readiness');
-    if (wrapper) {
-      return wrapper;
-    }
-    if (isHomeShell(shell)) {
-      return null;
-    }
-    wrapper = document.createElement('div');
-    wrapper.className = 'mel-event-studio-homepage-readiness';
-    const strip = shell.querySelector('[data-mel-readiness-strip]');
-    if (strip) {
-      strip.insertAdjacentElement('afterend', wrapper);
-    }
-    else {
-      const health = shell.querySelector('[data-mel-event-health]');
-      if (health) {
-        health.insertAdjacentElement('afterend', wrapper);
-      }
-      else {
-        const topbar = shell.querySelector('.mel-event-studio-topbar, [data-mel-studio-topbar]');
-        if (topbar) {
-          topbar.insertAdjacentElement('afterend', wrapper);
-        }
-        else {
-          shell.appendChild(wrapper);
-        }
-      }
-    }
-    return wrapper;
-  }
-
-  function updateHomeChecklist(list, items) {
+  function updateMissionControlChecklist(list, items) {
     const rows = Array.isArray(items) ? items : [];
     list.replaceChildren();
     if (rows.length === 0) {
@@ -398,10 +223,10 @@
       const complete = !!item.complete;
       const tone = typeof item.tone === 'string' ? item.tone : '';
       const li = document.createElement('li');
-      li.className = 'mel-event-workspace-home__check'
-        + (tone ? ` mel-event-workspace-home__check--${tone}` : '');
+      li.className = 'mel-event-studio-mission-control__check'
+        + (tone ? ` mel-event-studio-mission-control__check--${tone}` : '');
       const mark = document.createElement('span');
-      mark.className = 'mel-event-workspace-home__check-mark';
+      mark.className = 'mel-event-studio-mission-control__check-mark';
       mark.setAttribute('aria-hidden', 'true');
       mark.textContent = complete ? '✔' : ((tone === 'warning' || tone === 'idea') ? '◇' : '○');
       const sr = document.createElement('span');
@@ -418,87 +243,85 @@
       else {
         sr.textContent = Drupal.t('Required before publishing:');
       }
+      const label = document.createElement('span');
+      label.setAttribute('data-mel-mc-check-label', '');
+      label.textContent = item.label;
       li.appendChild(mark);
       li.appendChild(sr);
-      li.appendChild(document.createTextNode(' ' + item.label));
+      li.appendChild(label);
       list.appendChild(li);
     });
   }
 
   /**
-   * Applies AJAX readiness.home to Event Ready / checklist / next action.
-   * Home chrome has no readiness strip — this is the in-place dashboard updater.
+   * Applies Mission Control ViewModel (Home body or non-Home chrome).
+   * CTA mirrors Hero except approved Stripe Connect exception; publish mode
+   * defers to Hero publish control.
    */
-  function updateHomeDashboard(shell, readiness) {
-    if (!readiness || !readiness.home) {
+  function updateMissionControl(shell, readiness) {
+    if (!readiness) {
       return;
     }
-    const home = readiness.home;
-    const dashboard = shell.querySelector('[data-mel-home-dashboard]');
-    if (!dashboard) {
+    const mc = readiness.mission_control
+      || (readiness.home && readiness.home.mission_control)
+      || null;
+    if (!mc) {
+      return;
+    }
+    const root = shell.querySelector('[data-mel-mission-control]');
+    if (!root) {
       return;
     }
 
-    const readyCard = dashboard.querySelector('[data-mel-home-event-ready]');
-    const eventReady = home.event_ready || {};
-    if (readyCard && eventReady) {
-      const tone = typeof eventReady.tone === 'string' ? eventReady.tone : 'success';
-      readyCard.classList.remove(
-        'mel-event-workspace-home__card--attention',
-        'mel-event-workspace-home__card--success',
-      );
-      readyCard.classList.add(`mel-event-workspace-home__card--${tone}`);
-      readyCard.setAttribute('data-mel-home-tone', tone);
-      const mark = readyCard.querySelector('[data-mel-home-ready-mark]');
-      if (mark) {
-        mark.textContent = tone === 'attention' ? '⚠' : '✔';
-      }
-      setText(readyCard, '[data-mel-home-ready-headline]', eventReady.headline || '');
-      setText(readyCard, '[data-mel-home-ready-detail]', eventReady.detail || '');
-      setText(readyCard, '[data-mel-home-ready-complete]', eventReady.complete_label || '');
+    const tone = typeof mc.tone === 'string' ? mc.tone : 'success';
+    root.classList.remove(
+      'mel-event-studio-mission-control--attention',
+      'mel-event-studio-mission-control--success',
+    );
+    root.classList.add(`mel-event-studio-mission-control--${tone}`);
+    root.setAttribute('data-mel-mc-tone', tone);
 
-      const pill = readyCard.querySelector('[data-mel-home-status-pill]');
-      if (pill) {
-        const statusKey = typeof eventReady.status_key === 'string' ? eventReady.status_key : 'draft';
-        pill.className = `mel-event-workspace-home__pill mel-event-workspace-home__pill--${statusKey}`;
-        pill.setAttribute('data-mel-home-status-key', statusKey);
-        pill.textContent = eventReady.status_label || '';
+    const next = mc.next_step || {};
+    setText(root, '[data-mel-mc-next-title]', next.title || '');
+    const why = root.querySelector('[data-mel-mc-why]');
+    const whyText = typeof next.message === 'string' ? next.message : '';
+    if (why) {
+      const whyBody = why.querySelector('[data-mel-mc-why-text]');
+      if (whyBody) {
+        whyBody.textContent = whyText;
       }
-
-      const updated = readyCard.querySelector('[data-mel-home-updated]');
-      if (updated) {
-        const label = typeof eventReady.updated_label === 'string' ? eventReady.updated_label : '';
-        updated.textContent = label;
-        updated.hidden = label === '';
-      }
+      why.hidden = whyText === '';
     }
 
-    const readinessBlock = dashboard.querySelector('[data-mel-home-readiness]');
-    const homeReadiness = home.readiness || {};
-    if (readinessBlock && homeReadiness) {
-      setText(readinessBlock, '[data-mel-home-readiness-headline]', homeReadiness.headline || '');
-      setText(readinessBlock, '[data-mel-home-readiness-count]', homeReadiness.complete_label || '');
-      setText(readinessBlock, '[data-mel-home-readiness-explain]', homeReadiness.explanation || '');
-      const list = readinessBlock.querySelector('[data-mel-home-readiness-checklist]');
-      if (list && homeReadiness.items !== undefined) {
-        updateHomeChecklist(list, homeReadiness.items);
+    const mode = typeof next.mode === 'string' ? next.mode : 'link';
+    const cta = root.querySelector('[data-mel-mc-cta]');
+    let publishHint = root.querySelector('[data-mel-mc-publish-hint]');
+    if (mode === 'publish') {
+      if (!publishHint) {
+        publishHint = document.createElement('p');
+        publishHint.className = 'mel-event-studio-mission-control__publish-hint';
+        publishHint.setAttribute('data-mel-mc-publish-hint', '');
+        publishHint.textContent = Drupal.t('Use Publish in the header when you are ready.');
+        const nextBlock = root.querySelector('[data-mel-mc-next]');
+        if (nextBlock && cta) {
+          nextBlock.insertBefore(publishHint, cta);
+        }
+      }
+      publishHint.hidden = false;
+      if (cta) {
+        cta.hidden = true;
       }
     }
-
-    const nextCard = dashboard.querySelector('[data-mel-home-next-action]');
-    const next = home.next_action || {};
-    if (nextCard && next) {
-      setText(nextCard, '[data-mel-home-next-title]', next.title || '');
-      const message = nextCard.querySelector('[data-mel-home-next-message]');
-      if (message) {
-        const text = typeof next.message === 'string' ? next.message : '';
-        message.textContent = text;
-        message.hidden = text === '';
+    else {
+      if (publishHint) {
+        publishHint.hidden = true;
       }
-      const cta = nextCard.querySelector('[data-mel-home-next-cta]');
       if (cta) {
         const label = typeof next.action_label === 'string' ? next.action_label : '';
         const url = typeof next.url === 'string' ? next.url : '';
+        const key = typeof next.key === 'string' ? next.key : '';
+        cta.setAttribute('data-mel-mc-cta-key', key);
+        cta.setAttribute('data-mel-mc-mirrors-hero', next.mirrors_hero === false ? '0' : '1');
         if (label && url) {
           cta.textContent = label;
           cta.setAttribute('href', url);
@@ -509,107 +332,64 @@
         }
       }
     }
+
+    const improvements = mc.improvements || {};
+    const improvementsBlock = root.querySelector('[data-mel-mc-improvements]');
+    if (improvementsBlock) {
+      if (improvements.open) {
+        improvementsBlock.setAttribute('open', '');
+      }
+      else {
+        improvementsBlock.removeAttribute('open');
+      }
+      setText(improvementsBlock, '[data-mel-mc-improvements-count]', improvements.complete_label || '');
+      setText(improvementsBlock, '[data-mel-mc-improvements-headline]', improvements.headline || '');
+      const list = improvementsBlock.querySelector('[data-mel-mc-checklist]');
+      if (list && improvements.items !== undefined) {
+        updateMissionControlChecklist(list, improvements.items);
+      }
+    }
+
+    const quality = mc.event_quality || {};
+    const qualityBlock = root.querySelector('[data-mel-mc-quality]');
+    if (qualityBlock) {
+      const visible = !!quality.visible;
+      qualityBlock.hidden = !visible;
+      qualityBlock.classList.toggle('is-ready', !!quality.ready);
+      setText(qualityBlock, '[data-mel-mc-quality-score-value]', quality.score_label || ((quality.score || 0) + '%'));
+      const bar = qualityBlock.querySelector('[data-mel-mc-quality-bar]');
+      const fill = qualityBlock.querySelector('[data-mel-mc-quality-bar-fill]');
+      const score = typeof quality.score === 'number' ? quality.score : 0;
+      if (bar) {
+        bar.setAttribute('aria-valuenow', String(score));
+      }
+      if (fill) {
+        fill.style.width = score + '%';
+      }
+      const status = qualityBlock.querySelector('[data-mel-mc-quality-status]');
+      if (status) {
+        const statusLabel = typeof quality.status_label === 'string' ? quality.status_label : '';
+        status.textContent = statusLabel;
+        status.hidden = statusLabel === '';
+      }
+      const explain = qualityBlock.querySelector('[data-mel-mc-quality-explain]');
+      if (explain) {
+        const explanation = typeof quality.explanation === 'string' ? quality.explanation : '';
+        explain.textContent = explanation;
+        explain.hidden = explanation === '';
+      }
+    }
   }
 
   function updateReadiness(shell, readiness) {
     if (!readiness) {
       return;
     }
-    // Home: apply inline Event Ready / checklist — never invent the strip.
-    if (isHomeShell(shell)) {
-      updateHomeDashboard(shell, readiness);
-      return;
-    }
-    const published = shell.dataset.melPublished === '1' || !!studioSettings().published;
-    const hasBlockers = (readiness.errors || []).length > 0 || (readiness.warnings || []).length > 0;
-    const showStrip = readiness.show_publish_strip !== undefined
-      ? !!readiness.show_publish_strip
-      : (!published || !readiness.ready || hasBlockers);
-    const strip = ensureReadinessStrip(shell);
-    if (!strip) {
-      return;
-    }
-    strip.hidden = !showStrip;
-    if (!showStrip) {
-      return;
-    }
-    strip.classList.toggle('is-ready', !!readiness.ready);
-    strip.classList.toggle('needs-attention', !readiness.ready);
-    const title = readiness.strip_title
-      || (readiness.ready
-        ? (published ? Drupal.t('Published and ready') : Drupal.t('Ready to publish'))
-        : Drupal.t('Needs attention'));
-    setText(strip, '[data-mel-readiness-title]', title);
-    setText(strip, '[data-mel-readiness-state]', readiness.state || '');
-
-    const explain = ensureReadinessExplain(strip);
-    if (explain) {
-      const explanation = typeof readiness.strip_explanation === 'string'
-        ? readiness.strip_explanation
-        : '';
-      explain.textContent = explanation;
-      explain.hidden = explanation === '';
-    }
-
-    if (readiness.checklist !== undefined) {
-      updateReadinessChecklist(strip, readiness.checklist);
-    }
-
-    // Match server-rendered strip counts (mel-event-studio-workspace.html.twig).
-    setText(strip, '[data-mel-readiness-errors-count]', Drupal.t('@count to finish', { '@count': (readiness.errors || []).length }));
-    setText(strip, '[data-mel-readiness-warnings-count]', Drupal.t('@count to review', { '@count': (readiness.warnings || []).length }));
-    setText(strip, '[data-mel-readiness-recommendations-count]', Drupal.t('@count idea(s)', { '@count': (readiness.recommendations || []).length }));
-    setText(strip, '[data-mel-readiness-completed-count]', Drupal.t('@count complete', { '@count': (readiness.completed || []).length }));
+    updateMissionControl(shell, readiness);
   }
 
-  function updateHomepageReadiness(shell, readiness) {
-    if (!readiness || readiness.show_homepage_readiness === undefined || isHomeShell(shell)) {
-      return;
-    }
-    const wrapper = ensureHomepageReadinessWrapper(shell);
-    if (!wrapper) {
-      return;
-    }
-    if (readiness.homepage_readiness_html !== undefined) {
-      wrapper.innerHTML = readiness.homepage_readiness_html;
-    }
-    wrapper.hidden = readiness.show_homepage_readiness === false
-      || wrapper.innerHTML.trim() === '';
-  }
-
-  function updateEventHealth(shell, health) {
-    if (!health || !Array.isArray(health.items)) {
-      return;
-    }
-    const panel = shell.querySelector('[data-mel-event-health]');
-    if (!panel) {
-      return;
-    }
-    if (health.last_updated) {
-      setText(panel, '[data-mel-event-health-updated]', health.last_updated);
-    }
-    health.items.forEach((item) => {
-      if (!item || !item.key) {
-        return;
-      }
-      setText(panel, `[data-mel-event-health-value="${item.key}"]`, item.value || '');
-      const detailEl = panel.querySelector(`[data-mel-event-health-detail="${item.key}"]`);
-      if (detailEl) {
-        if (item.detail) {
-          detailEl.textContent = item.detail;
-          detailEl.hidden = false;
-        }
-        else {
-          detailEl.textContent = '';
-          detailEl.hidden = true;
-        }
-      }
-      const row = panel.querySelector(`[data-mel-event-health-row="${item.key}"]`);
-      if (row && item.tone) {
-        row.className = `mel-event-studio-event-health__item mel-event-studio-event-health__item--${item.tone}`;
-        row.setAttribute('data-mel-event-health-row', item.key);
-      }
-    });
+  function updateEventHealth() {
+    // Event Health chrome retired — Mission Control owns the operational summary.
   }
 
   function syncTopbarState(shell, stateText) {
@@ -706,6 +486,13 @@
       shell.dataset.melPublished = result.published ? '1' : '0';
     }
     setText(shell, '[data-mel-publish-status]', result.topbar.status || '');
+    const statusBadge = shell.querySelector('[data-mel-publish-status]');
+    if (statusBadge) {
+      const statusKey = typeof result.topbar.status_key === 'string'
+        ? result.topbar.status_key
+        : (result.published ? 'live' : 'draft');
+      statusBadge.className = `mel-event-studio-topbar__badge mel-event-studio-topbar__badge--${statusKey}`;
+    }
     syncTopbarState(shell, result.topbar.state || '');
     setText(shell, '[data-mel-publish-last-saved]', result.topbar.lastSaved || '');
     if (result.topbar.location) {
@@ -730,11 +517,82 @@
     if (button) {
       setPublishButtonState(button, result.published ? 'published' : 'idle');
     }
-    if (result.event_health) {
-      updateEventHealth(shell, result.event_health);
+    if (result.topbar && result.topbar.primary_cta) {
+      syncHeroPrimaryCta(shell, result.topbar.primary_cta, !!result.published);
     }
-    if (result.readiness) {
-      updateHomepageReadiness(shell, result.readiness);
+    else if (result.published) {
+      syncHeroPrimaryCta(shell, { key: 'share', mode: 'link', publish_is_primary: false }, true);
+    }
+  }
+
+  /**
+   * Keeps Workspace Hero to one primary CTA after publish AJAX.
+   */
+  function syncHeroPrimaryCta(shell, primaryCta, published) {
+    const key = (primaryCta && typeof primaryCta.key === 'string')
+      ? primaryCta.key
+      : (published ? 'share' : 'publish');
+    shell.querySelector('[data-mel-studio-topbar]')?.setAttribute('data-mel-hero-primary-key', key);
+
+    const share = shell.querySelector('[data-mel-hero-share]');
+    const primaryLink = shell.querySelector('[data-mel-hero-primary-link]');
+    const publish = shell.querySelector('[data-mel-publish-action]');
+
+    const setPrimaryClass = (el, isPrimary) => {
+      if (!el) {
+        return;
+      }
+      el.classList.toggle('mel-btn--primary', isPrimary);
+      el.classList.toggle('mel-btn--ghost', !isPrimary);
+      if (isPrimary) {
+        el.setAttribute('data-mel-hero-primary', '1');
+      }
+      else {
+        el.removeAttribute('data-mel-hero-primary');
+      }
+    };
+
+    if (key === 'share') {
+      setPrimaryClass(share, true);
+      if (primaryLink) {
+        primaryLink.hidden = true;
+        primaryLink.removeAttribute('data-mel-hero-primary');
+        primaryLink.classList.remove('mel-btn', 'mel-btn--primary', 'mel-btn--ghost');
+      }
+      if (publish) {
+        setPrimaryClass(publish, false);
+        publish.classList.remove('mel-btn--ghost');
+        publish.classList.add('mel-event-studio-topbar__status-action');
+      }
+      return;
+    }
+
+    if (key === 'continue_setup') {
+      if (primaryLink && primaryCta && primaryCta.url && primaryCta.label) {
+        primaryLink.hidden = false;
+        primaryLink.setAttribute('href', primaryCta.url);
+        primaryLink.textContent = primaryCta.label;
+        primaryLink.classList.add('mel-btn');
+        setPrimaryClass(primaryLink, true);
+      }
+      setPrimaryClass(share, false);
+      if (publish) {
+        setPrimaryClass(publish, false);
+        publish.classList.remove('mel-event-studio-topbar__status-action');
+      }
+      return;
+    }
+
+    // publish
+    if (primaryLink) {
+      primaryLink.hidden = true;
+      primaryLink.removeAttribute('data-mel-hero-primary');
+      primaryLink.classList.remove('mel-btn', 'mel-btn--primary', 'mel-btn--ghost');
+    }
+    setPrimaryClass(share, false);
+    if (publish) {
+      setPrimaryClass(publish, true);
+      publish.classList.remove('mel-event-studio-topbar__status-action');
     }
   }
 

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
@@ -257,14 +257,21 @@
    * Applies Mission Control ViewModel (Home body or non-Home chrome).
    * CTA mirrors Hero except approved Stripe Connect exception; publish mode
    * defers to Hero publish control.
+   *
+   * When the server could not attach mission_control, synthesise a degraded
+   * card from readiness checklist / strip fields so Hero and Mission Control
+   * do not diverge after publish or unpublish.
    */
   function updateMissionControl(shell, readiness) {
     if (!readiness) {
       return;
     }
-    const mc = readiness.mission_control
+    let mc = readiness.mission_control
       || (readiness.home && readiness.home.mission_control)
       || null;
+    if (!mc) {
+      mc = buildDegradedMissionControl(shell, readiness);
+    }
     if (!mc) {
       return;
     }
@@ -379,6 +386,84 @@
         explain.hidden = explanation === '';
       }
     }
+  }
+
+  /**
+   * Client-side Mission Control when readiness.mission_control is null.
+   */
+  function buildDegradedMissionControl(shell, readiness) {
+    if (!shell || !shell.querySelector('[data-mel-mission-control]')) {
+      return null;
+    }
+    const published = readiness.published === true || shell.dataset.melPublished === '1';
+    const ready = !!readiness.ready;
+    const checklist = Array.isArray(readiness.checklist) ? readiness.checklist : [];
+    const complete = checklist.filter((item) => item && item.complete).length;
+    const total = Math.max(1, checklist.length);
+    const stripTitle = typeof readiness.strip_title === 'string' ? readiness.strip_title : '';
+    let message = typeof readiness.strip_explanation === 'string' ? readiness.strip_explanation : '';
+    let title;
+    let mode = 'link';
+    let key = 'continue_setup';
+    let actionLabel = null;
+    let url = null;
+
+    if (!ready) {
+      title = Drupal.t('Continue setup');
+      key = 'continue_setup';
+      const publishingLink = shell.querySelector('a[href*="/studio/publishing"]');
+      if (publishingLink && publishingLink.getAttribute('href')) {
+        actionLabel = Drupal.t('Continue setup');
+        url = publishingLink.getAttribute('href');
+      }
+    }
+    else if (!published) {
+      title = Drupal.t('Ready when you are');
+      mode = 'publish';
+      key = 'publish';
+      if (!message) {
+        message = Drupal.t('Your event looks ready. Publish when you want guests to find it.');
+      }
+    }
+    else {
+      title = Drupal.t('Share your event');
+      key = 'share';
+      if (!message) {
+        message = Drupal.t('Your event is live. Share the page or message your attendees.');
+      }
+      const shareLink = shell.querySelector('[data-mel-primary-cta][data-mel-cta-key="share"], a[href*="/studio/marketing"]');
+      if (shareLink && shareLink.getAttribute('href')) {
+        actionLabel = Drupal.t('Share');
+        url = shareLink.getAttribute('href');
+      }
+    }
+
+    return {
+      tone: ready ? 'success' : 'attention',
+      degraded: true,
+      next_step: {
+        title: title,
+        message: message,
+        mode: mode,
+        key: key,
+        action_label: actionLabel,
+        url: url,
+        mirrors_hero: true,
+        publish_is_primary: mode === 'publish',
+      },
+      improvements: {
+        open: checklist.length <= 4,
+        complete_label: Drupal.t('@done of @total complete', {
+          '@done': complete,
+          '@total': total,
+        }),
+        headline: stripTitle,
+        items: checklist,
+      },
+      event_quality: {
+        visible: false,
+      },
+    };
   }
 
   function updateReadiness(shell, readiness) {

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
@@ -42,6 +42,7 @@ function myeventlane_event_studio_theme($existing, $type, $theme, $path) {
     ],
     'mel_event_studio_overview' => [
       'variables' => [
+        'mission_control' => [],
         'event_ready' => [],
         'next_action' => [],
         'readiness' => [],
@@ -55,6 +56,12 @@ function myeventlane_event_studio_theme($existing, $type, $theme, $path) {
       ],
       'template' => 'mel-event-studio-overview',
     ],
+    'mel_event_studio_mission_control' => [
+      'variables' => [
+        'mission_control' => [],
+      ],
+      'template' => 'mel-event-studio-mission-control',
+    ],
     'mel_event_studio_workspace' => [
       'variables' => [
         'node' => NULL,
@@ -67,6 +74,7 @@ function myeventlane_event_studio_theme($existing, $type, $theme, $path) {
         'topbar' => [],
         'event_health' => [],
         'readiness' => [],
+        'mission_control' => NULL,
         'homepage_readiness' => NULL,
         'boost' => NULL,
         'boost_extension_recommendation' => NULL,

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -17,6 +17,7 @@ services:
       - '@myeventlane_event_studio.preprocess'
       - '@myeventlane_vendor.service.boost_status'
       - '@myeventlane_event_studio.workspace_presentation'
+      - '@myeventlane_event_studio.overview_builder'
       - '@myeventlane_boost.extension_recommendation'
     tags:
       - { name: controller.service_arguments }

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
@@ -19,6 +19,7 @@ use Drupal\myeventlane_event_studio\Service\EventStudioAutosaveService;
 use Drupal\myeventlane_event_studio\Service\EventStudioEmptyStateBuilder;
 use Drupal\myeventlane_event_studio\Service\EventReadinessFacade;
 use Drupal\myeventlane_event_studio\Service\EventStudioWorkspacePresentation;
+use Drupal\myeventlane_event_studio\Service\EventWorkspaceOverviewBuilder;
 use Drupal\myeventlane_event_studio\Service\EventStudioSectionRenderer;
 use Drupal\myeventlane_boost\Service\BoostExtensionRecommendationService;
 use Drupal\myeventlane_vendor\Service\BoostStatusService;
@@ -54,6 +55,7 @@ final class EventStudioController extends ControllerBase {
     private readonly EventStudioPreprocess $eventStudioPreprocess,
     private readonly BoostStatusService $boostStatusService,
     private readonly EventStudioWorkspacePresentation $workspacePresentation,
+    private readonly EventWorkspaceOverviewBuilder $overviewBuilder,
     private readonly ?BoostExtensionRecommendationService $boostExtensionRecommendation = NULL,
   ) {
     $this->entityTypeManager = $entity_type_manager;
@@ -76,6 +78,7 @@ final class EventStudioController extends ControllerBase {
       $container->get('myeventlane_event_studio.preprocess'),
       $container->get('myeventlane_vendor.service.boost_status'),
       $container->get('myeventlane_event_studio.workspace_presentation'),
+      $container->get('myeventlane_event_studio.overview_builder'),
       $container->get('myeventlane_boost.extension_recommendation'),
     );
   }
@@ -292,7 +295,11 @@ final class EventStudioController extends ControllerBase {
     ]);
 
     $readiness_summary = $this->workspacePresentation->buildReadinessSummary($readiness_bundle, $node);
-    $event_health = $this->workspacePresentation->buildEventHealth($readiness_bundle, $node, $boost);
+    // Event Health retired from non-Home chrome — Mission Control owns next step,
+    // improvements, and Event Quality without a competing status card.
+    $mission_control = $section === 'overview'
+      ? NULL
+      : $this->overviewBuilder->buildMissionControl($node, $account, $section);
 
     return [
       '#theme' => 'mel_event_studio_workspace',
@@ -304,9 +311,10 @@ final class EventStudioController extends ControllerBase {
       '#current_section_metadata' => $sectionMetadata,
       '#section_content' => $sectionContent,
       '#topbar' => $this->buildTopbar($node, $readiness, $section),
-      '#event_health' => $event_health,
+      '#event_health' => NULL,
       '#readiness' => $readiness_summary,
-      '#homepage_readiness' => $this->workspacePresentation->buildHomepageReadinessCard($node, $readiness_bundle, $section),
+      '#mission_control' => $mission_control,
+      '#homepage_readiness' => NULL,
       '#boost' => $boost,
       '#boost_extension_recommendation' => $boost_extension_recommendation,
       '#publish_handoff' => $publish_handoff,
@@ -399,11 +407,26 @@ final class EventStudioController extends ControllerBase {
     $state = ($node->isPublished() && $readiness->ready) ? '' : $operational_state;
     $account = $this->currentUser();
     $isStaff = $account->hasPermission('administer nodes') || (int) $account->id() === 1;
+    $nid = (int) $node->id();
+    $date_label = $this->workspacePresentation->buildTopbarDateLabel($node);
+    $venue_label = $this->workspacePresentation->buildTopbarVenueLabel($node);
+    $status = $this->workspacePresentation->buildTopbarStatus($node);
+    $share_url = $this->safeRouteUrl('myeventlane_event_studio.workspace_marketing', ['node' => $nid], $account);
+    $primary_cta = $this->overviewBuilder->resolveAuthoritativePrimaryCta(
+      $readiness,
+      $node->isPublished(),
+      $nid,
+      $share_url,
+    );
 
     return [
       'title' => $node->label(),
+      'date_label' => $date_label,
+      'venue_label' => $venue_label,
+      'context_line' => $this->buildHeroContextLine($date_label, $venue_label),
       'location' => $this->workspacePresentation->buildTopbarLocation($node),
-      'status' => $node->isPublished() ? $this->t('Live') : $this->t('Draft'),
+      'status' => $status['label'],
+      'status_key' => $status['key'],
       'state' => $state,
       'show_last_saved' => FALSE,
       'restore_draft' => $this->autosaveService->hasDraft($node, $section),
@@ -413,9 +436,11 @@ final class EventStudioController extends ControllerBase {
         'query' => ['restore_draft' => '1'],
       ])->toString(),
       'preview_url' => $this->domainDetector->publicUrl(Url::fromRoute('entity.node.canonical', ['node' => $node->id()])->toString()),
+      'share_url' => $share_url,
       'publish_url' => Url::fromRoute('myeventlane_event_studio.publish', ['node' => $node->id()])->toString(),
       'published' => $node->isPublished(),
       'can_publish' => $readiness->ready,
+      'primary_cta' => $primary_cta,
       'current_section' => $section,
       'show_manage_event_link' => $isStaff,
       'manage_event_url' => $isStaff
@@ -425,6 +450,11 @@ final class EventStudioController extends ControllerBase {
       'changed' => $node->getChangedTime(),
       'revision_id' => (int) $node->getRevisionId(),
     ];
+  }
+
+  private function buildHeroContextLine(string $date_label, string $venue_label): string {
+    $parts = array_values(array_filter([$date_label, $venue_label], static fn(string $part): bool => $part !== ''));
+    return implode(' · ', $parts);
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
@@ -297,8 +297,8 @@ final class EventStudioController extends ControllerBase {
     $readiness_summary = $this->workspacePresentation->buildReadinessSummary($readiness_bundle, $node);
     // Event Health retired from non-Home chrome — Mission Control owns next step,
     // improvements, and Event Quality without a competing status card.
-    // Reuse the readiness bundle already evaluated above; do not rebuild the
-    // Home workspace view-model (sales/RSVP/ops cards) on every section page.
+    // Reuse the readiness bundle already evaluated above; Mission Control still
+    // loads the shared Home guide path (VM + Stripe) so section chrome matches Home.
     $mission_control = $section === 'overview'
       ? NULL
       : $this->overviewBuilder->buildMissionControl($node, $account, $section, $readiness_bundle);

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioController.php
@@ -297,9 +297,11 @@ final class EventStudioController extends ControllerBase {
     $readiness_summary = $this->workspacePresentation->buildReadinessSummary($readiness_bundle, $node);
     // Event Health retired from non-Home chrome — Mission Control owns next step,
     // improvements, and Event Quality without a competing status card.
+    // Reuse the readiness bundle already evaluated above; do not rebuild the
+    // Home workspace view-model (sales/RSVP/ops cards) on every section page.
     $mission_control = $section === 'overview'
       ? NULL
-      : $this->overviewBuilder->buildMissionControl($node, $account, $section);
+      : $this->overviewBuilder->buildMissionControl($node, $account, $section, $readiness_bundle);
 
     return [
       '#theme' => 'mel_event_studio_workspace',

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPublishController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPublishController.php
@@ -261,12 +261,16 @@ final class EventStudioPublishController {
       $readiness_bundle,
       $node,
     );
+    $ajax_section = $section !== '' ? $section : 'overview';
+    // Always initialise so shell JS never keeps a stale Mission Control card
+    // when the Home snapshot path fails after a successful publish.
+    $ajax_readiness['mission_control'] = NULL;
     try {
       // Same Stripe + mission-control guide cards as full Home render.
       $home_snapshot = $this->overviewBuilder->buildHomeAjaxGuideSnapshot(
         $node,
         $this->currentUser,
-        $section !== '' ? $section : 'overview',
+        $ajax_section,
       );
       $ajax_readiness['home'] = $home_snapshot;
       $ajax_readiness['mission_control'] = $home_snapshot['mission_control'] ?? NULL;
@@ -276,6 +280,23 @@ final class EventStudioPublishController {
         '@nid' => (string) $node->id(),
         '@message' => $e->getMessage(),
       ]);
+      try {
+        // Degraded path: reuse readiness bundle, skip Home VM so shell still
+        // refreshes next-step / checklist after publish when snapshot fails.
+        $ajax_readiness['mission_control'] = $this->overviewBuilder->buildMissionControl(
+          $node,
+          $this->currentUser,
+          $ajax_section,
+          $readiness_bundle,
+          FALSE,
+        );
+      }
+      catch (\Throwable $fallback) {
+        $this->logger->error('Event Workspace Mission Control AJAX fallback failed for event @nid: @message', [
+          '@nid' => (string) $node->id(),
+          '@message' => $fallback->getMessage(),
+        ]);
+      }
     }
     // Homepage readiness card retired from chrome — Event Quality lives in Mission Control.
     $ajax_readiness['homepage_readiness_html'] = '';

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPublishController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPublishController.php
@@ -311,6 +311,16 @@ final class EventStudioPublishController {
       $nid,
       $share_url,
     );
+    // Last resort: never leave mission_control null after Hero CTA is known.
+    // Presentation-only assembly — no VM / Stripe — so shell JS can refresh.
+    if (($ajax_readiness['mission_control'] ?? NULL) === NULL) {
+      $ajax_readiness['mission_control'] = $this->workspacePresentation->buildDegradedMissionControlPayload(
+        $ajax_readiness,
+        $primary_cta,
+        $node->isPublished(),
+        $ajax_section,
+      );
+    }
     $payload = [
       'ok' => $ok,
       'state' => $state,

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPublishController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPublishController.php
@@ -263,10 +263,13 @@ final class EventStudioPublishController {
     );
     try {
       // Same Stripe + mission-control guide cards as full Home render.
-      $ajax_readiness['home'] = $this->overviewBuilder->buildHomeAjaxGuideSnapshot(
+      $home_snapshot = $this->overviewBuilder->buildHomeAjaxGuideSnapshot(
         $node,
         $this->currentUser,
+        $section !== '' ? $section : 'overview',
       );
+      $ajax_readiness['home'] = $home_snapshot;
+      $ajax_readiness['mission_control'] = $home_snapshot['mission_control'] ?? NULL;
     }
     catch (\Throwable $e) {
       $this->logger->error('Event Workspace Home AJAX guide snapshot failed for event @nid: @message', [
@@ -274,18 +277,19 @@ final class EventStudioPublishController {
         '@message' => $e->getMessage(),
       ]);
     }
-    $homepage_card = $this->workspacePresentation->buildHomepageReadinessCard(
-      $node,
-      $readiness_bundle,
-      $section,
-    );
-    if ($homepage_card !== NULL) {
-      $ajax_readiness['homepage_readiness_html'] = (string) $this->renderer->renderPlain($homepage_card);
-    }
-    else {
-      $ajax_readiness['homepage_readiness_html'] = '';
-    }
+    // Homepage readiness card retired from chrome — Event Quality lives in Mission Control.
+    $ajax_readiness['homepage_readiness_html'] = '';
+    $ajax_readiness['show_homepage_readiness'] = FALSE;
 
+    $topbar_status = $this->workspacePresentation->buildTopbarStatus($node);
+    $nid = (int) $node->id();
+    $share_url = Url::fromRoute('myeventlane_event_studio.workspace_marketing', ['node' => $nid])->toString();
+    $primary_cta = $this->overviewBuilder->resolveAuthoritativePrimaryCta(
+      $publish_result,
+      $node->isPublished(),
+      $nid,
+      $share_url,
+    );
     $payload = [
       'ok' => $ok,
       'state' => $state,
@@ -293,18 +297,23 @@ final class EventStudioPublishController {
       'messages' => $messages,
       'published' => $node->isPublished(),
       'topbar' => [
-        // Match EventStudioController::buildTopbar Sprint 2 organiser copy.
-        'status' => $node->isPublished() ? (string) $this->t('Live') : (string) $this->t('Draft'),
+        // Same authoritative CTA contract as EventStudioController::buildTopbar.
+        'status' => $topbar_status['label'],
+        'status_key' => $topbar_status['key'],
         'state' => ($node->isPublished() && $publish_result->ready)
           ? ''
           : $this->workspacePresentation->operationalState($publish_result),
         'location' => $this->workspacePresentation->buildTopbarLocation($node),
+        'date_label' => $this->workspacePresentation->buildTopbarDateLabel($node),
+        'venue_label' => $this->workspacePresentation->buildTopbarVenueLabel($node),
+        'primary_cta' => $primary_cta,
         'lastSaved' => $node->getChangedTime() > 0 ? (string) $this->t('Last saved @time', [
           '@time' => $this->dateFormatter->format($node->getChangedTime(), 'short'),
         ]) : (string) $this->t('Not saved yet'),
       ],
       'readiness' => $ajax_readiness,
-      'event_health' => $this->workspacePresentation->buildEventHealth($readiness_bundle, $node, $boost),
+      // Event Health chrome retired — Mission Control owns operational summary.
+      'event_health' => NULL,
       'changed' => $node->getChangedTime(),
       'revisionId' => (int) $node->getRevisionId(),
     ];

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWorkspacePresentation.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWorkspacePresentation.php
@@ -292,6 +292,109 @@ final class EventStudioWorkspacePresentation {
     ];
   }
 
+  /**
+   * Last-resort Mission Control payload when Home snapshot + overview fallback fail.
+   *
+   * Uses only AJAX readiness fields and the authoritative Hero CTA — no view
+   * model or Stripe gate calls — so publish/unpublish responses can still
+   * refresh the card instead of leaving stale next-step copy.
+   *
+   * @param array<string, mixed> $ajax_readiness
+   * @param array{
+   *   key: string,
+   *   mode: string,
+   *   label: string,
+   *   url: string,
+   *   publish_is_primary: bool
+   * } $primary_cta
+   *
+   * @return array<string, mixed>
+   */
+  public function buildDegradedMissionControlPayload(
+    array $ajax_readiness,
+    array $primary_cta,
+    bool $published,
+    string $section = '',
+  ): array {
+    $ready = (bool) ($ajax_readiness['ready'] ?? FALSE);
+    $checklist = is_array($ajax_readiness['checklist'] ?? NULL)
+      ? $ajax_readiness['checklist']
+      : [];
+    $complete_count = count(array_filter(
+      $checklist,
+      static fn(mixed $item): bool => is_array($item) && !empty($item['complete']),
+    ));
+    $total_count = count($checklist);
+    if ($total_count < 1) {
+      $total_count = 1;
+    }
+    $tone = $ready ? 'success' : 'attention';
+    $headline = (string) ($ajax_readiness['strip_title'] ?? '');
+    $message = (string) ($ajax_readiness['strip_explanation'] ?? '');
+    $mode = (string) ($primary_cta['mode'] ?? 'link');
+    $key = (string) ($primary_cta['key'] ?? '');
+    $label = (string) ($primary_cta['label'] ?? '');
+    $url = (string) ($primary_cta['url'] ?? '');
+    $publish_is_primary = (bool) ($primary_cta['publish_is_primary'] ?? FALSE);
+
+    if (!$ready) {
+      $title = (string) $this->t('Continue setup');
+    }
+    elseif (!$published) {
+      $title = (string) $this->t('Ready when you are');
+      $message = $message !== ''
+        ? $message
+        : (string) $this->t('Your event looks ready. Publish when you want guests to find it.');
+    }
+    else {
+      $title = (string) $this->t('Share your event');
+      $message = $message !== ''
+        ? $message
+        : (string) $this->t('Your event is live. Share the page or message your attendees.');
+    }
+
+    return [
+      'heading' => (string) $this->t('Mission Control'),
+      'tone' => $tone,
+      'section' => $section,
+      'degraded' => TRUE,
+      'next_step' => [
+        'eyebrow' => (string) $this->t('Next step'),
+        'title' => $title,
+        'why_label' => (string) $this->t('Why this matters'),
+        'message' => $message,
+        'action_label' => $mode === 'publish' ? NULL : ($label !== '' ? $label : NULL),
+        'url' => $mode === 'publish' ? NULL : ($url !== '' ? $url : NULL),
+        'key' => $key,
+        'mode' => $mode,
+        'mirrors_hero' => TRUE,
+        'publish_is_primary' => $publish_is_primary,
+      ],
+      'improvements' => [
+        'heading' => (string) $this->t('Other improvements'),
+        'headline' => $headline,
+        'complete_count' => $complete_count,
+        'total_count' => $total_count,
+        'complete_label' => (string) $this->t('@done of @total complete', [
+          '@done' => $complete_count,
+          '@total' => $total_count,
+        ]),
+        'items' => $checklist,
+        'open' => count($checklist) <= 4,
+        'hint' => (string) $this->t('View checklist'),
+      ],
+      'event_quality' => [
+        'visible' => FALSE,
+        'heading' => (string) $this->t('Event Quality'),
+        'score' => 0,
+        'score_label' => (string) $this->t('@score%', ['@score' => 0]),
+        'status_label' => '',
+        'explanation' => '',
+        'ready' => FALSE,
+      ],
+    ];
+  }
+
   public function shouldShowHomepageReadinessCard(bool $promotion_ready, bool $published): bool {
     return !$promotion_ready || !$published;
   }

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWorkspacePresentation.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioWorkspacePresentation.php
@@ -178,12 +178,12 @@ final class EventStudioWorkspacePresentation {
   public function readinessStripTitle(EventReadinessResult $result, bool $published): string {
     if (!$result->ready) {
       if (count($result->errors) === 1) {
-        return (string) $this->t("You're almost there…");
+        return (string) $this->t('Almost ready');
       }
       return (string) $this->t('A few things left before publishing');
     }
     if ($published) {
-      return (string) $this->t('Published and ready');
+      return (string) $this->t('Live and ready');
     }
     return (string) $this->t('Ready to publish');
   }
@@ -191,9 +191,9 @@ final class EventStudioWorkspacePresentation {
   public function readinessStripExplanation(EventReadinessResult $result): string {
     if ($result->ready) {
       if ($result->warnings !== []) {
-        return (string) $this->t('You can publish now. Optional suggestions are still worth a quick look.');
+        return (string) $this->t('You can publish when you are ready. Optional suggestions are still worth a quick look.');
       }
-      return (string) $this->t('Everything needed to go live looks good.');
+      return (string) $this->t('Everything needed for guests to find and book looks good.');
     }
     if (count($result->errors) === 1) {
       return (string) $this->t('One more thing before publishing: @reason', [
@@ -201,7 +201,7 @@ final class EventStudioWorkspacePresentation {
       ]);
     }
     if ($result->errors !== []) {
-      return (string) $this->t('Finish the items below so guests can find and book your event.');
+      return (string) $this->t('Finish the required items below so guests can find and book your event.');
     }
     return (string) $this->t('Review the suggestions below to make your event page stronger.');
   }
@@ -277,6 +277,21 @@ final class EventStudioWorkspacePresentation {
     return !$published || !$result->ready || $result->errors !== [] || $result->warnings !== [];
   }
 
+  /**
+   * Theme wrapper for the shared Mission Control component.
+   *
+   * @param array<string, mixed> $mission_control
+   *   ViewModel from EventWorkspaceOverviewBuilder::buildMissionControl().
+   *
+   * @return array<string, mixed>
+   */
+  public function buildMissionControlRender(array $mission_control): array {
+    return [
+      '#theme' => 'mel_event_studio_mission_control',
+      '#mission_control' => $mission_control,
+    ];
+  }
+
   public function shouldShowHomepageReadinessCard(bool $promotion_ready, bool $published): bool {
     return !$promotion_ready || !$published;
   }
@@ -318,6 +333,78 @@ final class EventStudioWorkspacePresentation {
     return (string) $this->t('Last updated @time', [
       '@time' => $this->dateFormatter->format($node->getChangedTime(), 'short'),
     ]);
+  }
+
+  /**
+   * Formats event start for Workspace Hero (same field as vendor workspace VM).
+   *
+   * Display-only — does not invent schedule rules or readiness.
+   */
+  public function buildTopbarDateLabel(NodeInterface $node): string {
+    if ($node->bundle() !== 'event' || !$node->hasField('field_event_start') || $node->get('field_event_start')->isEmpty()) {
+      return '';
+    }
+    $item = $node->get('field_event_start')->first();
+    if ($item === NULL || !isset($item->date) || !$item->date) {
+      return '';
+    }
+    return $this->dateFormatter->format((int) $item->date->getTimestamp(), 'medium');
+  }
+
+  /**
+   * Hero / Health operational status label (Draft · Live · Past).
+   *
+   * Mirrors VendorEventWorkspaceViewModelBuilder::resolvePublicationStatus
+   * presentation rules without calling the full ViewModel or readiness facade.
+   *
+   * @return array{label: string, key: string}
+   */
+  public function buildTopbarStatus(NodeInterface $node): array {
+    if (!$node->isPublished()) {
+      return [
+        'label' => (string) $this->t('Draft'),
+        'key' => 'draft',
+      ];
+    }
+    if ($this->isEventPast($node)) {
+      return [
+        'label' => (string) $this->t('Past'),
+        'key' => 'past',
+      ];
+    }
+    return [
+      'label' => (string) $this->t('Live'),
+      'key' => 'live',
+    ];
+  }
+
+  /**
+   * True when field_event_end is set and before now (same field as workspace VM).
+   */
+  public function isEventPast(NodeInterface $node): bool {
+    if ($node->bundle() !== 'event' || !$node->hasField('field_event_end') || $node->get('field_event_end')->isEmpty()) {
+      return FALSE;
+    }
+    $item = $node->get('field_event_end')->first();
+    if ($item === NULL || !isset($item->date) || !$item->date) {
+      return FALSE;
+    }
+    return (int) $item->date->getTimestamp() < time();
+  }
+
+  /**
+   * Short venue line for Hero context (reuses topbar location primary).
+   */
+  public function buildTopbarVenueLabel(NodeInterface $node): string {
+    $location = $this->buildTopbarLocation($node);
+    if (!$location['configured']) {
+      return '';
+    }
+    $primary = trim((string) ($location['primary_line'] ?? ''));
+    if ($primary !== '' && $primary !== (string) $this->t('One-off venue')) {
+      return $primary;
+    }
+    return trim((string) ($location['secondary_line'] ?? $primary));
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventWorkspaceOverviewBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventWorkspaceOverviewBuilder.php
@@ -82,10 +82,12 @@ final class EventWorkspaceOverviewBuilder {
    * Presentation-only — reuses guide next_action, facade checklist, and
    * existing homepage readiness score. No new scoring.
    *
-   * Non-Home shell callers should pass the readiness bundle already evaluated
-   * for the workspace render. That path skips
-   * VendorEventWorkspaceViewModelBuilder (Home ops cards / sales / RSVP) and
-   * does not re-run EventReadinessFacade.
+   * Default path matches Home (workspace view-model + Stripe + next-action).
+   * Callers should pass the readiness bundle already evaluated for the request
+   * to avoid a second EventReadinessFacade evaluation.
+   *
+   * Set $include_workspace_model FALSE only for degraded AJAX fallback when the
+   * full Home snapshot fails — still Hero-aligned status + facade checklist.
    *
    * @param array<string, mixed>|null $readiness_bundle
    *   Optional facade payload from the current request.
@@ -97,9 +99,10 @@ final class EventWorkspaceOverviewBuilder {
     AccountInterface $account,
     string $section,
     ?array $readiness_bundle = NULL,
+    bool $include_workspace_model = TRUE,
   ): array {
     return $this->assembleMissionControl(
-      $this->buildGuideCardState($event, $account, $readiness_bundle, FALSE),
+      $this->buildGuideCardState($event, $account, $readiness_bundle, $include_workspace_model),
       $section,
     );
   }
@@ -210,8 +213,11 @@ final class EventWorkspaceOverviewBuilder {
       $nextRecommended['message'] = trim($nextRecommended['message'] . ' ' . (string) ($celebration['message'] ?? ''));
     }
 
-    $statusLabel = (string) ($eventMeta['status_label'] ?? ($published ? $this->t('Live') : $this->t('Draft')));
-    $statusKey = (string) ($eventMeta['status'] ?? ($published ? 'live' : 'draft'));
+    // Align Mission Control status copy with Hero (Draft · Live · Past).
+    // Do not trust published→live alone — ended events must use Past.
+    $guideStatus = $this->resolveGuidePublicationStatus($event, $eventMeta);
+    $statusLabel = $guideStatus['label'];
+    $statusKey = $guideStatus['key'];
 
     return [
       'workspace' => $workspace,
@@ -241,6 +247,51 @@ final class EventWorkspaceOverviewBuilder {
       'promotion_ready' => (bool) ($bundle['promotion_ready'] ?? FALSE),
       'published' => $published,
     ];
+  }
+
+  /**
+   * Hero-aligned publication status for Mission Control copy.
+   *
+   * Same Draft / Live / Past rules as
+   * EventStudioWorkspacePresentation::buildTopbarStatus() — entity end date
+   * wins over a naive published→live fallback when the workspace VM is absent.
+   *
+   * @param array<string, mixed> $eventMeta
+   *
+   * @return array{label: string, key: string}
+   */
+  private function resolveGuidePublicationStatus(NodeInterface $event, array $eventMeta): array {
+    if (!$event->isPublished()) {
+      return [
+        'label' => (string) ($eventMeta['status_label'] ?? $this->t('Draft')),
+        'key' => 'draft',
+      ];
+    }
+    if ($this->isEventEnded($event)) {
+      return [
+        'label' => (string) $this->t('Past'),
+        'key' => 'past',
+      ];
+    }
+    // Normalise VM "published" key to Hero "live" for Event Ready copy.
+    return [
+      'label' => (string) ($eventMeta['status_label'] ?? $this->t('Live')),
+      'key' => 'live',
+    ];
+  }
+
+  /**
+   * True when field_event_end is set and before now (Hero / workspace VM rule).
+   */
+  private function isEventEnded(NodeInterface $event): bool {
+    if ($event->bundle() !== 'event' || !$event->hasField('field_event_end') || $event->get('field_event_end')->isEmpty()) {
+      return FALSE;
+    }
+    $item = $event->get('field_event_end')->first();
+    if ($item === NULL || !isset($item->date) || !$item->date) {
+      return FALSE;
+    }
+    return (int) $item->date->getTimestamp() < time();
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventWorkspaceOverviewBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventWorkspaceOverviewBuilder.php
@@ -82,10 +82,26 @@ final class EventWorkspaceOverviewBuilder {
    * Presentation-only — reuses guide next_action, facade checklist, and
    * existing homepage readiness score. No new scoring.
    *
+   * Non-Home shell callers should pass the readiness bundle already evaluated
+   * for the workspace render. That path skips
+   * VendorEventWorkspaceViewModelBuilder (Home ops cards / sales / RSVP) and
+   * does not re-run EventReadinessFacade.
+   *
+   * @param array<string, mixed>|null $readiness_bundle
+   *   Optional facade payload from the current request.
+   *
    * @return array<string, mixed>
    */
-  public function buildMissionControl(NodeInterface $event, AccountInterface $account, string $section): array {
-    return $this->assembleMissionControl($this->buildGuideCardState($event, $account), $section);
+  public function buildMissionControl(
+    NodeInterface $event,
+    AccountInterface $account,
+    string $section,
+    ?array $readiness_bundle = NULL,
+  ): array {
+    return $this->assembleMissionControl(
+      $this->buildGuideCardState($event, $account, $readiness_bundle, FALSE),
+      $section,
+    );
   }
 
   /**
@@ -122,7 +138,13 @@ final class EventWorkspaceOverviewBuilder {
   }
 
   /**
-   * Shared guide-row state for full Home and AJAX (Stripe + mission-control).
+   * Shared guide-row state for full Home, AJAX, and shell Mission Control.
+   *
+   * @param array<string, mixed>|null $readiness_bundle
+   *   Optional facade payload; when set, skips a second evaluate().
+   * @param bool $include_workspace_model
+   *   When FALSE (non-Home shell), skips VendorEventWorkspaceViewModelBuilder.
+   *   Stripe booking type then comes from the event entity field fallback.
    *
    * @return array{
    *   workspace: array<string, mixed>,
@@ -134,19 +156,27 @@ final class EventWorkspaceOverviewBuilder {
    *   published: bool
    * }
    */
-  private function buildGuideCardState(NodeInterface $event, AccountInterface $account): array {
-    try {
-      $workspace = $this->workspaceViewModel->build($event, $account);
-    }
-    catch (\Throwable $e) {
-      $this->logger->error('Event Workspace home model failed for event @nid: @message', [
-        '@nid' => (string) $event->id(),
-        '@message' => $e->getMessage(),
-      ]);
-      $workspace = [];
+  private function buildGuideCardState(
+    NodeInterface $event,
+    AccountInterface $account,
+    ?array $readiness_bundle = NULL,
+    bool $include_workspace_model = TRUE,
+  ): array {
+    $workspace = [];
+    if ($include_workspace_model) {
+      try {
+        $workspace = $this->workspaceViewModel->build($event, $account);
+      }
+      catch (\Throwable $e) {
+        $this->logger->error('Event Workspace home model failed for event @nid: @message', [
+          '@nid' => (string) $event->id(),
+          '@message' => $e->getMessage(),
+        ]);
+        $workspace = [];
+      }
     }
 
-    $bundle = $this->readinessFacade->evaluate($event, $account);
+    $bundle = $readiness_bundle ?? $this->readinessFacade->evaluate($event, $account);
     $readiness = $bundle['publish'];
     $recommended = is_array($bundle['recommended'] ?? NULL) ? $bundle['recommended'] : [];
     $nid = (int) $event->id();

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventWorkspaceOverviewBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventWorkspaceOverviewBuilder.php
@@ -61,6 +61,8 @@ final class EventWorkspaceOverviewBuilder {
 
     return [
       '#theme' => 'mel_event_studio_overview',
+      '#mission_control' => $this->assembleMissionControl($guide, 'overview'),
+      // Legacy keys retained for AJAX/tests that still read guide snapshots.
       '#event_ready' => $guide['event_ready'],
       '#next_action' => $guide['next_action'],
       '#readiness' => $guide['readiness'],
@@ -75,6 +77,18 @@ final class EventWorkspaceOverviewBuilder {
   }
 
   /**
+   * Mission Control ViewModel for Home and non-Home shell (same component).
+   *
+   * Presentation-only — reuses guide next_action, facade checklist, and
+   * existing homepage readiness score. No new scoring.
+   *
+   * @return array<string, mixed>
+   */
+  public function buildMissionControl(NodeInterface $event, AccountInterface $account, string $section): array {
+    return $this->assembleMissionControl($this->buildGuideCardState($event, $account), $section);
+  }
+
+  /**
    * Home Event Ready / readiness / next action for publish AJAX refresh.
    *
    * Same Stripe + mission-control rules as full Home render — not a simplified
@@ -86,7 +100,7 @@ final class EventWorkspaceOverviewBuilder {
    *   next_action: array<string, mixed>
    * }
    */
-  public function buildHomeAjaxGuideSnapshot(NodeInterface $event, AccountInterface $account): array {
+  public function buildHomeAjaxGuideSnapshot(NodeInterface $event, AccountInterface $account, string $section = 'overview'): array {
     $guide = $this->buildGuideCardState($event, $account);
     $event_ready = $guide['event_ready'];
     $readiness = $guide['readiness'];
@@ -96,11 +110,14 @@ final class EventWorkspaceOverviewBuilder {
     ]);
     $event_ready['complete_label'] = $complete_label;
     $readiness['complete_label'] = $complete_label;
+    $mission_control = $this->assembleMissionControl($guide, $section);
+    $mission_control['improvements']['complete_label'] = $complete_label;
 
     return [
       'event_ready' => $event_ready,
       'readiness' => $readiness,
       'next_action' => $guide['next_action'],
+      'mission_control' => $mission_control,
     ];
   }
 
@@ -111,7 +128,10 @@ final class EventWorkspaceOverviewBuilder {
    *   workspace: array<string, mixed>,
    *   event_ready: array<string, mixed>,
    *   next_action: array<string, mixed>,
-   *   readiness: array<string, mixed>
+   *   readiness: array<string, mixed>,
+   *   promotion: array<string, mixed>,
+   *   promotion_ready: bool,
+   *   published: bool
    * }
    */
   private function buildGuideCardState(NodeInterface $event, AccountInterface $account): array {
@@ -187,7 +207,113 @@ final class EventWorkspaceOverviewBuilder {
         'headline' => $this->readinessHeadline($readiness->ready, $published, $remainingErrors),
         'explanation' => $this->readinessExplanation($readiness),
       ],
+      'promotion' => is_array($bundle['promotion'] ?? NULL) ? $bundle['promotion'] : [],
+      'promotion_ready' => (bool) ($bundle['promotion_ready'] ?? FALSE),
+      'published' => $published,
     ];
+  }
+
+  /**
+   * Maps existing guide + homepage readiness presentation into one card model.
+   *
+   * @param array<string, mixed> $guide
+   *
+   * @return array<string, mixed>
+   */
+  private function assembleMissionControl(array $guide, string $section): array {
+    $next = is_array($guide['next_action'] ?? NULL) ? $guide['next_action'] : [];
+    $readiness = is_array($guide['readiness'] ?? NULL) ? $guide['readiness'] : [];
+    $event_ready = is_array($guide['event_ready'] ?? NULL) ? $guide['event_ready'] : [];
+    $promotion = is_array($guide['promotion'] ?? NULL) ? $guide['promotion'] : [];
+    $promotion_ready = (bool) ($guide['promotion_ready'] ?? FALSE);
+    $published = (bool) ($guide['published'] ?? FALSE);
+    $tone = (string) ($event_ready['tone'] ?? 'success');
+    $items = is_array($readiness['items'] ?? NULL) ? $readiness['items'] : [];
+    $item_count = count($items);
+    $attention = $tone === 'attention';
+    $section_open = $this->sectionSuggestsOpenChecklist($section, $next);
+    // Collapse when long so Mission Control stays scannable; section context
+    // may still open the checklist when the CTA targets this section.
+    $improvements_open = $section_open || $item_count <= 4;
+
+    $why = trim((string) ($next['message'] ?? ''));
+    if ($why === '') {
+      $why = trim((string) ($readiness['explanation'] ?? ''));
+    }
+    if ($why === '') {
+      $why = trim((string) ($event_ready['detail'] ?? ''));
+    }
+
+    $complete_count = (int) ($readiness['complete_count'] ?? 0);
+    $total_count = (int) ($readiness['total_count'] ?? 1);
+    if ($total_count < 1) {
+      $total_count = 1;
+    }
+
+    $show_quality = (!$promotion_ready || !$published)
+      && !($section !== 'overview' && $promotion_ready);
+
+    $score = (int) ($promotion['score'] ?? 0);
+    $quality_status = (string) ($promotion['short_status_label'] ?? $promotion['status_label'] ?? '');
+    $quality_explain = $promotion_ready
+      ? (string) $this->t('Your event meets the basics for homepage promotion.')
+      : (string) $this->t('Improve event quality to unlock homepage promotion.');
+
+    return [
+      'heading' => (string) $this->t('Mission Control'),
+      'tone' => $tone,
+      'section' => $section,
+      'next_step' => [
+        'eyebrow' => (string) $this->t('Next step'),
+        'title' => (string) ($next['title'] ?? ''),
+        'why_label' => (string) $this->t('Why this matters'),
+        'message' => $why,
+        'action_label' => $next['action_label'] ?? NULL,
+        'url' => $next['url'] ?? NULL,
+        'key' => (string) ($next['key'] ?? ''),
+        'mode' => (string) ($next['mode'] ?? 'link'),
+        'mirrors_hero' => (bool) ($next['mirrors_hero'] ?? TRUE),
+        'publish_is_primary' => (bool) ($next['publish_is_primary'] ?? FALSE),
+      ],
+      'improvements' => [
+        'heading' => (string) $this->t('Other improvements'),
+        'headline' => (string) ($readiness['headline'] ?? ''),
+        'complete_count' => $complete_count,
+        'total_count' => $total_count,
+        'complete_label' => (string) $this->t('@done of @total complete', [
+          '@done' => $complete_count,
+          '@total' => $total_count,
+        ]),
+        'items' => $items,
+        'open' => $improvements_open,
+        'hint' => (string) ($event_ready['checklist_label'] ?? $this->t('View checklist')),
+      ],
+      'event_quality' => [
+        'visible' => $show_quality,
+        'heading' => (string) $this->t('Event Quality'),
+        'score' => $score,
+        'score_label' => (string) $this->t('@score%', ['@score' => $score]),
+        'status_label' => $quality_status,
+        'explanation' => $quality_explain,
+        'ready' => $promotion_ready,
+      ],
+    ];
+  }
+
+  /**
+   * Presentation-only: open checklist when CTA already targets this section.
+   *
+   * @param array<string, mixed> $next
+   */
+  private function sectionSuggestsOpenChecklist(string $section, array $next): bool {
+    if ($section === '' || $section === 'overview') {
+      return FALSE;
+    }
+    $url = (string) ($next['url'] ?? '');
+    if ($url === '') {
+      return FALSE;
+    }
+    return str_contains($url, '/' . $section) || str_contains($url, 'workspace_' . $section);
   }
 
   /**
@@ -230,8 +356,15 @@ final class EventWorkspaceOverviewBuilder {
     $headline = (string) $this->t('Ready to publish');
     $detail = (string) $this->t('Everything looks good.');
     if ($published && $readiness->ready) {
-      $headline = (string) $this->t('Live and healthy');
-      $detail = (string) $this->t('Your event is published and ready for guests.');
+      // status_key from workspace VM (past | published | draft) — presentation only.
+      if ($statusKey === 'past') {
+        $headline = (string) $this->t('Event completed');
+        $detail = (string) $this->t('This event has ended. Review activity and bookings below.');
+      }
+      else {
+        $headline = (string) $this->t('Live and healthy');
+        $detail = (string) $this->t('Your event is published and ready for guests.');
+      }
     }
     elseif (!$readiness->ready) {
       $tone = 'attention';
@@ -246,10 +379,15 @@ final class EventWorkspaceOverviewBuilder {
     if (($stripe['tone'] ?? '') === 'attention' && in_array($this->resolveEventBookingType($event, $eventMeta), ['paid', 'both'], TRUE)) {
       $tone = 'attention';
       if ($readiness->ready) {
-        // Published events stay Live on the status pill — never claim "Almost ready".
-        $headline = $published
-          ? (string) $this->t('Live — payments need attention')
-          : (string) $this->t('Almost ready');
+        // Published events stay Live/Past on the status pill — never claim "Almost ready".
+        if ($published) {
+          $headline = $statusKey === 'past'
+            ? (string) $this->t('Past — payments need attention')
+            : (string) $this->t('Live — payments need attention');
+        }
+        else {
+          $headline = (string) $this->t('Almost ready');
+        }
         $detail = (string) ($stripe['detail'] ?? $detail);
       }
     }
@@ -913,10 +1051,75 @@ final class EventWorkspaceOverviewBuilder {
   }
 
   /**
+   * Authoritative Workspace primary CTA (Hero + Mission Control share this).
+   *
+   * Lifecycle only: Continue setup → Publish → Share. Does not evaluate Stripe.
+   * Mission Control may apply the approved Stripe Connect exception separately.
+   *
+   * @return array{
+   *   key: string,
+   *   mode: string,
+   *   label: string,
+   *   url: string,
+   *   publish_is_primary: bool
+   * }
+   */
+  public function resolveAuthoritativePrimaryCta(
+    EventReadinessResult $readiness,
+    bool $published,
+    int $nid,
+    string $share_url = '',
+  ): array {
+    if (!$readiness->ready) {
+      return [
+        'key' => 'continue_setup',
+        'mode' => 'link',
+        'label' => (string) $this->t('Continue setup'),
+        'url' => (string) ($this->safeUrl('myeventlane_event_studio.workspace_publishing', ['node' => $nid]) ?? ''),
+        'publish_is_primary' => FALSE,
+      ];
+    }
+    if (!$published) {
+      return [
+        'key' => 'publish',
+        'mode' => 'publish',
+        'label' => (string) $this->t('Publish'),
+        'url' => '',
+        'publish_is_primary' => TRUE,
+      ];
+    }
+    $share = $share_url !== ''
+      ? $share_url
+      : (string) ($this->safeUrl('myeventlane_event_studio.workspace_marketing', ['node' => $nid]) ?? '');
+    return [
+      'key' => 'share',
+      'mode' => 'link',
+      'label' => (string) $this->t('Share'),
+      'url' => $share,
+      'publish_is_primary' => FALSE,
+    ];
+  }
+
+  /**
+   * Mission Control next-action narrative + CTA.
+   *
+   * CTA label/destination match {@see resolveAuthoritativePrimaryCta()} except the
+   * approved Stripe Connect exception (Mission Control may surface Connect while
+   * Hero keeps Publish/Share).
+   *
    * @param array<string, mixed> $next
    * @param array<string, mixed> $stripe
    *
-   * @return array{title: string, message: string, action_label: ?string, url: ?string}
+   * @return array{
+   *   title: string,
+   *   message: string,
+   *   action_label: ?string,
+   *   url: ?string,
+   *   key: string,
+   *   mode: string,
+   *   mirrors_hero: bool,
+   *   publish_is_primary: bool
+   * }
    */
   private function resolveNextRecommendedAction(
     array $next,
@@ -925,39 +1128,49 @@ final class EventWorkspaceOverviewBuilder {
     int $nid,
     array $stripe = [],
   ): array {
-    $title = trim((string) ($next['title'] ?? ''));
-    $severity = (string) ($next['severity'] ?? '');
-
-    if ($title !== '' && ($severity === 'error' || ($published && $severity === 'info'))) {
-      return [
-        'title' => $title,
-        'message' => (string) ($next['message'] ?? ''),
-        'action_label' => isset($next['action_label']) ? (string) $next['action_label'] : NULL,
-        'url' => isset($next['url']) && $next['url'] instanceof Url
-          ? $next['url']->toString()
-          : (isset($next['url']) ? (string) $next['url'] : NULL),
-      ];
-    }
+    $vmTitle = trim((string) ($next['title'] ?? ''));
+    $vmSeverity = (string) ($next['severity'] ?? '');
+    $vmMessage = (string) ($next['message'] ?? '');
+    $hero = $this->resolveAuthoritativePrimaryCta($readiness, $published, $nid);
 
     // Publish blockers win over Stripe Connect — never push payouts while
-    // checklist items (tickets, schedule, etc.) remain unresolved.
+    // checklist items remain unresolved.
     if (!$readiness->ready) {
+      $title = (string) $this->t('Continue setup');
+      $message = isset($readiness->errors[0])
+        ? $this->humaniseChecklistLabel($readiness->errors[0])
+        : (string) $this->t('Finish the readiness checklist so you can publish.');
+      // Keep a specific VM blocker title/message when present (e.g. Add RSVP).
+      if ($vmTitle !== '' && $vmSeverity === 'error') {
+        $title = $vmTitle;
+        if ($vmMessage !== '') {
+          $message = $vmMessage;
+        }
+      }
       return [
-        'title' => (string) $this->t('Continue setup'),
-        'message' => isset($readiness->errors[0])
-          ? $this->humaniseChecklistLabel($readiness->errors[0])
-          : (string) $this->t('Finish the readiness checklist so you can publish.'),
-        'action_label' => (string) $this->t('Review publishing'),
-        'url' => $this->safeUrl('myeventlane_event_studio.workspace_publishing', ['node' => $nid]),
+        'title' => $title,
+        'message' => $message,
+        'action_label' => $hero['label'],
+        'url' => $hero['url'] !== '' ? $hero['url'] : NULL,
+        'key' => $hero['key'],
+        'mode' => $hero['mode'],
+        'mirrors_hero' => TRUE,
+        'publish_is_primary' => $hero['publish_is_primary'],
       ];
     }
 
+    // Approved exception: Mission Control may prioritise Connect Stripe while
+    // Hero keeps Publish/Share as the chrome primary.
     if (($stripe['tone'] ?? '') === 'attention' && ($stripe['url'] ?? NULL)) {
       return [
         'title' => (string) $this->t('Connect Stripe'),
         'message' => (string) ($stripe['detail'] ?? $this->t('Connect payments so you can get paid.')),
         'action_label' => (string) $this->t('Connect Stripe'),
         'url' => (string) $stripe['url'],
+        'key' => 'connect_stripe',
+        'mode' => 'link',
+        'mirrors_hero' => FALSE,
+        'publish_is_primary' => FALSE,
       ];
     }
 
@@ -965,15 +1178,24 @@ final class EventWorkspaceOverviewBuilder {
       return [
         'title' => (string) $this->t('Ready when you are'),
         'message' => (string) $this->t('Your event looks ready. Publish when you want guests to find it.'),
-        'action_label' => (string) $this->t('Go to publishing'),
-        'url' => $this->safeUrl('myeventlane_event_studio.workspace_publishing', ['node' => $nid]),
+        'action_label' => $hero['label'],
+        'url' => NULL,
+        'key' => $hero['key'],
+        'mode' => $hero['mode'],
+        'mirrors_hero' => TRUE,
+        'publish_is_primary' => $hero['publish_is_primary'],
       ];
     }
+
     return [
       'title' => (string) $this->t('Share your event'),
       'message' => (string) $this->t('Your event is live. Share the page or message your attendees.'),
-      'action_label' => (string) $this->t('Share'),
-      'url' => $this->safeUrl('myeventlane_event_studio.workspace_marketing', ['node' => $nid]),
+      'action_label' => $hero['label'],
+      'url' => $hero['url'] !== '' ? $hero['url'] : NULL,
+      'key' => $hero['key'],
+      'mode' => $hero['mode'],
+      'mirrors_hero' => TRUE,
+      'publish_is_primary' => $hero['publish_is_primary'],
     ];
   }
 

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-mission-control.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-mission-control.html.twig
@@ -1,0 +1,125 @@
+{#
+/**
+ * @file
+ * Shared Mission Control card — Home and non-Home workspace chrome.
+ *
+ * Variables:
+ * - mission_control: ViewModel from EventWorkspaceOverviewBuilder.
+ *
+ * data-mel-mc-* hooks keep publish AJAX in sync without a second card kit.
+ */
+#}
+{% set mc = mission_control|default({}) %}
+{% set next = mc.next_step|default({}) %}
+{% set improvements = mc.improvements|default({}) %}
+{% set quality = mc.event_quality|default({}) %}
+{% set items = improvements.items|default([]) %}
+{% set score = quality.score|default(0) %}
+
+<section
+  class="mel-event-studio-mission-control mel-event-studio-mission-control--{{ mc.tone|default('success')|clean_class }}"
+  aria-labelledby="mel-mc-heading"
+  data-mel-mission-control
+  data-mel-mc-tone="{{ mc.tone|default('success')|e('html_attr') }}"
+  data-mel-mc-section="{{ mc.section|default('')|e('html_attr') }}"
+  role="region"
+>
+  <header class="mel-event-studio-mission-control__header">
+    <h2 id="mel-mc-heading" class="mel-event-studio-mission-control__title">{{ mc.heading|default('Mission Control'|t) }}</h2>
+  </header>
+
+  <div class="mel-event-studio-mission-control__next" data-mel-mc-next>
+    <p class="mel-event-studio-mission-control__eyebrow" data-mel-mc-next-eyebrow>{{ next.eyebrow|default('Next step'|t) }}</p>
+    <h3 class="mel-event-studio-mission-control__next-title" data-mel-mc-next-title>{{ next.title }}</h3>
+    <div class="mel-event-studio-mission-control__why" data-mel-mc-why{% if not next.message %} hidden{% endif %}>
+      <p class="mel-event-studio-mission-control__why-label">{{ next.why_label|default('Why this matters'|t) }}</p>
+      <p class="mel-event-studio-mission-control__why-text" data-mel-mc-why-text>{{ next.message }}</p>
+    </div>
+    {# Hero owns the visual primary. Mission Control mirrors the same action as secondary,
+       except the approved Stripe Connect exception. Publish mode defers to Hero publish control. #}
+    {% set cta_mode = next.mode|default('link') %}
+    {% set cta_key = next.key|default('') %}
+    {% if cta_mode == 'publish' %}
+      <p class="mel-event-studio-mission-control__publish-hint" data-mel-mc-publish-hint>
+        {{ 'Use Publish in the header when you are ready.'|t }}
+      </p>
+      <a class="mel-btn mel-btn--secondary mel-event-studio-mission-control__cta" href="#" data-mel-mc-cta hidden></a>
+    {% elseif next.url and next.action_label %}
+      <a
+        class="mel-btn mel-btn--secondary mel-event-studio-mission-control__cta"
+        href="{{ next.url }}"
+        data-mel-mc-cta
+        data-mel-mc-cta-key="{{ cta_key|e('html_attr') }}"
+        data-mel-mc-mirrors-hero="{{ next.mirrors_hero|default(true) ? '1' : '0' }}"
+      >{{ next.action_label }}</a>
+    {% else %}
+      <a class="mel-btn mel-btn--secondary mel-event-studio-mission-control__cta" href="#" data-mel-mc-cta hidden></a>
+    {% endif %}
+  </div>
+
+  <details
+    class="mel-event-studio-mission-control__improvements"
+    data-mel-mc-improvements
+    {% if improvements.open|default(false) %} open{% endif %}
+  >
+    <summary class="mel-event-studio-mission-control__improvements-summary">
+      <span class="mel-event-studio-mission-control__improvements-main">
+        <strong data-mel-mc-improvements-heading>{{ improvements.heading|default('Other improvements'|t) }}</strong>
+        <span class="mel-event-studio-mission-control__improvements-count" data-mel-mc-improvements-count>{{ improvements.complete_label|default('') }}</span>
+      </span>
+      <span class="mel-event-studio-mission-control__improvements-hint" data-mel-mc-improvements-hint>{{ improvements.hint|default('View checklist'|t) }}</span>
+    </summary>
+    <div class="mel-event-studio-mission-control__improvements-body">
+      {% if improvements.headline|default('') %}
+        <p class="mel-event-studio-mission-control__improvements-headline" data-mel-mc-improvements-headline>{{ improvements.headline }}</p>
+      {% endif %}
+      <ul class="mel-event-studio-mission-control__checklist" data-mel-mc-checklist{% if not items %} hidden{% endif %}>
+        {% for item in items %}
+          <li class="mel-event-studio-mission-control__check mel-event-studio-mission-control__check--{{ item.tone|default('attention')|clean_class }}">
+            <span class="mel-event-studio-mission-control__check-mark" aria-hidden="true">{{ item.complete ? '✔' : (item.tone|default('') in ['warning', 'idea'] ? '◇' : '○') }}</span>
+            <span class="visually-hidden">
+              {% if item.complete %}
+                {{ 'Complete:'|t }}
+              {% elseif item.tone|default('') == 'warning' %}
+                {{ 'Suggested review:'|t }}
+              {% elseif item.tone|default('') == 'idea' %}
+                {{ 'Idea:'|t }}
+              {% else %}
+                {{ 'Required before publishing:'|t }}
+              {% endif %}
+            </span>
+            <span data-mel-mc-check-label>{{ item.label }}</span>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+  </details>
+
+  <div
+    class="mel-event-studio-mission-control__quality{% if quality.ready|default(false) %} is-ready{% endif %}"
+    data-mel-mc-quality
+    {% if not quality.visible|default(false) %} hidden{% endif %}
+    {% if quality.visible|default(false) %}role="group" aria-labelledby="mel-mc-quality-heading"{% endif %}
+  >
+    <div class="mel-event-studio-mission-control__quality-head">
+      <h3 id="mel-mc-quality-heading" class="mel-event-studio-mission-control__quality-title" data-mel-mc-quality-heading>{{ quality.heading|default('Event Quality'|t) }}</h3>
+      <p class="mel-event-studio-mission-control__quality-score" data-mel-mc-quality-score>
+        <span class="visually-hidden">{{ 'Homepage readiness score'|t }}:</span>
+        <strong data-mel-mc-quality-score-value>{{ quality.score_label|default(score ~ '%') }}</strong>
+      </p>
+    </div>
+    <div
+      class="mel-event-studio-mission-control__quality-bar"
+      role="progressbar"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      aria-valuenow="{{ score }}"
+      aria-label="{{ 'Event quality'|t }}"
+      data-mel-mc-quality-bar
+    >
+      <span class="mel-event-studio-mission-control__quality-bar-fill" data-mel-mc-quality-bar-fill style="width: {{ score }}%;"></span>
+    </div>
+    <p class="mel-event-studio-mission-control__quality-status" data-mel-mc-quality-status{% if not quality.status_label|default('') %} hidden{% endif %}>{{ quality.status_label }}</p>
+    <p class="mel-event-studio-mission-control__quality-explain" data-mel-mc-quality-explain{% if not quality.explanation|default('') %} hidden{% endif %}>{{ quality.explanation }}</p>
+  </div>
+</section>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-overview.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-overview.html.twig
@@ -1,197 +1,134 @@
 {#
 /**
  * @file
- * Event Workspace Home — organiser operational dashboard for one event.
+ * Event Workspace Home — Mission Control + quieter ops/activity.
  *
- * Compositional redesign (not spacing polish). Answers five questions:
- * where am I, is it healthy, what next, how is business, what happened.
- *
- * data-mel-* hooks let shell AJAX apply readiness after topbar publish without
- * inventing the readiness strip on Home.
+ * Mission Control is the shared component (Home + Information chrome).
+ * data-mel-home-dashboard remains for shell AJAX target discovery.
  */
 #}
 <section class="mel-event-workspace-home" aria-label="{{ 'Event home'|t }}" data-mel-home-dashboard>
 
-  {# ROW 1 — Event Ready | Next Action (mobile: Next first via CSS order) #}
-  <div class="mel-event-workspace-home__row mel-event-workspace-home__row--guide">
-    <section class="mel-event-workspace-home__card mel-event-workspace-home__card--ready mel-event-workspace-home__card--{{ event_ready.tone|default('success')|clean_class }}" aria-labelledby="mel-home-ready-heading" data-mel-home-event-ready data-mel-home-tone="{{ event_ready.tone|default('success')|e('html_attr') }}">
-      <p class="mel-event-workspace-home__eyebrow">{{ 'Event Ready'|t }}</p>
-      <h2 id="mel-home-ready-heading" class="mel-event-workspace-home__card-title">
-        <span class="mel-event-workspace-home__ready-mark" aria-hidden="true" data-mel-home-ready-mark>{{ event_ready.tone|default('') == 'attention' ? '⚠' : '✔' }}</span>
-        <span data-mel-home-ready-headline>{{ event_ready.headline }}</span>
-      </h2>
-      <p class="mel-event-workspace-home__card-detail" data-mel-home-ready-detail>{{ event_ready.detail }}</p>
-      <ul class="mel-event-workspace-home__meta">
-        <li><span class="mel-event-workspace-home__pill mel-event-workspace-home__pill--{{ event_ready.status_key|default('draft')|clean_class }}" data-mel-home-status-pill data-mel-home-status-key="{{ event_ready.status_key|default('draft')|e('html_attr') }}">{{ event_ready.status_label }}</span></li>
-        {% if event_ready.updated_label %}
-          <li data-mel-home-updated>{{ event_ready.updated_label }}</li>
+  {% if mission_control %}
+    {{ include('@myeventlane_event_studio/mel-event-studio-mission-control.html.twig', {
+      mission_control: mission_control
+    }, with_context = false) }}
+  {% endif %}
+
+  {# Quieter operational awareness — Foundation does not redesign ops (Slice 6) #}
+  <div class="mel-event-workspace-home__secondary" aria-label="{{ 'Event overview'|t }}">
+    <div class="mel-event-workspace-home__row mel-event-workspace-home__row--ops">
+      <section class="mel-event-workspace-home__card mel-event-workspace-home__card--ops" aria-labelledby="mel-home-tickets-heading">
+        <h3 id="mel-home-tickets-heading" class="mel-event-workspace-home__card-title">{{ tickets.title }}</h3>
+        {% if tickets.empty %}
+          <p class="mel-event-workspace-home__card-detail">{{ tickets.empty_message }}</p>
         {% else %}
-          <li data-mel-home-updated hidden></li>
+          <ul class="mel-event-workspace-home__kpis">
+            {% for metric in tickets.metrics %}
+              <li>
+                {% if metric.value != '' %}<strong>{{ metric.value }}</strong> {% endif %}{{ metric.label }}
+              </li>
+            {% endfor %}
+          </ul>
         {% endif %}
-        <li data-mel-home-ready-complete>{{ '@done of @total complete'|t({'@done': event_ready.complete_count, '@total': event_ready.total_count}) }}</li>
-      </ul>
-      <a class="mel-event-workspace-home__text-link" href="#mel-home-readiness">{{ event_ready.checklist_label }}</a>
-    </section>
+        {% if tickets.url %}
+          <a class="mel-btn mel-btn--ghost" href="{{ tickets.url }}">{{ tickets.action_label }}</a>
+        {% endif %}
+      </section>
 
-    <section class="mel-event-workspace-home__card mel-event-workspace-home__card--next mel-event-workspace-home__card--guide" aria-labelledby="mel-home-next-heading" data-mel-home-next-action>
-      <p class="mel-event-workspace-home__eyebrow">{{ 'Next recommended action'|t }}</p>
-      <h2 id="mel-home-next-heading" class="mel-event-workspace-home__card-title" data-mel-home-next-title>{{ next_action.title }}</h2>
-      <p class="mel-event-workspace-home__card-detail" data-mel-home-next-message{% if not next_action.message %} hidden{% endif %}>{{ next_action.message }}</p>
-      {% if next_action.url and next_action.action_label %}
-        <a class="mel-btn mel-btn--primary" href="{{ next_action.url }}" data-mel-home-next-cta>{{ next_action.action_label }}</a>
-      {% else %}
-        <a class="mel-btn mel-btn--primary" href="#" data-mel-home-next-cta hidden></a>
-      {% endif %}
-    </section>
-  </div>
-
-  {# Compact readiness — expandable #}
-  <details class="mel-event-workspace-home__readiness" id="mel-home-readiness" data-mel-home-readiness>
-    <summary class="mel-event-workspace-home__readiness-summary">
-      <span class="mel-event-workspace-home__readiness-summary-main">
-        <strong data-mel-home-readiness-headline>{{ readiness.headline }}</strong>
-        <span class="mel-event-workspace-home__readiness-count" data-mel-home-readiness-count>{{ '@done of @total complete'|t({'@done': readiness.complete_count, '@total': readiness.total_count}) }}</span>
-      </span>
-      <span class="mel-event-workspace-home__readiness-hint">{{ 'View checklist'|t }}</span>
-    </summary>
-    <div class="mel-event-workspace-home__readiness-body">
-      <p class="mel-event-workspace-home__card-detail" data-mel-home-readiness-explain>{{ readiness.explanation }}</p>
-      <ul class="mel-event-workspace-home__checklist" data-mel-home-readiness-checklist{% if not readiness.items %} hidden{% endif %}>
-        {% for item in readiness.items %}
-          <li class="mel-event-workspace-home__check mel-event-workspace-home__check--{{ item.tone|clean_class }}">
-            <span class="mel-event-workspace-home__check-mark" aria-hidden="true">{{ item.complete ? '✔' : (item.tone == 'warning' or item.tone == 'idea' ? '◇' : '○') }}</span>
-            <span class="visually-hidden">
-              {% if item.complete %}
-                {{ 'Complete:'|t }}
-              {% elseif item.tone == 'warning' %}
-                {{ 'Suggested review:'|t }}
-              {% elseif item.tone == 'idea' %}
-                {{ 'Idea:'|t }}
-              {% else %}
-                {{ 'Required before publishing:'|t }}
-              {% endif %}
-            </span>
-            {{ item.label }}
-          </li>
-        {% endfor %}
-      </ul>
+      <section class="mel-event-workspace-home__card mel-event-workspace-home__card--ops" aria-labelledby="mel-home-attendees-heading">
+        <h3 id="mel-home-attendees-heading" class="mel-event-workspace-home__card-title">{{ attendees.title }}</h3>
+        {% if attendees.empty %}
+          <p class="mel-event-workspace-home__card-detail">{{ attendees.empty_message }}</p>
+        {% else %}
+          <ul class="mel-event-workspace-home__kpis">
+            {% for metric in attendees.metrics %}
+              <li><strong>{{ metric.value }}</strong> {{ metric.label }}</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+        {% if attendees.url %}
+          <a class="mel-btn mel-btn--ghost" href="{{ attendees.url }}">{{ attendees.action_label }}</a>
+        {% endif %}
+      </section>
     </div>
-  </details>
 
-  {# ROW 2 — Operational #}
-  <div class="mel-event-workspace-home__row mel-event-workspace-home__row--ops">
-    <section class="mel-event-workspace-home__card mel-event-workspace-home__card--ops" aria-labelledby="mel-home-tickets-heading">
-      <h3 id="mel-home-tickets-heading" class="mel-event-workspace-home__card-title">{{ tickets.title }}</h3>
-      {% if tickets.empty %}
-        <p class="mel-event-workspace-home__card-detail">{{ tickets.empty_message }}</p>
+    <div class="mel-event-workspace-home__row mel-event-workspace-home__row--business">
+      <section class="mel-event-workspace-home__card mel-event-workspace-home__card--kpi" aria-labelledby="mel-home-sales-heading">
+        <h3 id="mel-home-sales-heading" class="mel-event-workspace-home__card-title">{{ sales.title }}</h3>
+        {% if sales.empty %}
+          <p class="mel-event-workspace-home__card-detail">{{ sales.empty_message }}</p>
+        {% else %}
+          <ul class="mel-event-workspace-home__kpis">
+            {% for metric in sales.metrics %}
+              <li class="{% if metric.primary|default(false) %}is-primary{% endif %}">
+                <strong>{{ metric.value }}</strong> {{ metric.label }}
+              </li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+        {% if sales.url %}
+          <a class="mel-btn mel-btn--ghost" href="{{ sales.url }}">{{ sales.action_label }}</a>
+        {% endif %}
+      </section>
+
+      <section class="mel-event-workspace-home__card mel-event-workspace-home__card--kpi" aria-labelledby="mel-home-marketing-heading">
+        <h3 id="mel-home-marketing-heading" class="mel-event-workspace-home__card-title">{{ marketing.title }}</h3>
+        <ul class="mel-event-workspace-home__lines">
+          {% for line in marketing.lines %}
+            <li>{{ line }}</li>
+          {% endfor %}
+        </ul>
+        {% if marketing.url %}
+          <a class="mel-btn mel-btn--ghost" href="{{ marketing.url }}">{{ marketing.action_label }}</a>
+        {% endif %}
+      </section>
+
+      <section class="mel-event-workspace-home__card mel-event-workspace-home__card--kpi{% if boost.active %} is-active{% endif %}" aria-labelledby="mel-home-boost-heading">
+        <h3 id="mel-home-boost-heading" class="mel-event-workspace-home__card-title">{{ boost.title }}</h3>
+        <p class="mel-event-workspace-home__pill">{{ boost.status }}</p>
+        <p class="mel-event-workspace-home__card-detail">{{ boost.detail }}</p>
+        {% if boost.url %}
+          <a class="mel-btn mel-btn--ghost" href="{{ boost.url }}">{{ boost.action_label }}</a>
+        {% endif %}
+      </section>
+
+      <section class="mel-event-workspace-home__card mel-event-workspace-home__card--kpi" aria-labelledby="mel-home-analytics-heading">
+        <h3 id="mel-home-analytics-heading" class="mel-event-workspace-home__card-title">{{ analytics.title }}</h3>
+        {% if analytics.empty %}
+          <p class="mel-event-workspace-home__card-detail">{{ analytics.empty_message }}</p>
+        {% else %}
+          <ul class="mel-event-workspace-home__kpis">
+            {% for metric in analytics.metrics %}
+              <li class="{% if metric.primary|default(false) %}is-primary{% endif %}">
+                <strong>{{ metric.value }}</strong> {{ metric.label }}
+              </li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+        {% if analytics.url %}
+          <a class="mel-btn mel-btn--ghost" href="{{ analytics.url }}">{{ analytics.action_label }}</a>
+        {% endif %}
+      </section>
+    </div>
+
+    <section class="mel-event-workspace-home__card mel-event-workspace-home__card--activity" aria-labelledby="mel-home-activity-heading">
+      <h3 id="mel-home-activity-heading" class="mel-event-workspace-home__card-title">{{ 'Activity'|t }}</h3>
+      {% if activity.empty %}
+        <p class="mel-event-workspace-home__card-detail">{{ activity.empty_message }}</p>
       {% else %}
-        <ul class="mel-event-workspace-home__kpis">
-          {% for metric in tickets.metrics %}
-            <li>
-              {% if metric.value != '' %}<strong>{{ metric.value }}</strong> {% endif %}{{ metric.label }}
+        <ol class="mel-event-workspace-home__timeline">
+          {% for item in activity.items %}
+            <li class="mel-event-workspace-home__timeline-item mel-event-workspace-home__timeline-item--{{ item.type|default('order')|clean_class }}">
+              <strong class="mel-event-workspace-home__timeline-title">{{ item.title }}</strong>
+              {% if item.detail %}
+                <span class="mel-event-workspace-home__timeline-detail">{{ item.detail }}</span>
+              {% endif %}
             </li>
           {% endfor %}
-        </ul>
-      {% endif %}
-      {% if tickets.url %}
-        <a class="mel-btn mel-btn--ghost" href="{{ tickets.url }}">{{ tickets.action_label }}</a>
-      {% endif %}
-    </section>
-
-    <section class="mel-event-workspace-home__card mel-event-workspace-home__card--ops" aria-labelledby="mel-home-attendees-heading">
-      <h3 id="mel-home-attendees-heading" class="mel-event-workspace-home__card-title">{{ attendees.title }}</h3>
-      {% if attendees.empty %}
-        <p class="mel-event-workspace-home__card-detail">{{ attendees.empty_message }}</p>
-      {% else %}
-        <ul class="mel-event-workspace-home__kpis">
-          {% for metric in attendees.metrics %}
-            <li><strong>{{ metric.value }}</strong> {{ metric.label }}</li>
-          {% endfor %}
-        </ul>
-      {% endif %}
-      {% if attendees.url %}
-        <a class="mel-btn mel-btn--ghost" href="{{ attendees.url }}">{{ attendees.action_label }}</a>
+        </ol>
       {% endif %}
     </section>
   </div>
-
-  {# ROW 3 — Business KPIs #}
-  <div class="mel-event-workspace-home__row mel-event-workspace-home__row--business">
-    <section class="mel-event-workspace-home__card mel-event-workspace-home__card--kpi" aria-labelledby="mel-home-sales-heading">
-      <h3 id="mel-home-sales-heading" class="mel-event-workspace-home__card-title">{{ sales.title }}</h3>
-      {% if sales.empty %}
-        <p class="mel-event-workspace-home__card-detail">{{ sales.empty_message }}</p>
-      {% else %}
-        <ul class="mel-event-workspace-home__kpis">
-          {% for metric in sales.metrics %}
-            <li class="{% if metric.primary|default(false) %}is-primary{% endif %}">
-              <strong>{{ metric.value }}</strong> {{ metric.label }}
-            </li>
-          {% endfor %}
-        </ul>
-      {% endif %}
-      {% if sales.url %}
-        <a class="mel-btn mel-btn--ghost" href="{{ sales.url }}">{{ sales.action_label }}</a>
-      {% endif %}
-    </section>
-
-    <section class="mel-event-workspace-home__card mel-event-workspace-home__card--kpi" aria-labelledby="mel-home-marketing-heading">
-      <h3 id="mel-home-marketing-heading" class="mel-event-workspace-home__card-title">{{ marketing.title }}</h3>
-      <ul class="mel-event-workspace-home__lines">
-        {% for line in marketing.lines %}
-          <li>{{ line }}</li>
-        {% endfor %}
-      </ul>
-      {% if marketing.url %}
-        <a class="mel-btn mel-btn--ghost" href="{{ marketing.url }}">{{ marketing.action_label }}</a>
-      {% endif %}
-    </section>
-
-    <section class="mel-event-workspace-home__card mel-event-workspace-home__card--kpi{% if boost.active %} is-active{% endif %}" aria-labelledby="mel-home-boost-heading">
-      <h3 id="mel-home-boost-heading" class="mel-event-workspace-home__card-title">{{ boost.title }}</h3>
-      <p class="mel-event-workspace-home__pill">{{ boost.status }}</p>
-      <p class="mel-event-workspace-home__card-detail">{{ boost.detail }}</p>
-      {% if boost.url %}
-        <a class="mel-btn mel-btn--ghost" href="{{ boost.url }}">{{ boost.action_label }}</a>
-      {% endif %}
-    </section>
-
-    <section class="mel-event-workspace-home__card mel-event-workspace-home__card--kpi" aria-labelledby="mel-home-analytics-heading">
-      <h3 id="mel-home-analytics-heading" class="mel-event-workspace-home__card-title">{{ analytics.title }}</h3>
-      {% if analytics.empty %}
-        <p class="mel-event-workspace-home__card-detail">{{ analytics.empty_message }}</p>
-      {% else %}
-        <ul class="mel-event-workspace-home__kpis">
-          {% for metric in analytics.metrics %}
-            <li class="{% if metric.primary|default(false) %}is-primary{% endif %}">
-              <strong>{{ metric.value }}</strong> {{ metric.label }}
-            </li>
-          {% endfor %}
-        </ul>
-      {% endif %}
-      {% if analytics.url %}
-        <a class="mel-btn mel-btn--ghost" href="{{ analytics.url }}">{{ analytics.action_label }}</a>
-      {% endif %}
-    </section>
-  </div>
-
-  {# ROW 4 — Activity #}
-  <section class="mel-event-workspace-home__card mel-event-workspace-home__card--activity" aria-labelledby="mel-home-activity-heading">
-    <h3 id="mel-home-activity-heading" class="mel-event-workspace-home__card-title">{{ 'Activity'|t }}</h3>
-    {% if activity.empty %}
-      <p class="mel-event-workspace-home__card-detail">{{ activity.empty_message }}</p>
-    {% else %}
-      <ol class="mel-event-workspace-home__timeline">
-        {% for item in activity.items %}
-          <li class="mel-event-workspace-home__timeline-item mel-event-workspace-home__timeline-item--{{ item.type|default('order')|clean_class }}">
-            <strong class="mel-event-workspace-home__timeline-title">{{ item.title }}</strong>
-            {% if item.detail %}
-              <span class="mel-event-workspace-home__timeline-detail">{{ item.detail }}</span>
-            {% endif %}
-          </li>
-        {% endfor %}
-      </ol>
-    {% endif %}
-  </section>
 
 </section>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-sidebar.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-sidebar.html.twig
@@ -4,10 +4,10 @@
  * Event Workspace sidebar navigation.
  */
 #}
-<aside class="mel-event-studio-sidebar" id="mel-event-studio-sidebar" aria-label="{{ 'Event workspace'|t }}">
+<aside class="mel-event-studio-sidebar" id="mel-event-studio-sidebar" aria-label="{{ 'Event Workspace'|t }}">
   <div class="mel-event-studio-sidebar__inner">
     {% for group, items in sections %}
-      <nav class="mel-event-studio-sidebar__group" aria-label="{{ 'Event workspace sections'|t }}">
+      <nav class="mel-event-studio-sidebar__group" aria-label="{{ 'Event Workspace sections'|t }}">
         {% if group and group != 'Workspace' %}
           <h2 class="mel-event-studio-sidebar__heading" id="mel-studio-nav-{{ loop.index }}">{{ group }}</h2>
         {% endif %}

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-topbar.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-topbar.html.twig
@@ -1,10 +1,17 @@
 {#
 /**
  * @file
- * Event Workspace top bar.
+ * Event Workspace Hero (event chrome).
+ *
+ * Identity · status · date/venue · one primary CTA · View / Share secondary.
+ * Publish control always keeps data-mel-publish-action for shell JS.
  */
 #}
-<header class="mel-event-studio-topbar" role="banner">
+{% set primary = topbar.primary_cta|default({}) %}
+{% set primary_key = primary.key|default(topbar.published ? 'share' : 'publish') %}
+{% set publish_is_primary = primary.publish_is_primary|default(primary_key == 'publish') %}
+{% set share_url = topbar.share_url|default('') %}
+<header class="mel-event-studio-topbar" role="banner" data-mel-studio-topbar data-mel-hero-primary-key="{{ primary_key|e('html_attr') }}">
   <div class="mel-event-studio-topbar__primary">
     <nav class="mel-event-studio-topbar__breadcrumb" aria-label="{{ 'Event breadcrumb'|t }}">
       <a class="mel-event-studio-topbar__breadcrumb-link" href="{{ topbar.events_url|default('/vendor/events') }}">{{ 'Events'|t }}</a>
@@ -12,9 +19,21 @@
       <span class="mel-event-studio-topbar__breadcrumb-current">{{ topbar.title }}</span>
     </nav>
     <p class="mel-event-studio-topbar__eyebrow">{{ 'Event Workspace'|t }}</p>
-    <h1 class="mel-event-studio-topbar__title">{{ topbar.title }}</h1>
+    <div class="mel-event-studio-topbar__identity">
+      <h1 class="mel-event-studio-topbar__title">{{ topbar.title }}</h1>
+      <span class="mel-event-studio-topbar__badge mel-event-studio-topbar__badge--{{ topbar.status_key|default(topbar.published ? 'live' : 'draft')|clean_class }}" data-mel-publish-status>{{ topbar.status }}</span>
+    </div>
+    {% if topbar.context_line|default('') %}
+      <p class="mel-event-studio-topbar__context" data-mel-hero-context>{{ topbar.context_line }}</p>
+    {% elseif topbar.date_label|default('') or topbar.venue_label|default('') %}
+      <p class="mel-event-studio-topbar__context" data-mel-hero-context>
+        {% if topbar.date_label|default('') %}<span data-mel-hero-date>{{ topbar.date_label }}</span>{% endif %}
+        {% if topbar.date_label|default('') and topbar.venue_label|default('') %}<span aria-hidden="true"> · </span>{% endif %}
+        {% if topbar.venue_label|default('') %}<span data-mel-hero-venue>{{ topbar.venue_label }}</span>{% endif %}
+      </p>
+    {% endif %}
     {% set location = topbar.location|default({}) %}
-    <div class="mel-event-studio-topbar__location" data-mel-topbar-location role="status" aria-live="polite">
+    <div class="mel-event-studio-topbar__location" data-mel-topbar-location role="status" aria-live="polite"{% if topbar.venue_label|default('') and location.configured|default(false) %} hidden{% endif %}>
       {% if location.configured|default(false) %}
         {% if location.primary_line|default('') %}
           <p class="mel-event-studio-topbar__location-line mel-event-studio-topbar__location-line--primary">
@@ -34,8 +53,7 @@
         </p>
       {% endif %}
     </div>
-    <div class="mel-event-studio-topbar__meta" aria-label="{{ 'Event status'|t }}">
-      <span class="mel-event-studio-topbar__badge" data-mel-publish-status>{{ topbar.status }}</span>
+    <div class="mel-event-studio-topbar__meta" role="group" aria-label="{{ 'Event status'|t }}">
       {% if topbar.state %}
         <span class="mel-event-studio-topbar__state" data-mel-publish-state>{{ topbar.state }}</span>
       {% endif %}
@@ -49,19 +67,38 @@
       </span>
     </div>
   </div>
-  <div class="mel-event-studio-topbar__actions">
+  <div class="mel-event-studio-topbar__actions" data-mel-hero-actions>
     {% if topbar.show_manage_event_link %}
       <a class="mel-btn mel-btn--secondary mel-event-studio-topbar__manage-event" href="{{ topbar.manage_event_url }}">{{ 'Staff Overview'|t }}</a>
     {% endif %}
-    <a class="mel-btn mel-btn--ghost" href="{{ topbar.preview_url }}" target="_blank" rel="noopener noreferrer">{{ 'View page'|t }}</a>
+    <a class="mel-btn mel-btn--ghost mel-event-studio-topbar__view" href="{{ topbar.preview_url }}" target="_blank" rel="noopener noreferrer">{{ 'View'|t }}</a>
+    {% if share_url %}
+      <a
+        class="mel-btn mel-event-studio-topbar__share{% if primary_key == 'share' %} mel-btn--primary{% else %} mel-btn--ghost{% endif %}"
+        href="{{ share_url }}"
+        data-mel-hero-share
+        {% if primary_key == 'share' %}data-mel-hero-primary="1"{% endif %}
+      >{{ 'Share'|t }}</a>
+    {% endif %}
+    {% if primary_key == 'continue_setup' and primary.url|default('') %}
+      <a
+        class="mel-btn mel-btn--primary mel-event-studio-topbar__primary-link"
+        href="{{ primary.url }}"
+        data-mel-hero-primary-link
+        data-mel-hero-primary="1"
+      >{{ primary.label }}</a>
+    {% else %}
+      <a class="mel-event-studio-topbar__primary-link" href="#" data-mel-hero-primary-link hidden aria-hidden="true" tabindex="-1"></a>
+    {% endif %}
     <button
-      class="mel-btn{% if topbar.published %} mel-btn--ghost mel-event-studio-topbar__status-action{% else %} mel-btn--primary{% endif %}"
+      class="mel-btn mel-event-studio-topbar__publish{% if publish_is_primary %} mel-btn--primary{% elseif topbar.published %} mel-event-studio-topbar__status-action{% else %} mel-btn--ghost{% endif %}"
       type="button"
       data-mel-publish-action
       data-mel-publish-url="{{ topbar.publish_url|e('html_attr') }}"
       data-mel-current-section="{{ topbar.current_section|e('html_attr') }}"
       data-mel-node-changed="{{ topbar.changed }}"
       data-mel-node-revision="{{ topbar.revision_id }}"
+      {% if publish_is_primary %}data-mel-hero-primary="1"{% endif %}
       {% if topbar.published %}disabled aria-disabled="true" aria-label="{{ 'Event is published'|t }}"{% endif %}
     >{{ topbar.published ? 'Published'|t : 'Publish'|t }}</button>
   </div>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
@@ -1,10 +1,11 @@
 {#
 /**
  * @file
- * Canonical Event Studio operational workspace shell.
+ * Canonical Event Workspace shell (Studio runtime).
  *
- * Home (overview) composition (VX2): topbar + active Boost only.
- * Event Health, readiness strip, and homepage readiness are suppressed on Home.
+ * Home (overview): Hero topbar + Mission Control in section body.
+ * Non-Home: Event Health + shared Mission Control (replaces Needs Attention
+ * strip + Homepage Readiness card).
  */
 #}
 {% set is_home = current_section == 'overview' %}
@@ -23,53 +24,13 @@
   }, with_context = false) }}
 
   {% if not is_home %}
-    {{ include('@myeventlane_event_studio/mel-event-studio-event-health.html.twig', {
-      event_health: event_health
-    }, with_context = false) }}
-
-    <section class="mel-event-studio-readiness-strip{% if readiness.ready %} is-ready{% else %} needs-attention{% endif %}" aria-label="{{ 'Publish readiness'|t }}" data-mel-readiness-strip{% if not readiness.show_publish_strip|default(true) %} hidden{% endif %}>
-      <div class="mel-event-studio-readiness-strip__summary">
-        <strong data-mel-readiness-title>{{ readiness.strip_title|default(readiness.ready ? 'Ready to publish'|t : 'Needs attention'|t) }}</strong>
-        <span data-mel-readiness-state>{{ readiness.state }}</span>
-        {% if readiness.strip_explanation|default('') %}
-          <p class="mel-event-studio-readiness-strip__explain" data-mel-readiness-explain>{{ readiness.strip_explanation }}</p>
-        {% endif %}
+    {% if mission_control %}
+      <div class="mel-event-studio-mission-control-shell" data-mel-mission-control-shell>
+        {{ include('@myeventlane_event_studio/mel-event-studio-mission-control.html.twig', {
+          mission_control: mission_control
+        }, with_context = false) }}
       </div>
-      {% if readiness.checklist|default([]) %}
-        <ul class="mel-event-studio-readiness-strip__checklist" data-mel-readiness-checklist>
-          {% for item in readiness.checklist %}
-            <li class="mel-event-studio-readiness-strip__check{% if item.complete %} is-complete{% endif %}{% if item.tone|default('') %} mel-event-studio-readiness-strip__check--{{ item.tone|clean_class }}{% endif %}">
-              <span aria-hidden="true">{{ item.complete ? '✔' : (item.tone|default('') in ['warning', 'idea'] ? '◇' : '○') }}</span>
-              <span class="visually-hidden">
-                {% if item.complete %}
-                  {{ 'Complete'|t }}
-                {% elseif item.tone|default('') == 'warning' %}
-                  {{ 'Suggested review'|t }}
-                {% elseif item.tone|default('') == 'idea' %}
-                  {{ 'Idea'|t }}
-                {% else %}
-                  {{ 'Outstanding'|t }}
-                {% endif %}
-              </span>
-              {{ item.label }}
-            </li>
-          {% endfor %}
-        </ul>
-      {% else %}
-        <div class="mel-event-studio-readiness-strip__counts" data-mel-readiness-counts>
-          <span data-mel-readiness-errors-count>{{ readiness.errors|length }} {{ 'to finish'|t }}</span>
-          <span data-mel-readiness-warnings-count>{{ readiness.warnings|length }} {{ 'to review'|t }}</span>
-          <span data-mel-readiness-recommendations-count>{{ readiness.recommendations|default([])|length }} {{ 'idea(s)'|t }}</span>
-          <span data-mel-readiness-completed-count>{{ readiness.completed|length }} {{ 'complete'|t }}</span>
-        </div>
-      {% endif %}
-    </section>
-
-    <div class="mel-event-studio-homepage-readiness"{% if not homepage_readiness %} hidden{% endif %}>
-      {% if homepage_readiness %}
-        {{ homepage_readiness }}
-      {% endif %}
-    </div>
+    {% endif %}
   {% endif %}
 
   {# Home: active Boost only. Other sections keep recommendation banner too. #}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioReadinessStabilityTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioReadinessStabilityTest.php
@@ -65,7 +65,8 @@ final class EventStudioReadinessStabilityTest extends UnitTestCase {
     $this->assertStringContainsString('myeventlane_event_studio.readiness_facade', $services);
     $this->assertStringContainsString('EventReadinessFacade', $controller);
     $this->assertStringContainsString('workspacePresentation', $controller);
-    $this->assertStringContainsString('buildHomepageReadinessCard', $controller);
+    $this->assertStringContainsString('overviewBuilder', $controller);
+    $this->assertStringContainsString('buildMissionControl', $controller);
     $this->assertStringContainsString('buildChecklistCardFromPresentation', $presentation);
   }
 

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspacePresentationContractTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspacePresentationContractTest.php
@@ -125,7 +125,44 @@ final class EventStudioWorkspacePresentationContractTest extends UnitTestCase {
     $this->assertIsString($presentation);
     $this->assertStringContainsString('data-mel-topbar-location', $topbar);
     $this->assertStringContainsString('buildTopbarLocation', $presentation);
+    $this->assertStringContainsString('buildTopbarDateLabel', $presentation);
+    $this->assertStringContainsString('buildTopbarVenueLabel', $presentation);
+    $this->assertStringContainsString('buildTopbarStatus', $presentation);
+    $this->assertStringContainsString('data-mel-hero-primary-key', $topbar);
     $this->assertStringContainsString('eventCardViewModel', $presentation);
+  }
+
+  public function testTopbarStatusPastWhenEventEndPassed(): void {
+    $past = $this->createMock(NodeInterface::class);
+    $past->method('isPublished')->willReturn(TRUE);
+    $past->method('bundle')->willReturn('event');
+    $past->method('hasField')->willReturnCallback(static fn(string $field): bool => $field === 'field_event_end');
+    $pastDate = new \DateTimeImmutable('2020-01-01T12:00:00');
+    $endItem = new class($pastDate) {
+      public object $date;
+      public function __construct(object $date) {
+        $this->date = $date;
+      }
+    };
+    $endField = $this->createMock(\Drupal\Core\Field\FieldItemListInterface::class);
+    $endField->method('isEmpty')->willReturn(FALSE);
+    $endField->method('first')->willReturn($endItem);
+    $past->method('get')->willReturnCallback(static function (string $field) use ($endField) {
+      return $field === 'field_event_end' ? $endField : NULL;
+    });
+
+    $status = $this->presentation->buildTopbarStatus($past);
+    $this->assertSame('Past', $status['label']);
+    $this->assertSame('past', $status['key']);
+  }
+
+  public function testTopbarStatusDraftWhenUnpublished(): void {
+    $draft = $this->node(FALSE, 301);
+    $draft->method('bundle')->willReturn('event');
+    $draft->method('hasField')->willReturn(FALSE);
+    $status = $this->presentation->buildTopbarStatus($draft);
+    $this->assertSame('Draft', $status['label']);
+    $this->assertSame('draft', $status['key']);
   }
 
   public function testPublishControllerUsesFacadeBundleForAjaxPayload(): void {
@@ -133,20 +170,21 @@ final class EventStudioWorkspacePresentationContractTest extends UnitTestCase {
     $this->assertIsString($publish);
     $this->assertStringContainsString('readinessFacade->evaluate', $publish);
     $this->assertStringContainsString('buildAjaxReadinessPayloadFromBundle', $publish);
-    $this->assertStringContainsString('buildEventHealth($readiness_bundle', $publish);
+    $this->assertStringContainsString('resolveAuthoritativePrimaryCta', $publish);
+    $this->assertStringContainsString('mission_control', $publish);
     $this->assertStringContainsString('homepage_readiness_html', $publish);
     $this->assertStringNotContainsString('buildAjaxReadinessPayload(', $publish);
-    // Topbar badge must match Sprint 2 full-page copy after in-place publish.
-    $this->assertStringContainsString("\$this->t('Live')", $publish);
+    // Topbar badge uses presentation status (Draft / Live / Past) — not hardcoded Live-only.
+    $this->assertStringContainsString('buildTopbarStatus', $publish);
     $this->assertStringNotContainsString("'status' => \$node->isPublished() ? (string) \$this->t('Published')", $publish);
   }
 
-  public function testShellJsSyncsHomepageReadinessVisibility(): void {
+  public function testShellJsSyncsMissionControlAfterPublish(): void {
     $js = file_get_contents(dirname(__DIR__, 3) . '/js/mel-event-studio-shell.js');
     $this->assertIsString($js);
-    $this->assertStringContainsString('updateHomepageReadiness', $js);
-    $this->assertStringContainsString('homepage_readiness_html', $js);
-    $this->assertStringContainsString('show_homepage_readiness', $js);
+    $this->assertStringContainsString('updateMissionControl', $js);
+    $this->assertStringContainsString('mission_control', $js);
+    $this->assertStringContainsString('data-mel-mc-quality', $js);
   }
 
   public function testPublishControllerUsesOverviewBuilderForHomeAjax(): void {
@@ -161,6 +199,7 @@ final class EventStudioWorkspacePresentationContractTest extends UnitTestCase {
     $this->assertStringContainsString('buildHomeAjaxGuideSnapshot', $publish);
     $this->assertStringContainsString('overviewBuilder', $publish);
     $this->assertStringContainsString("ajax_readiness['home']", $publish);
+    $this->assertStringContainsString("ajax_readiness['mission_control']", $publish);
     $this->assertStringContainsString('@myeventlane_event_studio.overview_builder', $services);
     $this->assertStringContainsString('function buildHomeAjaxGuideSnapshot', $overview);
     $this->assertStringContainsString('buildStripeHealth', $overview);
@@ -170,12 +209,13 @@ final class EventStudioWorkspacePresentationContractTest extends UnitTestCase {
     $this->assertStringNotContainsString('buildHomeNextAction', $presentation);
   }
 
-  public function testShellJsAppliesHomeDashboardAfterPublish(): void {
+  public function testShellJsAppliesMissionControlAfterPublish(): void {
     $js = file_get_contents(dirname(__DIR__, 3) . '/js/mel-event-studio-shell.js');
     $this->assertIsString($js);
-    $this->assertStringContainsString('function updateHomeDashboard', $js);
-    $this->assertStringContainsString('updateHomeDashboard(shell, readiness)', $js);
+    $this->assertStringContainsString('function updateMissionControl', $js);
+    $this->assertStringContainsString('updateMissionControl(shell, readiness)', $js);
     $this->assertStringContainsString('readiness.home', $js);
+    $this->assertStringContainsString('mission_control', $js);
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceStateMatrixTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceStateMatrixTest.php
@@ -51,7 +51,7 @@ final class EventStudioWorkspaceStateMatrixTest extends UnitTestCase {
     $summary = $this->presentation->buildReadinessSummary($bundle, $node);
 
     $this->assertTrue($summary['show_publish_strip']);
-    $this->assertSame("You're almost there…", $summary['strip_title']);
+    $this->assertSame('Almost ready', $summary['strip_title']);
     $this->assertStringContainsString('One more thing before publishing', $summary['strip_explanation']);
     $this->assertNotEmpty($summary['checklist']);
   }
@@ -62,7 +62,7 @@ final class EventStudioWorkspaceStateMatrixTest extends UnitTestCase {
     $summary = $this->presentation->buildReadinessSummary($bundle, $node);
 
     $this->assertFalse($summary['show_publish_strip']);
-    $this->assertSame('Published and ready', $summary['strip_title']);
+    $this->assertSame('Live and ready', $summary['strip_title']);
   }
 
   public function testPublishedPromotionIssueShowsHomepageCard(): void {
@@ -232,48 +232,35 @@ final class EventStudioWorkspaceStateMatrixTest extends UnitTestCase {
     }
   }
 
-  public function testWorkspaceTemplateIncludesEventHealthBeforePublishStrip(): void {
+  public function testWorkspaceTemplateIncludesMissionControlWithoutEventHealth(): void {
     $workspace = file_get_contents(dirname(__DIR__, 3) . '/templates/mel-event-studio-workspace.html.twig');
     $publish = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/EventStudioPublishController.php');
     $this->assertIsString($workspace);
     $this->assertIsString($publish);
-    $this->assertStringContainsString('mel-event-studio-event-health', $workspace);
-    $healthPos = strpos($workspace, 'mel-event-studio-event-health');
-    $stripPos = strpos($workspace, 'mel-event-studio-readiness-strip');
-    $this->assertNotFalse($healthPos);
-    $this->assertNotFalse($stripPos);
-    $this->assertLessThan($stripPos, $healthPos);
-    $this->assertStringContainsString("'event_health'", $publish);
+    $this->assertStringContainsString('mel-event-studio-mission-control', $workspace);
+    $this->assertStringNotContainsString('mel-event-studio-event-health', $workspace);
     $this->assertStringContainsString('buildAjaxReadinessPayloadFromBundle', $publish);
     $this->assertStringContainsString('buildHomeAjaxGuideSnapshot', $publish);
+    $this->assertStringContainsString('mission_control', $publish);
+    $this->assertStringContainsString('resolveAuthoritativePrimaryCta', $publish);
   }
 
-  public function testShellJsUpdatesEventHealthAfterPublish(): void {
+  public function testShellJsUpdatesMissionControlAfterPublish(): void {
     $js = file_get_contents(dirname(__DIR__, 3) . '/js/mel-event-studio-shell.js');
     $this->assertIsString($js);
-    $this->assertStringContainsString('function updateEventHealth', $js);
-    $this->assertStringContainsString('result.event_health', $js);
-    $this->assertStringContainsString('ensureReadinessStrip', $js);
+    $this->assertStringContainsString('function updateMissionControl', $js);
     $this->assertStringContainsString('isHomeShell', $js);
     $this->assertStringContainsString('mel-event-studio--home', $js);
-    $this->assertStringContainsString('updateHomepageReadiness', $js);
-    $this->assertStringContainsString('updateHomeDashboard', $js);
-    $this->assertStringContainsString('data-mel-home-dashboard', $js);
+    $this->assertStringContainsString('data-mel-mission-control', $js);
     $this->assertStringContainsString('readiness.home', $js);
-    $this->assertStringContainsString('updateReadinessChecklist', $js);
-    $this->assertStringContainsString('strip_explanation', $js);
-    $this->assertStringContainsString('data-mel-readiness-explain', $js);
-    // Count-mode copy must match mel-event-studio-workspace.html.twig.
-    $this->assertStringContainsString("@count to finish", $js);
-    $this->assertStringContainsString("@count to review", $js);
-    $this->assertStringNotContainsString('blocker(s)', $js);
+    $this->assertStringContainsString('mission_control', $js);
     $this->assertStringContainsString("tone === 'idea'", $js);
-    $this->assertStringContainsString("Drupal.t('Idea')", $js);
+    $this->assertStringNotContainsString('function ensureReadinessStrip', $js);
+    $this->assertStringNotContainsString('function updateHomepageReadiness', $js);
     $twig = file_get_contents(dirname(__DIR__, 3) . '/templates/mel-event-studio-overview.html.twig');
     $this->assertIsString($twig);
     $this->assertStringContainsString('data-mel-home-dashboard', $twig);
-    $this->assertStringContainsString('data-mel-home-event-ready', $twig);
-    $this->assertStringContainsString('data-mel-home-readiness-checklist', $twig);
+    $this->assertStringContainsString('mel-event-studio-mission-control.html.twig', $twig);
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceUxConsolidationTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceUxConsolidationTest.php
@@ -75,7 +75,7 @@ final class EventStudioWorkspaceUxConsolidationTest extends UnitTestCase {
     $this->assertStringContainsString('assembleMissionControl', $builder);
   }
 
-  public function testNonHomeMissionControlReusesReadinessAndSkipsWorkspaceVm(): void {
+  public function testNonHomeMissionControlReusesReadinessAndSharesHomeGuide(): void {
     $controller = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/EventStudioController.php');
     $builder = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventWorkspaceOverviewBuilder.php');
     $this->assertIsString($controller);
@@ -86,10 +86,18 @@ final class EventStudioWorkspaceUxConsolidationTest extends UnitTestCase {
     );
     $this->assertStringContainsString('?array $readiness_bundle = NULL', $builder);
     $this->assertStringContainsString('bool $include_workspace_model = TRUE', $builder);
-    $this->assertStringContainsString(
-      'buildGuideCardState($event, $account, $readiness_bundle, FALSE)',
-      $builder,
-    );
+    // Shared Mission Control contract: default includes workspace VM like Home.
+    $this->assertStringContainsString('function resolveGuidePublicationStatus', $builder);
+    $this->assertStringContainsString('function isEventEnded', $builder);
+  }
+
+  public function testPublishAjaxFallsBackToMissionControlWhenHomeSnapshotFails(): void {
+    $publish = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/EventStudioPublishController.php');
+    $this->assertIsString($publish);
+    $this->assertStringContainsString("ajax_readiness['mission_control'] = NULL", $publish);
+    $this->assertStringContainsString('buildMissionControl(', $publish);
+    $this->assertStringContainsString('FALSE,', $publish);
+    $this->assertStringContainsString('Mission Control AJAX fallback failed', $publish);
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceUxConsolidationTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceUxConsolidationTest.php
@@ -75,4 +75,21 @@ final class EventStudioWorkspaceUxConsolidationTest extends UnitTestCase {
     $this->assertStringContainsString('assembleMissionControl', $builder);
   }
 
+  public function testNonHomeMissionControlReusesReadinessAndSkipsWorkspaceVm(): void {
+    $controller = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/EventStudioController.php');
+    $builder = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventWorkspaceOverviewBuilder.php');
+    $this->assertIsString($controller);
+    $this->assertIsString($builder);
+    $this->assertStringContainsString(
+      'buildMissionControl($node, $account, $section, $readiness_bundle)',
+      $controller,
+    );
+    $this->assertStringContainsString('?array $readiness_bundle = NULL', $builder);
+    $this->assertStringContainsString('bool $include_workspace_model = TRUE', $builder);
+    $this->assertStringContainsString(
+      'buildGuideCardState($event, $account, $readiness_bundle, FALSE)',
+      $builder,
+    );
+  }
+
 }

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceUxConsolidationTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceUxConsolidationTest.php
@@ -93,11 +93,19 @@ final class EventStudioWorkspaceUxConsolidationTest extends UnitTestCase {
 
   public function testPublishAjaxFallsBackToMissionControlWhenHomeSnapshotFails(): void {
     $publish = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/EventStudioPublishController.php');
+    $presentation = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioWorkspacePresentation.php');
+    $js = file_get_contents(dirname(__DIR__, 3) . '/js/mel-event-studio-shell.js');
     $this->assertIsString($publish);
+    $this->assertIsString($presentation);
+    $this->assertIsString($js);
     $this->assertStringContainsString("ajax_readiness['mission_control'] = NULL", $publish);
     $this->assertStringContainsString('buildMissionControl(', $publish);
     $this->assertStringContainsString('FALSE,', $publish);
     $this->assertStringContainsString('Mission Control AJAX fallback failed', $publish);
+    $this->assertStringContainsString('buildDegradedMissionControlPayload', $publish);
+    $this->assertStringContainsString('function buildDegradedMissionControlPayload', $presentation);
+    $this->assertStringContainsString('function buildDegradedMissionControl', $js);
+    $this->assertStringContainsString('buildDegradedMissionControl(shell, readiness)', $js);
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceUxConsolidationTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceUxConsolidationTest.php
@@ -13,30 +13,28 @@ use Drupal\Tests\UnitTestCase;
  */
 final class EventStudioWorkspaceUxConsolidationTest extends UnitTestCase {
 
-  public function testWorkspaceShellOrdersStatusBeforeBoost(): void {
+  public function testWorkspaceShellOrdersMissionControlBeforeBoost(): void {
     $workspace = file_get_contents(dirname(__DIR__, 3) . '/templates/mel-event-studio-workspace.html.twig');
     $this->assertIsString($workspace);
-    $healthPos = strpos($workspace, 'mel-event-studio-event-health');
-    $readinessPos = strpos($workspace, 'mel-event-studio-readiness-strip');
-    $homepagePos = strpos($workspace, 'mel-event-studio-homepage-readiness');
+    $missionPos = strpos($workspace, 'mel-event-studio-mission-control');
     $boostPos = strpos($workspace, 'mel-boost-active-banner');
-    $this->assertNotFalse($healthPos);
-    $this->assertNotFalse($readinessPos);
-    $this->assertNotFalse($homepagePos);
+    $this->assertNotFalse($missionPos);
     $this->assertNotFalse($boostPos);
-    $this->assertLessThan($readinessPos, $healthPos);
-    $this->assertLessThan($boostPos, $readinessPos);
-    $this->assertLessThan($boostPos, $homepagePos);
+    $this->assertLessThan($boostPos, $missionPos);
+    $this->assertStringNotContainsString('mel-event-studio-event-health', $workspace);
+    $this->assertStringNotContainsString('mel-event-studio-readiness-strip', $workspace);
+    $this->assertStringNotContainsString('mel-event-studio-homepage-readiness', $workspace);
   }
 
-  public function testWorkspaceHidesPublishStripWhenConfigured(): void {
-    $workspace = file_get_contents(dirname(__DIR__, 3) . '/templates/mel-event-studio-workspace.html.twig');
-    $presentation = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioWorkspacePresentation.php');
-    $this->assertIsString($workspace);
-    $this->assertIsString($presentation);
-    $this->assertStringContainsString('readiness.show_publish_strip', $workspace);
-    $this->assertStringContainsString('shouldShowPublishStrip', $presentation);
-    $this->assertStringContainsString('readinessStripTitle', $presentation);
+  public function testMissionControlThemeIsRegistered(): void {
+    $module = file_get_contents(dirname(__DIR__, 3) . '/myeventlane_event_studio.module');
+    $template = file_get_contents(dirname(__DIR__, 3) . '/templates/mel-event-studio-mission-control.html.twig');
+    $this->assertIsString($module);
+    $this->assertIsString($template);
+    $this->assertStringContainsString('mel_event_studio_mission_control', $module);
+    $this->assertStringContainsString('data-mel-mission-control', $template);
+    $this->assertStringContainsString('Event Quality', $template);
+    $this->assertStringContainsString('Other improvements', $template);
   }
 
   public function testHomepageReadinessSupportsSummaryOnlyDisplay(): void {
@@ -58,12 +56,23 @@ final class EventStudioWorkspaceUxConsolidationTest extends UnitTestCase {
     $this->assertStringNotContainsString('What lives here', $renderer);
   }
 
-  public function testShellJsHidesReadinessStripForPublishedReadyEvents(): void {
+  public function testShellJsUpdatesMissionControlAfterPublish(): void {
     $js = file_get_contents(dirname(__DIR__, 3) . '/js/mel-event-studio-shell.js');
     $this->assertIsString($js);
-    $this->assertStringContainsString('Published and ready', $js);
-    $this->assertStringContainsString('strip.hidden = !showStrip', $js);
+    $this->assertStringContainsString('function updateMissionControl', $js);
+    $this->assertStringContainsString('updateMissionControl(shell, readiness)', $js);
+    $this->assertStringContainsString('data-mel-mission-control', $js);
     $this->assertStringContainsString('dataset.melPublished', $js);
+  }
+
+  public function testOverviewIncludesSharedMissionControl(): void {
+    $overview = file_get_contents(dirname(__DIR__, 3) . '/templates/mel-event-studio-overview.html.twig');
+    $builder = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventWorkspaceOverviewBuilder.php');
+    $this->assertIsString($overview);
+    $this->assertIsString($builder);
+    $this->assertStringContainsString('mel-event-studio-mission-control.html.twig', $overview);
+    $this->assertStringContainsString('function buildMissionControl', $builder);
+    $this->assertStringContainsString('assembleMissionControl', $builder);
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventWorkspaceOverviewChecklistTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventWorkspaceOverviewChecklistTest.php
@@ -103,10 +103,12 @@ final class EventWorkspaceOverviewChecklistTest extends UnitTestCase {
     $builder = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventWorkspaceOverviewBuilder.php');
     $services = file_get_contents(dirname(__DIR__, 3) . '/myeventlane_event_studio.services.yml');
     $twig = file_get_contents(dirname(__DIR__, 3) . '/templates/mel-event-studio-overview.html.twig');
+    $mission = file_get_contents(dirname(__DIR__, 3) . '/templates/mel-event-studio-mission-control.html.twig');
     $module = file_get_contents(dirname(__DIR__, 3) . '/myeventlane_event_studio.module');
     $this->assertIsString($builder);
     $this->assertIsString($services);
     $this->assertIsString($twig);
+    $this->assertIsString($mission);
     $this->assertIsString($module);
 
     $this->assertStringContainsString('EventReadinessFacade $readinessFacade', $builder);
@@ -114,8 +116,9 @@ final class EventWorkspaceOverviewChecklistTest extends UnitTestCase {
     $this->assertStringContainsString('$recommended', $builder);
     $this->assertStringContainsString("'@myeventlane_event_studio.readiness_facade'", $services);
     $this->assertStringContainsString('mel-event-workspace-home', $twig);
-    $this->assertStringContainsString('event_ready', $module);
-    $this->assertStringContainsString('View checklist', $twig);
+    $this->assertStringContainsString('mission_control', $module);
+    $this->assertStringContainsString('mel-event-studio-mission-control.html.twig', $twig);
+    $this->assertStringContainsString('View checklist', $mission);
   }
 
   public function testActivityOrderIdSortIsTableQualified(): void {

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventWorkspaceOverviewNextActionTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventWorkspaceOverviewNextActionTest.php
@@ -31,7 +31,7 @@ final class EventWorkspaceOverviewNextActionTest extends UnitTestCase {
     );
 
     $this->assertSame('Continue setup', $action['title']);
-    $this->assertSame('Review publishing', $action['action_label']);
+    $this->assertSame('Continue setup', $action['action_label']);
   }
 
   public function testDraftReadyGenericMissionControlYieldsPublishCta(): void {
@@ -48,7 +48,10 @@ final class EventWorkspaceOverviewNextActionTest extends UnitTestCase {
     );
 
     $this->assertSame('Ready when you are', $action['title']);
-    $this->assertSame('Go to publishing', $action['action_label']);
+    $this->assertSame('Publish', $action['action_label']);
+    $this->assertSame('publish', $action['mode']);
+    $this->assertTrue($action['mirrors_hero']);
+    $this->assertNull($action['url']);
   }
 
   public function testLiveIdleLooksReadyYieldsMarketingCta(): void {
@@ -68,7 +71,7 @@ final class EventWorkspaceOverviewNextActionTest extends UnitTestCase {
     $this->assertSame('Share', $action['action_label']);
   }
 
-  public function testLiveBookingActivityKeepsMissionControlAction(): void {
+  public function testLiveBookingActivityReflectsHeroShareCta(): void {
     $action = $this->resolve(
       [
         'severity' => 'info',
@@ -81,12 +84,13 @@ final class EventWorkspaceOverviewNextActionTest extends UnitTestCase {
       TRUE,
     );
 
-    $this->assertSame('Manage bookings', $action['title']);
-    $this->assertSame('View attendees', $action['action_label']);
-    $this->assertSame('/vendor/events/1/attendees', $action['url']);
+    // Hero owns Share; booking ops stay in secondary cards — Focus mirrors Hero.
+    $this->assertSame('Share your event', $action['title']);
+    $this->assertSame('Share', $action['action_label']);
+    $this->assertNotSame('View attendees', $action['action_label']);
   }
 
-  public function testUnknownTypeErrorKeepsMissionControlActionOnDraft(): void {
+  public function testUnknownTypeErrorAlignsCtaWithHeroContinueSetup(): void {
     $action = $this->resolve(
       [
         'severity' => 'error',
@@ -100,7 +104,8 @@ final class EventWorkspaceOverviewNextActionTest extends UnitTestCase {
     );
 
     $this->assertSame('Add RSVP or tickets', $action['title']);
-    $this->assertSame('Edit event', $action['action_label']);
+    $this->assertSame('Continue setup', $action['action_label']);
+    $this->assertNotSame('Edit event', $action['action_label']);
   }
 
   public function testPublishBlockersBeatStripeConnectRecommendation(): void {
@@ -122,7 +127,7 @@ final class EventWorkspaceOverviewNextActionTest extends UnitTestCase {
     );
 
     $this->assertSame('Continue setup', $action['title']);
-    $this->assertSame('Review publishing', $action['action_label']);
+    $this->assertSame('Continue setup', $action['action_label']);
     $this->assertNotSame('Connect Stripe', $action['title']);
   }
 
@@ -146,6 +151,33 @@ final class EventWorkspaceOverviewNextActionTest extends UnitTestCase {
 
     $this->assertSame('Connect Stripe', $action['title']);
     $this->assertSame('/vendor/payouts', $action['url']);
+    $this->assertFalse($action['mirrors_hero']);
+    $this->assertSame('connect_stripe', $action['key']);
+  }
+
+  public function testAuthoritativePrimaryCtaMatchesMissionControlWhenNotStripe(): void {
+    $translator = $this->createMock(TranslationInterface::class);
+    $translator->method('translateString')->willReturnCallback(
+      static fn (\Drupal\Core\StringTranslation\TranslatableMarkup $markup): string => $markup->getUntranslatedString(),
+    );
+    $builder = (new ReflectionClass(EventWorkspaceOverviewBuilder::class))
+      ->newInstanceWithoutConstructor();
+    (new ReflectionClass(EventWorkspaceOverviewBuilder::class))
+      ->getProperty('stringTranslation')
+      ->setValue($builder, $translator);
+
+    $readiness = EventReadinessResult::create(['Add tickets.']);
+    $hero = (new ReflectionClass(EventWorkspaceOverviewBuilder::class))
+      ->getMethod('resolveAuthoritativePrimaryCta')
+      ->invoke($builder, $readiness, FALSE, 1, '');
+    $mc = (new ReflectionClass(EventWorkspaceOverviewBuilder::class))
+      ->getMethod('resolveNextRecommendedAction')
+      ->invoke($builder, [], $readiness, FALSE, 1, []);
+
+    $this->assertSame($hero['label'], $mc['action_label']);
+    $this->assertSame($hero['key'], $mc['key']);
+    $this->assertSame($hero['mode'], $mc['mode']);
+    $this->assertTrue($mc['mirrors_hero']);
   }
 
   public function testAjaxGuideSnapshotReusesStripeAwareBuilders(): void {
@@ -164,7 +196,7 @@ final class EventWorkspaceOverviewNextActionTest extends UnitTestCase {
    * @param array<string, mixed> $stripe
    *   Optional Stripe health payload.
    *
-   * @return array{title: string, message: string, action_label: ?string, url: ?string}
+   * @return array<string, mixed>
    */
   private function resolve(array $next, EventReadinessResult $readiness, bool $published, array $stripe = []): array {
     $translator = $this->createMock(TranslationInterface::class);
@@ -181,7 +213,7 @@ final class EventWorkspaceOverviewNextActionTest extends UnitTestCase {
     $method = (new ReflectionClass(EventWorkspaceOverviewBuilder::class))
       ->getMethod('resolveNextRecommendedAction');
 
-    /** @var array{title: string, message: string, action_label: ?string, url: ?string} $action */
+    /** @var array<string, mixed> $action */
     $action = $method->invoke($builder, $next, $readiness, $published, 1, $stripe);
     return $action;
   }


### PR DESCRIPTION
## Summary
- Ships Vendor Workspace Foundation on Event Studio: shared Mission Control for Home and non-Home chrome, Hero + Mission Control primary CTA contract (`resolveAuthoritativePrimaryCta`), Event Health chrome cleanup, and AJAX/JS alignment.
- Accepts **DDR-008** (canonical Event Workspace / transitional `/studio`) and **DDR-009** (Workspace navigation; Attendees before Orders) against the shipped runtime; includes Workspace v2 discovery pack and PDS CHANGELOG/INDEX/README updates.
- Path unification (`/vendor/events/{id}` without `/studio`) and Publishing Experience remain out of scope until after this Foundation merge.

## Test plan
- [ ] `composer validate` / `ddev drush cr`
- [ ] `ddev exec ./vendor/bin/phpunit -c web/modules/custom/myeventlane_event_studio/phpunit.xml`
- [ ] `npm run mel:lint` && `npm run mel:build`
- [ ] Smoke Home + Details (Information) on a draft Ready event: Mission Control once; Hero CTA matches MC except Stripe Connect exception
- [ ] Confirm nav labels Home / Details / Images and Attendees before Orders
- [ ] Wait for CI green before merge; do not start Publishing Experience until merged


Made with [Cursor](https://cursor.com)