### PR TITLE
Feature/vendor workspace foundation

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -5600,12 +5600,12 @@
   box-shadow: 0 8px 24px rgba(36, 48, 58, 0.04);
 }
 
-/* Phase 2A — shared Mission Control (Home + Information chrome) */
+/* Phase 2B — Mission Control progressive disclosure (compact by default) */
 .mel-event-studio-mission-control {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  padding: 1rem 1.1rem;
+  gap: 0.35rem;
+  padding: 0.7rem 0.95rem;
   border-radius: 16px;
   border: 1px solid rgba(36, 48, 58, 0.1);
   background: var(--mel-surface, #fff);
@@ -5617,102 +5617,232 @@
 }
 
 .mel-event-studio-mission-control__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.35rem 0.75rem;
   margin: 0;
 }
 
+/* Beat body.mel-vendor h2 / h3 type scale — Mission Control is assistant chrome. */
+body.mel-vendor .mel-event-studio-mission-control__title,
 .mel-event-studio-mission-control__title {
   margin: 0;
   font-size: 0.75rem;
   font-weight: 700;
   letter-spacing: 0.04em;
+  line-height: 1.3;
   text-transform: uppercase;
   color: var(--mel-text-muted, #64748b);
+}
+
+.mel-event-studio-mission-control__quality-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0;
+  max-width: 100%;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(36, 48, 58, 0.12);
+  background: rgba(36, 48, 58, 0.03);
+  font-size: 0.8rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--mel-text, #24303a);
+}
+
+.mel-event-studio-mission-control__quality-badge[hidden] {
+  display: none !important;
+}
+
+.mel-event-studio-mission-control__quality-badge.is-ready {
+  border-color: rgba(21, 128, 61, 0.28);
+  background: rgba(21, 128, 61, 0.08);
+}
+
+.mel-event-studio-mission-control__quality-pip {
+  flex: 0 0 auto;
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: #b45309;
+}
+
+.mel-event-studio-mission-control__quality-badge.is-ready .mel-event-studio-mission-control__quality-pip {
+  background: #15803d;
 }
 
 .mel-event-studio-mission-control__next {
   display: flex;
   flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+body.mel-vendor .mel-event-studio-mission-control__next-title,
+.mel-event-studio-mission-control__next-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  line-height: 1.25;
+  color: var(--mel-text, #24303a);
+}
+
+.mel-event-studio-mission-control__support {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.35;
+  color: var(--mel-text, #24303a);
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow: hidden;
+}
+
+.mel-event-studio-mission-control__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 0.85rem;
+  margin-top: 0.15rem;
+}
+
+.mel-event-studio-mission-control__cta {
+  align-self: center;
+  min-height: 44px;
+  margin: 0;
+}
+
+.mel-event-studio-mission-control__publish-hint {
+  margin: 0;
+  flex: 1 1 12rem;
+  font-size: 0.875rem;
+  line-height: 1.35;
+  color: var(--mel-text-muted, #64748b);
+}
+
+.mel-event-studio-mission-control__details {
+  margin: 0;
+  border: 0;
+  padding: 0;
+  flex: 1 1 8rem;
+  min-width: 7rem;
+}
+
+.mel-event-studio-mission-control__details[open] {
+  flex: 1 1 100%;
+}
+
+/* Override .mel-vendor details > summary peach panel chrome. */
+body.mel-vendor .mel-event-studio-mission-control__details > .mel-event-studio-mission-control__details-summary,
+.mel-event-studio-mission-control__details > .mel-event-studio-mission-control__details-summary {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  margin: 0;
+  padding: 0.15rem 0;
+  cursor: pointer;
+  list-style: none;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--mel-text-muted, #64748b);
+  background: transparent;
+  border: 0;
+  border-radius: 8px;
+  box-shadow: none;
+}
+
+.mel-event-studio-mission-control__details-summary::-webkit-details-marker {
+  display: none;
+}
+
+.mel-event-studio-mission-control__details-summary::after {
+  content: '';
+  width: 0.4rem;
+  height: 0.4rem;
+  margin-left: 0.45rem;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+}
+
+.mel-event-studio-mission-control__details[open] > .mel-event-studio-mission-control__details-summary::after {
+  transform: rotate(225deg);
+  margin-top: 0.2rem;
+}
+
+.mel-event-studio-mission-control__details-summary:focus {
+  outline: none;
+}
+
+.mel-event-studio-mission-control__details-summary:focus-visible {
+  outline: 2px solid var(--mel-focus, #2563eb);
+  outline-offset: 2px;
+}
+
+.mel-event-studio-mission-control__details-label--hide {
+  display: none;
+}
+
+.mel-event-studio-mission-control__details[open] > .mel-event-studio-mission-control__details-summary .mel-event-studio-mission-control__details-label--show {
+  display: none;
+}
+
+.mel-event-studio-mission-control__details[open] > .mel-event-studio-mission-control__details-summary .mel-event-studio-mission-control__details-label--hide {
+  display: inline;
+}
+
+.mel-event-studio-mission-control__details-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.5rem 0 0.15rem;
+}
+
+@supports (interpolate-size: allow-keywords) {
+  .mel-event-studio-mission-control__details::details-content {
+    block-size: 0;
+    overflow: hidden;
+    interpolate-size: allow-keywords;
+    transition:
+      block-size 0.22s ease,
+      content-visibility 0.22s allow-discrete;
+  }
+
+  .mel-event-studio-mission-control__details[open]::details-content {
+    block-size: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mel-event-studio-mission-control__details-summary::after,
+  .mel-event-studio-mission-control__details::details-content {
+    transition: none;
+  }
+}
+
+.mel-event-studio-mission-control__improvements {
+  display: flex;
+  flex-direction: column;
   gap: 0.4rem;
 }
 
-.mel-event-studio-mission-control__eyebrow {
+.mel-event-studio-mission-control__improvements-count {
   margin: 0;
   font-size: 0.8rem;
   font-weight: 600;
   color: var(--mel-text-muted, #64748b);
 }
 
-.mel-event-studio-mission-control__next-title {
-  margin: 0;
-  font-size: 1.25rem;
-  font-weight: 700;
-  line-height: 1.25;
-  color: var(--mel-text, #24303a);
-}
-
-.mel-event-studio-mission-control__why-label {
-  margin: 0;
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--mel-text-muted, #64748b);
-}
-
-.mel-event-studio-mission-control__why-text {
-  margin: 0.15rem 0 0;
-  font-size: 0.95rem;
-  line-height: 1.4;
-  color: var(--mel-text, #24303a);
-}
-
-.mel-event-studio-mission-control__cta {
-  align-self: flex-start;
-  min-height: 44px;
-  margin-top: 0.35rem;
-}
-
-.mel-event-studio-mission-control__publish-hint {
-  margin: 0.25rem 0 0;
-  font-size: 0.9rem;
-  line-height: 1.4;
-  color: var(--mel-text-muted, #64748b);
-}
-
-.mel-event-studio-mission-control__improvements {
-  border-top: 1px solid rgba(36, 48, 58, 0.08);
-  padding-top: 0.65rem;
-}
-
-.mel-event-studio-mission-control__improvements-summary {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-  cursor: pointer;
-  list-style: none;
-  min-height: 44px;
-}
-
-.mel-event-studio-mission-control__improvements-summary::-webkit-details-marker {
-  display: none;
-}
-
-.mel-event-studio-mission-control__improvements-main {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  gap: 0.5rem;
-}
-
-.mel-event-studio-mission-control__improvements-count,
-.mel-event-studio-mission-control__improvements-hint {
-  font-size: 0.85rem;
-  color: var(--mel-text-muted, #64748b);
-}
-
 .mel-event-studio-mission-control__improvements-headline {
-  margin: 0 0 0.5rem;
-  font-size: 0.9rem;
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.35;
   color: var(--mel-text-muted, #64748b);
 }
 
@@ -5757,6 +5887,10 @@
   gap: 0.35rem;
 }
 
+.mel-event-studio-mission-control__quality[hidden] {
+  display: none !important;
+}
+
 .mel-event-studio-mission-control__quality-head {
   display: flex;
   flex-wrap: wrap;
@@ -5765,10 +5899,12 @@
   gap: 0.5rem;
 }
 
+body.mel-vendor .mel-event-studio-mission-control__quality-title,
 .mel-event-studio-mission-control__quality-title {
   margin: 0;
   font-size: 0.95rem;
   font-weight: 700;
+  line-height: 1.3;
   color: var(--mel-text, #24303a);
 }
 
@@ -5810,12 +5946,21 @@
 
 @media (max-width: 47.99em) {
   .mel-event-studio-mission-control {
-    padding: 0.9rem 1rem;
-    gap: 0.65rem;
+    padding: 0.65rem 0.85rem;
+    gap: 0.3rem;
   }
 
+  body.mel-vendor .mel-event-studio-mission-control__next-title,
   .mel-event-studio-mission-control__next-title {
-    font-size: 1.15rem;
+    font-size: 1rem;
+  }
+
+  .mel-event-studio-mission-control__quality-badge {
+    font-size: 0.75rem;
+  }
+
+  .mel-event-studio-mission-control__actions {
+    gap: 0.25rem 0.65rem;
   }
 }
 

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
@@ -208,6 +208,63 @@
     ));
   }
 
+  const MISSION_CONTROL_DETAILS_STORAGE_KEY = 'mel.eventStudio.missionControl.expanded';
+
+  function readMissionControlExpanded() {
+    try {
+      return sessionStorage.getItem(MISSION_CONTROL_DETAILS_STORAGE_KEY) === '1';
+    }
+    catch (e) {
+      return false;
+    }
+  }
+
+  function writeMissionControlExpanded(expanded) {
+    try {
+      sessionStorage.setItem(MISSION_CONTROL_DETAILS_STORAGE_KEY, expanded ? '1' : '0');
+    }
+    catch (e) {
+      // Session persistence is best-effort only.
+    }
+  }
+
+  /**
+   * Session-scoped expand/collapse for Mission Control details.
+   * Default collapsed; once expanded, stays open across Workspace navigations.
+   */
+  function bindMissionControlDetails(shell) {
+    if (!shell) {
+      return;
+    }
+    once('mel-event-studio-mission-control-details', '[data-mel-mc-details]', shell).forEach((details) => {
+      details.open = readMissionControlExpanded();
+      details.addEventListener('toggle', () => {
+        writeMissionControlExpanded(!!details.open);
+      });
+    });
+  }
+
+  function formatMissionControlQualityBadge(quality) {
+    const status = typeof quality.status_label === 'string' ? quality.status_label.trim() : '';
+    const scoreLabel = typeof quality.score_label === 'string' && quality.score_label
+      ? quality.score_label
+      : ((typeof quality.score === 'number' ? quality.score : 0) + '%');
+    if (status) {
+      return status + ' · ' + scoreLabel;
+    }
+    return scoreLabel;
+  }
+
+  function setOptionalText(root, selector, value) {
+    const el = root.querySelector(selector);
+    if (!el) {
+      return;
+    }
+    const text = typeof value === 'string' ? value : '';
+    el.textContent = text;
+    el.hidden = text === '';
+  }
+
   function updateMissionControlChecklist(list, items) {
     const rows = Array.isArray(items) ? items : [];
     list.replaceChildren();
@@ -290,12 +347,17 @@
 
     const next = mc.next_step || {};
     setText(root, '[data-mel-mc-next-title]', next.title || '');
-    const why = root.querySelector('[data-mel-mc-why]');
     const whyText = typeof next.message === 'string' ? next.message : '';
+    const why = root.querySelector('[data-mel-mc-why]');
     if (why) {
-      const whyBody = why.querySelector('[data-mel-mc-why-text]');
+      const whyBody = why.matches('[data-mel-mc-why-text]')
+        ? why
+        : why.querySelector('[data-mel-mc-why-text]');
       if (whyBody) {
         whyBody.textContent = whyText;
+      }
+      else {
+        why.textContent = whyText;
       }
       why.hidden = whyText === '';
     }
@@ -309,9 +371,12 @@
         publishHint.className = 'mel-event-studio-mission-control__publish-hint';
         publishHint.setAttribute('data-mel-mc-publish-hint', '');
         publishHint.textContent = Drupal.t('Use Publish in the header when you are ready.');
-        const nextBlock = root.querySelector('[data-mel-mc-next]');
-        if (nextBlock && cta) {
-          nextBlock.insertBefore(publishHint, cta);
+        if (cta && cta.parentNode) {
+          cta.parentNode.insertBefore(publishHint, cta);
+        }
+        else {
+          const nextBlock = root.querySelector('[data-mel-mc-next]');
+          nextBlock?.appendChild(publishHint);
         }
       }
       publishHint.hidden = false;
@@ -340,17 +405,17 @@
       }
     }
 
+    // Disclosure open state is session-owned — do not reset from ViewModel.
+    const details = root.querySelector('[data-mel-mc-details]');
+    if (details) {
+      details.open = readMissionControlExpanded();
+    }
+
     const improvements = mc.improvements || {};
     const improvementsBlock = root.querySelector('[data-mel-mc-improvements]');
     if (improvementsBlock) {
-      if (improvements.open) {
-        improvementsBlock.setAttribute('open', '');
-      }
-      else {
-        improvementsBlock.removeAttribute('open');
-      }
-      setText(improvementsBlock, '[data-mel-mc-improvements-count]', improvements.complete_label || '');
-      setText(improvementsBlock, '[data-mel-mc-improvements-headline]', improvements.headline || '');
+      setOptionalText(improvementsBlock, '[data-mel-mc-improvements-count]', improvements.complete_label || '');
+      setOptionalText(improvementsBlock, '[data-mel-mc-improvements-headline]', improvements.headline || '');
       const list = improvementsBlock.querySelector('[data-mel-mc-checklist]');
       if (list && improvements.items !== undefined) {
         updateMissionControlChecklist(list, improvements.items);
@@ -358,11 +423,22 @@
     }
 
     const quality = mc.event_quality || {};
+    const visible = !!quality.visible;
+    const ready = !!quality.ready;
+    const badge = root.querySelector('[data-mel-mc-quality-badge]');
+    if (badge) {
+      badge.hidden = !visible;
+      badge.classList.toggle('is-ready', ready);
+      const badgeText = badge.querySelector('[data-mel-mc-quality-badge-text]');
+      if (badgeText) {
+        badgeText.textContent = formatMissionControlQualityBadge(quality);
+      }
+    }
+
     const qualityBlock = root.querySelector('[data-mel-mc-quality]');
     if (qualityBlock) {
-      const visible = !!quality.visible;
       qualityBlock.hidden = !visible;
-      qualityBlock.classList.toggle('is-ready', !!quality.ready);
+      qualityBlock.classList.toggle('is-ready', ready);
       setText(qualityBlock, '[data-mel-mc-quality-score-value]', quality.score_label || ((quality.score || 0) + '%'));
       const bar = qualityBlock.querySelector('[data-mel-mc-quality-bar]');
       const fill = qualityBlock.querySelector('[data-mel-mc-quality-bar-fill]');
@@ -860,6 +936,7 @@
 
       once('mel-event-studio-mobile-priority', '[data-mel-studio-shell]', context).forEach((shell) => {
         applyMobilePriorities(shell);
+        bindMissionControlDetails(shell);
         const handoff = studioSettings().publishHandoff;
         if (handoff) {
           renderPublishSuccessFeedback(shell, handoff);

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-mission-control.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-mission-control.html.twig
@@ -3,6 +3,7 @@
  * @file
  * Shared Mission Control card — Home and non-Home workspace chrome.
  *
+ * Phase 2B: compact by default; details expand on demand.
  * Variables:
  * - mission_control: ViewModel from EventWorkspaceOverviewBuilder.
  *
@@ -15,6 +16,17 @@
 {% set quality = mc.event_quality|default({}) %}
 {% set items = improvements.items|default([]) %}
 {% set score = quality.score|default(0) %}
+{% set quality_visible = quality.visible|default(false) %}
+{% set quality_badge = '' %}
+{% if quality_visible %}
+  {% set quality_status = quality.status_label|default('') %}
+  {% set quality_score_label = quality.score_label|default(score ~ '%') %}
+  {% if quality_status %}
+    {% set quality_badge = quality_status ~ ' · ' ~ quality_score_label %}
+  {% else %}
+    {% set quality_badge = quality_score_label %}
+  {% endif %}
+{% endif %}
 
 <section
   class="mel-event-studio-mission-control mel-event-studio-mission-control--{{ mc.tone|default('success')|clean_class }}"
@@ -26,100 +38,114 @@
 >
   <header class="mel-event-studio-mission-control__header">
     <h2 id="mel-mc-heading" class="mel-event-studio-mission-control__title">{{ mc.heading|default('Mission Control'|t) }}</h2>
+    <p
+      class="mel-event-studio-mission-control__quality-badge{% if quality.ready|default(false) %} is-ready{% endif %}"
+      data-mel-mc-quality-badge
+      {% if not quality_visible %} hidden{% endif %}
+    >
+      <span class="mel-event-studio-mission-control__quality-pip" aria-hidden="true"></span>
+      <span class="visually-hidden">{{ 'Event quality'|t }}:</span>
+      <span data-mel-mc-quality-badge-text>{{ quality_badge }}</span>
+    </p>
   </header>
 
   <div class="mel-event-studio-mission-control__next" data-mel-mc-next>
-    <p class="mel-event-studio-mission-control__eyebrow" data-mel-mc-next-eyebrow>{{ next.eyebrow|default('Next step'|t) }}</p>
     <h3 class="mel-event-studio-mission-control__next-title" data-mel-mc-next-title>{{ next.title }}</h3>
-    <div class="mel-event-studio-mission-control__why" data-mel-mc-why{% if not next.message %} hidden{% endif %}>
-      <p class="mel-event-studio-mission-control__why-label">{{ next.why_label|default('Why this matters'|t) }}</p>
-      <p class="mel-event-studio-mission-control__why-text" data-mel-mc-why-text>{{ next.message }}</p>
-    </div>
+    <p
+      class="mel-event-studio-mission-control__support"
+      data-mel-mc-why
+      data-mel-mc-why-text
+      {% if not next.message %} hidden{% endif %}
+    >{{ next.message }}</p>
     {# Hero owns the visual primary. Mission Control mirrors the same action as secondary,
        except the approved Stripe Connect exception. Publish mode defers to Hero publish control. #}
     {% set cta_mode = next.mode|default('link') %}
     {% set cta_key = next.key|default('') %}
-    {% if cta_mode == 'publish' %}
-      <p class="mel-event-studio-mission-control__publish-hint" data-mel-mc-publish-hint>
-        {{ 'Use Publish in the header when you are ready.'|t }}
-      </p>
-      <a class="mel-btn mel-btn--secondary mel-event-studio-mission-control__cta" href="#" data-mel-mc-cta hidden></a>
-    {% elseif next.url and next.action_label %}
-      <a
-        class="mel-btn mel-btn--secondary mel-event-studio-mission-control__cta"
-        href="{{ next.url }}"
-        data-mel-mc-cta
-        data-mel-mc-cta-key="{{ cta_key|e('html_attr') }}"
-        data-mel-mc-mirrors-hero="{{ next.mirrors_hero|default(true) ? '1' : '0' }}"
-      >{{ next.action_label }}</a>
-    {% else %}
-      <a class="mel-btn mel-btn--secondary mel-event-studio-mission-control__cta" href="#" data-mel-mc-cta hidden></a>
-    {% endif %}
-  </div>
-
-  <details
-    class="mel-event-studio-mission-control__improvements"
-    data-mel-mc-improvements
-    {% if improvements.open|default(false) %} open{% endif %}
-  >
-    <summary class="mel-event-studio-mission-control__improvements-summary">
-      <span class="mel-event-studio-mission-control__improvements-main">
-        <strong data-mel-mc-improvements-heading>{{ improvements.heading|default('Other improvements'|t) }}</strong>
-        <span class="mel-event-studio-mission-control__improvements-count" data-mel-mc-improvements-count>{{ improvements.complete_label|default('') }}</span>
-      </span>
-      <span class="mel-event-studio-mission-control__improvements-hint" data-mel-mc-improvements-hint>{{ improvements.hint|default('View checklist'|t) }}</span>
-    </summary>
-    <div class="mel-event-studio-mission-control__improvements-body">
-      {% if improvements.headline|default('') %}
-        <p class="mel-event-studio-mission-control__improvements-headline" data-mel-mc-improvements-headline>{{ improvements.headline }}</p>
+    <div class="mel-event-studio-mission-control__actions">
+      {% if cta_mode == 'publish' %}
+        <p class="mel-event-studio-mission-control__publish-hint" data-mel-mc-publish-hint>
+          {{ 'Use Publish in the header when you are ready.'|t }}
+        </p>
+        <a class="mel-btn mel-btn--secondary mel-event-studio-mission-control__cta" href="#" data-mel-mc-cta hidden></a>
+      {% elseif next.url and next.action_label %}
+        <a
+          class="mel-btn mel-btn--secondary mel-event-studio-mission-control__cta"
+          href="{{ next.url }}"
+          data-mel-mc-cta
+          data-mel-mc-cta-key="{{ cta_key|e('html_attr') }}"
+          data-mel-mc-mirrors-hero="{{ next.mirrors_hero|default(true) ? '1' : '0' }}"
+        >{{ next.action_label }}</a>
+      {% else %}
+        <a class="mel-btn mel-btn--secondary mel-event-studio-mission-control__cta" href="#" data-mel-mc-cta hidden></a>
       {% endif %}
-      <ul class="mel-event-studio-mission-control__checklist" data-mel-mc-checklist{% if not items %} hidden{% endif %}>
-        {% for item in items %}
-          <li class="mel-event-studio-mission-control__check mel-event-studio-mission-control__check--{{ item.tone|default('attention')|clean_class }}">
-            <span class="mel-event-studio-mission-control__check-mark" aria-hidden="true">{{ item.complete ? '✔' : (item.tone|default('') in ['warning', 'idea'] ? '◇' : '○') }}</span>
-            <span class="visually-hidden">
-              {% if item.complete %}
-                {{ 'Complete:'|t }}
-              {% elseif item.tone|default('') == 'warning' %}
-                {{ 'Suggested review:'|t }}
-              {% elseif item.tone|default('') == 'idea' %}
-                {{ 'Idea:'|t }}
-              {% else %}
-                {{ 'Required before publishing:'|t }}
-              {% endif %}
-            </span>
-            <span data-mel-mc-check-label>{{ item.label }}</span>
-          </li>
-        {% endfor %}
-      </ul>
-    </div>
-  </details>
 
-  <div
-    class="mel-event-studio-mission-control__quality{% if quality.ready|default(false) %} is-ready{% endif %}"
-    data-mel-mc-quality
-    {% if not quality.visible|default(false) %} hidden{% endif %}
-    {% if quality.visible|default(false) %}role="group" aria-labelledby="mel-mc-quality-heading"{% endif %}
-  >
-    <div class="mel-event-studio-mission-control__quality-head">
-      <h3 id="mel-mc-quality-heading" class="mel-event-studio-mission-control__quality-title" data-mel-mc-quality-heading>{{ quality.heading|default('Event Quality'|t) }}</h3>
-      <p class="mel-event-studio-mission-control__quality-score" data-mel-mc-quality-score>
-        <span class="visually-hidden">{{ 'Homepage readiness score'|t }}:</span>
-        <strong data-mel-mc-quality-score-value>{{ quality.score_label|default(score ~ '%') }}</strong>
-      </p>
+      <details class="mel-event-studio-mission-control__details" data-mel-mc-details>
+        <summary class="mel-event-studio-mission-control__details-summary">
+          <span class="mel-event-studio-mission-control__details-label mel-event-studio-mission-control__details-label--show">{{ 'Show details'|t }}</span>
+          <span class="mel-event-studio-mission-control__details-label mel-event-studio-mission-control__details-label--hide">{{ 'Hide details'|t }}</span>
+        </summary>
+        <div class="mel-event-studio-mission-control__details-panel">
+          <div class="mel-event-studio-mission-control__improvements" data-mel-mc-improvements>
+            {% if improvements.complete_label|default('') %}
+              <p class="mel-event-studio-mission-control__improvements-count" data-mel-mc-improvements-count>{{ improvements.complete_label }}</p>
+            {% else %}
+              <p class="mel-event-studio-mission-control__improvements-count" data-mel-mc-improvements-count hidden></p>
+            {% endif %}
+            {% if improvements.headline|default('') %}
+              <p class="mel-event-studio-mission-control__improvements-headline" data-mel-mc-improvements-headline>{{ improvements.headline }}</p>
+            {% else %}
+              <p class="mel-event-studio-mission-control__improvements-headline" data-mel-mc-improvements-headline hidden></p>
+            {% endif %}
+            <ul class="mel-event-studio-mission-control__checklist" data-mel-mc-checklist{% if not items %} hidden{% endif %}>
+              {% for item in items %}
+                <li class="mel-event-studio-mission-control__check mel-event-studio-mission-control__check--{{ item.tone|default('attention')|clean_class }}">
+                  <span class="mel-event-studio-mission-control__check-mark" aria-hidden="true">{{ item.complete ? '✔' : (item.tone|default('') in ['warning', 'idea'] ? '◇' : '○') }}</span>
+                  <span class="visually-hidden">
+                    {% if item.complete %}
+                      {{ 'Complete:'|t }}
+                    {% elseif item.tone|default('') == 'warning' %}
+                      {{ 'Suggested review:'|t }}
+                    {% elseif item.tone|default('') == 'idea' %}
+                      {{ 'Idea:'|t }}
+                    {% else %}
+                      {{ 'Required before publishing:'|t }}
+                    {% endif %}
+                  </span>
+                  <span data-mel-mc-check-label>{{ item.label }}</span>
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+
+          <div
+            class="mel-event-studio-mission-control__quality{% if quality.ready|default(false) %} is-ready{% endif %}"
+            data-mel-mc-quality
+            {% if not quality_visible %} hidden{% endif %}
+            {% if quality_visible %}role="group" aria-labelledby="mel-mc-quality-heading"{% endif %}
+          >
+            <div class="mel-event-studio-mission-control__quality-head">
+              <h3 id="mel-mc-quality-heading" class="mel-event-studio-mission-control__quality-title" data-mel-mc-quality-heading>{{ quality.heading|default('Event Quality'|t) }}</h3>
+              <p class="mel-event-studio-mission-control__quality-score" data-mel-mc-quality-score>
+                <span class="visually-hidden">{{ 'Homepage readiness score'|t }}:</span>
+                <strong data-mel-mc-quality-score-value>{{ quality.score_label|default(score ~ '%') }}</strong>
+              </p>
+            </div>
+            <div
+              class="mel-event-studio-mission-control__quality-bar"
+              role="progressbar"
+              aria-valuemin="0"
+              aria-valuemax="100"
+              aria-valuenow="{{ score }}"
+              aria-label="{{ 'Event quality'|t }}"
+              data-mel-mc-quality-bar
+            >
+              <span class="mel-event-studio-mission-control__quality-bar-fill" data-mel-mc-quality-bar-fill style="width: {{ score }}%;"></span>
+            </div>
+            <p class="mel-event-studio-mission-control__quality-status" data-mel-mc-quality-status{% if not quality.status_label|default('') %} hidden{% endif %}>{{ quality.status_label }}</p>
+            <p class="mel-event-studio-mission-control__quality-explain" data-mel-mc-quality-explain{% if not quality.explanation|default('') %} hidden{% endif %}>{{ quality.explanation }}</p>
+          </div>
+        </div>
+      </details>
     </div>
-    <div
-      class="mel-event-studio-mission-control__quality-bar"
-      role="progressbar"
-      aria-valuemin="0"
-      aria-valuemax="100"
-      aria-valuenow="{{ score }}"
-      aria-label="{{ 'Event quality'|t }}"
-      data-mel-mc-quality-bar
-    >
-      <span class="mel-event-studio-mission-control__quality-bar-fill" data-mel-mc-quality-bar-fill style="width: {{ score }}%;"></span>
-    </div>
-    <p class="mel-event-studio-mission-control__quality-status" data-mel-mc-quality-status{% if not quality.status_label|default('') %} hidden{% endif %}>{{ quality.status_label }}</p>
-    <p class="mel-event-studio-mission-control__quality-explain" data-mel-mc-quality-explain{% if not quality.explanation|default('') %} hidden{% endif %}>{{ quality.explanation }}</p>
   </div>
 </section>

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceUxConsolidationTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceUxConsolidationTest.php
@@ -34,7 +34,21 @@ final class EventStudioWorkspaceUxConsolidationTest extends UnitTestCase {
     $this->assertStringContainsString('mel_event_studio_mission_control', $module);
     $this->assertStringContainsString('data-mel-mission-control', $template);
     $this->assertStringContainsString('Event Quality', $template);
-    $this->assertStringContainsString('Other improvements', $template);
+    $this->assertStringContainsString('data-mel-mc-details', $template);
+    $this->assertStringContainsString('Show details', $template);
+    $this->assertStringContainsString('data-mel-mc-quality-badge', $template);
+    $this->assertStringNotContainsString('Next step', $template);
+    $this->assertStringNotContainsString('Why this matters', $template);
+    $this->assertStringNotContainsString('Other improvements', $template);
+  }
+
+  public function testMissionControlDisclosureUsesSessionStorage(): void {
+    $js = file_get_contents(dirname(__DIR__, 3) . '/js/mel-event-studio-shell.js');
+    $this->assertIsString($js);
+    $this->assertStringContainsString('mel.eventStudio.missionControl.expanded', $js);
+    $this->assertStringContainsString('function bindMissionControlDetails', $js);
+    $this->assertStringContainsString('bindMissionControlDetails(shell)', $js);
+    $this->assertStringContainsString('sessionStorage', $js);
   }
 
   public function testHomepageReadinessSupportsSummaryOnlyDisplay(): void {

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventWorkspaceOverviewChecklistTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventWorkspaceOverviewChecklistTest.php
@@ -118,7 +118,9 @@ final class EventWorkspaceOverviewChecklistTest extends UnitTestCase {
     $this->assertStringContainsString('mel-event-workspace-home', $twig);
     $this->assertStringContainsString('mission_control', $module);
     $this->assertStringContainsString('mel-event-studio-mission-control.html.twig', $twig);
-    $this->assertStringContainsString('View checklist', $mission);
+    $this->assertStringContainsString('Show details', $mission);
+    $this->assertStringContainsString('data-mel-mc-details', $mission);
+    $this->assertStringContainsString('data-mel-mc-checklist', $mission);
   }
 
   public function testActivityOrderIdSortIsTableQualified(): void {


### PR DESCRIPTION
## Summary

<!-- What changed and why (organiser outcome, not only technical delta). -->

## Vendor Studio Design System References

<!-- Required for any PR that changes Vendor Studio / organiser console experience or `docs/design/vendor-studio/`.
     Remove this section only for PRs with zero Vendor Studio impact. -->

This implementation follows:

- <!-- e.g. 02-information-architecture.md -->
- <!-- e.g. 05-component-library.md -->
- <!-- e.g. 11-design-tokens.md -->
- <!-- e.g. 16-design-review-checklist.md -->
- <!-- e.g. 21-definition-of-done.md -->
- <!-- e.g. ADR-0001 -->
- <!-- e.g. DDR-003 -->

**PDS home:** `docs/design/vendor-studio/` (Vendor Studio Product Design System v1.0 — FROZEN)

Please also apply the GitHub label: `design-system`

## Definition of Done / checklist

- [ ] Applicable gates in `docs/design/vendor-studio/21-definition-of-done.md`
- [ ] `docs/design/vendor-studio/16-design-review-checklist.md` completed (or N/A with rationale)
- [ ] No contradiction of higher-order PDS docs ([ADR-0001](../docs/design/vendor-studio/decisions/ADR-0001-design-authority.md))

## Test plan

- [x] <!-- Manual / automated checks -->

## Risk

<!-- Access, Commerce, payments, cache, PII — or "None" -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Vendor Studio UI and client-side session preference only; no backend or auth changes.
> 
> **Overview**
> **Phase 2B** refactors Event Studio **Mission Control** so the card stays **compact by default** and only shows checklist + full event quality when the organiser expands **Show details**.
> 
> The collapsed surface emphasizes the next-step title, a single-line support message (replacing “Next step” / “Why this matters”), CTA/publish hint in a shared actions row, and an optional **event quality badge** in the header (status · score, with ready styling). Improvements and the quality bar move inside a `<details>` panel; vendor `details` chrome is overridden so the summary reads as a light text control.
> 
> **Shell JS** persists expand/collapse in **sessionStorage** (`mel.eventStudio.missionControl.expanded`), binds on attach, and keeps that state when AJAX refreshes the Mission Control view model (no longer driven by `improvements.open`). Quality badge text is updated on refresh via `formatMissionControlQualityBadge`.
> 
> Unit tests assert the new template hooks and sessionStorage behavior instead of the old “Other improvements” / “View checklist” copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe46af4c50450cbc42d55ea7b00afde6fd4a0e98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->