### PR TITLE
feat(vendor-workspace): Launch Centre composition (Sprint 3C.1)

### DIFF
--- a/docs/design/vendor-studio/INDEX.md
+++ b/docs/design/vendor-studio/INDEX.md
@@ -66,6 +66,7 @@ Full reading paths: [README.md](README.md) · [CONTRIBUTING.md](CONTRIBUTING.md)
 | [13 Event Workspace philosophy](13-event-workspace-philosophy.md) | Workspace specification |
 | [06 Workspace patterns](06-workspace-patterns.md) | Hub composition patterns |
 | [05 Component library](05-component-library.md) | Component contracts |
+| [Workspace component catalogue](../vendor-workspace-v2/23-vendor-component-catalogue.md) | Freeze / status ledger (not a style guide) |
 | [07 Interaction guidelines](07-interaction-guidelines.md) | Behaviour |
 | [08 Mobile guidelines](08-mobile-guidelines.md) | Mobile ops |
 | [19 Anti-patterns](19-anti-patterns.md) | What not to do |

--- a/docs/design/vendor-workspace-v2/15-publishing-runtime-discovery.md
+++ b/docs/design/vendor-workspace-v2/15-publishing-runtime-discovery.md
@@ -1,0 +1,322 @@
+# Vendor Workspace v2 — Publishing Runtime Discovery
+
+**Status:** Product discovery (Sprint 3A) — documentation only  
+**Date:** 2026-07-25  
+**Branch:** `feature/vendor-workspace-foundation`  
+**Scope:** Complete Publishing architecture for Event Workspace / Event Studio  
+**Constraint:** No runtime behaviour changes. Mission Control is FROZEN.
+
+---
+
+## 1. Repository safety (Stage 1)
+
+| Check | Result |
+| --- | --- |
+| Branch | `feature/vendor-workspace-foundation` (tracks `origin/feature/vendor-workspace-foundation`) |
+| `git status` | Clean working tree |
+| `git diff` | Empty |
+| `git fetch origin` | OK — branch up to date |
+| DDEV | OK — Drupal 11.4.4 · PHP 8.3 · MariaDB 10.11 |
+| `ddev drush status` | Bootstrap successful |
+| `ddev drush config:status` | **Known local drift** (Klaro apps, payment gateways, some field/config) — pre-existing; not introduced by this sprint |
+| `composer validate` | `./composer.json is valid` |
+
+**Assumption hold:** Tree clean; DDEV healthy; composer valid. Config drift noted; does not block design discovery. No stash/clean performed.
+
+---
+
+## 2. Architecture map
+
+```text
+┌─ Organiser UI (vendor theme + Event Studio shell) ─────────────────────────┐
+│  Hero / Topbar  ── authoritative primary CTA (Continue setup | Publish | Share)
+│  Mission Control (FROZEN) ── checklist / next-action / quality (read-only reuse)
+│  Section: Publishing ── Launch Centre (target) / publishing hub (today)
+└────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─ Routes ───────────────────────────────────────────────────────────────────┐
+│  GET  /vendor/events/{node}/studio/publishing
+│       → myeventlane_event_studio.workspace_publishing
+│       → EventStudioController::workspace (section=publishing)
+│  POST /vendor/events/{node}/studio/publish
+│       → myeventlane_event_studio.publish
+│       → EventStudioPublishController::publish (AJAX JSON)
+└────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─ Enforcement ──────────────────────────────────────────────────────────────┐
+│  EventStudioPublishController
+│    → dirty / stale / autosave draft guards (409)
+│    → EventStudioSaveService::setNodePublishedState
+│         → PublishEligibilityEvaluator::evaluate   ← SOURCE OF ENFORCEMENT
+│              1. VendorPublishRequirementsGate
+│              2. PaidPublishStripeGate (paid|both)
+│              3. EventReadinessService::evaluate
+│         → node status + moderation_state sync + revision save
+└────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─ Presentation / confidence ────────────────────────────────────────────────┐
+│  EventReadinessFacade → publish + promotion bundle
+│  EventWorkspaceOverviewBuilder → Mission Control + resolveAuthoritativePrimaryCta
+│  EventStudioWorkspacePresentation → AJAX readiness / degraded MC payload
+│  EventStudioPreprocess::buildPublishSuccessHandoff → celebrate / share
+│  mel-event-studio-shell.js → fetch publish, refresh chrome + MC + feedback
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. What owns publishing?
+
+| Concern | Owner | Evidence |
+| --- | --- | --- |
+| **Publish / unpublish mutation** | `EventStudioSaveService::setNodePublishedState` | `web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php` |
+| **Eligibility enforcement** | `PublishEligibilityEvaluator` (`myeventlane_event_studio.publish_eligibility`) | `src/Service/PublishEligibilityEvaluator.php` |
+| **Readiness display + checklist** | `EventReadinessService` (`myeventlane_event_studio.readiness`) | `src/Service/EventReadinessService.php` |
+| **Publish + promotion bundle** | `EventReadinessFacade` | `src/Service/EventReadinessFacade.php` |
+| **AJAX operation** | `EventStudioPublishController` | `src/Controller/EventStudioPublishController.php` |
+| **Publishing section UI** | `PublishingSection` + `EventStudioSectionRenderer::buildPublishingHub` | Section plugin + renderer |
+| **Publish action card UI** | `EventStudioPublishForm` / `EventSettingsForm` | Forms embed card with `data-mel-publish-*` |
+| **Authoritative Hero CTA** | `EventWorkspaceOverviewBuilder::resolveAuthoritativePrimaryCta` | Overview builder |
+| **Success handoff** | `EventStudioPreprocess::buildPublishSuccessHandoff` | Preprocess + shell JS |
+| **Vendor / Stripe gates** | `VendorPublishRequirementsGate`, `PaidPublishStripeGate` | `myeventlane_vendor` |
+| **Access** | `EventStudioAccess::access` + controller re-check via `EventVendorAccessChecker` | Access + publish controller |
+
+**Source of truth for “may this event go live?”:**  
+`PublishEligibilityEvaluator` (enforcement). Display readiness is `EventReadinessService` / facade — **not** a second publish path, but eligibility re-runs vendor + Stripe + readiness before mutation.
+
+**Source of truth for node live flag:** Drupal node `status` (+ `moderation_state` when present), mutated only through orchestrated save for Studio.
+
+---
+
+## 4. Routes (complete)
+
+| Route ID | Path | Handler | Role |
+| --- | --- | --- | --- |
+| `myeventlane_event_studio.workspace_publishing` | `/vendor/events/{node}/studio/publishing` | `EventStudioController::workspace` | Canonical Publishing section |
+| `myeventlane_event_studio.publish` | `/vendor/events/{node}/studio/publish` | `EventStudioPublishController::publish` | POST AJAX publish/unpublish |
+| `myeventlane_event_studio.edit_publish` | `/vendor/events/{node}/edit/publish` | `redirectLegacyEditToSettings` | Legacy → Settings |
+| `myeventlane_vendor.console.event_publish` | `/vendor/events/{event}/publish` | Vendor workspace controller | Legacy; vendors redirected |
+| `myeventlane_vendor.console.event_unpublish` | `/vendor/events/{event}/unpublish` | `EventUnpublishForm` | Legacy confirm; vendors redirected |
+| `myeventlane_event.wizard.publish` | `/vendor/events/{event}/build/publish` | `EventWizardPublishForm` | Legacy wizard |
+| `myeventlane_event.wizard.success` | `/vendor/events/{event}/build/success` | Wizard success | Legacy |
+
+Access on Studio routes: `_custom_access: EventStudioAccess::access`.  
+Publish POST also requires `_csrf_request_header_token: TRUE`.
+
+---
+
+## 5. Controllers, forms, services
+
+### Controllers
+
+- **`EventStudioPublishController::publish`** — JSON publish/unpublish; returns readiness AJAX bundle, topbar CTA, optional `handoff`.
+- **`EventStudioController::workspace`** — builds `mel_event_studio_workspace`; section `publishing` renders hub; `?mel_celebrate=1` attaches handoff.
+
+### Forms
+
+| Form | Form ID | Role |
+| --- | --- | --- |
+| `EventStudioPublishForm` | `mel_event_studio_wizard_publish` | Publish action card UI |
+| `EventSettingsForm` extends PublishForm | `myeventlane_event_studio_settings_form` | Visibility + publish card; **embedded in publishing hub** |
+| `EventWizardPublishForm` | `event_wizard_publish_form` | Legacy; separate validator |
+| `EventUnpublishForm` | `myeventlane_vendor_event_unpublish` | Legacy direct unpublish |
+
+### Key services
+
+| Service ID | Class |
+| --- | --- |
+| `myeventlane_event_studio.publish_eligibility` | `PublishEligibilityEvaluator` |
+| `myeventlane_event_studio.readiness` | `EventReadinessService` |
+| `myeventlane_event_studio.readiness_facade` | `EventReadinessFacade` |
+| `myeventlane_vendor.publish_requirements_gate` | `VendorPublishRequirementsGate` |
+| `myeventlane_vendor.paid_publish_stripe_gate` | `PaidPublishStripeGate` |
+| `myeventlane_event_studio.save` | `EventStudioSaveService` |
+| `myeventlane_event_studio.overview_builder` | `EventWorkspaceOverviewBuilder` |
+| `myeventlane_event_studio.workspace_presentation` | `EventStudioWorkspacePresentation` |
+| `myeventlane_event_studio.section_renderer` | `EventStudioSectionRenderer` |
+| `myeventlane_event.featured_readiness` | `FeaturedEventReadinessService` (promotion only) |
+
+---
+
+## 6. Publish vs Readiness
+
+| | **Readiness** | **Publish eligibility** |
+| --- | --- | --- |
+| Service | `EventReadinessService` | `PublishEligibilityEvaluator` |
+| Purpose | Confidence UI — checklist, Mission Control, “ready” boolean | **Hard gate** before `setPublished(TRUE)` |
+| Output | `EventReadinessResult` `{ready, errors, warnings, completed, recommendations}` | `{allowed, reason, messages}` |
+| Vendor / Stripe | Folded into readiness errors | Checked again first (`vendor_denied`, `stripe`) |
+| Blocks publish? | Indirectly (`ready === false` → eligibility fails) | Directly throws / 422 |
+| Unpublish | N/A | **Not required** — unpublish skips eligibility |
+
+**Rule for Launch Centre product language:**  
+Readiness answers *“What’s left?”*  
+Eligibility answers *“May we flip live?”*  
+Organisers should never see two conflicting greens.
+
+---
+
+## 7. Readiness checks (actual)
+
+Monolithic evaluator — tagged `Readiness/` provider classes exist as **future contracts only** (not wired for gating).
+
+| Check | Severity when failing |
+| --- | --- |
+| Title present / not “Untitled event” | error |
+| Start + end dates; end after start | error |
+| Booking mode (`field_event_type`) | error |
+| External URL when external | error |
+| ≥1 active paid ticket (paid/both) | error |
+| Stripe charge-ready (`PaidPublishStripeGate`) for paid/both | error |
+| Organiser profile / terms / Stripe connect (`VendorPublishRequirementsGate`) | error |
+| Capacity validity | error / warning |
+| Question template findings | blocker / warning |
+| Cover image missing | recommendation |
+| Summary / donations / accessibility contact | recommendations |
+
+**Promotion readiness** (`FeaturedEventReadinessService` via facade) does **not** block publish.
+
+---
+
+## 8. Vendor / Stripe gate detail
+
+### `VendorPublishRequirementsGate::getLivePublishDenialReasons`
+
+- Signed in
+- Vendor membership + entity
+- Terms accepted
+- Onboarding completed
+- Stripe connected (studio create helper)
+
+Staff/admin bypass for uid 1 / `administer site configuration`.
+
+### `PaidPublishStripeGate::validatePaidPublishAllowed`
+
+For paid/both events: Commerce store, valid `acct_*`, `charges_enabled` (and related store fields). Returns blocked message or `NULL`.
+
+**Product note:** Vendor gate requires Stripe connect for **all** organisers in the denial list, while charge-readiness is paid/both-specific — both can surface as readiness errors for paid events. Launch Centre copy must stay honest without double-shaming.
+
+---
+
+## 9. Publishing hub (today)
+
+`EventStudioSectionRenderer::buildPublishingHub()` returns a render array (no dedicated Twig theme):
+
+- Headline: “Ready to publish” / “Your event is live” / “A few things left…”
+- Explanation + item_list checklist (completed ✔ / remaining ○)
+- Embedded `EventSettingsForm` (visibility + publish action card)
+
+Section plugin: `PublishingSection` — `renderTarget: publishing_hub`, route `workspace_publishing`, `readiness_participant: TRUE`.
+
+---
+
+## 10. AJAX / JS / cache
+
+| Layer | Behaviour |
+| --- | --- |
+| Shell JS | `js/mel-event-studio-shell.js` — `fetch(publishUrl)` with `action: publish|unpublish`; updates topbar, Mission Control, panels, feedback; `renderPublishSuccessFeedback(handoff)` |
+| Selectors | `[data-mel-publish-action]`, `[data-mel-card-publish-action]`, `[data-mel-unpublish-action]`, `[data-mel-publish-feedback]` |
+| Legacy JS | `js/mel-event-studio.js` — builder celebrate / panels |
+| Workspace cache | `#cache` contexts include `url.query_args:mel_celebrate` |
+| Publish JSON | Uncached response; returns changed + revisionId for concurrency |
+
+Pre-mutation guards: dirty section (409), stale changed/revision (409), pending autosave draft (409).
+
+---
+
+## 11. Success / celebrate
+
+1. AJAX 200 + `state: published` → `payload.handoff` from `buildPublishSuccessHandoff`
+2. Query `?mel_celebrate=1` on workspace → same handoff attached to render
+3. Form path (`EventStudioPublishForm`) redirects to workspace with celebrate query when first going live
+4. Handoff fields: `title` (“Your event is now live”), `message`, `view_url`, social `share`, `boost_url`, `calendar_url`
+
+---
+
+## 12. Unpublish
+
+| Path | Eligibility? |
+| --- | --- |
+| Shell AJAX `action: unpublish` → `setNodePublishedState(..., FALSE)` | No — still dirty/stale/autosave guards |
+| Legacy `EventUnpublishForm` | Direct `setUnpublished()`; typical vendors redirected to Settings |
+
+---
+
+## 13. Scheduled / future publish
+
+**Not supported** for Event Studio node publish. No schedule-publish service/UI in focus modules. “Future” in product language means event start in the future while already published — not deferred publish.
+
+---
+
+## 14. Legacy vs canonical
+
+```text
+CANONICAL
+  workspace_publishing + Hero Publish CTA
+  POST myeventlane_event_studio.publish
+  PublishEligibilityEvaluator → setNodePublishedState
+  EventSettingsForm inside publishing hub
+  mel-event-studio-shell.js
+
+LEGACY (still in repo; vendors redirected by VendorLegacyWizardRedirectSubscriber)
+  wizard.publish / wizard.success
+  console.event_publish / event_unpublish
+  EventWizardPublishForm + EventWizardPublishValidator
+  EventUnpublishForm (ungated)
+  mel-event-studio.html.twig builder celebrate
+```
+
+Legacy redirect target for typical vendors: **Settings** (not always Publishing section) — product friction for Launch Centre IA.
+
+---
+
+## 15. Templates & assets (evidence)
+
+| Asset | Path |
+| --- | --- |
+| Workspace shell | `templates/mel-event-studio-workspace.html.twig` |
+| Mission Control | `templates/mel-event-studio-mission-control.html.twig` |
+| Topbar | `templates/mel-event-studio-topbar.html.twig` |
+| Boost CTA include | `templates/mel-publish-boost-cta.html.twig` |
+| Legacy builder | `templates/mel-event-studio.html.twig` |
+| Settings page (vendor theme) | `myeventlane_vendor_theme/.../mel-event-settings-page.html.twig` |
+| Shell JS | `js/mel-event-studio-shell.js` |
+
+---
+
+## 16. Business rules — where enforced
+
+| Rule | Enforcement point |
+| --- | --- |
+| Vendor ownership / parity | `EventStudioAccess` + publish controller |
+| CSRF on publish POST | Route requirement |
+| Autosave / concurrency | Publish controller 409 guards |
+| Organiser profile / terms / Stripe connect | `VendorPublishRequirementsGate` |
+| Paid charges enabled | `PaidPublishStripeGate` |
+| Event content completeness | `EventReadinessService` |
+| Combined publish allow | `PublishEligibilityEvaluator` inside `setNodePublishedState` |
+| Moderation sync | `setNodePublishedState` |
+| CTA single authority (Hero) | `resolveAuthoritativePrimaryCta` |
+
+Twig and Mission Control **must not** invent eligibility.
+
+---
+
+## 17. Residual discovery risks
+
+1. Dual unpublish paths (Studio orchestrated vs legacy form) — mitigated by redirects for typical vendors.
+2. Dual publish validators (Studio eligibility vs legacy wizard validator) — different rule sets.
+3. Stripe messaging can appear twice (vendor gate + paid gate).
+4. Publishing hub embeds full Settings form → visual/decision overload vs Launch Centre intent.
+5. Provider architecture scaffolding unused — do not design as if tagged providers gate publish today.
+
+---
+
+## Verdict (discovery)
+
+Publishing is **owned**, **gated**, and **AJAX-capable** in Event Studio. The gap is product composition: today’s Publishing section is a checklist + settings form + publish card — not yet a calm Launch Centre narrative.
+
+**Next docs:** product audit (`16`), state model (`17`), wireframes (`18`).

--- a/docs/design/vendor-workspace-v2/16-publishing-product-audit.md
+++ b/docs/design/vendor-workspace-v2/16-publishing-product-audit.md
@@ -1,0 +1,150 @@
+# Vendor Workspace v2 — Publishing Product Audit
+
+**Status:** Product discovery + audit (Sprint 3A/3B) — documentation only  
+**Date:** 2026-07-25  
+**Authority:** PDS 13 · 14 · 15 · Workspace docs `02` · `08` · `10` · `14` · runtime discovery `15`  
+**Frozen:** Mission Control — do not redesign; Launch Centre sits **below** it in page hierarchy when on Publishing section.
+
+---
+
+## Part A — Organiser journey (current)
+
+Goal of Publishing Experience: answer **“Am I ready to launch my event?”** with confidence — not administer a CMS publish flag.
+
+### Journey map
+
+```text
+Draft → Incomplete (Needs attention) → Ready → Publishing (in flight)
+  → Live → Sharing → Editing live → Returning later
+  → Past / Closed → (Unpublish) → Draft again
+  → Future scheduling: NOT SUPPORTED (node-level)
+```
+
+| Stage | What organiser experiences today | Runtime evidence |
+| --- | --- | --- |
+| **Draft** | Event unpublished; Hero CTA **Continue setup** → Publishing section; Mission Control lists blockers | `resolveAuthoritativePrimaryCta` when `!$readiness->ready` |
+| **Incomplete** | Publishing hub: “A few things left…” + checklist ○ items + Settings form + Publish card (often disabled / blocked) | `buildPublishingHub` |
+| **Ready** | Hub: “Ready to publish”; Hero primary becomes **Publish** (AJAX); Mission Control may hint “Use Publish in the header” | CTA key `publish`; shell JS publish mode |
+| **Publishing** | Button `is-publishing` state during fetch; guards for dirty/stale/autosave | `EventStudioPublishController` + shell JS |
+| **Live** | Status live; Hero → **Share**; hub “Your event is live”; unpublish ghost button; celebrate/handoff optional | `buildPublishSuccessHandoff`; panels `live` |
+| **Returning later** | Autosave drafts; Continue setup resumes; last-saved in topbar | Autosave + topbar `lastSaved` |
+| **Editing live** | Section saves; “Updates publish when you save” copy on live panel | `EventStudioPublishForm` live panel |
+| **Sharing** | Share CTA → Marketing workspace; handoff social links; Boost CTA optional | Marketing route; handoff `share` |
+| **Unpublishing** | Supported via shell AJAX; legacy confirm form exists but redirected | `action: unpublish` |
+| **Closing / Past** | Event date past; still “Share” primary unless readiness regresses — **weak lifecycle language** on Publishing section | Lifecycle model `08` vs hub copy |
+| **Future scheduling** | **Absent** — cannot schedule node publish for later | Discovery `15` §13 |
+
+### Pain points
+
+| ID | Pain | Severity |
+| --- | --- | --- |
+| P1 | Publishing section embeds **full Settings form** (visibility + publish) — feels like admin, not Launch Centre | MAJOR |
+| P2 | **Competing Publish affordances**: Hero primary + card “Publish now” + Mission Control narrative (MC frozen but still present on Home) | MAJOR on Publishing page |
+| P3 | Checklist is raw error strings + ✔ markup — weak visual hierarchy / fix links | MAJOR |
+| P4 | Success is thin: messenger “Your event is live” / handoff panel — not a guided “what next” Launch success | MAJOR |
+| P5 | Legacy redirects land on **Settings**, not Publishing — confusing recovery paths | MINOR |
+| P6 | Stripe / organiser denials can feel duplicated | MINOR |
+| P7 | Past/closed events still framed as publish/share without aftermath guidance | MINOR |
+| P8 | No scheduled publish — organisers may expect “go live at” | Known gap (product decision) |
+| P9 | Mobile: Settings + checklist + card stack = scroll fatigue; sticky CTA helps but page body remains dense | MAJOR @390 |
+| P10 | Terminology: Publishing / Settings / Studio / publish flag — mixed mental models | MINOR |
+
+### Duplicate actions
+
+- Hero **Publish** vs card **Publish now** (`data-mel-publish-action` / `data-mel-card-publish-action`) — both hit same AJAX endpoint (good technically; bad product competition).
+- Unpublish on card vs Settings danger zone (vendor theme settings page).
+- Share after live: Hero Share + handoff share + Marketing section.
+
+### Confusing terminology
+
+| Term | Risk |
+| --- | --- |
+| Publishing vs Settings | Two sections; publish UI lives in both (hub embeds settings form) |
+| Ready vs Published | Product “Ready” ≠ Drupal published |
+| Live vs On sale | Lifecycle `08` richer than hub headlines |
+| Cannot publish yet | Accurate but anxious — prefer “Finish setup to launch” |
+
+### Unnecessary decisions
+
+- Visibility controls on the same screen as first-time launch (should be secondary / progressive).
+- Boost offered immediately in success path without calm “share first” primacy (Boost OK as secondary).
+
+### Missing feedback
+
+- No progressive “X of Y ready” confidence meter on Publishing (Mission Control has checklist; hub list is flatter).
+- Failed publish messages exist (422/409/500) but recovery CTAs uneven.
+- After unpublish: little guidance on “you’re draft again — here’s what that means for guests”.
+
+### Mobile friction
+
+- Dense vertical stack: headline → checklist → visibility fields → publish card.
+- Touch targets generally use `.mel-btn` (PASS if preserved).
+- Sticky Hero CTA helps; body still asks for multiple decisions.
+
+### Accessibility concerns
+
+- Publish panels use `hidden` + `aria-hidden` (good).
+- Checklist as `item_list` of markup strings — weak semantics vs proper list of links with status.
+- Celebrate/handoff must announce via `aria-live` (shell feedback region — verify in implementation sprint; design requires it in `19`).
+- Competing focusables (Hero + card Publish) — keyboard users get two primaries.
+
+---
+
+## Part B — Product audit ratings
+
+Scale: **PASS** · **MINOR** · **MAJOR**
+
+| Area | Rating | Notes |
+| --- | --- | --- |
+| Information hierarchy | **MAJOR** | Settings form dominates Launch intent |
+| Visual hierarchy | **MAJOR** | Checklist + form + card compete equally |
+| Navigation | **PASS** | Section exists; shell frozen; legacy Settings redirect is MINOR |
+| CTA ownership | **MINOR** | Authoritative resolver exists; UI still duplicates Publish controls |
+| Feedback | **MINOR** | AJAX states exist; copy/structure underplay confidence |
+| Loading | **PASS** | `is-publishing` button state |
+| Errors | **PASS** | Fail-loud codes + messages; reasons from eligibility |
+| Success | **MAJOR** | Handoff exists but not Launch-success experience |
+| Confidence | **MAJOR** | Checklist present but buried in admin chrome |
+| Trust | **PASS** | Server-side eligibility; no Twig gate bypass |
+| Discoverability | **MINOR** | Continue setup → Publishing works; Settings redirect muddies |
+| Calm / one narrative | **MAJOR** | Fails Launch Centre philosophy |
+| Mission Control coexistence | **PASS** | MC frozen; Publishing must not steal Home narrative |
+| Accessibility | **MINOR** | Foundation OK; dual primary + weak checklist semantics |
+| Mobile 390 | **MAJOR** | Density / decision overload |
+
+### Overall product verdict
+
+**Not ready as Launch Centre.**  
+Technical publish path is solid. Product composition fails the five-second confidence test on the Publishing section itself.
+
+| Question | Today |
+| --- | --- |
+| Am I ready to launch? | Partially — checklist exists but framed as admin |
+| What should I do next? | Split between Hero, MC (Home), and card |
+| What happens when I publish? | Under-explained until after |
+| What next after live? | Thin share/boost |
+
+---
+
+## Part C — Design principles for Launch Centre (audit → design)
+
+1. **One narrative:** Ready to Launch → checklist → one control → aftercare.
+2. **One primary action:** Mirror `resolveAuthoritativePrimaryCta` — never two Publish buttons.
+3. **Settings ≠ Launch:** Visibility / danger zone move to Settings or progressive disclosure.
+4. **Reuse readiness truth:** Facade / `EventReadinessService` only — no new calculator.
+5. **Respect Mission Control freeze:** Do not redesign MC; Launch Centre is the Publishing section composition.
+6. **Calm confidence:** Australian English; no FOMO; honest blockers with fix links.
+7. **Success is a journey beat:** Guided share, not fireworks spam.
+
+---
+
+## Outstanding product questions (for PO)
+
+1. Should visibility (public / private / passcode) remain on Launch Centre as a collapsed “Who can find this?” band, or Settings-only?
+2. Is scheduled publish in scope for v2 Launch Centre, or explicitly deferred?
+3. After publish, is **Share** always primary, or should paid events with zero tickets sold elevate **View public page** briefly?
+4. Unpublish confirmation: inline modal on Launch Centre vs Settings-only destructive action?
+
+---
+
+**Recommendation seed:** Design docs `17`–`21` assume visibility secondary, scheduled publish deferred, Share primary after live, unpublish confirmed secondary.

--- a/docs/design/vendor-workspace-v2/17-publishing-state-model.md
+++ b/docs/design/vendor-workspace-v2/17-publishing-state-model.md
@@ -1,0 +1,218 @@
+# Vendor Workspace v2 — Publishing State Model
+
+**Status:** Product design (Sprint 3B) — documentation only  
+**Date:** 2026-07-25  
+**Authority:** Runtime discovery `15` · audit `16` · lifecycle `08` · CTA resolver `EventWorkspaceOverviewBuilder::resolveAuthoritativePrimaryCta`  
+**Frozen:** Mission Control
+
+---
+
+## Principles
+
+1. Shell membership constant; Publishing section emphasis changes by state.
+2. **One authoritative primary CTA** (Hero). Publishing page never introduces a second primary of the same verb.
+3. Readiness (display) ≠ Eligibility (enforcement) — organisers see one honest story.
+4. Australian English; no CMS vocabulary (“node”, “moderation”) in UI.
+
+---
+
+## Authoritative CTA model (Stage 7)
+
+| State key | Primary CTA label | Mode | Destination / behaviour |
+| --- | --- | --- | --- |
+| Draft / Needs attention | **Continue setup** | link | Deep-link first blocker (prefer section URL; Publishing checklist item) |
+| Ready | **Publish event** | publish | Hero AJAX publish only — card becomes status, not second Publish |
+| Publishing (transient) | **Publishing…** | disabled | Same control; loading |
+| Published / Live | **Share event** | link | Marketing workspace (existing) |
+| Past | **View attendees** | link | Attendees workspace |
+| Closed | **Duplicate event** | link | Duplicate flow **if** route exists; else **View event** until confirmed |
+| Unpublished again | **Continue setup** or **Publish event** | per readiness | Same matrix as Draft/Ready |
+
+**Runtime today:** labels are `Continue setup` / `Publish` / `Share` — product design lengthens to **Publish event** / **Share event** for clarity (implementation may keep short labels if chrome width demands; meaning must match).
+
+**Rules:**
+
+- No competing Publish buttons on Launch Centre.
+- When Ready, Mission Control (Home) may keep “Use Publish in the header” hint — **do not** add a second Publish on Publishing page.
+- Stripe Connect exception remains Mission Control / Home only (approved Foundation behaviour) — Launch Centre surfaces Stripe as a checklist blocker with Connect link, not a second Hero.
+
+---
+
+## State catalogue
+
+### 1. Draft
+
+| Dimension | Spec |
+| --- | --- |
+| **Meaning** | Event exists; unpublished; setup incomplete or not yet reviewed |
+| **User expectation** | “I can leave and come back; nothing is public” |
+| **Allowed actions** | Edit sections; preview if meaningful; open Launch Centre; cannot successfully publish |
+| **Primary CTA** | Continue setup |
+| **Secondary** | Preview · View Launch checklist |
+| **Transitions** | → Needs attention (same, with errors) · → Ready when `readiness.ready` |
+| **Evidence** | `node->isPublished() === FALSE`; `EventReadinessResult->ready === FALSE` |
+
+### 2. Needs attention
+
+| Dimension | Spec |
+| --- | --- |
+| **Meaning** | Explicit incomplete readiness — blockers present |
+| **User expectation** | Clear list of what’s wrong + how to fix |
+| **Allowed actions** | Fix via deep links; Launch Centre checklist interactive |
+| **Primary CTA** | Continue setup (to first blocker) |
+| **Secondary** | Open any incomplete item |
+| **Transitions** | → Ready when errors empty; stays if eligibility still fails (vendor/Stripe) |
+| **Evidence** | `readiness->errors !== []`; eligibility `reason: readiness|vendor_denied|stripe` |
+
+### 3. Ready
+
+| Dimension | Spec |
+| --- | --- |
+| **Meaning** | Eligibility would allow publish; still unpublished |
+| **User expectation** | Calm confidence — “ready when you are”; understand public consequences |
+| **Allowed actions** | Publish (Hero); preview public page; review visibility (secondary) |
+| **Primary CTA** | Publish event |
+| **Secondary** | Preview · Who can find this? (disclosure) |
+| **Transitions** | → Publishing (transient) → Published; or leave as Ready |
+| **Evidence** | `readiness->ready === TRUE` && unpublished; eligibility `allowed: true` |
+
+### 4. Publishing
+
+| Dimension | Spec |
+| --- | --- |
+| **Meaning** | Transient UI/network state during POST |
+| **User expectation** | Something is happening; no double-submit |
+| **Allowed actions** | None until response |
+| **Primary CTA** | Publishing… (disabled) |
+| **Secondary** | None |
+| **Transitions** | → Published (200) · → Needs attention / Ready (422/409) · → Failure with retry |
+| **Evidence** | Shell `is-publishing`; no durable Drupal state |
+
+### 5. Published (Live)
+
+| Dimension | Spec |
+| --- | --- |
+| **Meaning** | Node published; discoverable per visibility rules |
+| **User expectation** | Guests can find/RSVP/buy per configuration; edits update live |
+| **Allowed actions** | Share; view public; edit sections; unpublish (secondary, confirmed) |
+| **Primary CTA** | Share event |
+| **Secondary** | View public page · Marketing · Unpublish |
+| **Transitions** | → Needs attention if readiness regresses while live · → Draft via unpublish · → Past when event ended |
+| **Evidence** | `node->isPublished() === TRUE`; moderation `published` when field present |
+
+### 6. Past
+
+| Dimension | Spec |
+| --- | --- |
+| **Meaning** | Event end datetime in the past; still published or unpublished |
+| **User expectation** | Ops shift to attendees/aftermath — not “launch” |
+| **Allowed actions** | View attendees; messages; analytics; unpublish/archive later |
+| **Primary CTA** | View attendees |
+| **Secondary** | View public page · Duplicate (if available) |
+| **Transitions** | → Closed (product language) when organiser marks complete / archive future |
+| **Evidence** | Lifecycle `08`; date fields — Launch Centre must detect past for copy (confirm field usage at implementation from `field_event_end`) |
+
+### 7. Closed
+
+| Dimension | Spec |
+| --- | --- |
+| **Meaning** | Event intentionally wound down (product state; may map to unpublished + past or future archive flag) |
+| **User expectation** | No new guests; historical record preserved |
+| **Allowed actions** | View attendees; duplicate; limited edit |
+| **Primary CTA** | Duplicate event (or View attendees if duplicate unavailable) |
+| **Secondary** | Analytics · Support |
+| **Transitions** | Terminal for this occurrence |
+| **Evidence** | **Partial today** — no first-class “closed” flag confirmed in Studio publish path. Product state for Launch Centre; implementation must not invent fields — map to unpublished+past until archive exists |
+
+### 8. Future (scheduled event date)
+
+| Dimension | Spec |
+| --- | --- |
+| **Meaning** | Published (or Ready) with start date in the future |
+| **User expectation** | “Live page now; event happens later” — **not** “will auto-publish later” |
+| **Allowed actions** | Share; edit; unpublish |
+| **Primary CTA** | Share event (if published) or Publish event (if Ready) |
+| **Secondary** | Preview · Calendar |
+| **Transitions** | Same as Published/Ready |
+| **Evidence** | Start date future; **no** deferred node publish |
+
+### 9. Archived (future)
+
+| Dimension | Spec |
+| --- | --- |
+| **Meaning** | Soft-removed from active portfolio; not primary ops |
+| **User expectation** | Recoverable history |
+| **Allowed actions** | View-only / restore (TBD) |
+| **Primary CTA** | View event |
+| **Secondary** | Restore (future) |
+| **Transitions** | Out of Launch Centre scope for Sprint 3 |
+| **Evidence** | Vendor archive routes exist elsewhere — **do not** fold into Launch Centre without separate discovery |
+
+---
+
+## Transition diagram
+
+```text
+                    ┌──────────────┐
+                    │    Draft     │
+                    └──────┬───────┘
+                           │ blockers
+                    ┌──────▼───────┐
+              ┌─────│ Needs attention│────┐
+              │     └──────┬───────┘     │
+              │            │ ready        │
+              │     ┌──────▼───────┐     │
+              │     │    Ready     │     │
+              │     └──────┬───────┘     │
+              │            │ publish     │
+              │     ┌──────▼───────┐     │
+              │     │  Publishing  │     │
+              │     └──────┬───────┘     │
+              │         ok │             │
+              │     ┌──────▼───────┐     │
+              └─────│  Published   │◄────┘ (fix → may still be live)
+                    │   (Live)     │
+                    └──────┬───────┘
+                           │ end date / wind-down
+                    ┌──────▼───────┐
+                    │ Past → Closed│
+                    └──────────────┘
+
+  Published ──unpublish──► Draft / Needs attention
+```
+
+---
+
+## Launch Centre band emphasis by state
+
+| State | Ready to Launch band | Checklist | Controls | Aftercare |
+| --- | --- | --- | --- | --- |
+| Needs attention | “Almost there” | Open, blockers first | Hidden / disabled publish | Soft tips |
+| Ready | “Ready to launch” | Collapsed summary ✔ | Hero owns Publish | Preview consequences |
+| Publishing | “Going live…” | Frozen | Disabled | — |
+| Live | “Your event is live” | Collapsed | Share primary; Unpublish secondary | Share guidance |
+| Past | “This event has ended” | Hidden | Attendees primary | Aftermath |
+
+---
+
+## Mapping to runtime keys
+
+| Product state | `published` | `readiness.ready` | CTA `key` (today) |
+| --- | --- | --- | --- |
+| Draft / Needs attention | false | false | `continue_setup` |
+| Ready | false | true | `publish` |
+| Published / Live / Future-dated live | true | true | `share` |
+| Live + regression | true | false | `continue_setup` (fix) |
+| Past | true/false | * | Product override → attendees (design; **not** in resolver today) |
+
+**Gap:** Past/Closed CTA override is **design-new** relative to `resolveAuthoritativePrimaryCta` — implementation strategy (`21`) must extend resolver carefully or keep Share until Past detection approved.
+
+---
+
+## Unpublish contract
+
+- Allowed from Live (and Past if still published).
+- Always **confirm** (consequences: public page unavailable; tickets/RSVP implications stated honestly).
+- No eligibility check.
+- After success: state = Draft or Needs attention; CTA returns to Continue setup / Publish event.
+- Primary never remains “Unpublish”.

--- a/docs/design/vendor-workspace-v2/18-launch-centre-wireframes.md
+++ b/docs/design/vendor-workspace-v2/18-launch-centre-wireframes.md
@@ -1,0 +1,256 @@
+# Vendor Workspace v2 — Launch Centre Wireframes
+
+**Status:** High-fidelity product design (Sprint 3B) — documentation only  
+**Date:** 2026-07-25  
+**Surface:** Publishing section = **Launch Centre**  
+**URL (transitional):** `/vendor/events/{id}/studio/publishing`  
+**Authority:** PDS 03 · 05 · 06 · 08 · 13 · 14 · state model `17` · audit `16`  
+**Frozen:** Mission Control (Home). This doc does **not** redesign Overview.
+
+---
+
+## Design intent
+
+| Feel | Means |
+| --- | --- |
+| Calm | One column narrative; generous space |
+| Confident | Honest readiness; one launch control |
+| Focused | Launch question only — not Settings dump |
+| Guided | Checklist with fix links; aftercare after live |
+| Premium | Restraint; no FOMO badges |
+
+**Avoid:** Dual Publish buttons · full Settings form on Launch · nested card walls · competing Boost primary.
+
+---
+
+## Page hierarchy (locked)
+
+```text
+Workspace chrome (Hero — FROZEN contract)
+    ↓
+Section: Publishing (Launch Centre)
+    ↓
+1. Ready to Launch          (status narrative)
+    ↓
+2. Launch checklist         (readiness items + fix links)
+    ↓
+3. Publishing controls      (status / confirm — NOT second primary Publish)
+    ↓
+4. After publishing guidance (only when live, or preview of “what happens”)
+```
+
+Hero remains the **only** primary Publish / Share / Continue setup control (`17`).
+
+---
+
+## Shared chrome (all breakpoints)
+
+Identical to Workspace Foundation chrome (`09`):
+
+```text
+← Events    {Event name}     [Status]    [ Primary CTA ]  [ View ]
+            {Date · Venue}               (one only)       [ Share* ]
+```
+
+\* Share secondary when primary is not already Share.
+
+Section nav: Publishing emphasised; Settings available but not the launch path.
+
+---
+
+## A. Desktop (≥1200px) — Ready state
+
+```text
+┌─ GLOBAL + EVENT CHROME ─────────────────────────────────────────────────────┐
+│ …  Summer Summer Night Market     Ready      [ Publish event ]  [ View ]
+│                           Sat 18 Oct · Fitzroy
+├─ SECTIONS … Publishing ● … ─────────────────────────────────────────────────┤
+│                                                                             │
+│  READY TO LAUNCH                                                            │
+│  ───────────────                                                            │
+│  You’re ready to go live.                                                   │
+│  Guests will be able to discover this event and RSVP or buy tickets         │
+│  according to your setup.                                                   │
+│                                                                             │
+│  LAUNCH CHECKLIST                                                    All ✔  │
+│  ┌─────────────────────────────────────────────────────────────────────┐   │
+│  │ ✔ Event title     ✔ Schedule     ✔ Booking mode     ✔ Tickets       │   │
+│  │ ✔ Payments        ✔ Organiser profile     ✔ Cover (optional done)   │   │
+│  └─────────────────────────────────────────────────────────────────────┘   │
+│  (collapsed by default when Ready — expand to review)                       │
+│                                                                             │
+│  LAUNCH CONTROL                                                             │
+│  ┌─────────────────────────────────────────────────────────────────────┐   │
+│  │ Status: Ready · not live yet                                        │   │
+│  │ Use Publish event in the header when you are ready.                 │   │
+│  │                                                                     │   │
+│  │ Who can find this?  Public ▾     [Preview public page]              │   │
+│  │ (progressive — not a full settings form)                            │   │
+│  └─────────────────────────────────────────────────────────────────────┘   │
+│                                                                             │
+│  AFTER YOU LAUNCH                                                           │
+│  You’ll be able to share your link, track RSVPs or sales, and edit         │
+│  anytime. Updates appear on the public page when you save.                 │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## B. Desktop — Needs attention
+
+```text
+│  READY TO LAUNCH                                                            │
+│  Almost there — 2 things left before you can launch.                        │
+│                                                                             │
+│  LAUNCH CHECKLIST                                                           │
+│  ┌─────────────────────────────────────────────────────────────────────┐   │
+│  │ ○ Add at least one active paid ticket          [ Fix → Tickets ]    │   │
+│  │ ○ Connect Stripe before publishing             [ Connect Stripe ]   │   │
+│  │ ✔ Event title   ✔ Schedule   ✔ Booking mode                         │   │
+│  └─────────────────────────────────────────────────────────────────────┘   │
+│                                                                             │
+│  LAUNCH CONTROL                                                             │
+│  Publish is unavailable until the checklist is clear.                       │
+│  Header shows Continue setup → first blocker.                               │
+```
+
+---
+
+## C. Desktop — Live (post-publish)
+
+```text
+│  … Status: Live …     [ Share event ]  [ View ]                             │
+│                                                                             │
+│  READY TO LAUNCH → becomes YOUR EVENT IS LIVE                               │
+│  People can discover, RSVP or buy, and share — per your visibility.         │
+│                                                                             │
+│  LAUNCH CHECKLIST — collapsed “Setup complete”                              │
+│                                                                             │
+│  NEXT                                                                         │
+│  ┌─────────────────────────────────────────────────────────────────────┐   │
+│  │ Recommended: Share your event                                       │   │
+│  │ [ Copy link ]  [ Share on Facebook ]  [ LinkedIn ]  [ Post ]        │   │
+│  │                                              [ Open Marketing → ]   │   │
+│  └─────────────────────────────────────────────────────────────────────┘   │
+│                                                                             │
+│  SECONDARY                                                                    │
+│  [ Boost visibility ] (quiet) · [ Unpublish… ] (ghost, confirm)             │
+```
+
+---
+
+## D. Tablet (~768px)
+
+```text
+┌─ CHROME (primary CTA remains in header) ────────────────┐
+│ Event name · Ready · [ Publish event ] · ⋮              │
+├─ Section drawer / horizontal scroll ─ Publishing ● ─────┤
+│                                                         │
+│ Ready to Launch                                         │
+│ Checklist (full width cards, one item per row)          │
+│ Launch control (hint to header — no second Publish)     │
+│ After guidance                                          │
+└─────────────────────────────────────────────────────────┘
+```
+
+- Checklist items become stacked rows with trailing fix buttons (≥44px).
+- Visibility disclosure as single select row.
+- No sticky duplicate Publish unless header scrolls away — then sticky bar mirrors **same** Hero CTA only.
+
+---
+
+## E. Mobile 390px
+
+```text
+┌────────────────────────────┐
+│ ← Events                   │
+│ Summer Night Market        │
+│ Ready                      │
+│ Sat 18 Oct · Fitzroy       │
+├────────────────────────────┤
+│ Ready to launch            │
+│ You’re ready to go live.   │
+│ Guests can discover…       │
+├────────────────────────────┤
+│ Checklist            All ✔ │
+│ (tap to expand)            │
+├────────────────────────────┤
+│ Launch                     │
+│ Use Publish in the bar →   │
+│ Who can find this? Public  │
+│ Preview public page        │
+├────────────────────────────┤
+│ After you launch           │
+│ Share · track · edit…      │
+├────────────────────────────┤
+│ ┌────────────────────────┐ │
+│ │   Publish event        │ │  ← sticky bottom = Hero primary only
+│ └────────────────────────┘ │
+└────────────────────────────┘
+```
+
+**Rules @390:**
+
+- One sticky primary matching Hero key.
+- Checklist collapsed when Ready; open when Needs attention.
+- No Boost above Share after live.
+- Unpublish behind “More” / secondary text link — not sticky.
+
+---
+
+## F. Publishing in progress (all breakpoints)
+
+```text
+Primary CTA: Publishing…
+Checklist frozen
+Optional inline: “Going live — this usually takes a moment.”
+No other actions
+```
+
+---
+
+## G. Component inventory (reuse, don’t invent)
+
+| Band | Reuse |
+| --- | --- |
+| Chrome / Hero CTA | Existing topbar + `resolveAuthoritativePrimaryCta` |
+| Ready narrative | New presentation props from existing readiness/publish flags |
+| Checklist | Same readiness items as Mission Control / hub — **presentation only** |
+| Launch control hint | Align with MC publish hint pattern (“Use Publish in the header”) |
+| Visibility | Slim subset of `EventSettingsForm` visibility — or link to Settings |
+| Success / share | Extend `buildPublishSuccessHandoff` presentation (`20`) |
+| Buttons | `.mel-btn` / `.mel-btn--primary` / `--ghost` |
+
+**Do not** add a new eligibility service or parallel checklist calculator.
+
+---
+
+## H. CTA ownership on this page
+
+| State | Page body primary? | Body copy |
+| --- | --- | --- |
+| Needs attention | No — Hero Continue setup | Fix links only |
+| Ready | No second Publish | “Use Publish event in the header…” |
+| Live | Share actions OK as **recommended next** but Hero owns Share | Match labels |
+| Past | Link to Attendees | No Publish |
+
+---
+
+## I. Anti-patterns (explicit)
+
+1. Embedding full `EventSettingsForm` on Launch Centre.
+2. Card button labelled Publish now beside Hero Publish.
+3. Equal-weight Boost + Share.
+4. Green “ready” while eligibility would fail.
+5. Redesigning Mission Control to compensate for Launch Centre.
+
+---
+
+## J. Wireframe alternatives (Ready band copy)
+
+**A (calm):** “You’re ready to go live.”  
+**B (action):** “Launch when you’re ready.”  
+**C (guest-centred):** “Guests can find this event as soon as you publish.”
+
+**Recommendation:** A + one guest-centred supporting sentence (shown in desktop wireframe).

--- a/docs/design/vendor-workspace-v2/19-publishing-ux-rules.md
+++ b/docs/design/vendor-workspace-v2/19-publishing-ux-rules.md
@@ -1,0 +1,172 @@
+# Vendor Workspace v2 — Publishing UX Rules
+
+**Status:** Product design (Sprint 3B) — documentation only  
+**Date:** 2026-07-25  
+**Authority:** PDS 07 · 08 · audit `16` · state model `17` · wireframes `18`  
+**Runtime anchors:** `EventStudioPublishController`, `mel-event-studio-shell.js`, `buildPublishSuccessHandoff`
+
+---
+
+## 1. Interaction principles
+
+1. One primary action at a time.
+2. Fail loud with recovery — never silent publish failure.
+3. Prefer inline calm messaging over modal spam; confirm only for destructive/irreversible.
+4. Respect `prefers-reduced-motion`.
+5. Australian English.
+
+---
+
+## 2. Loading
+
+| Moment | Behaviour |
+| --- | --- |
+| Publish request starts | Primary CTA → **Publishing…**; `disabled`; `aria-busy="true"` |
+| Page body | Launch checklist frozen; no competing clicks |
+| Duration | Expect &lt;2s typical; after 5s keep spinner + “Still working…” |
+| Network offline | Immediate failure message + Retry |
+
+Do not navigate away during request.
+
+---
+
+## 3. Publishing in progress
+
+- Button class pattern may keep `is-publishing` (existing shell).
+- Announce to screen readers: “Publishing your event” via `aria-live="polite"` region.
+- Block double-submit (ignore further clicks).
+
+---
+
+## 4. Success
+
+| Channel | Content |
+| --- | --- |
+| Hero | Status → Live; CTA → Share event |
+| Inline Launch Centre | Swap to live narrative (`20`) |
+| Live region | “Your event is now live” |
+| Optional toast | Quiet, auto-dismiss 5s — **not** required if inline success is visible |
+| Handoff payload | Reuse `buildPublishSuccessHandoff` fields |
+
+No full-page redirect required for AJAX path (current behaviour). Celebrate query path remains supported for form handoffs.
+
+---
+
+## 5. Failure
+
+Map existing codes to organiser language:
+
+| Code / HTTP | Organiser message | Recovery |
+| --- | --- | --- |
+| `unsaved_changes` 409 | Save this section before changing publish state | Save / stay |
+| `stale_state` 409 | This event changed — refresh to continue safely | Refresh |
+| `autosave_draft` 409 | Autosaved draft waiting in {section} | Restore or save |
+| `cannot_publish` 422 | Cannot launch yet — {first reason} | Continue setup / Fix |
+| `publish_failed` 500 | Publish failed. Try again shortly | Retry |
+| `cannot_unpublish` / `unpublish_failed` | Parallel unpublish copy | Retry / Support |
+
+Inline alert (role=`alert` for failures). Keep checklist visible when readiness-related.
+
+---
+
+## 6. Retry
+
+- Primary failure CTA: **Try again** (re-invoke same publish).
+- If readiness: **Continue setup** instead of retry.
+- After 2 hard 500s: suggest refresh + Support link (help audience: vendor).
+
+---
+
+## 7. Warnings
+
+| Type | Treatment |
+| --- | --- |
+| Recommendations (cover, summary) | Non-blocking; secondary list “Nice to have” |
+| Stripe / profile blockers | Blocking checklist rows |
+| Live + readiness regression | Warning banner on Launch Centre + Hero Continue setup |
+
+Never mark Ready/green if eligibility would deny.
+
+---
+
+## 8. Confirmation
+
+| Action | Confirm? | Pattern |
+| --- | --- | --- |
+| Publish | No modal if Ready (deliberate Hero click is consent) | Optional one-line consequence already visible |
+| Unpublish | **Yes** | Modal or disclose panel: public page hidden; share links break; tickets/RSVP implications |
+| Visibility → private/passcode while live | Soft confirm | “Guests may lose access” |
+
+---
+
+## 9. Toast vs inline
+
+| Prefer inline | Prefer toast |
+| --- | --- |
+| Launch success narrative | Brief “Saved” / “Link copied” |
+| Publish blockers | — |
+| Unpublish result | Optional short toast after inline state change |
+
+Toasts: max one; do not stack with celebrate panel.
+
+---
+
+## 10. Animations
+
+| Motion | Spec |
+| --- | --- |
+| Success enter | Soft fade/slide ≤200ms |
+| Checklist check | Subtle check morph ≤150ms |
+| Confetti / emoji burst | **Optional** and **off** when reduced motion — prefer calm checkmark |
+| Sticky CTA | No bounce |
+
+---
+
+## 11. Reduced motion
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  /* no celebrate motion; instant state swap; no spinner animation — use static “Publishing…” text */
+}
+```
+
+Shell JS must not rely on animation completion for state.
+
+---
+
+## 12. Accessibility (Stage 10 requirements)
+
+| Area | Requirement |
+| --- | --- |
+| Keyboard | All Launch actions reachable; focus order: narrative → checklist links → secondary → sticky CTA |
+| Focus | After publish success, move focus to success heading (“Your event is now live”) |
+| After failure | Focus to alert |
+| Screen readers | `aria-live="polite"` for progress/success; `alert` for failures |
+| ARIA | Primary CTA `aria-busy` while publishing; panels `aria-hidden` when unused (existing) |
+| Touch targets | ≥44×44px @390 |
+| Contrast | WCAG AA on status badges and checklist icons |
+| 390 layout | Sticky primary only; no horizontal overflow |
+| Dual Publish | Forbidden — avoids ambiguous accessible name collision |
+
+---
+
+## 13. Copy snippets (approved direction)
+
+| Situation | Copy |
+| --- | --- |
+| Ready | “You’re ready to go live.” |
+| Blocked | “Almost there — finish the checklist to launch.” |
+| Publishing | “Publishing…” / “Going live — this usually takes a moment.” |
+| Success | “Your event is now live” |
+| Unpublish confirm | “Unpublish this event? Your public page will no longer be available.” |
+| Retry | “Something went wrong. Try again.” |
+
+Avoid: exclusive, VIP, FOMO, “Publish node”, “moderation”.
+
+---
+
+## 14. Mission Control interaction
+
+- Publishing AJAX may refresh Mission Control payload (existing) — **presentation only**.
+- Do not change MC information architecture in this sprint’s implementation phase either without PO + unfreeze.
+- Launch Centre owns launch narrative; MC owns Home ops narrative.

--- a/docs/design/vendor-workspace-v2/20-launch-success-experience.md
+++ b/docs/design/vendor-workspace-v2/20-launch-success-experience.md
@@ -1,0 +1,155 @@
+# Vendor Workspace v2 — Launch Success Experience
+
+**Status:** Product design (Sprint 3B) — documentation only  
+**Date:** 2026-07-25  
+**Goal:** After publish, organiser feels confident, excited, guided — knows what happened and what next.  
+**Runtime seed:** `EventStudioPreprocess::buildPublishSuccessHandoff` · shell `renderPublishSuccessFeedback` · `?mel_celebrate=1`
+
+---
+
+## Emotional target
+
+| Feel | Design move |
+| --- | --- |
+| Confident | Clear “now live” + what guests can do |
+| Excited | Warm, brief celebration — not carnival |
+| Guided | One recommended next step (Share) |
+| Calm | Secondary actions quiet; no pressure Boost |
+
+---
+
+## Non‑negotiables
+
+1. Reuse handoff payload fields: `title`, `message`, `view_url`, `share`, `boost_url`, `calendar_url`.
+2. Hero CTA becomes **Share event** immediately.
+3. Focus moves to success heading (a11y `19`).
+4. Reduced motion: no confetti; static success panel.
+5. Boost is **never** the primary next step.
+
+---
+
+## Alternative A — Recommended (calm Launch success)
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│  Your event is now live                                     │
+│                                                             │
+│  People can now:                                            │
+│  ✓ discover your event                                      │
+│  ✓ RSVP or buy tickets                                      │
+│  ✓ share your event                                         │
+│                                                             │
+│  Recommended next step                                      │
+│  [ Share your event → ]                                     │
+│                                                             │
+│  [ Copy link ]   [ View public page ]                       │
+│                                                             │
+│  Grow later                                                 │
+│  Boost visibility (optional)                                │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Why recommended:** Matches sprint example; one narrative; Share primacy; Boost demoted.
+
+---
+
+## Alternative B — Compact toast + inline strip
+
+```text
+Toast: Event is live · Share →
+
+Inline strip under Ready band:
+Live · Public link ready · [ Copy ] [ Share ]
+```
+
+**Use when:** Organiser already on Marketing intent; less interruption.  
+**Risk:** Easier to miss next step on mobile.
+
+---
+
+## Alternative C — Full celebrate panel (legacy-aligned)
+
+```text
+Large celebrate panel with social icons + calendar + Boost card
+(existing mel_publish_celebrate_* / boost CTA patterns)
+```
+
+**Use when:** First-ever publish for organiser (onboarding delight).  
+**Risk:** Feels heavy on return publishes; Boost competition.
+
+**Rule:** If C used, auto-collapse after first dismiss; subsequent publishes use A.
+
+---
+
+## Alternative D — Guest preview first
+
+```text
+Your event is now live
+[ Open public page ] as recommended
+Share as secondary
+```
+
+**Use when:** Visibility was private/passcode — organiser should verify guest view.  
+**Not default** for public events.
+
+---
+
+## State variants
+
+| Context | Success treatment |
+| --- | --- |
+| First publish | Alternative A (+ optional one-time soft motion) |
+| Re-publish after unpublish | A, shorter: “You’re live again” |
+| Paid + Stripe just connected | A + quiet “Payments ready” note |
+| Passcode/private | D hybrid: View public/passcode path + Share |
+| Reduced motion | A static |
+
+---
+
+## Copy bank
+
+| Element | Copy |
+| --- | --- |
+| Title | Your event is now live |
+| Re-publish | You’re live again |
+| People can | discover your event · RSVP or buy tickets · share your event |
+| Next | Share your event |
+| Secondary | Copy link · View public page |
+| Boost | Optional — Grow visibility later |
+| Dismiss | Continue to workspace |
+
+RSVP-only events: “RSVP” not “buy tickets”. Paid-only: “buy tickets”. Both: keep both.
+
+---
+
+## Social / share mechanics
+
+Reuse handoff URLs:
+
+- Facebook / LinkedIn / Twitter(X) intent links from `share`
+- Copy uses `view_url` (public absolute URL)
+- Calendar optional if `calendar_url` present
+
+Do not invent new social networks in v1 Launch success.
+
+---
+
+## Failure-to-success edge
+
+If publish returns 200 but handoff null (shouldn’t when published): still update Hero + show “Your event is live” with View link from canonical route — fail soft, log already exists server-side patterns.
+
+---
+
+## Measurement (product, not analytics build)
+
+Success of this experience:
+
+- Time-to-first-share after publish
+- % who unpublish within 10 minutes (regret signal)
+- Support contacts tagged “can’t find publish / not live”
+
+---
+
+## Recommendation
+
+**Ship Alternative A** as Launch Centre default; keep handoff API; demote legacy full celebrate (C) to first-publish optional. Document in implementation strategy `21`.

--- a/docs/design/vendor-workspace-v2/21-publishing-implementation-strategy.md
+++ b/docs/design/vendor-workspace-v2/21-publishing-implementation-strategy.md
@@ -1,0 +1,228 @@
+# Vendor Workspace v2 — Publishing Implementation Strategy
+
+**Status:** Implementation readiness (Sprint 3B) — documentation only  
+**Date:** 2026-07-25  
+**Do not implement until Product Owner review of docs `15`–`20`.**  
+**Frozen:** Mission Control · Workspace Foundation chrome contracts  
+**No DDR acceptance in this sprint.**
+
+---
+
+## 1. Strategy summary
+
+Build **Launch Centre** as a presentation refactor of the existing Publishing section — not a new app, route family, or eligibility engine.
+
+```text
+KEEP     PublishEligibilityEvaluator · EventReadinessService · Facade
+KEEP     EventStudioPublishController · setNodePublishedState
+KEEP     resolveAuthoritativePrimaryCta (extend carefully for Past)
+KEEP     buildPublishSuccessHandoff · shell AJAX publish
+CHANGE   EventStudioSectionRenderer::buildPublishingHub composition
+CHANGE   Twig/SCSS presentation for Launch Centre bands
+CHANGE   Shell JS feedback/success rendering toward Alternative A
+AVOID    New publish architecture · new readiness calculator · MC redesign
+```
+
+---
+
+## 2. Reuse map
+
+| Need | Reuse |
+| --- | --- |
+| Eligibility | `myeventlane_event_studio.publish_eligibility` |
+| Readiness checklist data | `EventReadinessService` / `EventReadinessFacade` |
+| Publish mutation | `EventStudioPublishController` + `EventStudioSaveService::setNodePublishedState` |
+| Hero CTA | `EventWorkspaceOverviewBuilder::resolveAuthoritativePrimaryCta` |
+| Success URLs/copy seed | `EventStudioPreprocess::buildPublishSuccessHandoff` |
+| Section plug-in | `PublishingSection` (keep id `publishing`) |
+| Buttons / tokens | Vendor theme `.mel-btn`, existing Studio SCSS |
+| Access | `EventStudioAccess` — no weakening |
+
+---
+
+## 3. Files likely to change (implementation sprint)
+
+### PHP (presentation / light orchestration)
+
+| File | Change type |
+| --- | --- |
+| `.../Service/EventStudioSectionRenderer.php` | Rebuild `buildPublishingHub()` into Launch Centre bands; stop embedding full `EventSettingsForm` by default |
+| `.../Service/EventWorkspaceOverviewBuilder.php` | Optional Past CTA extension in `resolveAuthoritativePrimaryCta` **only if PO approves** |
+| `.../EventStudioPreprocess.php` | Enrich handoff copy for Alternative A (people can…); keep structure |
+| `.../Form/EventSettingsForm.php` | Extract slim visibility fragment **or** link out — do not delete form |
+| `.../Controller/EventStudioController.php` | Pass Launch Centre presentation vars if needed (keep thin) |
+
+### Twig
+
+| File | Change type |
+| --- | --- |
+| New theme suggestion e.g. `mel-event-studio-launch-centre.html.twig` **or** structured render arrays only | Prefer one dedicated template for clarity |
+| `mel-event-studio-workspace.html.twig` | Slot success region if required |
+| `mel-publish-boost-cta.html.twig` | Demote placement / conditional |
+
+### JS / CSS
+
+| File | Change type |
+| --- | --- |
+| `js/mel-event-studio-shell.js` | Success feedback → Alternative A; ensure focus + aria-live; **remove/ignore card Publish as primary** |
+| Vendor / Studio SCSS (`_mel-builder.scss`, workspace publishing) | Launch Centre layout; 390 sticky already in chrome |
+
+### Tests
+
+| File | Change type |
+| --- | --- |
+| `PublishEligibilityEvaluatorTest` | Unchanged unless gates change (should not) |
+| `EventStudioWorkspacePresentationContractTest` | Assert Launch Centre props / CTA |
+| `EventWorkspaceOverviewNextActionTest` | If CTA resolver extended |
+| New unit test for hub builder presentation | Checklist bands without Settings dump |
+
+---
+
+## 4. Files that must NOT change
+
+| File / area | Why |
+| --- | --- |
+| Mission Control template/SCSS contracts (Phase 2 frozen) | Explicit freeze |
+| `PublishEligibilityEvaluator` rule order | Source of enforcement truth |
+| `VendorPublishRequirementsGate` / `PaidPublishStripeGate` logic | Payments/safety — no drive-by |
+| Checkout / Commerce payment gateways | Out of scope |
+| Legacy wizard validators (unless deleting dead code in later cleanup) | Separate chore |
+| DDR documents / accepting DDRs | PO process |
+| Public theme event cards / heroes | Unrelated |
+
+---
+
+## 5. Proposed implementation slices (post-PO)
+
+| Slice | Scope | Risk |
+| --- | --- | --- |
+| **3C.1** | Launch Centre layout: Ready / checklist / control hint / aftercare — data from existing readiness | Theme/UX |
+| **3C.2** | Remove dual Publish: card becomes status; Hero only | CTA regression — test matrix |
+| **3C.3** | Success Alternative A wiring (handoff + focus + a11y) | Low |
+| **3C.4** | Visibility progressive disclosure or Settings link | Form split care |
+| **3C.5** | Unpublish confirm UX | Destructive — careful |
+| **3C.6** | Past CTA (optional) | Requires date logic confirmation |
+
+Do not start 3C until PO marks design READY.
+
+---
+
+## 6. Cache implications
+
+| Item | Notes |
+| --- | --- |
+| Workspace `#cache` | Keep existing contexts (`mel_celebrate`, user, route, permissions) |
+| Publish JSON | Remains uncached |
+| New template | Add cache contexts/tags from event + readiness deps via controllers/builders as today |
+| Avoid | Caching “Ready” without user/vendor context |
+
+---
+
+## 7. AJAX implications
+
+| Keep | Careful |
+| --- | --- |
+| POST publish/unpublish contract | Payload shape consumed by shell JS |
+| Mission Control refresh after publish | Do not alter MC IA while refreshing |
+| `primary_cta` in topbar | Must stay authoritative |
+| Handoff on success | Extend fields additively; don’t rename without JS update |
+
+**Contract test:** after publish 200, Hero key `share`, Launch Centre shows live narrative, MC payload non-null (existing degraded fallbacks remain).
+
+---
+
+## 8. Testing strategy
+
+### Automated
+
+- Unit: eligibility unchanged golden cases
+- Unit: hub builder — Ready vs Needs attention band props
+- Unit: CTA resolver matrix (include Past if implemented)
+- Contract: shell selectors still find `[data-mel-publish-action]` once
+- PHPUnit existing Studio workspace state matrix updates
+
+### Manual / browser
+
+| Case | Viewport |
+| --- | --- |
+| Draft → checklist blockers → Continue setup | 390, desktop |
+| Ready → single Publish in Hero → success A | 390, 768, desktop |
+| Live → Share primary; Boost secondary | desktop |
+| Failure 422 readiness | desktop |
+| Failure 409 stale / autosave | desktop |
+| Unpublish confirm → draft | desktop |
+| Keyboard-only publish + focus to success | desktop |
+| `prefers-reduced-motion` | desktop |
+| Paid Stripe blocked | desktop |
+
+### Regression guards
+
+- Mission Control Home unchanged visually (screenshot / checklist from Phase A.5)
+- No publish without eligibility (attempt via UI + confirm 422)
+- Vendor isolation: other vendor’s event 403
+
+---
+
+## 9. Config / deploy
+
+- Expect **no** `config/sync` changes for Launch Centre presentation.
+- If visibility field widgets move, still no config unless form display modes change — verify before cex.
+- Validation commands after implementation:
+
+```bash
+ddev drush cr
+ddev drush config:status
+composer validate
+npm run mel:lint
+npm run mel:build
+# targeted phpunit for event_studio unit tests
+```
+
+---
+
+## 10. Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Splitting Settings form breaks passcode validation | Keep `EventSettingsForm` intact on Settings route; Launch only slim/link |
+| Removing card Publish confuses users who learned card path | Header hint + sticky mobile CTA |
+| Past CTA wrong date timezone | Confirm `field_event_end` handling from existing presentation helpers before coding |
+| Success panel fights Boost card | Explicit demotion in Twig |
+| Scope creep into MC | Freeze enforcement in PR checklist |
+| Legacy redirects still → Settings | Optional follow-up: redirect publish legacy → Launch Centre |
+
+---
+
+## 11. Outstanding questions (blockers for some slices)
+
+1. Visibility on Launch Centre vs Settings-only? (affects 3C.4)
+2. Past/Closed CTA in resolver now or later? (affects 3C.6)
+3. First-publish celebrate C vs always A? (affects 3C.3)
+4. Unpublish modal vs disclose? (affects 3C.5)
+
+Non-blocking for 3C.1–3C.2 if PO accepts defaults in `16` recommendation seed.
+
+---
+
+## 12. Definition of done (implementation sprint)
+
+- [ ] Launch Centre answers “Am I ready to launch?” in ≤5 seconds
+- [ ] Exactly one primary Publish affordance when Ready
+- [ ] Eligibility/readiness ownership unchanged
+- [ ] Success Alternative A shipped with a11y focus/live region
+- [ ] Mission Control visually unchanged
+- [ ] Tests + mel:lint/build + drush cr green
+- [ ] PDS references on PR; no DDR silently accepted
+
+---
+
+## Recommendation
+
+**READY FOR IMPLEMENTATION** of slices **3C.1–3C.3** after PO sign-off on docs `15`–`20`, assuming defaults:
+
+- Visibility secondary
+- Scheduled publish deferred
+- Success Alternative A
+- Past CTA deferred to 3C.6
+
+**ADDITIONAL DISCOVERY REQUIRED** only if PO rejects defaults on visibility/Past/unpublish — then spike those before coding.

--- a/docs/design/vendor-workspace-v2/22-sprint-3c1-launch-centre-implementation.md
+++ b/docs/design/vendor-workspace-v2/22-sprint-3c1-launch-centre-implementation.md
@@ -1,0 +1,38 @@
+# Sprint 3C.1 — Launch Centre Composition (implementation note)
+
+**Status:** Implemented · Product Owner approved (2026-07-25) — composition **Frozen**  
+**Date:** 2026-07-25  
+**Branch:** `feature/vendor-workspace-foundation`  
+**Scope:** Publishing section composition only  
+**Catalogue:** [23-vendor-component-catalogue.md](23-vendor-component-catalogue.md) — Launch Centre 🔒 Frozen (composition)  
+
+## What changed
+
+Replaced the Publishing Hub (checklist markup + full `EventSettingsForm` including publish card) with the approved **Launch Centre** hierarchy:
+
+1. Ready to Launch (narrative + Hero hint)  
+2. Launch checklist (expand when blocked, collapse when ready)  
+3. Who can find this? (progressive disclosure + slim visibility form)  
+4. After you publish (informational only)
+
+## Explicit non-goals (deferred)
+
+- Launch Success (3C.2)  
+- Failure / retry / toast UX  
+- Dual-Publish removal beyond removing the card from this section (Hero unchanged)  
+- Mission Control / Hero redesign  
+- Eligibility / readiness rule changes  
+
+## Architecture confirmation
+
+| Concern | Still owned by |
+| --- | --- |
+| Eligibility | `PublishEligibilityEvaluator` |
+| Mutation | `EventStudioSaveService::setNodePublishedState` |
+| Readiness data | `EventReadinessService` |
+| Hero CTA | `resolveAuthoritativePrimaryCta` |
+| Publish UI | Hero only |
+
+## Files
+
+See git status / final report.

--- a/docs/design/vendor-workspace-v2/23-vendor-component-catalogue.md
+++ b/docs/design/vendor-workspace-v2/23-vendor-component-catalogue.md
@@ -1,0 +1,91 @@
+# Vendor Workspace — Component Catalogue
+
+**Status:** Living catalogue (Product Owner endorsed 2026-07-25)  
+**Authority:** Status & freeze board for Event Workspace / Vendor Studio surfaces  
+**Not:** A style guide, token book, or second PDS component library  
+
+**Contracts live in:** [PDS 05 — Component Library](../vendor-studio/05-component-library.md)  
+**This document answers:** *May I change this component?*
+
+---
+
+## How to use
+
+| Status | Meaning | Rule |
+| --- | --- | --- |
+| 🔒 **Frozen** | PO-approved; composition/contracts locked | Do not redesign. Bugfixes and a11y-only only. Unfreeze requires PO + note here. |
+| 🔒 **Reusable** | Stable pattern; extend, don’t fork | Reuse existing Twig/SCSS/VM contracts. New variants need a catalogue row. |
+| 🚧 **In progress** | Active sprint slice | Implement only against approved design docs for that slice. |
+| 🚧 **Next** | Queued; design exists or is imminent | Do not invent ad-hoc replacements ahead of the sprint. |
+| 🧪 **Experimental** | Local / unapproved | Must not ship to organisers without catalogue promotion. |
+| ⛔ **Deprecated** | Do not use on new surfaces | Prefer listed replacement. |
+
+**Precedence:** Catalogue freeze **overrides** opportunistic polish in PRs. PDS philosophy still applies; this board is the freeze ledger for Workspace v2.
+
+---
+
+## Catalogue
+
+| Component | Status | Surface / owner | Design refs | Runtime seed |
+| --- | --- | --- | --- | --- |
+| **Hero** (event chrome + primary CTA) | 🔒 Frozen | Workspace shell | `09` · `03` · PDS 05 §1 | `mel-event-studio-topbar` · `resolveAuthoritativePrimaryCta` |
+| **Mission Control** | 🔒 Frozen | Overview / chrome card | `10` · `04` · Phase 2B | `mel-event-studio-mission-control` · `EventWorkspaceOverviewBuilder` |
+| **Launch Centre** | 🔒 Frozen (composition) | Publishing section | `18` · `22` · Sprint 3C.1 | `mel-event-studio-launch-centre` · `buildPublishingHub` |
+| **Launch Success** | 🚧 In progress | Post-publish handoff | `20` Alternative A · Sprint 3C.2 | `buildPublishSuccessHandoff` · shell feedback (extend) |
+| **Launch checklist** | 🔒 Reusable | Launch Centre (and aligned lists) | `18` · `17` | Launch Centre checklist band; readiness items from facade/service |
+| **Workspace section header** | 🔒 Reusable | Section chrome | PDS 05 · `09` | `mel_event_studio_section` / workspace section wrappers |
+| **Empty state** | 🔒 Reusable | Any section | PDS 05 · empty-state builder | `EventStudioEmptyStateBuilder` |
+| **Success panel** | 🚧 Next | Inline success (non-Launch) | `19` · `20` | Prefer Launch Success A pattern; generalise after 3C.2 |
+| **Error panel** | 🚧 Next | Inline failure / recovery | `19` | Publish AJAX codes exist; dedicated panel composition deferred |
+| **Hero publish hint** | 🔒 Reusable | Launch Centre / MC publish mode | `18` · MC hint pattern | “Use Publish… in the header” — never a second Publish button |
+| **Visibility disclosure** | 🔒 Reusable | Launch Centre band | `18` · 3C.1 | `EventLaunchVisibilityForm` in `<details>` |
+| **After you publish** (info band) | 🔒 Reusable | Launch Centre | `18` · 3C.1 | Informational only — not Launch Success |
+| **Primary CTA (authoritative)** | 🔒 Frozen (resolver) | Hero | `17` | `resolveAuthoritativePrimaryCta` — single owner |
+| **Readiness / eligibility** | 🔒 Frozen (services) | Backend truth | `15` | `EventReadinessService` · `PublishEligibilityEvaluator` — no parallel calculators |
+
+---
+
+## Freeze ledger (Workspace v2)
+
+| When | What | Decision |
+| --- | --- | --- |
+| Phase A / Foundation | Shell + Hero CTA ownership | Frozen |
+| Phase 2B | Mission Control compact progressive disclosure | Frozen |
+| Sprint 3C.1 | Launch Centre composition | Frozen (composition) |
+| Sprint 3C.2 (approved) | Launch Success Alternative A | In progress → freeze on PO accept |
+
+---
+
+## Rules for new components
+
+1. **Search this catalogue** before adding a Twig/SCSS pattern.  
+2. If a frozen component almost fits — **extend presentation props**, do not fork.  
+3. New organiser-facing chrome needs a **catalogue row** in the same PR as the first implementation.  
+4. Status promotions (🚧 → 🔒) require **Product Owner** acknowledgement (chat or review note).  
+5. Do not invent a parallel “success toast system” while Success Panel is 🚧 Next — follow `19` / `20`.
+
+---
+
+## Explicit non-goals of this catalogue
+
+- Colour tokens, type scales, or button recipes → PDS `11` / `05`  
+- Full Drupal field mapping → `05-drupal-mapping.md` / PDS `09`  
+- Accepting DDRs or unfreezing PDS 1.0 → ADR/DDR process  
+
+---
+
+## Next actions
+
+| Action | Owner |
+| --- | --- |
+| Implement Sprint **3C.2** Launch Success (Alternative A only) | Engineering (when PO says start) |
+| On 3C.2 accept → set Launch Success to 🔒 Frozen | Catalogue update in same PR |
+| After 3C.2 → promote Success Panel / Error Panel design if still needed | Product + design |
+
+---
+
+## Related
+
+- [20-launch-success-experience.md](20-launch-success-experience.md) — Alternative A (approved for 3C.2)  
+- [22-sprint-3c1-launch-centre-implementation.md](22-sprint-3c1-launch-centre-implementation.md)  
+- [PDS 05 Component Library](../vendor-studio/05-component-library.md) — behavioural contracts  

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -6824,3 +6824,244 @@ body.mel-vendor:has(.mel-event-studio--workspace) .mel-vendor-console.mel-vendor
     flex: 1 1 auto;
   }
 }
+
+/* -------------------------------------------------------------------------
+ * Launch Centre (Publishing section) — Sprint 3C.1 composition only.
+ * Hero owns Publish. No competing Publish controls in this surface.
+ * ---------------------------------------------------------------------- */
+
+.mel-launch-centre {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  max-width: 42rem;
+  margin: 0;
+  padding: 0 0 1.5rem;
+}
+
+.mel-launch-centre__eyebrow {
+  margin: 0 0 0.35rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--mel-text-muted, #5c5a66);
+}
+
+.mel-launch-centre__headline {
+  margin: 0 0 0.5rem;
+  font-size: 1.5rem;
+  line-height: 1.25;
+  font-weight: 700;
+  color: var(--mel-text, #1c1a22);
+}
+
+.mel-launch-centre__explanation,
+.mel-launch-centre__hero-hint {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: var(--mel-text, #1c1a22);
+}
+
+.mel-launch-centre__hero-hint {
+  margin-top: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  background: var(--mel-surface-soft, #f6f4fa);
+  border: 1px solid var(--mel-border-soft, #e6e2ef);
+  font-weight: 560;
+}
+
+.mel-launch-centre__checklist,
+.mel-launch-centre__visibility {
+  border: 1px solid var(--mel-border-soft, #e6e2ef);
+  border-radius: 0.75rem;
+  background: var(--mel-surface, #fff);
+  padding: 0;
+}
+
+.mel-launch-centre__checklist-summary,
+.mel-launch-centre__visibility-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem 1rem;
+  list-style: none;
+  cursor: pointer;
+  padding: 0.875rem 1rem;
+  min-height: 44px;
+  font-weight: 600;
+}
+
+.mel-launch-centre__checklist-summary::-webkit-details-marker,
+.mel-launch-centre__visibility-summary::-webkit-details-marker {
+  display: none;
+}
+
+.mel-launch-centre__checklist-summary:focus-visible,
+.mel-launch-centre__visibility-summary:focus-visible,
+.mel-launch-centre__fix:focus-visible,
+.mel-launch-centre__settings-link a:focus-visible {
+  outline: 2px solid var(--mel-focus, #5b4db8);
+  outline-offset: 2px;
+}
+
+.mel-launch-centre__checklist-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+  color: var(--mel-text-muted, #5c5a66);
+  font-size: 0.875rem;
+}
+
+.mel-launch-centre__checklist-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.5rem;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  background: var(--mel-surface-soft, #f6f4fa);
+  font-variant-numeric: tabular-nums;
+}
+
+.mel-launch-centre__list {
+  list-style: none;
+  margin: 0;
+  padding: 0 1rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.mel-launch-centre__item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.75rem;
+  padding: 0.5rem 0;
+  border-top: 1px solid var(--mel-border-soft, #eeeaf5);
+  min-height: 44px;
+}
+
+.mel-launch-centre__item:first-child {
+  border-top: 0;
+}
+
+.mel-launch-centre__mark {
+  flex: 0 0 1.25rem;
+  text-align: center;
+  font-weight: 700;
+}
+
+.mel-launch-centre__item--attention .mel-launch-centre__mark,
+.mel-launch-centre__item--attention .mel-launch-centre__item-label {
+  color: var(--mel-attention, #8a4b00);
+}
+
+.mel-launch-centre__item--success .mel-launch-centre__mark {
+  color: var(--mel-success, #1f6b3a);
+}
+
+.mel-launch-centre__item-label {
+  flex: 1 1 12rem;
+  line-height: 1.4;
+}
+
+.mel-launch-centre__fix {
+  flex: 0 0 auto;
+  min-height: 44px;
+  min-width: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 0.85rem;
+  text-decoration: none;
+}
+
+.mel-launch-centre__visibility-current {
+  font-weight: 500;
+  color: var(--mel-text-muted, #5c5a66);
+  font-size: 0.875rem;
+}
+
+.mel-launch-centre__visibility-body {
+  padding: 0 1rem 1rem;
+}
+
+.mel-launch-centre__visibility-body .mel-visibility-section {
+  margin-top: 0.25rem;
+}
+
+.mel-launch-centre__settings-link {
+  margin: 0.75rem 0 0;
+  font-size: 0.9375rem;
+}
+
+.mel-launch-centre__settings-link a {
+  color: var(--mel-link, #3d34a0);
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.mel-launch-centre__after {
+  padding: 1rem 1.1rem;
+  border-radius: 0.75rem;
+  background: var(--mel-surface-soft, #f6f4fa);
+  border: 1px solid var(--mel-border-soft, #e6e2ef);
+}
+
+.mel-launch-centre__after-title {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.mel-launch-centre__after-list {
+  margin: 0;
+  padding-left: 1.15rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  line-height: 1.45;
+}
+
+.mel-launch-centre--ready .mel-launch-centre__hero-hint {
+  border-color: var(--mel-success-border, #b7dfc4);
+  background: var(--mel-success-soft, #eef8f1);
+}
+
+.mel-launch-centre--live .mel-launch-centre__hero-hint {
+  border-color: var(--mel-border-soft, #e6e2ef);
+}
+
+@media (max-width: 47.99rem) {
+  .mel-launch-centre {
+    max-width: none;
+    gap: 1rem;
+  }
+
+  .mel-launch-centre__headline {
+    font-size: 1.35rem;
+  }
+
+  .mel-launch-centre__item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .mel-launch-centre__fix {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mel-launch-centre * {
+    transition: none !important;
+    animation: none !important;
+  }
+}

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
@@ -312,6 +312,9 @@
   /**
    * Presentation-only deep links — mirrors EventStudioSectionRenderer::resolveLaunchFixLink.
    *
+   * Studio section URLs inherit language prefixes from publishUrl. Vendor console
+   * paths must do the same — never hardcode bare /vendor/... on multilingual sites.
+   *
    * @return {{fix_url: ?string, fix_label: ?string}}
    */
   function resolveLaunchFixLinkClient(label) {
@@ -323,11 +326,11 @@
     let path = '';
     let fixLabel = Drupal.t('Fix → Details');
     if (lower.includes('stripe') || lower.includes('payment') || lower.includes('get paid')) {
-      path = '/vendor/payments';
+      path = vendorConsolePathFromPublishUrl(publishUrl, 'payments');
       fixLabel = Drupal.t('Connect Stripe');
     }
     else if (lower.includes('organiser') || lower.includes('terms') || lower.includes('signed in') || lower.includes('profile')) {
-      path = '/vendor/settings';
+      path = vendorConsolePathFromPublishUrl(publishUrl, 'settings');
       fixLabel = Drupal.t('Open account');
     }
     else if (!studioBase) {
@@ -357,6 +360,29 @@
       fix_url: path,
       fix_label: fixLabel,
     };
+  }
+
+  /**
+   * Builds /vendor/{segment} with the same language prefix as publishUrl.
+   *
+   * publishUrl comes from Url::fromRoute() and already includes path prefixes
+   * (e.g. /en/vendor/events/12/studio/publish). Bare /vendor/payments would skip them.
+   */
+  function vendorConsolePathFromPublishUrl(publishUrl, segment) {
+    const safeSegment = String(segment || '').replace(/^\/+|\/+$/g, '');
+    const url = String(publishUrl || '');
+    const vendorMatch = url.match(/^(.*?)\/vendor\/events\//);
+    if (vendorMatch) {
+      return `${vendorMatch[1]}/vendor/${safeSegment}`;
+    }
+    const pathPrefix = (typeof drupalSettings !== 'undefined'
+      && drupalSettings.path
+      && typeof drupalSettings.path.pathPrefix === 'string')
+      ? drupalSettings.path.pathPrefix.replace(/^\/+|\/+$/g, '')
+      : '';
+    return pathPrefix
+      ? `/${pathPrefix}/vendor/${safeSegment}`
+      : `/vendor/${safeSegment}`;
   }
 
   function isLaunchScheduleFixLabelClient(lower) {

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
@@ -247,6 +247,8 @@
    * Rebuilds checklist rows from payload items, or from readiness when items are omitted.
    *
    * Prevents “All required items complete” while stale blocker rows remain.
+   * When rebuilding from readiness, preserves Fix links from the current DOM and
+   * resolves missing ones client-side so blockers do not lose “Fix → …” CTAs.
    */
   function syncLaunchChecklistList(list, checklist, readiness, ready) {
     if (Array.isArray(checklist.items)) {
@@ -257,8 +259,9 @@
       return;
     }
     if (readiness) {
+      const preservedFixLinks = collectLaunchFixLinksFromList(list);
       list.replaceChildren();
-      buildLaunchChecklistItemsFromReadiness(readiness).forEach((item) => {
+      buildLaunchChecklistItemsFromReadiness(readiness, preservedFixLinks).forEach((item) => {
         list.appendChild(buildLaunchChecklistItem(item));
       });
       return;
@@ -271,22 +274,138 @@
     }
   }
 
-  function buildLaunchChecklistItemsFromReadiness(readiness) {
+  function normalizeLaunchChecklistLabel(label) {
+    return String(label || '').replace(/\.$/, '').trim().toLowerCase();
+  }
+
+  /**
+   * Snapshots Fix links already rendered in Launch Centre before a readiness rebuild.
+   *
+   * @return {Object<string, {fix_url: string, fix_label: ?string}>}
+   */
+  function collectLaunchFixLinksFromList(list) {
+    const map = {};
+    list.querySelectorAll('.mel-launch-centre__item').forEach((li) => {
+      const labelEl = li.querySelector('.mel-launch-centre__item-label');
+      const fix = li.querySelector('a.mel-launch-centre__fix');
+      if (!labelEl || !fix) {
+        return;
+      }
+      const href = fix.getAttribute('href');
+      if (!href) {
+        return;
+      }
+      const clone = labelEl.cloneNode(true);
+      clone.querySelectorAll('.visually-hidden').forEach((el) => el.remove());
+      const key = normalizeLaunchChecklistLabel(clone.textContent);
+      if (!key) {
+        return;
+      }
+      map[key] = {
+        fix_url: href,
+        fix_label: (fix.textContent || '').trim() || null,
+      };
+    });
+    return map;
+  }
+
+  /**
+   * Presentation-only deep links — mirrors EventStudioSectionRenderer::resolveLaunchFixLink.
+   *
+   * @return {{fix_url: ?string, fix_label: ?string}}
+   */
+  function resolveLaunchFixLinkClient(label) {
+    const lower = String(label || '').toLowerCase();
+    const publishUrl = String(studioSettings().publishUrl || '');
+    const studioMatch = publishUrl.match(/^(.*\/studio)\/publish\/?(\?.*)?$/);
+    const studioBase = studioMatch ? studioMatch[1] : '';
+
+    let path = '';
+    let fixLabel = Drupal.t('Fix → Details');
+    if (lower.includes('stripe') || lower.includes('payment') || lower.includes('get paid')) {
+      path = '/vendor/payments';
+      fixLabel = Drupal.t('Connect Stripe');
+    }
+    else if (lower.includes('organiser') || lower.includes('terms') || lower.includes('signed in') || lower.includes('profile')) {
+      path = '/vendor/settings';
+      fixLabel = Drupal.t('Open account');
+    }
+    else if (!studioBase) {
+      return { fix_url: null, fix_label: null };
+    }
+    else if (lower.includes('ticket') || lower.includes('capacity')) {
+      path = `${studioBase}/tickets`;
+      fixLabel = Drupal.t('Fix → Tickets');
+    }
+    else if (lower.includes('cover') || lower.includes('image') || lower.includes('branding')) {
+      path = `${studioBase}/images`;
+      fixLabel = Drupal.t('Fix → Images');
+    }
+    else if (isLaunchScheduleFixLabelClient(lower)) {
+      path = `${studioBase}/schedule`;
+      fixLabel = Drupal.t('Fix → Schedule');
+    }
+    else if (lower.includes('question')) {
+      path = `${studioBase}/questions`;
+      fixLabel = Drupal.t('Fix → Questions');
+    }
+    else {
+      path = `${studioBase}/details`;
+    }
+
+    return {
+      fix_url: path,
+      fix_label: fixLabel,
+    };
+  }
+
+  function isLaunchScheduleFixLabelClient(lower) {
+    if (lower.includes('schedule')) {
+      return true;
+    }
+    if (lower.includes('start date') || lower.includes('end date')) {
+      return true;
+    }
+    return /\bdates?\b/.test(lower);
+  }
+
+  function buildLaunchChecklistItemsFromReadiness(readiness, preservedFixLinks) {
     const items = [];
     const trimDot = (label) => String(label || '').replace(/\.$/, '');
+    const preserved = preservedFixLinks || {};
+    const attachFix = (item) => {
+      if (item.complete) {
+        return item;
+      }
+      const key = normalizeLaunchChecklistLabel(item.label);
+      if (preserved[key] && preserved[key].fix_url) {
+        return {
+          ...item,
+          fix_url: preserved[key].fix_url,
+          fix_label: preserved[key].fix_label || item.fix_label || null,
+        };
+      }
+      const resolved = resolveLaunchFixLinkClient(item.label);
+      return {
+        ...item,
+        fix_url: resolved.fix_url,
+        fix_label: resolved.fix_label,
+      };
+    };
+
     (Array.isArray(readiness.errors) ? readiness.errors : []).forEach((label) => {
-      items.push({
+      items.push(attachFix({
         label: trimDot(label),
         complete: false,
         tone: 'attention',
-      });
+      }));
     });
     (Array.isArray(readiness.warnings) ? readiness.warnings : []).forEach((label) => {
-      items.push({
+      items.push(attachFix({
         label: trimDot(label),
         complete: false,
         tone: 'warning',
-      });
+      }));
     });
     (Array.isArray(readiness.completed) ? readiness.completed : []).forEach((label) => {
       items.push({
@@ -296,11 +415,11 @@
       });
     });
     (Array.isArray(readiness.recommendations) ? readiness.recommendations : []).forEach((label) => {
-      items.push({
+      items.push(attachFix({
         label: trimDot(label),
         complete: false,
         tone: 'idea',
-      });
+      }));
     });
     return items;
   }

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
@@ -170,6 +170,126 @@
     });
   }
 
+  /**
+   * Refreshes Launch Centre from publish AJAX payload (no second Publish control).
+   */
+  function updateLaunchCentre(shell, launch) {
+    const root = shell.querySelector('[data-mel-launch-centre]');
+    if (!root || !launch) {
+      return;
+    }
+    const state = typeof launch.state === 'string' ? launch.state : 'needs_attention';
+    const stateClass = state.replace(/_/g, '-');
+    root.className = `mel-launch-centre mel-launch-centre--${stateClass}`;
+    root.dataset.melLaunchState = state;
+    root.dataset.melLaunchReady = launch.ready ? '1' : '0';
+    root.dataset.melLaunchPublished = launch.published ? '1' : '0';
+
+    setText(root, '[data-mel-launch-eyebrow]', launch.eyebrow || '');
+    setText(root, '[data-mel-launch-headline]', launch.headline || '');
+    const explanation = root.querySelector('[data-mel-launch-explanation]');
+    if (explanation) {
+      explanation.textContent = launch.explanation || '';
+      explanation.hidden = !launch.explanation;
+    }
+    const heroHint = root.querySelector('[data-mel-launch-hero-hint]');
+    if (heroHint) {
+      heroHint.textContent = launch.hero_hint || '';
+      heroHint.hidden = !launch.hero_hint;
+    }
+
+    const checklist = launch.checklist || {};
+    const details = root.querySelector('[data-mel-launch-checklist]');
+    if (details) {
+      details.open = !!checklist.open;
+    }
+    setText(root, '[data-mel-launch-checklist-summary]', checklist.summary || '');
+    const countEl = root.querySelector('[data-mel-launch-checklist-count]');
+    if (countEl) {
+      const total = Number(checklist.total_count) || 0;
+      if (total > 0) {
+        countEl.hidden = false;
+        countEl.textContent = `${Number(checklist.complete_count) || 0}/${total}`;
+      }
+      else {
+        countEl.hidden = true;
+        countEl.textContent = '';
+      }
+    }
+
+    const list = root.querySelector('[data-mel-launch-checklist-list]');
+    if (list && Array.isArray(checklist.items)) {
+      list.replaceChildren();
+      checklist.items.forEach((item) => {
+        list.appendChild(buildLaunchChecklistItem(item));
+      });
+    }
+
+    const visibilityCurrent = launch.visibility && launch.visibility.current_label;
+    if (visibilityCurrent) {
+      setText(root, '[data-mel-launch-visibility-current]', visibilityCurrent);
+    }
+
+    const after = launch.after || {};
+    const afterRoot = root.querySelector('[data-mel-launch-after]');
+    if (afterRoot) {
+      const afterItems = Array.isArray(after.items) ? after.items : [];
+      afterRoot.hidden = afterItems.length === 0;
+      setText(afterRoot, '[data-mel-launch-after-title]', after.title || '');
+      const afterList = afterRoot.querySelector('[data-mel-launch-after-list]');
+      if (afterList) {
+        afterList.replaceChildren();
+        afterItems.forEach((line) => {
+          const li = document.createElement('li');
+          li.textContent = String(line);
+          afterList.appendChild(li);
+        });
+      }
+    }
+  }
+
+  function buildLaunchChecklistItem(item) {
+    const tone = (item && item.tone) ? String(item.tone) : 'success';
+    const complete = !!(item && item.complete);
+    const li = document.createElement('li');
+    li.className = `mel-launch-centre__item mel-launch-centre__item--${tone.replace(/_/g, '-')}${complete ? ' is-complete' : ''}`;
+
+    const mark = document.createElement('span');
+    mark.className = 'mel-launch-centre__mark';
+    mark.setAttribute('aria-hidden', 'true');
+    mark.textContent = complete ? '✓' : (tone === 'attention' ? '○' : '·');
+    li.appendChild(mark);
+
+    const labelWrap = document.createElement('span');
+    labelWrap.className = 'mel-launch-centre__item-label';
+    const sr = document.createElement('span');
+    sr.className = 'visually-hidden';
+    if (complete) {
+      sr.textContent = Drupal.t('Complete:');
+    }
+    else if (tone === 'attention') {
+      sr.textContent = Drupal.t('Needs attention:');
+    }
+    else if (tone === 'warning') {
+      sr.textContent = Drupal.t('Warning:');
+    }
+    else {
+      sr.textContent = Drupal.t('Suggestion:');
+    }
+    labelWrap.appendChild(sr);
+    labelWrap.appendChild(document.createTextNode(` ${item && item.label ? String(item.label) : ''}`));
+    li.appendChild(labelWrap);
+
+    if (!complete && item && item.fix_url) {
+      const fix = document.createElement('a');
+      fix.className = 'mel-launch-centre__fix mel-btn mel-btn--ghost';
+      fix.href = String(item.fix_url);
+      fix.textContent = item.fix_label ? String(item.fix_label) : Drupal.t('Fix');
+      li.appendChild(fix);
+    }
+    return li;
+  }
+
   function updateFormMetadata(shell, result) {
     if (!result) {
       return;
@@ -1144,6 +1264,7 @@
             const result = await response.json().catch(() => ({}));
             updateTopbar(shell, result);
             updateReadiness(shell, result.readiness);
+            updateLaunchCentre(shell, result.launch_centre);
             if (!response.ok || !result.ok) {
               const messages = result.messages && result.messages.length
                 ? result.messages
@@ -1214,6 +1335,7 @@
             const result = await response.json().catch(() => ({}));
             updateTopbar(shell, result);
             updateReadiness(shell, result.readiness);
+            updateLaunchCentre(shell, result.launch_centre);
             if (!response.ok || !result.ok) {
               const messages = result.messages && result.messages.length
                 ? result.messages
@@ -1290,6 +1412,7 @@
             const result = await response.json().catch(() => ({}));
             updateTopbar(shell, result);
             updateReadiness(shell, result.readiness);
+            updateLaunchCentre(shell, result.launch_centre);
             if (!response.ok || !result.ok) {
               const messages = result.messages && result.messages.length
                 ? result.messages

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
@@ -172,18 +172,29 @@
 
   /**
    * Refreshes Launch Centre from publish AJAX payload (no second Publish control).
+   *
+   * When launch_centre is missing, applies a degraded update from published + readiness
+   * so the Publishing section does not stay on the pre-action narrative.
    */
-  function updateLaunchCentre(shell, launch) {
+  function updateLaunchCentre(shell, launch, result) {
     const root = shell.querySelector('[data-mel-launch-centre]');
-    if (!root || !launch) {
+    if (!root) {
       return;
     }
+    if (!launch) {
+      applyDegradedLaunchCentre(root, result || {});
+      return;
+    }
+    root.removeAttribute('data-mel-launch-stale');
     const state = typeof launch.state === 'string' ? launch.state : 'needs_attention';
     const stateClass = state.replace(/_/g, '-');
     root.className = `mel-launch-centre mel-launch-centre--${stateClass}`;
     root.dataset.melLaunchState = state;
     root.dataset.melLaunchReady = launch.ready ? '1' : '0';
     root.dataset.melLaunchPublished = launch.published ? '1' : '0';
+    if (launch.degraded) {
+      root.dataset.melLaunchStale = '1';
+    }
 
     setText(root, '[data-mel-launch-eyebrow]', launch.eyebrow || '');
     setText(root, '[data-mel-launch-headline]', launch.headline || '');
@@ -200,12 +211,14 @@
 
     const checklist = launch.checklist || {};
     const details = root.querySelector('[data-mel-launch-checklist]');
-    if (details) {
+    if (details && checklist.open !== undefined) {
       details.open = !!checklist.open;
     }
-    setText(root, '[data-mel-launch-checklist-summary]', checklist.summary || '');
+    if (checklist.summary) {
+      setText(root, '[data-mel-launch-checklist-summary]', checklist.summary);
+    }
     const countEl = root.querySelector('[data-mel-launch-checklist-count]');
-    if (countEl) {
+    if (countEl && checklist.total_count !== undefined) {
       const total = Number(checklist.total_count) || 0;
       if (total > 0) {
         countEl.hidden = false;
@@ -232,12 +245,14 @@
 
     const after = launch.after || {};
     const afterRoot = root.querySelector('[data-mel-launch-after]');
-    if (afterRoot) {
+    if (afterRoot && (after.title || Array.isArray(after.items))) {
       const afterItems = Array.isArray(after.items) ? after.items : [];
       afterRoot.hidden = afterItems.length === 0;
-      setText(afterRoot, '[data-mel-launch-after-title]', after.title || '');
+      if (after.title) {
+        setText(afterRoot, '[data-mel-launch-after-title]', after.title);
+      }
       const afterList = afterRoot.querySelector('[data-mel-launch-after-list]');
-      if (afterList) {
+      if (afterList && Array.isArray(after.items)) {
         afterList.replaceChildren();
         afterItems.forEach((line) => {
           const li = document.createElement('li');
@@ -245,6 +260,58 @@
           afterList.appendChild(li);
         });
       }
+    }
+  }
+
+  /**
+   * Last-resort Launch Centre sync when the server omitted launch_centre.
+   */
+  function applyDegradedLaunchCentre(root, result) {
+    const published = !!result.published;
+    const ready = !!(result.readiness && result.readiness.ready);
+    const state = !ready ? 'needs_attention' : (published ? 'live' : 'ready');
+    const stateClass = state.replace(/_/g, '-');
+    root.className = `mel-launch-centre mel-launch-centre--${stateClass}`;
+    root.dataset.melLaunchState = state;
+    root.dataset.melLaunchReady = ready ? '1' : '0';
+    root.dataset.melLaunchPublished = published ? '1' : '0';
+    root.dataset.melLaunchStale = '1';
+
+    const eyebrow = !ready
+      ? Drupal.t('Needs attention')
+      : (published ? Drupal.t('Your event is live') : Drupal.t('Ready to launch'));
+    const headline = !ready
+      ? (published
+        ? Drupal.t('Your event is live — a few things need attention')
+        : Drupal.t('A few things left before launching'))
+      : (published ? Drupal.t('Your event is live') : Drupal.t('Ready to launch'));
+    const heroHint = !ready
+      ? (published
+        ? Drupal.t('Continue setup from the header to fix what needs attention.')
+        : Drupal.t('Publish is unavailable until the checklist is clear. Continue setup from the header.'))
+      : (published
+        ? Drupal.t('Use Share event in the header to spread the word.')
+        : Drupal.t('Use Publish event in the header when you are ready.'));
+
+    setText(root, '[data-mel-launch-eyebrow]', eyebrow);
+    setText(root, '[data-mel-launch-headline]', headline);
+    const explanation = root.querySelector('[data-mel-launch-explanation]');
+    if (explanation) {
+      explanation.textContent = published && ready
+        ? Drupal.t('People can discover your event and RSVP or buy tickets according to your setup. Share from the header when you are ready.')
+        : (!ready
+          ? Drupal.t('Finish the checklist below. We never block without explaining why.')
+          : Drupal.t("You're ready to go live. Guests will be able to discover this event and RSVP or buy tickets according to your setup."));
+      explanation.hidden = false;
+    }
+    const heroHintEl = root.querySelector('[data-mel-launch-hero-hint]');
+    if (heroHintEl) {
+      heroHintEl.textContent = heroHint;
+      heroHintEl.hidden = false;
+    }
+    const details = root.querySelector('[data-mel-launch-checklist]');
+    if (details) {
+      details.open = !ready;
     }
   }
 
@@ -1264,7 +1331,7 @@
             const result = await response.json().catch(() => ({}));
             updateTopbar(shell, result);
             updateReadiness(shell, result.readiness);
-            updateLaunchCentre(shell, result.launch_centre);
+            updateLaunchCentre(shell, result.launch_centre, result);
             if (!response.ok || !result.ok) {
               const messages = result.messages && result.messages.length
                 ? result.messages
@@ -1335,7 +1402,7 @@
             const result = await response.json().catch(() => ({}));
             updateTopbar(shell, result);
             updateReadiness(shell, result.readiness);
-            updateLaunchCentre(shell, result.launch_centre);
+            updateLaunchCentre(shell, result.launch_centre, result);
             if (!response.ok || !result.ok) {
               const messages = result.messages && result.messages.length
                 ? result.messages
@@ -1412,7 +1479,7 @@
             const result = await response.json().catch(() => ({}));
             updateTopbar(shell, result);
             updateReadiness(shell, result.readiness);
-            updateLaunchCentre(shell, result.launch_centre);
+            updateLaunchCentre(shell, result.launch_centre, result);
             if (!response.ok || !result.ok) {
               const messages = result.messages && result.messages.length
                 ? result.messages

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
@@ -231,11 +231,8 @@
     }
 
     const list = root.querySelector('[data-mel-launch-checklist-list]');
-    if (list && Array.isArray(checklist.items)) {
-      list.replaceChildren();
-      checklist.items.forEach((item) => {
-        list.appendChild(buildLaunchChecklistItem(item));
-      });
+    if (list) {
+      syncLaunchChecklistList(list, checklist, result && result.readiness, !!launch.ready);
     }
 
     const visibilityCurrent = launch.visibility && launch.visibility.current_label;
@@ -243,23 +240,103 @@
       setText(root, '[data-mel-launch-visibility-current]', visibilityCurrent);
     }
 
-    const after = launch.after || {};
+    syncLaunchAfterBand(root, launch.after || null, !!launch.published);
+  }
+
+  /**
+   * Rebuilds checklist rows from payload items, or from readiness when items are omitted.
+   *
+   * Prevents “All required items complete” while stale blocker rows remain.
+   */
+  function syncLaunchChecklistList(list, checklist, readiness, ready) {
+    if (Array.isArray(checklist.items)) {
+      list.replaceChildren();
+      checklist.items.forEach((item) => {
+        list.appendChild(buildLaunchChecklistItem(item));
+      });
+      return;
+    }
+    if (readiness) {
+      list.replaceChildren();
+      buildLaunchChecklistItemsFromReadiness(readiness).forEach((item) => {
+        list.appendChild(buildLaunchChecklistItem(item));
+      });
+      return;
+    }
+    if (ready) {
+      // Last resort: drop attention blockers so summary cannot contradict the list.
+      list.querySelectorAll('.mel-launch-centre__item--attention').forEach((item) => {
+        item.remove();
+      });
+    }
+  }
+
+  function buildLaunchChecklistItemsFromReadiness(readiness) {
+    const items = [];
+    const trimDot = (label) => String(label || '').replace(/\.$/, '');
+    (Array.isArray(readiness.errors) ? readiness.errors : []).forEach((label) => {
+      items.push({
+        label: trimDot(label),
+        complete: false,
+        tone: 'attention',
+      });
+    });
+    (Array.isArray(readiness.warnings) ? readiness.warnings : []).forEach((label) => {
+      items.push({
+        label: trimDot(label),
+        complete: false,
+        tone: 'warning',
+      });
+    });
+    (Array.isArray(readiness.completed) ? readiness.completed : []).forEach((label) => {
+      items.push({
+        label: trimDot(label),
+        complete: true,
+        tone: 'success',
+      });
+    });
+    (Array.isArray(readiness.recommendations) ? readiness.recommendations : []).forEach((label) => {
+      items.push({
+        label: trimDot(label),
+        complete: false,
+        tone: 'idea',
+      });
+    });
+    return items;
+  }
+
+  /**
+   * Updates the aftercare band so live events do not keep pre-launch copy.
+   */
+  function syncLaunchAfterBand(root, after, published) {
     const afterRoot = root.querySelector('[data-mel-launch-after]');
-    if (afterRoot && (after.title || Array.isArray(after.items))) {
-      const afterItems = Array.isArray(after.items) ? after.items : [];
-      afterRoot.hidden = afterItems.length === 0;
-      if (after.title) {
-        setText(afterRoot, '[data-mel-launch-after-title]', after.title);
-      }
-      const afterList = afterRoot.querySelector('[data-mel-launch-after-list]');
-      if (afterList && Array.isArray(after.items)) {
-        afterList.replaceChildren();
-        afterItems.forEach((line) => {
-          const li = document.createElement('li');
-          li.textContent = String(line);
-          afterList.appendChild(li);
-        });
-      }
+    if (!afterRoot) {
+      return;
+    }
+    let title = after && after.title ? String(after.title) : '';
+    let afterItems = after && Array.isArray(after.items) ? after.items : null;
+    if (!title || !afterItems) {
+      title = published
+        ? Drupal.t('While your event is live')
+        : Drupal.t('After you publish');
+      afterItems = [
+        Drupal.t('Guests can discover your event'),
+        Drupal.t('People can RSVP or buy tickets according to your setup'),
+        published
+          ? Drupal.t('Share your event from the header')
+          : Drupal.t("You'll be able to share your event"),
+      ];
+    }
+    afterRoot.hidden = afterItems.length === 0;
+    setText(afterRoot, '[data-mel-launch-after-title]', title);
+    const afterList = afterRoot.querySelector('[data-mel-launch-after-list]');
+    if (afterList) {
+      afterList.replaceChildren();
+      afterItems.forEach((line) => {
+        const li = document.createElement('li');
+        li.textContent = String(line);
+        afterList.appendChild(li);
+      });
     }
   }
 
@@ -309,10 +386,22 @@
       heroHintEl.textContent = heroHint;
       heroHintEl.hidden = false;
     }
+
     const details = root.querySelector('[data-mel-launch-checklist]');
     if (details) {
       details.open = !ready;
     }
+    const summary = ready
+      ? Drupal.t('All required items complete')
+      : Drupal.t('Finish the checklist before you can launch');
+    setText(root, '[data-mel-launch-checklist-summary]', summary);
+
+    const list = root.querySelector('[data-mel-launch-checklist-list]');
+    if (list) {
+      syncLaunchChecklistList(list, {}, result.readiness || null, ready);
+    }
+
+    syncLaunchAfterBand(root, null, published);
   }
 
   function buildLaunchChecklistItem(item) {

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -168,7 +168,7 @@ mel_ticket_preview:
 
 # Reuse Event Studio layout shell (sidebar + main) without wizard JS — onboarding, etc.
 mel_event_studio_shell_only:
-  version: 1.8
+  version: 1.9
   css:
     theme:
       css/mel-event-studio-nav.css: {}

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -168,7 +168,7 @@ mel_ticket_preview:
 
 # Reuse Event Studio layout shell (sidebar + main) without wizard JS — onboarding, etc.
 mel_event_studio_shell_only:
-  version: 1.9
+  version: 1.10
   css:
     theme:
       css/mel-event-studio-nav.css: {}

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -168,7 +168,7 @@ mel_ticket_preview:
 
 # Reuse Event Studio layout shell (sidebar + main) without wizard JS — onboarding, etc.
 mel_event_studio_shell_only:
-  version: 1.6
+  version: 1.7
   css:
     theme:
       css/mel-event-studio-nav.css: {}

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -168,7 +168,7 @@ mel_ticket_preview:
 
 # Reuse Event Studio layout shell (sidebar + main) without wizard JS — onboarding, etc.
 mel_event_studio_shell_only:
-  version: 1.10
+  version: 1.11
   css:
     theme:
       css/mel-event-studio-nav.css: {}

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -168,7 +168,7 @@ mel_ticket_preview:
 
 # Reuse Event Studio layout shell (sidebar + main) without wizard JS — onboarding, etc.
 mel_event_studio_shell_only:
-  version: 1.7
+  version: 1.8
   css:
     theme:
       css/mel-event-studio-nav.css: {}

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -168,7 +168,7 @@ mel_ticket_preview:
 
 # Reuse Event Studio layout shell (sidebar + main) without wizard JS — onboarding, etc.
 mel_event_studio_shell_only:
-  version: 1.5
+  version: 1.6
   css:
     theme:
       css/mel-event-studio-nav.css: {}

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.module
@@ -62,6 +62,13 @@ function myeventlane_event_studio_theme($existing, $type, $theme, $path) {
       ],
       'template' => 'mel-event-studio-mission-control',
     ],
+    'mel_event_studio_launch_centre' => [
+      'variables' => [
+        'launch' => [],
+        'visibility_form' => NULL,
+      ],
+      'template' => 'mel-event-studio-launch-centre',
+    ],
     'mel_event_studio_workspace' => [
       'variables' => [
         'node' => NULL,

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -524,6 +524,7 @@ services:
       - '@logger.channel.myeventlane_event_studio'
       - '@string_translation'
       - '@myeventlane_event_studio.preprocess'
+      - '@myeventlane_event_studio.section_renderer'
     tags:
       - { name: controller.service_arguments }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPublishController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPublishController.php
@@ -17,6 +17,7 @@ use Drupal\myeventlane_event_studio\Service\EventReadinessFacade;
 use Drupal\myeventlane_event_studio\Service\EventReadinessService;
 use Drupal\myeventlane_event_studio\Service\EventStudioAutosaveService;
 use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
+use Drupal\myeventlane_event_studio\Service\EventStudioSectionRenderer;
 use Drupal\myeventlane_event_studio\Service\EventStudioWorkspacePresentation;
 use Drupal\myeventlane_event_studio\Service\EventWorkspaceOverviewBuilder;
 use Drupal\myeventlane_vendor\Service\BoostStatusService;
@@ -51,6 +52,7 @@ final class EventStudioPublishController {
     private readonly LoggerInterface $logger,
     TranslationInterface $stringTranslation,
     private readonly EventStudioPreprocess $eventStudioPreprocess,
+    private readonly EventStudioSectionRenderer $sectionRenderer,
   ) {
     $this->stringTranslation = $stringTranslation;
   }
@@ -321,6 +323,18 @@ final class EventStudioPublishController {
         $ajax_section,
       );
     }
+    $launch_centre = NULL;
+    try {
+      // Same ViewModel as Publishing section render — refresh Launch Centre after AJAX.
+      $launch_centre = $this->sectionRenderer->buildLaunchCentreViewModel($node);
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('Event Studio Launch Centre AJAX payload failed for event @nid: @message', [
+        '@nid' => (string) $node->id(),
+        '@message' => $e->getMessage(),
+      ]);
+    }
+
     $payload = [
       'ok' => $ok,
       'state' => $state,
@@ -345,6 +359,7 @@ final class EventStudioPublishController {
       'readiness' => $ajax_readiness,
       // Event Health chrome retired — Mission Control owns operational summary.
       'event_health' => NULL,
+      'launch_centre' => $launch_centre,
       'changed' => $node->getChangedTime(),
       'revisionId' => (int) $node->getRevisionId(),
     ];

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPublishController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioPublishController.php
@@ -334,6 +334,18 @@ final class EventStudioPublishController {
         '@message' => $e->getMessage(),
       ]);
     }
+    if ($launch_centre === NULL) {
+      try {
+        // Keep Launch Centre narrative aligned with Hero even when full VM fails.
+        $launch_centre = $this->sectionRenderer->buildDegradedLaunchCentreViewModel($node, $publish_result);
+      }
+      catch (\Throwable $e) {
+        $this->logger->error('Event Studio Launch Centre degraded AJAX payload failed for event @nid: @message', [
+          '@nid' => (string) $node->id(),
+          '@message' => $e->getMessage(),
+        ]);
+      }
+    }
 
     $payload = [
       'ok' => $ok,

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventLaunchVisibilityForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventLaunchVisibilityForm.php
@@ -11,6 +11,7 @@ use Drupal\node\NodeInterface;
  * Launch Centre visibility-only form (no publish controls).
  *
  * Hero owns publish/unpublish. This form answers "Who can find this?" only.
+ * Saves as draft so EventStudioSaveService never applies mel[status].
  */
 final class EventLaunchVisibilityForm extends EventSettingsForm {
 
@@ -37,6 +38,15 @@ final class EventLaunchVisibilityForm extends EventSettingsForm {
 
   /**
    * {@inheritdoc}
+   *
+   * Visibility must never run the publish-form non-draft save path.
+   */
+  protected function isDraftWizardSave(): bool {
+    return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
    */
   protected function getContinueButtonLabel() {
     return $this->t('Save visibility');
@@ -53,20 +63,29 @@ final class EventLaunchVisibilityForm extends EventSettingsForm {
   /**
    * {@inheritdoc}
    *
-   * Visibility controls only — never the publish action card.
+   * Strip any publish flag before merge/save — Hero owns live state.
+   */
+  protected function persistWizardMel(FormStateInterface $form_state, bool $draft): ?array {
+    $mel = $form_state->getValue('mel');
+    if (is_array($mel)) {
+      unset($mel['status']);
+      $form_state->setValue('mel', $mel);
+    }
+    // Force draft regardless of caller — never mutate publish via this form.
+    return parent::persistWizardMel($form_state, TRUE);
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Visibility controls only — never the publish action card or mel[status].
    */
   protected function buildWizardStepContent(array &$form, FormStateInterface $form_state, NodeInterface $node, array $melDefaults): void {
-    $form_state->set('mel_was_published_snapshot', $node->isPublished());
     $this->buildVisibilityControls($form, $node, $melDefaults);
     // Launch Centre summary already labels this band — avoid a second H3.
     if (isset($form['mel']['visibility_section']['title'])) {
       $form['mel']['visibility_section']['title']['#access'] = FALSE;
     }
-    // Preserve publish state without exposing publish/unpublish UI.
-    $form['mel']['status'] = [
-      '#type' => 'hidden',
-      '#default_value' => $node->isPublished() ? '1' : '0',
-    ];
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventLaunchVisibilityForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventLaunchVisibilityForm.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Form;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Launch Centre visibility-only form (no publish controls).
+ *
+ * Hero owns publish/unpublish. This form answers "Who can find this?" only.
+ */
+final class EventLaunchVisibilityForm extends EventSettingsForm {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'myeventlane_event_studio_launch_visibility_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getNextRouteName(): string {
+    return 'myeventlane_event_studio.workspace_publishing';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getCurrentStepId(): string {
+    return 'launch_visibility';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getContinueButtonLabel() {
+    return $this->t('Save visibility');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function onWizardStepSaveSuccess(NodeInterface $saved, FormStateInterface $form_state): void {
+    $this->messenger()->addStatus($this->t('Visibility saved.'));
+    $form_state->setRedirect('myeventlane_event_studio.workspace_publishing', ['node' => $saved->id()]);
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * Visibility controls only — never the publish action card.
+   */
+  protected function buildWizardStepContent(array &$form, FormStateInterface $form_state, NodeInterface $node, array $melDefaults): void {
+    $form_state->set('mel_was_published_snapshot', $node->isPublished());
+    $this->buildVisibilityControls($form, $node, $melDefaults);
+    // Launch Centre summary already labels this band — avoid a second H3.
+    if (isset($form['mel']['visibility_section']['title'])) {
+      $form['mel']['visibility_section']['title']['#access'] = FALSE;
+    }
+    // Preserve publish state without exposing publish/unpublish UI.
+    $form['mel']['status'] = [
+      '#type' => 'hidden',
+      '#default_value' => $node->isPublished() ? '1' : '0',
+    ];
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventSettingsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventSettingsForm.php
@@ -11,7 +11,7 @@ use Drupal\node\NodeInterface;
 /**
  * Isolated Event Studio form for publish/settings controls.
  */
-final class EventSettingsForm extends EventStudioPublishForm {
+class EventSettingsForm extends EventStudioPublishForm {
 
   public function getFormId(): string {
     return 'myeventlane_event_studio_settings_form';
@@ -88,9 +88,11 @@ final class EventSettingsForm extends EventStudioPublishForm {
   /**
    * Builds the visibility radio selector and passcode input.
    *
+   * Shared by Settings and Launch Centre (visibility-only) forms.
+   *
    * @param array<string, mixed> $melDefaults
    */
-  private function buildVisibilityControls(array &$form, NodeInterface $node, array $melDefaults): void {
+  protected function buildVisibilityControls(array &$form, NodeInterface $node, array $melDefaults): void {
     $current_visibility = '';
     if ($node->hasField('field_event_visibility') && !$node->get('field_event_visibility')->isEmpty()) {
       $current_visibility = (string) $node->get('field_event_visibility')->value;

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
@@ -15,6 +15,8 @@ use Drupal\myeventlane_core\Service\DomainDetector;
 use Drupal\myeventlane_event_attendees\Service\EventAttendeeWorkspaceBuilder;
 use Drupal\myeventlane_event_studio\DTO\EventReadinessResult;
 use Drupal\myeventlane_event_studio\DTO\ReadonlySectionProjection;
+use Drupal\myeventlane_event\Service\PublicEventVisibility;
+use Drupal\myeventlane_event_studio\Form\EventLaunchVisibilityForm;
 use Drupal\myeventlane_event_studio\Form\EventSettingsForm;
 use Drupal\myeventlane_event_studio\Form\EventStudioOperationalTicketsForm;
 use Drupal\myeventlane_event_studio\Form\EventStudioTicketsForm;
@@ -323,53 +325,264 @@ final class EventStudioSectionRenderer {
   }
 
   /**
+   * Launch Centre composition for the Publishing section (Sprint 3C.1).
+   *
+   * Presentation only — reuses EventReadinessService. Hero owns publish/unpublish.
+   * Does not embed EventSettingsForm or a second Publish control.
+   *
    * @return array<string, mixed>
    */
   private function buildPublishingHub(NodeInterface $event): array {
     $account = $this->currentUser;
     $readiness = $this->eventReadiness->evaluate($event, $account);
+    $published = $event->isPublished();
+    $ready = $readiness->ready;
     $remaining = count($readiness->errors);
-    $headline = $readiness->ready
-      ? ($event->isPublished()
-        ? (string) $this->t('Your event is live')
-        : (string) $this->t('Ready to publish'))
-      : ($remaining === 1
-        ? (string) $this->t("You're almost there…")
-        : (string) $this->t('A few things left before publishing'));
-    $explanation = $readiness->ready
-      ? (string) $this->t('Everything needed to go live looks good.')
-      : ($remaining === 1 && $readiness->errors !== []
-        ? (string) $this->t('One more thing before publishing: @reason', ['@reason' => $readiness->errors[0]])
-        : (string) $this->t('Finish the checklist below. We never block without explaining why.'));
+    $nid = (int) $event->id();
 
-    $checklist = [];
-    foreach ($readiness->completed as $item) {
-      $checklist[] = ['#markup' => '✔ ' . $this->humanChecklistLabel((string) $item)];
+    $checklist_open = !$ready;
+    $checklist_items = $this->buildLaunchChecklistItems($readiness, $nid);
+    $complete_count = count(array_filter($checklist_items, static fn(array $item): bool => !empty($item['complete'])));
+    $total_count = count($checklist_items);
+
+    $settings_url = NULL;
+    try {
+      $settings_url = Url::fromRoute('myeventlane_event_studio.workspace_settings', ['node' => $nid])->toString();
     }
-    foreach ($readiness->errors as $item) {
-      $checklist[] = ['#markup' => '○ ' . (string) $item];
+    catch (\Throwable) {
+      $settings_url = NULL;
     }
 
     return [
-      '#type' => 'container',
-      '#attributes' => ['class' => ['mel-event-workspace-publishing']],
-      'headline' => [
-        '#type' => 'html_tag',
-        '#tag' => 'h3',
-        '#value' => $headline,
+      '#theme' => 'mel_event_studio_launch_centre',
+      '#launch' => [
+        'state' => $published ? 'live' : ($ready ? 'ready' : 'needs_attention'),
+        'published' => $published,
+        'ready' => $ready,
+        'headline' => $this->launchHeadline($ready, $published, $remaining),
+        'explanation' => $this->launchExplanation($readiness, $published),
+        'hero_hint' => $this->launchHeroHint($ready, $published),
+        'checklist' => [
+          'title' => (string) $this->t('Launch checklist'),
+          'open' => $checklist_open,
+          'summary' => $ready
+            ? (string) $this->t('All required items complete')
+            : (string) $this->formatPlural(
+              $remaining,
+              '1 thing left before you can launch',
+              '@count things left before you can launch',
+            ),
+          'complete_count' => $complete_count,
+          'total_count' => $total_count,
+          'items' => $checklist_items,
+        ],
+        'visibility' => [
+          'summary_label' => (string) $this->t('Who can find this?'),
+          'current_label' => $this->currentVisibilityLabel($event),
+          'open' => FALSE,
+          'settings_url' => $settings_url,
+          'settings_label' => (string) $this->t('More settings'),
+        ],
+        'after' => $this->launchAfterGuidance($event, $published),
       ],
-      'explain' => [
-        '#type' => 'html_tag',
-        '#tag' => 'p',
-        '#value' => $explanation,
+      '#visibility_form' => $this->formBuilder->getForm(EventLaunchVisibilityForm::class, $event),
+      '#cache' => [
+        'contexts' => ['user', 'user.permissions'],
+        'tags' => $event->getCacheTags(),
+        'max-age' => 0,
       ],
-      'checklist' => [
-        '#theme' => 'item_list',
-        '#title' => $this->t('Publishing checklist'),
-        '#items' => $checklist,
-      ],
-      'settings' => $this->formBuilder->getForm(EventSettingsForm::class, $event),
     ];
+  }
+
+  /**
+   * @return list<array{label: string, complete: bool, tone: string, fix_url: ?string, fix_label: ?string}>
+   */
+  private function buildLaunchChecklistItems(EventReadinessResult $readiness, int $nid): array {
+    $items = [];
+    foreach ($readiness->errors as $label) {
+      $text = rtrim((string) $label, '.');
+      $fix = $this->resolveLaunchFixLink($text, $nid);
+      $items[] = [
+        'label' => $text,
+        'complete' => FALSE,
+        'tone' => 'attention',
+        'fix_url' => $fix['url'] ?? NULL,
+        'fix_label' => $fix['label'] ?? NULL,
+      ];
+    }
+    foreach ($readiness->warnings as $label) {
+      $text = rtrim((string) $label, '.');
+      $fix = $this->resolveLaunchFixLink($text, $nid);
+      $items[] = [
+        'label' => $text,
+        'complete' => FALSE,
+        'tone' => 'warning',
+        'fix_url' => $fix['url'] ?? NULL,
+        'fix_label' => $fix['label'] ?? NULL,
+      ];
+    }
+    foreach ($readiness->completed as $label) {
+      $items[] = [
+        'label' => $this->humanChecklistLabel((string) $label),
+        'complete' => TRUE,
+        'tone' => 'success',
+        'fix_url' => NULL,
+        'fix_label' => NULL,
+      ];
+    }
+    foreach ($readiness->recommendations as $label) {
+      $text = rtrim((string) $label, '.');
+      $fix = $this->resolveLaunchFixLink($text, $nid);
+      $items[] = [
+        'label' => $text,
+        'complete' => FALSE,
+        'tone' => 'idea',
+        'fix_url' => $fix['url'] ?? NULL,
+        'fix_label' => $fix['label'] ?? NULL,
+      ];
+    }
+    return $items;
+  }
+
+  /**
+   * Presentation-only deep links for checklist blockers (no new eligibility rules).
+   *
+   * @return array{url: ?string, label: ?string}
+   */
+  private function resolveLaunchFixLink(string $label, int $nid): array {
+    $lower = mb_strtolower($label);
+    $route = 'myeventlane_event_studio.workspace_details';
+    $params = ['node' => $nid];
+    $fix_label = (string) $this->t('Fix → Details');
+
+    if (str_contains($lower, 'stripe') || str_contains($lower, 'payment') || str_contains($lower, 'get paid')) {
+      $route = 'myeventlane_vendor.console.payments';
+      $params = [];
+      $fix_label = (string) $this->t('Connect Stripe');
+    }
+    elseif (str_contains($lower, 'organiser') || str_contains($lower, 'terms') || str_contains($lower, 'signed in') || str_contains($lower, 'profile')) {
+      $route = 'myeventlane_vendor.console.settings';
+      $params = [];
+      $fix_label = (string) $this->t('Open account');
+    }
+    elseif (str_contains($lower, 'ticket') || str_contains($lower, 'capacity')) {
+      $route = 'myeventlane_event_studio.workspace_tickets';
+      $fix_label = (string) $this->t('Fix → Tickets');
+    }
+    elseif (str_contains($lower, 'cover') || str_contains($lower, 'image') || str_contains($lower, 'branding')) {
+      $route = 'myeventlane_event_studio.workspace_images';
+      $fix_label = (string) $this->t('Fix → Images');
+    }
+    elseif (str_contains($lower, 'date') || str_contains($lower, 'schedule') || str_contains($lower, 'start') || str_contains($lower, 'end')) {
+      $route = 'myeventlane_event_studio.workspace_schedule';
+      $fix_label = (string) $this->t('Fix → Schedule');
+    }
+    elseif (str_contains($lower, 'question')) {
+      $route = 'myeventlane_event_studio.workspace_questions';
+      $fix_label = (string) $this->t('Fix → Questions');
+    }
+
+    try {
+      return [
+        'url' => Url::fromRoute($route, $params)->toString(),
+        'label' => $fix_label,
+      ];
+    }
+    catch (\Throwable) {
+      if ($route === 'myeventlane_vendor.console.settings') {
+        try {
+          return [
+            'url' => Url::fromRoute('myeventlane_vendor.console.payments')->toString(),
+            'label' => (string) $this->t('Connect Stripe'),
+          ];
+        }
+        catch (\Throwable) {
+          return ['url' => NULL, 'label' => NULL];
+        }
+      }
+      return ['url' => NULL, 'label' => NULL];
+    }
+  }
+
+  private function launchHeadline(bool $ready, bool $published, int $remaining): string {
+    if ($published) {
+      return (string) $this->t('Your event is live');
+    }
+    if ($ready) {
+      return (string) $this->t('Ready to launch');
+    }
+    if ($remaining === 1) {
+      return (string) $this->t("You're almost there");
+    }
+    return (string) $this->t('A few things left before launching');
+  }
+
+  private function launchExplanation(EventReadinessResult $readiness, bool $published): string {
+    if ($published) {
+      return (string) $this->t('People can discover your event and RSVP or buy tickets according to your setup. Share from the header when you are ready.');
+    }
+    if ($readiness->ready) {
+      return (string) $this->t("You're ready to go live. Guests will be able to discover this event and RSVP or buy tickets according to your setup.");
+    }
+    if (count($readiness->errors) === 1) {
+      return (string) $this->t('One more thing before you can launch: @reason', [
+        '@reason' => rtrim($readiness->errors[0], '.'),
+      ]);
+    }
+    return (string) $this->t('Finish the checklist below. We never block without explaining why.');
+  }
+
+  private function launchHeroHint(bool $ready, bool $published): string {
+    if ($published) {
+      return (string) $this->t('Use Share event in the header to spread the word.');
+    }
+    if ($ready) {
+      return (string) $this->t('Use Publish event in the header when you are ready.');
+    }
+    return (string) $this->t('Publish is unavailable until the checklist is clear. Continue setup from the header.');
+  }
+
+  /**
+   * @return array{title: string, items: list<string>}
+   */
+  private function launchAfterGuidance(NodeInterface $event, bool $published): array {
+    $event_type = 'rsvp';
+    if ($event->hasField('field_event_type') && !$event->get('field_event_type')->isEmpty()) {
+      $event_type = (string) $event->get('field_event_type')->value;
+    }
+
+    $join = match ($event_type) {
+      'paid' => (string) $this->t('People can buy tickets'),
+      'both' => (string) $this->t('People can RSVP or buy tickets'),
+      'external' => (string) $this->t('People can follow your external booking link'),
+      default => (string) $this->t('People can RSVP'),
+    };
+
+    $items = [
+      (string) $this->t('Guests can discover your event'),
+      $join,
+      (string) $this->t("You'll be able to share your event"),
+    ];
+
+    return [
+      'title' => $published
+        ? (string) $this->t('After publishing')
+        : (string) $this->t('After you publish'),
+      'items' => $items,
+    ];
+  }
+
+  private function currentVisibilityLabel(NodeInterface $event): string {
+    $value = PublicEventVisibility::VISIBILITY_PUBLIC;
+    if ($event->hasField('field_event_visibility') && !$event->get('field_event_visibility')->isEmpty()) {
+      $value = (string) $event->get('field_event_visibility')->value;
+    }
+    return match ($value) {
+      PublicEventVisibility::VISIBILITY_UNLISTED => (string) $this->t('Unlisted'),
+      PublicEventVisibility::VISIBILITY_PRIVATE => (string) $this->t('Private'),
+      PublicEventVisibility::VISIBILITY_PASSCODE => (string) $this->t('Passcode protected'),
+      default => (string) $this->t('Public'),
+    };
   }
 
   private function humanChecklistLabel(string $label): string {

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
@@ -333,6 +333,25 @@ final class EventStudioSectionRenderer {
    * @return array<string, mixed>
    */
   private function buildPublishingHub(NodeInterface $event): array {
+    $launch = $this->buildLaunchCentreViewModel($event);
+    return [
+      '#theme' => 'mel_event_studio_launch_centre',
+      '#launch' => $launch,
+      '#visibility_form' => $this->formBuilder->getForm(EventLaunchVisibilityForm::class, $event),
+      '#cache' => [
+        'contexts' => ['user', 'user.permissions'],
+        'tags' => $event->getCacheTags(),
+        'max-age' => 0,
+      ],
+    ];
+  }
+
+  /**
+   * Builds the Launch Centre ViewModel for Twig and publish AJAX refresh.
+   *
+   * @return array<string, mixed>
+   */
+  public function buildLaunchCentreViewModel(NodeInterface $event): array {
     $account = $this->currentUser;
     $readiness = $this->eventReadiness->evaluate($event, $account);
     $published = $event->isPublished();
@@ -340,6 +359,8 @@ final class EventStudioSectionRenderer {
     $remaining = count($readiness->errors);
     $nid = (int) $event->id();
 
+    // Readiness wins over published: live + blockers must mirror Hero Continue setup.
+    $state = !$ready ? 'needs_attention' : ($published ? 'live' : 'ready');
     $checklist_open = !$ready;
     $checklist_items = $this->buildLaunchChecklistItems($readiness, $nid);
     // Progress fraction is required items only (complete + blockers).
@@ -360,43 +381,35 @@ final class EventStudioSectionRenderer {
     }
 
     return [
-      '#theme' => 'mel_event_studio_launch_centre',
-      '#launch' => [
-        'state' => $published ? 'live' : ($ready ? 'ready' : 'needs_attention'),
-        'published' => $published,
-        'ready' => $ready,
-        'headline' => $this->launchHeadline($ready, $published, $remaining),
-        'explanation' => $this->launchExplanation($readiness, $published),
-        'hero_hint' => $this->launchHeroHint($ready, $published),
-        'checklist' => [
-          'title' => (string) $this->t('Launch checklist'),
-          'open' => $checklist_open,
-          'summary' => $ready
-            ? (string) $this->t('All required items complete')
-            : (string) $this->formatPlural(
-              $remaining,
-              '1 thing left before you can launch',
-              '@count things left before you can launch',
-            ),
-          'complete_count' => $complete_count,
-          'total_count' => $total_count,
-          'items' => $checklist_items,
-        ],
-        'visibility' => [
-          'summary_label' => (string) $this->t('Who can find this?'),
-          'current_label' => $this->currentVisibilityLabel($event),
-          'open' => FALSE,
-          'settings_url' => $settings_url,
-          'settings_label' => (string) $this->t('More settings'),
-        ],
-        'after' => $this->launchAfterGuidance($event, $published),
+      'state' => $state,
+      'published' => $published,
+      'ready' => $ready,
+      'eyebrow' => $this->launchEyebrow($state),
+      'headline' => $this->launchHeadline($ready, $published, $remaining),
+      'explanation' => $this->launchExplanation($readiness, $published),
+      'hero_hint' => $this->launchHeroHint($ready, $published),
+      'checklist' => [
+        'title' => (string) $this->t('Launch checklist'),
+        'open' => $checklist_open,
+        'summary' => $ready
+          ? (string) $this->t('All required items complete')
+          : (string) $this->formatPlural(
+            $remaining,
+            '1 thing left before you can launch',
+            '@count things left before you can launch',
+          ),
+        'complete_count' => $complete_count,
+        'total_count' => $total_count,
+        'items' => $checklist_items,
       ],
-      '#visibility_form' => $this->formBuilder->getForm(EventLaunchVisibilityForm::class, $event),
-      '#cache' => [
-        'contexts' => ['user', 'user.permissions'],
-        'tags' => $event->getCacheTags(),
-        'max-age' => 0,
+      'visibility' => [
+        'summary_label' => (string) $this->t('Who can find this?'),
+        'current_label' => $this->currentVisibilityLabel($event),
+        'open' => FALSE,
+        'settings_url' => $settings_url,
+        'settings_label' => (string) $this->t('More settings'),
       ],
+      'after' => $this->launchAfterGuidance($event, $published),
     ];
   }
 
@@ -528,42 +541,65 @@ final class EventStudioSectionRenderer {
     return preg_match('/\bdates?\b/', $lower) === 1;
   }
 
+  private function launchEyebrow(string $state): string {
+    return match ($state) {
+      'live' => (string) $this->t('Your event is live'),
+      'ready' => (string) $this->t('Ready to launch'),
+      default => (string) $this->t('Needs attention'),
+    };
+  }
+
   private function launchHeadline(bool $ready, bool $published, int $remaining): string {
+    // Live + readiness regression: blockers first (align with Hero Continue setup).
+    if (!$ready) {
+      if ($published) {
+        return $remaining === 1
+          ? (string) $this->t('Your event is live — one thing needs attention')
+          : (string) $this->t('Your event is live — a few things need attention');
+      }
+      if ($remaining === 1) {
+        return (string) $this->t("You're almost there");
+      }
+      return (string) $this->t('A few things left before launching');
+    }
     if ($published) {
       return (string) $this->t('Your event is live');
     }
-    if ($ready) {
-      return (string) $this->t('Ready to launch');
-    }
-    if ($remaining === 1) {
-      return (string) $this->t("You're almost there");
-    }
-    return (string) $this->t('A few things left before launching');
+    return (string) $this->t('Ready to launch');
   }
 
   private function launchExplanation(EventReadinessResult $readiness, bool $published): string {
+    if (!$readiness->ready) {
+      if ($published) {
+        return count($readiness->errors) === 1
+          ? (string) $this->t('Guests can still see your event, but fix this so everything works as expected: @reason', [
+            '@reason' => rtrim($readiness->errors[0], '.'),
+          ])
+          : (string) $this->t('Guests can still see your event. Finish the checklist so booking and discovery keep working as expected.');
+      }
+      if (count($readiness->errors) === 1) {
+        return (string) $this->t('One more thing before you can launch: @reason', [
+          '@reason' => rtrim($readiness->errors[0], '.'),
+        ]);
+      }
+      return (string) $this->t('Finish the checklist below. We never block without explaining why.');
+    }
     if ($published) {
       return (string) $this->t('People can discover your event and RSVP or buy tickets according to your setup. Share from the header when you are ready.');
     }
-    if ($readiness->ready) {
-      return (string) $this->t("You're ready to go live. Guests will be able to discover this event and RSVP or buy tickets according to your setup.");
-    }
-    if (count($readiness->errors) === 1) {
-      return (string) $this->t('One more thing before you can launch: @reason', [
-        '@reason' => rtrim($readiness->errors[0], '.'),
-      ]);
-    }
-    return (string) $this->t('Finish the checklist below. We never block without explaining why.');
+    return (string) $this->t("You're ready to go live. Guests will be able to discover this event and RSVP or buy tickets according to your setup.");
   }
 
   private function launchHeroHint(bool $ready, bool $published): string {
+    if (!$ready) {
+      return $published
+        ? (string) $this->t('Continue setup from the header to fix what needs attention.')
+        : (string) $this->t('Publish is unavailable until the checklist is clear. Continue setup from the header.');
+    }
     if ($published) {
       return (string) $this->t('Use Share event in the header to spread the word.');
     }
-    if ($ready) {
-      return (string) $this->t('Use Publish event in the header when you are ready.');
-    }
-    return (string) $this->t('Publish is unavailable until the checklist is clear. Continue setup from the header.');
+    return (string) $this->t('Use Publish event in the header when you are ready.');
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
@@ -417,7 +417,8 @@ final class EventStudioSectionRenderer {
    * Minimal Launch Centre payload when the full ViewModel cannot be built.
    *
    * Reuses an already-evaluated readiness result — no second eligibility path.
-   * Omits checklist items so shell JS can refresh narrative without wiping the list.
+   * Still includes checklist items so AJAX refresh cannot leave stale blockers
+   * under an “All required items complete” summary.
    *
    * @return array<string, mixed>
    */
@@ -425,7 +426,15 @@ final class EventStudioSectionRenderer {
     $published = $event->isPublished();
     $ready = $readiness->ready;
     $remaining = count($readiness->errors);
+    $nid = (int) $event->id();
     $state = !$ready ? 'needs_attention' : ($published ? 'live' : 'ready');
+    $checklist_items = $this->buildLaunchChecklistItems($readiness, $nid);
+    $required_items = array_values(array_filter(
+      $checklist_items,
+      static fn(array $item): bool => in_array($item['tone'] ?? '', ['success', 'attention'], TRUE),
+    ));
+    $complete_count = count(array_filter($required_items, static fn(array $item): bool => !empty($item['complete'])));
+    $total_count = count($required_items);
 
     return [
       'state' => $state,
@@ -446,6 +455,9 @@ final class EventStudioSectionRenderer {
             '1 thing left before you can launch',
             '@count things left before you can launch',
           ),
+        'complete_count' => $complete_count,
+        'total_count' => $total_count,
+        'items' => $checklist_items,
       ],
       'visibility' => [
         'current_label' => $this->currentVisibilityLabel($event),

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
@@ -414,6 +414,47 @@ final class EventStudioSectionRenderer {
   }
 
   /**
+   * Minimal Launch Centre payload when the full ViewModel cannot be built.
+   *
+   * Reuses an already-evaluated readiness result — no second eligibility path.
+   * Omits checklist items so shell JS can refresh narrative without wiping the list.
+   *
+   * @return array<string, mixed>
+   */
+  public function buildDegradedLaunchCentreViewModel(NodeInterface $event, EventReadinessResult $readiness): array {
+    $published = $event->isPublished();
+    $ready = $readiness->ready;
+    $remaining = count($readiness->errors);
+    $state = !$ready ? 'needs_attention' : ($published ? 'live' : 'ready');
+
+    return [
+      'state' => $state,
+      'published' => $published,
+      'ready' => $ready,
+      'degraded' => TRUE,
+      'eyebrow' => $this->launchEyebrow($state),
+      'headline' => $this->launchHeadline($ready, $published, $remaining),
+      'explanation' => $this->launchExplanation($readiness, $published),
+      'hero_hint' => $this->launchHeroHint($ready, $published),
+      'checklist' => [
+        'title' => (string) $this->t('Launch checklist'),
+        'open' => !$ready,
+        'summary' => $ready
+          ? (string) $this->t('All required items complete')
+          : (string) $this->formatPlural(
+            $remaining,
+            '1 thing left before you can launch',
+            '@count things left before you can launch',
+          ),
+      ],
+      'visibility' => [
+        'current_label' => $this->currentVisibilityLabel($event),
+      ],
+      'after' => $this->launchAfterGuidance($event, $published),
+    ];
+  }
+
+  /**
    * @return list<array{label: string, complete: bool, tone: string, fix_url: ?string, fix_label: ?string}>
    */
   private function buildLaunchChecklistItems(EventReadinessResult $readiness, int $nid): array {
@@ -618,17 +659,24 @@ final class EventStudioSectionRenderer {
       default => (string) $this->t('People can RSVP'),
     };
 
-    $items = [
-      (string) $this->t('Guests can discover your event'),
-      $join,
-      (string) $this->t("You'll be able to share your event"),
-    ];
+    if ($published) {
+      return [
+        'title' => (string) $this->t('While your event is live'),
+        'items' => [
+          (string) $this->t('Guests can discover your event'),
+          $join,
+          (string) $this->t('Share your event from the header'),
+        ],
+      ];
+    }
 
     return [
-      'title' => $published
-        ? (string) $this->t('After publishing')
-        : (string) $this->t('After you publish'),
-      'items' => $items,
+      'title' => (string) $this->t('After you publish'),
+      'items' => [
+        (string) $this->t('Guests can discover your event'),
+        $join,
+        (string) $this->t("You'll be able to share your event"),
+      ],
     ];
   }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
@@ -342,8 +342,14 @@ final class EventStudioSectionRenderer {
 
     $checklist_open = !$ready;
     $checklist_items = $this->buildLaunchChecklistItems($readiness, $nid);
-    $complete_count = count(array_filter($checklist_items, static fn(array $item): bool => !empty($item['complete'])));
-    $total_count = count($checklist_items);
+    // Progress fraction is required items only (complete + blockers).
+    // Warnings/ideas stay visible but must not contradict "All required items complete".
+    $required_items = array_values(array_filter(
+      $checklist_items,
+      static fn(array $item): bool => in_array($item['tone'] ?? '', ['success', 'attention'], TRUE),
+    ));
+    $complete_count = count(array_filter($required_items, static fn(array $item): bool => !empty($item['complete'])));
+    $total_count = count($required_items);
 
     $settings_url = NULL;
     try {
@@ -473,7 +479,7 @@ final class EventStudioSectionRenderer {
       $route = 'myeventlane_event_studio.workspace_images';
       $fix_label = (string) $this->t('Fix → Images');
     }
-    elseif (str_contains($lower, 'date') || str_contains($lower, 'schedule') || str_contains($lower, 'start') || str_contains($lower, 'end')) {
+    elseif ($this->isLaunchScheduleFixLabel($lower)) {
       $route = 'myeventlane_event_studio.workspace_schedule';
       $fix_label = (string) $this->t('Fix → Schedule');
     }
@@ -489,19 +495,37 @@ final class EventStudioSectionRenderer {
       ];
     }
     catch (\Throwable) {
+      // Organiser/terms blockers must not fall through to Stripe Connect.
       if ($route === 'myeventlane_vendor.console.settings') {
-        try {
-          return [
-            'url' => Url::fromRoute('myeventlane_vendor.console.payments')->toString(),
-            'label' => (string) $this->t('Connect Stripe'),
-          ];
-        }
-        catch (\Throwable) {
-          return ['url' => NULL, 'label' => NULL];
+        foreach (['myeventlane_vendor.console.settings_profile'] as $fallback) {
+          try {
+            return [
+              'url' => Url::fromRoute($fallback)->toString(),
+              'label' => $fix_label,
+            ];
+          }
+          catch (\Throwable) {
+            // Try next fallback.
+          }
         }
       }
       return ['url' => NULL, 'label' => NULL];
     }
+  }
+
+  /**
+   * True when a readiness label is about event schedule dates (not "attendee").
+   */
+  private function isLaunchScheduleFixLabel(string $lower): bool {
+    if (str_contains($lower, 'schedule')) {
+      return TRUE;
+    }
+    // Prefer explicit phrases used by EventReadinessService.
+    if (str_contains($lower, 'start date') || str_contains($lower, 'end date')) {
+      return TRUE;
+    }
+    // Word-boundary "date"/"dates" — avoids "update", keeps "Event dates are invalid".
+    return preg_match('/\bdates?\b/', $lower) === 1;
   }
 
   private function launchHeadline(bool $ready, bool $published, int $remaining): string {

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-launch-centre.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-launch-centre.html.twig
@@ -1,0 +1,126 @@
+{#
+/**
+ * @file
+ * Launch Centre — Publishing section composition (Sprint 3C.1).
+ *
+ * Hierarchy: Ready to Launch → Checklist → Who can find this? → After you publish.
+ * Hero owns Publish / Unpublish. This template must never render a Publish button.
+ *
+ * Variables:
+ * - launch: presentation ViewModel from EventStudioSectionRenderer::buildPublishingHub().
+ * - visibility_form: slim EventLaunchVisibilityForm render array.
+ */
+#}
+{% set L = launch|default({}) %}
+{% set checklist = L.checklist|default({}) %}
+{% set visibility = L.visibility|default({}) %}
+{% set after = L.after|default({}) %}
+{% set items = checklist.items|default([]) %}
+{% set state = L.state|default('needs_attention') %}
+
+<section
+  class="mel-launch-centre mel-launch-centre--{{ state|clean_class }}"
+  data-mel-launch-centre
+  data-mel-launch-state="{{ state|e('html_attr') }}"
+  data-mel-launch-ready="{{ L.ready|default(false) ? '1' : '0' }}"
+  data-mel-launch-published="{{ L.published|default(false) ? '1' : '0' }}"
+  aria-labelledby="mel-launch-centre-heading"
+  role="region"
+>
+  {# 1. Ready to Launch #}
+  <header class="mel-launch-centre__ready">
+    <p class="mel-launch-centre__eyebrow">{{ 'Ready to launch'|t }}</p>
+    <h2 id="mel-launch-centre-heading" class="mel-launch-centre__headline">{{ L.headline }}</h2>
+    {% if L.explanation %}
+      <p class="mel-launch-centre__explanation">{{ L.explanation }}</p>
+    {% endif %}
+    {% if L.hero_hint %}
+      <p class="mel-launch-centre__hero-hint" data-mel-launch-hero-hint>{{ L.hero_hint }}</p>
+    {% endif %}
+  </header>
+
+  {# 2. Launch checklist — open when blocked, collapsed when ready #}
+  <details
+    class="mel-launch-centre__checklist"
+    data-mel-launch-checklist
+    {% if checklist.open|default(false) %}open{% endif %}
+  >
+    <summary class="mel-launch-centre__checklist-summary">
+      <span class="mel-launch-centre__checklist-title">{{ checklist.title|default('Launch checklist'|t) }}</span>
+      <span class="mel-launch-centre__checklist-meta">
+        {% if checklist.summary %}
+          <span class="mel-launch-centre__checklist-summary-text">{{ checklist.summary }}</span>
+        {% endif %}
+        {% if checklist.total_count|default(0) > 0 %}
+          <span class="mel-launch-centre__checklist-count" aria-hidden="true">
+            {{ checklist.complete_count|default(0) }}/{{ checklist.total_count }}
+          </span>
+        {% endif %}
+      </span>
+    </summary>
+    <ul class="mel-launch-centre__list" role="list">
+      {% for item in items %}
+        {% set tone = item.tone|default('success') %}
+        <li class="mel-launch-centre__item mel-launch-centre__item--{{ tone|clean_class }}{% if item.complete %} is-complete{% endif %}">
+          <span class="mel-launch-centre__mark" aria-hidden="true">
+            {% if item.complete %}✓{% elseif tone == 'attention' %}○{% else %}·{% endif %}
+          </span>
+          <span class="mel-launch-centre__item-label">
+            {% if item.complete %}
+              <span class="visually-hidden">{{ 'Complete:'|t }}</span>
+            {% elseif tone == 'attention' %}
+              <span class="visually-hidden">{{ 'Needs attention:'|t }}</span>
+            {% elseif tone == 'warning' %}
+              <span class="visually-hidden">{{ 'Warning:'|t }}</span>
+            {% else %}
+              <span class="visually-hidden">{{ 'Suggestion:'|t }}</span>
+            {% endif %}
+            {{ item.label }}
+          </span>
+          {% if item.fix_url and not item.complete %}
+            <a
+              class="mel-launch-centre__fix mel-btn mel-btn--ghost"
+              href="{{ item.fix_url }}"
+            >{{ item.fix_label|default('Fix'|t) }}</a>
+          {% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+  </details>
+
+  {# 3. Who can find this? — progressive disclosure #}
+  <details
+    class="mel-launch-centre__visibility"
+    data-mel-launch-visibility
+    {% if visibility.open|default(false) %}open{% endif %}
+  >
+    <summary class="mel-launch-centre__visibility-summary">
+      <span class="mel-launch-centre__visibility-title">{{ visibility.summary_label|default('Who can find this?'|t) }}</span>
+      {% if visibility.current_label %}
+        <span class="mel-launch-centre__visibility-current">{{ visibility.current_label }}</span>
+      {% endif %}
+    </summary>
+    <div class="mel-launch-centre__visibility-body">
+      {% if visibility_form %}
+        {{ visibility_form }}
+      {% endif %}
+      {% if visibility.settings_url %}
+        <p class="mel-launch-centre__settings-link">
+          <a href="{{ visibility.settings_url }}">{{ visibility.settings_label|default('More settings'|t) }}</a>
+        </p>
+      {% endif %}
+    </div>
+  </details>
+
+  {# 4. After you publish — informational only (no Launch Success UI) #}
+  {% if after.items|default([]) %}
+    <aside class="mel-launch-centre__after" aria-labelledby="mel-launch-after-heading">
+      <h3 id="mel-launch-after-heading" class="mel-launch-centre__after-title">{{ after.title }}</h3>
+      <ul class="mel-launch-centre__after-list">
+        {% for line in after.items %}
+          <li>{{ line }}</li>
+        {% endfor %}
+      </ul>
+    </aside>
+  {% endif %}
+</section>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-launch-centre.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-launch-centre.html.twig
@@ -7,7 +7,7 @@
  * Hero owns Publish / Unpublish. This template must never render a Publish button.
  *
  * Variables:
- * - launch: presentation ViewModel from EventStudioSectionRenderer::buildPublishingHub().
+ * - launch: presentation ViewModel from EventStudioSectionRenderer::buildLaunchCentreViewModel().
  * - visibility_form: slim EventLaunchVisibilityForm render array.
  */
 #}
@@ -29,14 +29,10 @@
 >
   {# 1. Ready to Launch #}
   <header class="mel-launch-centre__ready">
-    <p class="mel-launch-centre__eyebrow">{{ 'Ready to launch'|t }}</p>
-    <h2 id="mel-launch-centre-heading" class="mel-launch-centre__headline">{{ L.headline }}</h2>
-    {% if L.explanation %}
-      <p class="mel-launch-centre__explanation">{{ L.explanation }}</p>
-    {% endif %}
-    {% if L.hero_hint %}
-      <p class="mel-launch-centre__hero-hint" data-mel-launch-hero-hint>{{ L.hero_hint }}</p>
-    {% endif %}
+    <p class="mel-launch-centre__eyebrow" data-mel-launch-eyebrow>{{ L.eyebrow|default('Ready to launch'|t) }}</p>
+    <h2 id="mel-launch-centre-heading" class="mel-launch-centre__headline" data-mel-launch-headline>{{ L.headline }}</h2>
+    <p class="mel-launch-centre__explanation" data-mel-launch-explanation{% if not L.explanation %} hidden{% endif %}>{{ L.explanation }}</p>
+    <p class="mel-launch-centre__hero-hint" data-mel-launch-hero-hint{% if not L.hero_hint %} hidden{% endif %}>{{ L.hero_hint }}</p>
   </header>
 
   {# 2. Launch checklist — open when blocked, collapsed when ready #}
@@ -49,16 +45,16 @@
       <span class="mel-launch-centre__checklist-title">{{ checklist.title|default('Launch checklist'|t) }}</span>
       <span class="mel-launch-centre__checklist-meta">
         {% if checklist.summary %}
-          <span class="mel-launch-centre__checklist-summary-text">{{ checklist.summary }}</span>
+          <span class="mel-launch-centre__checklist-summary-text" data-mel-launch-checklist-summary>{{ checklist.summary }}</span>
         {% endif %}
         {% if checklist.total_count|default(0) > 0 %}
-          <span class="mel-launch-centre__checklist-count" aria-hidden="true">
+          <span class="mel-launch-centre__checklist-count" data-mel-launch-checklist-count aria-hidden="true">
             {{ checklist.complete_count|default(0) }}/{{ checklist.total_count }}
           </span>
         {% endif %}
       </span>
     </summary>
-    <ul class="mel-launch-centre__list" role="list">
+    <ul class="mel-launch-centre__list" role="list" data-mel-launch-checklist-list>
       {% for item in items %}
         {% set tone = item.tone|default('success') %}
         <li class="mel-launch-centre__item mel-launch-centre__item--{{ tone|clean_class }}{% if item.complete %} is-complete{% endif %}">
@@ -97,7 +93,7 @@
     <summary class="mel-launch-centre__visibility-summary">
       <span class="mel-launch-centre__visibility-title">{{ visibility.summary_label|default('Who can find this?'|t) }}</span>
       {% if visibility.current_label %}
-        <span class="mel-launch-centre__visibility-current">{{ visibility.current_label }}</span>
+        <span class="mel-launch-centre__visibility-current" data-mel-launch-visibility-current>{{ visibility.current_label }}</span>
       {% endif %}
     </summary>
     <div class="mel-launch-centre__visibility-body">
@@ -113,14 +109,12 @@
   </details>
 
   {# 4. After you publish — informational only (no Launch Success UI) #}
-  {% if after.items|default([]) %}
-    <aside class="mel-launch-centre__after" aria-labelledby="mel-launch-after-heading">
-      <h3 id="mel-launch-after-heading" class="mel-launch-centre__after-title">{{ after.title }}</h3>
-      <ul class="mel-launch-centre__after-list">
-        {% for line in after.items %}
-          <li>{{ line }}</li>
-        {% endfor %}
-      </ul>
-    </aside>
-  {% endif %}
+  <aside class="mel-launch-centre__after" data-mel-launch-after aria-labelledby="mel-launch-after-heading"{% if not after.items|default([]) %} hidden{% endif %}>
+    <h3 id="mel-launch-after-heading" class="mel-launch-centre__after-title" data-mel-launch-after-title>{{ after.title|default('After you publish'|t) }}</h3>
+    <ul class="mel-launch-centre__after-list" data-mel-launch-after-list>
+      {% for line in after.items|default([]) %}
+        <li>{{ line }}</li>
+      {% endfor %}
+    </ul>
+  </aside>
 </section>

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioLaunchCentreTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioLaunchCentreTest.php
@@ -69,6 +69,11 @@ final class EventStudioLaunchCentreTest extends UnitTestCase {
     $this->assertStringContainsString('function syncLaunchAfterBand(root, after, published)', $js);
     $this->assertStringContainsString('function collectLaunchFixLinksFromList(list)', $js);
     $this->assertStringContainsString('function resolveLaunchFixLinkClient(label)', $js);
+    $this->assertStringContainsString('function vendorConsolePathFromPublishUrl(publishUrl, segment)', $js);
+    $this->assertStringContainsString('vendorConsolePathFromPublishUrl(publishUrl, \'payments\')', $js);
+    $this->assertStringContainsString('vendorConsolePathFromPublishUrl(publishUrl, \'settings\')', $js);
+    $this->assertStringNotContainsString("path = '/vendor/payments'", $js);
+    $this->assertStringNotContainsString("path = '/vendor/settings'", $js);
     $this->assertStringContainsString('buildLaunchChecklistItemsFromReadiness(readiness, preservedFixLinks)', $js);
     $this->assertStringContainsString('updateLaunchCentre(shell, result.launch_centre, result)', $js);
     $this->assertGreaterThanOrEqual(3, substr_count($js, 'updateLaunchCentre(shell, result.launch_centre, result)'));

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioLaunchCentreTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioLaunchCentreTest.php
@@ -19,10 +19,31 @@ final class EventStudioLaunchCentreTest extends UnitTestCase {
     $method = $this->extractMethodBody($renderer, 'buildPublishingHub');
     $this->assertStringContainsString('mel_event_studio_launch_centre', $method);
     $this->assertStringContainsString('EventLaunchVisibilityForm::class', $method);
-    $this->assertStringContainsString('$checklist_open = !$ready', $method);
+    $this->assertStringContainsString('buildLaunchCentreViewModel', $method);
     $this->assertStringNotContainsString('EventSettingsForm::class', $method);
     $this->assertStringNotContainsString('data-mel-card-publish-action', $method);
     $this->assertStringNotContainsString('Publish now', $method);
+  }
+
+  public function testLaunchCentreStatePrefersReadinessOverPublished(): void {
+    $renderer = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioSectionRenderer.php');
+    $this->assertIsString($renderer);
+    $method = $this->extractMethodBody($renderer, 'buildLaunchCentreViewModel');
+    $this->assertStringContainsString("\$state = !\$ready ? 'needs_attention' : (\$published ? 'live' : 'ready')", $method);
+    $this->assertStringNotContainsString("\$published ? 'live' : (\$ready ? 'ready' : 'needs_attention')", $method);
+    $this->assertStringContainsString('$checklist_open = !$ready', $method);
+  }
+
+  public function testLaunchCopyHandlesLivePlusNeedsAttention(): void {
+    $renderer = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioSectionRenderer.php');
+    $this->assertIsString($renderer);
+    $headline = $this->extractMethodBody($renderer, 'launchHeadline');
+    $this->assertStringContainsString('Your event is live — one thing needs attention', $headline);
+    $this->assertStringContainsString('Your event is live — a few things need attention', $headline);
+    $hint = $this->extractMethodBody($renderer, 'launchHeroHint');
+    $this->assertStringContainsString('Continue setup from the header to fix what needs attention.', $hint);
+    $this->assertStringContainsString('Use Publish event in the header when you are ready.', $hint);
+    $this->assertStringContainsString('Use Share event in the header to spread the word.', $hint);
   }
 
   public function testLaunchHeroHintDefersPublishToHeader(): void {
@@ -32,6 +53,18 @@ final class EventStudioLaunchCentreTest extends UnitTestCase {
     $this->assertStringContainsString('Use Publish event in the header when you are ready.', $method);
     $this->assertStringContainsString('Use Share event in the header to spread the word.', $method);
     $this->assertStringContainsString('Publish is unavailable until the checklist is clear.', $method);
+  }
+
+  public function testPublishAjaxIncludesLaunchCentrePayload(): void {
+    $controller = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/EventStudioPublishController.php');
+    $this->assertIsString($controller);
+    $this->assertStringContainsString('buildLaunchCentreViewModel', $controller);
+    $this->assertStringContainsString("'launch_centre' => \$launch_centre", $controller);
+    $js = file_get_contents(dirname(__DIR__, 3) . '/js/mel-event-studio-shell.js');
+    $this->assertIsString($js);
+    $this->assertStringContainsString('function updateLaunchCentre(shell, launch)', $js);
+    $this->assertStringContainsString('updateLaunchCentre(shell, result.launch_centre)', $js);
+    $this->assertGreaterThanOrEqual(3, substr_count($js, 'updateLaunchCentre(shell, result.launch_centre)'));
   }
 
   public function testLaunchVisibilityFormOmitsPublishCard(): void {
@@ -50,6 +83,8 @@ final class EventStudioLaunchCentreTest extends UnitTestCase {
     $this->assertIsString($twig);
     $this->assertStringContainsString('mel-launch-centre', $twig);
     $this->assertStringContainsString('data-mel-launch-hero-hint', $twig);
+    $this->assertStringContainsString('data-mel-launch-eyebrow', $twig);
+    $this->assertStringContainsString('data-mel-launch-headline', $twig);
     $this->assertStringContainsString('Who can find this?', $twig);
     $this->assertStringContainsString('After you publish', $twig);
     $this->assertStringContainsString('data-mel-launch-checklist', $twig);
@@ -99,7 +134,7 @@ final class EventStudioLaunchCentreTest extends UnitTestCase {
   public function testLaunchChecklistProgressCountsRequiredItemsOnly(): void {
     $renderer = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioSectionRenderer.php');
     $this->assertIsString($renderer);
-    $method = $this->extractMethodBody($renderer, 'buildPublishingHub');
+    $method = $this->extractMethodBody($renderer, 'buildLaunchCentreViewModel');
     $this->assertStringContainsString("in_array(\$item['tone'] ?? '', ['success', 'attention'], TRUE)", $method);
     $this->assertStringContainsString('required_items', $method);
   }

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioLaunchCentreTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioLaunchCentreTest.php
@@ -59,12 +59,14 @@ final class EventStudioLaunchCentreTest extends UnitTestCase {
     $controller = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/EventStudioPublishController.php');
     $this->assertIsString($controller);
     $this->assertStringContainsString('buildLaunchCentreViewModel', $controller);
+    $this->assertStringContainsString('buildDegradedLaunchCentreViewModel', $controller);
     $this->assertStringContainsString("'launch_centre' => \$launch_centre", $controller);
     $js = file_get_contents(dirname(__DIR__, 3) . '/js/mel-event-studio-shell.js');
     $this->assertIsString($js);
-    $this->assertStringContainsString('function updateLaunchCentre(shell, launch)', $js);
-    $this->assertStringContainsString('updateLaunchCentre(shell, result.launch_centre)', $js);
-    $this->assertGreaterThanOrEqual(3, substr_count($js, 'updateLaunchCentre(shell, result.launch_centre)'));
+    $this->assertStringContainsString('function updateLaunchCentre(shell, launch, result)', $js);
+    $this->assertStringContainsString('function applyDegradedLaunchCentre(root, result)', $js);
+    $this->assertStringContainsString('updateLaunchCentre(shell, result.launch_centre, result)', $js);
+    $this->assertGreaterThanOrEqual(3, substr_count($js, 'updateLaunchCentre(shell, result.launch_centre, result)'));
   }
 
   public function testLaunchVisibilityFormOmitsPublishCard(): void {
@@ -76,6 +78,22 @@ final class EventStudioLaunchCentreTest extends UnitTestCase {
     $this->assertStringNotContainsString('data-mel-card-publish-action', $form);
     $this->assertStringNotContainsString('Publish now', $form);
     $this->assertStringContainsString('workspace_publishing', $form);
+    $this->assertStringContainsString('isDraftWizardSave', $form);
+    $this->assertStringContainsString('return TRUE;', $form);
+    $this->assertStringContainsString("unset(\$mel['status'])", $form);
+    $this->assertStringContainsString('parent::persistWizardMel($form_state, TRUE)', $form);
+    $this->assertStringNotContainsString("\$form['mel']['status']", $form);
+  }
+
+  public function testLaunchAfterGuidanceUsesLiveWordingWhenPublished(): void {
+    $renderer = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioSectionRenderer.php');
+    $this->assertIsString($renderer);
+    $method = $this->extractMethodBody($renderer, 'launchAfterGuidance');
+    $this->assertStringContainsString('While your event is live', $method);
+    $this->assertStringContainsString('Share your event from the header', $method);
+    $this->assertStringContainsString("You'll be able to share your event", $method);
+    $this->assertStringContainsString('After you publish', $method);
+    $this->assertStringNotContainsString("'After publishing'", $method);
   }
 
   public function testLaunchCentreTemplateHasNoPublishButton(): void {

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioLaunchCentreTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioLaunchCentreTest.php
@@ -67,6 +67,9 @@ final class EventStudioLaunchCentreTest extends UnitTestCase {
     $this->assertStringContainsString('function applyDegradedLaunchCentre(root, result)', $js);
     $this->assertStringContainsString('function syncLaunchChecklistList(list, checklist, readiness, ready)', $js);
     $this->assertStringContainsString('function syncLaunchAfterBand(root, after, published)', $js);
+    $this->assertStringContainsString('function collectLaunchFixLinksFromList(list)', $js);
+    $this->assertStringContainsString('function resolveLaunchFixLinkClient(label)', $js);
+    $this->assertStringContainsString('buildLaunchChecklistItemsFromReadiness(readiness, preservedFixLinks)', $js);
     $this->assertStringContainsString('updateLaunchCentre(shell, result.launch_centre, result)', $js);
     $this->assertGreaterThanOrEqual(3, substr_count($js, 'updateLaunchCentre(shell, result.launch_centre, result)'));
     $this->assertStringContainsString('While your event is live', $js);

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioLaunchCentreTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioLaunchCentreTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Launch Centre composition contracts (Sprint 3C.1).
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventStudioLaunchCentreTest extends UnitTestCase {
+
+  public function testPublishingHubUsesLaunchCentreThemeNotSettingsForm(): void {
+    $renderer = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioSectionRenderer.php');
+    $this->assertIsString($renderer);
+    $method = $this->extractMethodBody($renderer, 'buildPublishingHub');
+    $this->assertStringContainsString('mel_event_studio_launch_centre', $method);
+    $this->assertStringContainsString('EventLaunchVisibilityForm::class', $method);
+    $this->assertStringContainsString('$checklist_open = !$ready', $method);
+    $this->assertStringNotContainsString('EventSettingsForm::class', $method);
+    $this->assertStringNotContainsString('data-mel-card-publish-action', $method);
+    $this->assertStringNotContainsString('Publish now', $method);
+  }
+
+  public function testLaunchHeroHintDefersPublishToHeader(): void {
+    $renderer = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioSectionRenderer.php');
+    $this->assertIsString($renderer);
+    $method = $this->extractMethodBody($renderer, 'launchHeroHint');
+    $this->assertStringContainsString('Use Publish event in the header when you are ready.', $method);
+    $this->assertStringContainsString('Use Share event in the header to spread the word.', $method);
+    $this->assertStringContainsString('Publish is unavailable until the checklist is clear.', $method);
+  }
+
+  public function testLaunchVisibilityFormOmitsPublishCard(): void {
+    $form = file_get_contents(dirname(__DIR__, 3) . '/src/Form/EventLaunchVisibilityForm.php');
+    $this->assertIsString($form);
+    $this->assertStringContainsString('extends EventSettingsForm', $form);
+    $this->assertStringContainsString('buildVisibilityControls', $form);
+    $this->assertStringNotContainsString('parent::buildWizardStepContent', $form);
+    $this->assertStringNotContainsString('data-mel-card-publish-action', $form);
+    $this->assertStringNotContainsString('Publish now', $form);
+    $this->assertStringContainsString('workspace_publishing', $form);
+  }
+
+  public function testLaunchCentreTemplateHasNoPublishButton(): void {
+    $twig = file_get_contents(dirname(__DIR__, 3) . '/templates/mel-event-studio-launch-centre.html.twig');
+    $this->assertIsString($twig);
+    $this->assertStringContainsString('mel-launch-centre', $twig);
+    $this->assertStringContainsString('data-mel-launch-hero-hint', $twig);
+    $this->assertStringContainsString('Who can find this?', $twig);
+    $this->assertStringContainsString('After you publish', $twig);
+    $this->assertStringContainsString('data-mel-launch-checklist', $twig);
+    $this->assertStringContainsString('data-mel-launch-visibility', $twig);
+    $this->assertStringNotContainsString('data-mel-publish-action', $twig);
+    $this->assertStringNotContainsString('data-mel-card-publish-action', $twig);
+    $this->assertStringNotContainsString('Publish now', $twig);
+    $this->assertStringNotContainsString('data-mel-unpublish-action', $twig);
+  }
+
+  public function testThemeHookRegistersLaunchCentre(): void {
+    $module = file_get_contents(dirname(__DIR__, 3) . '/myeventlane_event_studio.module');
+    $this->assertIsString($module);
+    $this->assertStringContainsString("'mel_event_studio_launch_centre'", $module);
+    $this->assertStringContainsString('mel-event-studio-launch-centre', $module);
+  }
+
+  public function testSettingsFormStillOwnsFullSettingsPath(): void {
+    $renderer = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioSectionRenderer.php');
+    $this->assertIsString($renderer);
+    $method = $this->extractMethodBody($renderer, 'buildSettingsSection');
+    $this->assertStringContainsString('EventSettingsForm::class', $method);
+  }
+
+  public function testAuthoritativeCtaResolverUntouched(): void {
+    $overview = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventWorkspaceOverviewBuilder.php');
+    $this->assertIsString($overview);
+    $this->assertStringContainsString('function resolveAuthoritativePrimaryCta', $overview);
+    $eligibility = file_get_contents(dirname(__DIR__, 3) . '/src/Service/PublishEligibilityEvaluator.php');
+    $this->assertIsString($eligibility);
+    $this->assertStringContainsString('VendorPublishRequirementsGate', $eligibility);
+  }
+
+  private function extractMethodBody(string $source, string $methodName): string {
+    $pattern = '/(?:private|public|protected) function ' . preg_quote($methodName, '/') . '\(/';
+    if (!preg_match($pattern, $source, $match, PREG_OFFSET_CAPTURE)) {
+      $this->fail("Method {$methodName} not found");
+    }
+    $start = (int) $match[0][1];
+    $brace = strpos($source, '{', $start);
+    $this->assertNotFalse($brace);
+    $depth = 0;
+    $len = strlen($source);
+    for ($i = (int) $brace; $i < $len; $i++) {
+      $ch = $source[$i];
+      if ($ch === '{') {
+        $depth++;
+      }
+      elseif ($ch === '}') {
+        $depth--;
+        if ($depth === 0) {
+          return substr($source, $start, $i - $start + 1);
+        }
+      }
+    }
+    $this->fail("Could not extract {$methodName}");
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioLaunchCentreTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioLaunchCentreTest.php
@@ -65,8 +65,21 @@ final class EventStudioLaunchCentreTest extends UnitTestCase {
     $this->assertIsString($js);
     $this->assertStringContainsString('function updateLaunchCentre(shell, launch, result)', $js);
     $this->assertStringContainsString('function applyDegradedLaunchCentre(root, result)', $js);
+    $this->assertStringContainsString('function syncLaunchChecklistList(list, checklist, readiness, ready)', $js);
+    $this->assertStringContainsString('function syncLaunchAfterBand(root, after, published)', $js);
     $this->assertStringContainsString('updateLaunchCentre(shell, result.launch_centre, result)', $js);
     $this->assertGreaterThanOrEqual(3, substr_count($js, 'updateLaunchCentre(shell, result.launch_centre, result)'));
+    $this->assertStringContainsString('While your event is live', $js);
+    $this->assertStringContainsString('Share your event from the header', $js);
+  }
+
+  public function testDegradedLaunchCentreIncludesChecklistItems(): void {
+    $renderer = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioSectionRenderer.php');
+    $this->assertIsString($renderer);
+    $method = $this->extractMethodBody($renderer, 'buildDegradedLaunchCentreViewModel');
+    $this->assertStringContainsString('buildLaunchChecklistItems', $method);
+    $this->assertStringContainsString("'items' => \$checklist_items", $method);
+    $this->assertStringNotContainsString('Omits checklist items', $method);
   }
 
   public function testLaunchVisibilityFormOmitsPublishCard(): void {

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioLaunchCentreTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioLaunchCentreTest.php
@@ -83,6 +83,41 @@ final class EventStudioLaunchCentreTest extends UnitTestCase {
     $this->assertStringContainsString('VendorPublishRequirementsGate', $eligibility);
   }
 
+  public function testLaunchFixLinkDoesNotMatchEndInsideAttendee(): void {
+    $renderer = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioSectionRenderer.php');
+    $this->assertIsString($renderer);
+    $method = $this->extractMethodBody($renderer, 'resolveLaunchFixLink');
+    $this->assertStringNotContainsString("str_contains(\$lower, 'end')", $method);
+    $this->assertStringNotContainsString("str_contains(\$lower, 'start')", $method);
+    $this->assertStringContainsString('isLaunchScheduleFixLabel', $method);
+    $schedule = $this->extractMethodBody($renderer, 'isLaunchScheduleFixLabel');
+    $this->assertStringContainsString('start date', $schedule);
+    $this->assertStringContainsString('end date', $schedule);
+    $this->assertStringContainsString('\\bdates?\\b', $schedule);
+  }
+
+  public function testLaunchChecklistProgressCountsRequiredItemsOnly(): void {
+    $renderer = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioSectionRenderer.php');
+    $this->assertIsString($renderer);
+    $method = $this->extractMethodBody($renderer, 'buildPublishingHub');
+    $this->assertStringContainsString("in_array(\$item['tone'] ?? '', ['success', 'attention'], TRUE)", $method);
+    $this->assertStringContainsString('required_items', $method);
+  }
+
+  public function testOrganiserFixFallbackIsNotConnectStripe(): void {
+    $renderer = file_get_contents(dirname(__DIR__, 3) . '/src/Service/EventStudioSectionRenderer.php');
+    $this->assertIsString($renderer);
+    $method = $this->extractMethodBody($renderer, 'resolveLaunchFixLink');
+    $this->assertStringContainsString('settings_profile', $method);
+    $this->assertStringContainsString('Organiser/terms blockers must not fall through to Stripe Connect', $method);
+    // Catch block must keep the Open account label, never rebadge as Connect Stripe.
+    $catchPos = strpos($method, 'catch (\Throwable)');
+    $this->assertNotFalse($catchPos);
+    $catchBody = substr($method, $catchPos);
+    $this->assertStringNotContainsString('Connect Stripe', $catchBody);
+    $this->assertStringNotContainsString('console.payments', $catchBody);
+  }
+
   private function extractMethodBody(string $source, string $methodName): string {
     $pattern = '/(?:private|public|protected) function ' . preg_quote($methodName, '/') . '\(/';
     if (!preg_match($pattern, $source, $match, PREG_OFFSET_CAPTURE)) {


### PR DESCRIPTION
## Summary
- Replace the Publishing Hub with the approved **Launch Centre** composition (Ready → Checklist → Who can find this? → After you publish).
- Keep **Hero as the sole Publish owner**; remove duplicate Publish controls from the Publishing section.
- Add slim `EventLaunchVisibilityForm` with progressive disclosure; full Settings remains on Settings.
- Add Vendor Component Catalogue and Publishing Product Design System docs (`15`–`23`).
- Freeze Launch Centre composition (PO approved). Mission Control remains frozen.

## Test plan
- [ ] Draft / Needs attention / Ready / Published on Publishing section
- [ ] Desktop, 768px, 390px: one narrative; no second Publish button
- [ ] Checklist expands when blocked, collapses when Ready
- [ ] Visibility disclosure + More settings link
- [ ] Hero still owns Publish / Share / Continue setup
- [ ] Unit: `EventStudioLaunchCentreTest` + workspace presentation/state matrix
- [ ] `ddev drush cr`, `composer validate`, `npm run mel:lint`

## Notes
- Sprint **3C.2** (Launch Success Alternative A) starts only after this PR is open and CI is green.
- Do not merge until Product Owner review of the full Phase 3 slice (or this PR alone if preferred).


Made with [Cursor](https://cursor.com)