### PR TITLE
fix(vendor-workspace): align VL-5A outcome hierarchy

### DIFF
--- a/docs/design/vendor-studio-visual/reviews/vl5a/README.md
+++ b/docs/design/vendor-studio-visual/reviews/vl5a/README.md
@@ -1,7 +1,7 @@
 # VL-5A — Launch Success Alternative A
 
 **Date:** 2026-07-25  
-**Status:** ⏳ Ready for Product Owner review (not committed)  
+**Status:** ✅ VL-5A merged via PR #721 · VL-5A.1 conformance correction approved  
 **Scope:** Outcome zone presentation only — Alternative A  
 **Branch:** `feature/vendor-workspace-vl5a-launch-success`
 
@@ -104,4 +104,4 @@ ddev drush cr      # success
 
 - Builder-path celebrate UI in `mel-event-studio.html.twig` (non-workspace) still uses legacy celebrate + Boost card — out of VL-5A Workspace Outcome scope.
 - Secondary social intent links remain available (existing networks only); marketing Share remains the recommended primary.
-- PO review required before commit/push.
+- VL-5A.1 corrects the Outcome zone order and action hierarchy before VL-5B.

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
@@ -70,73 +70,6 @@
     </section>
   {% endif %}
 
-  {# Outcome zone — Launch Success Alternative A (VL-5A). Same panel for AJAX + ?mel_celebrate=1. #}
-  <section
-    class="mel-event-studio-publish-feedback mel-launch-success"
-    aria-live="polite"
-    aria-atomic="true"
-    data-mel-publish-feedback
-    data-mel-launch-success
-    hidden
-  >
-    <div class="mel-event-studio-publish-feedback__error" data-mel-publish-error hidden>
-      <h2 class="mel-event-studio-publish-feedback__title" data-mel-publish-feedback-title>{{ 'Cannot publish yet'|t }}</h2>
-      <ul class="mel-event-studio-publish-feedback__list" data-mel-publish-feedback-list></ul>
-      <a class="mel-event-studio-publish-feedback__restore" href="#" data-mel-publish-restore hidden>{{ 'Restore draft'|t }}</a>
-    </div>
-    <div
-      class="mel-event-studio-publish-feedback__success mel-launch-success__panel"
-      data-mel-publish-success
-      hidden
-      role="region"
-      aria-labelledby="mel-publish-success-title"
-    >
-      <p class="visually-hidden" data-mel-publish-success-announce></p>
-      <h2
-        id="mel-publish-success-title"
-        class="mel-event-studio-publish-feedback__title mel-launch-success__title"
-        data-mel-publish-success-title
-        tabindex="-1"
-      ></h2>
-      <p class="mel-event-studio-publish-feedback__status mel-launch-success__status visually-hidden" data-mel-publish-success-message></p>
-
-      <div class="mel-launch-success__people" data-mel-publish-success-people hidden>
-        <p class="mel-launch-success__people-intro" data-mel-publish-success-people-intro>{{ 'People can now:'|t }}</p>
-        <ul class="mel-launch-success__people-list" data-mel-publish-success-people-list></ul>
-      </div>
-
-      <div class="mel-launch-success__recommended" data-mel-publish-success-recommended hidden>
-        <p class="mel-launch-success__eyebrow" data-mel-publish-success-recommended-eyebrow>{{ 'Recommended next step'|t }}</p>
-        <a class="mel-btn mel-btn--primary mel-launch-success__share" href="#" data-mel-publish-success-share>{{ 'Share your event'|t }}</a>
-      </div>
-
-      <div class="mel-event-studio-publish-feedback__row mel-launch-success__secondary" data-mel-publish-success-secondary hidden>
-        <button
-          type="button"
-          class="mel-btn mel-btn--secondary"
-          data-mel-publish-success-copy
-          hidden
-        >{{ 'Copy link'|t }}</button>
-        <a
-          class="mel-btn mel-btn--secondary"
-          href="#"
-          target="_blank"
-          rel="noopener noreferrer"
-          data-mel-publish-success-view
-          hidden
-        >{{ 'View public page'|t }}</a>
-        <span class="mel-launch-success__copy-feedback visually-hidden" data-mel-publish-success-copy-feedback aria-live="polite"></span>
-      </div>
-
-      <div class="mel-event-studio-publish-feedback__row mel-event-studio-publish-feedback__social mel-launch-success__social" data-mel-publish-success-social hidden role="group" aria-label="{{ 'Share on social'|t }}"></div>
-
-      <div class="mel-launch-success__boost" data-mel-publish-success-boost-card hidden>
-        <p class="mel-launch-success__eyebrow" data-mel-publish-success-boost-eyebrow>{{ 'Grow later'|t }}</p>
-        <a class="mel-launch-success__boost-link" href="#" data-mel-publish-success-boost>{{ 'Boost visibility (optional)'|t }}</a>
-      </div>
-    </div>
-  </section>
-
   <button
     class="mel-event-studio-sidebar-toggle"
     type="button"
@@ -178,4 +111,72 @@
       }, with_context = false) }}
     </main>
   </div>
+
+  {# Outcome zone — Launch Success Alternative A (VL-5A). Same panel for AJAX + ?mel_celebrate=1. #}
+  <section
+    class="mel-event-studio-publish-feedback mel-launch-success"
+    aria-live="polite"
+    aria-atomic="true"
+    data-mel-publish-feedback
+    data-mel-launch-success
+    hidden
+  >
+    <div class="mel-event-studio-publish-feedback__error" data-mel-publish-error hidden>
+      <h2 class="mel-event-studio-publish-feedback__title" data-mel-publish-feedback-title>{{ 'Cannot publish yet'|t }}</h2>
+      <ul class="mel-event-studio-publish-feedback__list" data-mel-publish-feedback-list></ul>
+      <a class="mel-event-studio-publish-feedback__restore" href="#" data-mel-publish-restore hidden>{{ 'Restore draft'|t }}</a>
+    </div>
+    <div
+      class="mel-event-studio-publish-feedback__success mel-launch-success__panel"
+      data-mel-publish-success
+      hidden
+      role="region"
+      aria-labelledby="mel-publish-success-title"
+    >
+      <p class="visually-hidden" data-mel-publish-success-announce></p>
+      <h2
+        id="mel-publish-success-title"
+        class="mel-event-studio-publish-feedback__title mel-launch-success__title"
+        data-mel-publish-success-title
+        tabindex="-1"
+      ></h2>
+      <p class="mel-event-studio-publish-feedback__status mel-launch-success__status visually-hidden" data-mel-publish-success-message></p>
+
+      <div class="mel-launch-success__people" data-mel-publish-success-people hidden>
+        <p class="mel-launch-success__people-intro" data-mel-publish-success-people-intro>{{ 'People can now:'|t }}</p>
+        <ul class="mel-launch-success__people-list" data-mel-publish-success-people-list></ul>
+      </div>
+
+      <div class="mel-launch-success__recommended" data-mel-publish-success-recommended hidden>
+        <p class="mel-launch-success__eyebrow" data-mel-publish-success-recommended-eyebrow>{{ 'Recommended next step'|t }}</p>
+        <a class="mel-btn mel-btn--secondary mel-launch-success__share" href="#" data-mel-publish-success-share>{{ 'Share your event'|t }}</a>
+      </div>
+
+      <div class="mel-event-studio-publish-feedback__row mel-launch-success__secondary" data-mel-publish-success-secondary hidden>
+        <button
+          type="button"
+          class="mel-btn mel-btn--ghost"
+          data-mel-publish-success-copy
+          hidden
+        >{{ 'Copy link'|t }}</button>
+        <a
+          class="mel-btn mel-btn--secondary"
+          href="#"
+          target="_blank"
+          rel="noopener noreferrer"
+          data-mel-publish-success-view
+          hidden
+        >{{ 'View public page'|t }}</a>
+        <span class="mel-launch-success__copy-feedback visually-hidden" data-mel-publish-success-copy-feedback aria-live="polite"></span>
+      </div>
+
+      <div class="mel-event-studio-publish-feedback__row mel-event-studio-publish-feedback__social mel-launch-success__social" data-mel-publish-success-social hidden role="group" aria-label="{{ 'Share on social'|t }}"></div>
+
+      <div class="mel-launch-success__boost" data-mel-publish-success-boost-card hidden>
+        <p class="mel-launch-success__eyebrow" data-mel-publish-success-boost-eyebrow>{{ 'Grow later'|t }}</p>
+        <a class="mel-launch-success__boost-link" href="#" data-mel-publish-success-boost>{{ 'Boost visibility (optional)'|t }}</a>
+      </div>
+    </div>
+  </section>
+
 </div>

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioLaunchSuccessTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioLaunchSuccessTest.php
@@ -67,6 +67,14 @@ final class EventStudioLaunchSuccessTest extends UnitTestCase {
     $this->assertStringContainsString('View public page', $twig);
     $this->assertStringContainsString('Boost visibility (optional)', $twig);
     $this->assertStringContainsString('Grow later', $twig);
+    $this->assertStringContainsString('mel-btn--secondary mel-launch-success__share', $twig);
+    $this->assertStringContainsString('mel-btn--ghost', $twig);
+    $this->assertStringNotContainsString('mel-btn--primary mel-launch-success__share', $twig);
+    $work_position = strpos($twig, '<div class="mel-event-studio-workspace">');
+    $outcome_position = strpos($twig, 'data-mel-launch-success');
+    $this->assertNotFalse($work_position);
+    $this->assertNotFalse($outcome_position);
+    $this->assertGreaterThan($work_position, $outcome_position);
     $this->assertStringNotContainsString('Boost my event', $twig);
     $this->assertStringNotContainsString('mel-publish-boost-cta__features', $twig);
     $this->assertStringNotContainsString('data-mel-publish-success-view-row', $twig);

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-event-studio-launch-success.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-event-studio-launch-success.scss
@@ -115,7 +115,7 @@
 }
 
 // ============================================================================
-// RECOMMENDED — Share as sole Outcome primary
+// RECOMMENDED — Share as a strong secondary; Hero retains the sole primary
 // ============================================================================
 
 .mel-event-studio--workspace .mel-launch-success__eyebrow {
@@ -131,20 +131,20 @@
   margin: 0 0 $spacing-4;
 }
 
-.mel-vendor-console.mel-vendor-shell .mel-event-studio--workspace .mel-launch-success__share.mel-btn--primary,
-.mel-event-studio--workspace .mel-launch-success__share.mel-btn--primary {
+.mel-vendor-console.mel-vendor-shell .mel-event-studio--workspace .mel-launch-success__share.mel-btn--secondary,
+.mel-event-studio--workspace .mel-launch-success__share.mel-btn--secondary {
   min-height: 44px;
-  background-color: $mel-brand-purple;
-  border-color: $mel-brand-purple;
-  color: #fff;
+  background-color: $mel-ws-purple-tint;
+  border-color: $mel-ws-purple-border;
+  color: $mel-brand-purple;
   font-weight: $font-weight-semibold;
   box-shadow: none;
 
   &:hover,
   &:focus {
-    background-color: #5a38e0;
-    border-color: #5a38e0;
-    color: #fff;
+    background-color: $mel-ws-lavender;
+    border-color: $mel-brand-lavender;
+    color: $text-primary;
   }
 
   &:focus-visible {
@@ -163,6 +163,7 @@
 }
 
 .mel-event-studio--workspace .mel-launch-success__secondary .mel-btn--secondary:focus-visible,
+.mel-event-studio--workspace .mel-launch-success__secondary .mel-btn--ghost:focus-visible,
 .mel-event-studio--workspace .mel-launch-success__social-link:focus-visible {
   outline: 3px solid $mel-brand-coral;
   outline-offset: 2px;


### PR DESCRIPTION
## Summary

Corrects three VL-5A conformance defects found after PR #721 merged:

- places Launch Success after the Workspace Work region
- makes Outcome Share a strong secondary action while preserving the Hero as the sole filled purple primary
- makes Copy link tertiary/ghost while retaining View public page as secondary

This is a presentation-only VL-5A.1 correction. It does not change publish behaviour, handoff data, AJAX contracts, eligibility, Commerce, routes, Hero, Mission Control or Launch Centre.

## Zone map

```text
Identity: Hero remains frozen and owns the sole filled purple primary
Guidance: Mission Control remains frozen
Work:     Workspace section content remains unchanged
Outcome:  Launch Success now follows Work and uses secondary/tertiary actions
```

Authority: `docs/design/vendor-studio-visual/07-workspace-zones.md`

## Vendor Studio Design System references

- `docs/design/vendor-studio-visual/07-workspace-zones.md`
- `docs/design/vendor-studio-visual/03-option-b5.md`
- `docs/design/vendor-workspace-v2/19-publishing-ux-rules.md`
- `docs/design/vendor-workspace-v2/20-launch-success-experience.md`
- `docs/design/vendor-studio-visual/06-implementation-guide.md`
- ADR-0001
- ADR-0002

## Definition of Done

- [x] Zone Gate map present
- [x] Outcome follows Identity → Guidance → Work
- [x] Hero remains the only filled purple primary
- [x] Outcome Share is visually secondary
- [x] Copy link is tertiary/ghost
- [x] View public page remains secondary
- [x] No frozen behaviour or business logic changed
- [x] Regression assertions cover DOM order and button hierarchy
- [ ] Runtime review at desktop, 768px and 390px
- [ ] AJAX publish success path verified in DDEV
- [ ] `?mel_celebrate=1` success path verified in DDEV
- [ ] PHPUnit and theme lint/build run in the full checkout

## Validation completed here

Source-contract validation passed:

- branch is based on current `main` (`fed0922d4545d8295293ebbeb90e61cbdee43587`)
- exactly four scoped files changed
- Outcome DOM follows the Workspace Work container
- no Outcome Share primary class or primary-specific SCSS remains
- Share uses existing B.5 lavender/purple-tint secondary tokens
- Copy uses the existing ghost variant and retains a focus-visible ring
- View remains secondary
- contract test includes the new hierarchy assertions

The current Codex workspace does not contain the Drupal/DDEV checkout, so runtime, browser, Sass and PHPUnit checks are deliberately left open rather than claimed.

## Risk

Low. Twig placement and presentation classes only, plus SCSS, tests and the stale review status. No PHP, JavaScript, services, cache, access, Commerce, Stripe, routes or publish mutation changes.