### PR TITLE
feat(vendor-workspace): add shared outcome states

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-shell.js
@@ -1217,6 +1217,23 @@
     return ok;
   }
 
+  function setOutcomeTone(feedback, tone) {
+    feedback.classList.remove(
+      'is-success',
+      'is-error',
+      'mel-outcome--success',
+      'mel-outcome--error',
+      'mel-launch-success--enter',
+    );
+
+    if (tone === 'success') {
+      feedback.classList.add('is-success', 'mel-outcome--success');
+    }
+    else if (tone === 'error') {
+      feedback.classList.add('is-error', 'mel-outcome--error');
+    }
+  }
+
   function renderPublishFeedback(shell, title, messages, restoreUrl) {
     const feedback = shell.querySelector('[data-mel-publish-feedback]');
     if (!feedback) {
@@ -1230,7 +1247,7 @@
     if (errorPanel) {
       errorPanel.hidden = false;
     }
-    feedback.classList.remove('is-success', 'mel-launch-success--enter');
+    setOutcomeTone(feedback, 'error');
 
     const list = feedback.querySelector('[data-mel-publish-feedback-list]');
     const heading = feedback.querySelector('[data-mel-publish-feedback-title]');
@@ -1257,9 +1274,8 @@
       }
     }
     feedback.hidden = false;
-    if (typeof feedback.focus === 'function') {
-      feedback.setAttribute('tabindex', '-1');
-      feedback.focus({ preventScroll: true });
+    if (heading && typeof heading.focus === 'function') {
+      heading.focus({ preventScroll: true });
     }
   }
 
@@ -1423,7 +1439,7 @@
     }
 
     successPanel.hidden = false;
-    feedback.classList.add('is-success');
+    setOutcomeTone(feedback, 'success');
     feedback.classList.toggle('mel-launch-success--enter', !prefersReducedMotion());
     feedback.hidden = false;
 
@@ -1444,7 +1460,7 @@
     const feedback = shell.querySelector('[data-mel-publish-feedback]');
     if (feedback) {
       feedback.hidden = true;
-      feedback.classList.remove('is-success', 'mel-launch-success--enter');
+      setOutcomeTone(feedback, null);
       const errorPanel = feedback.querySelector('[data-mel-publish-error]');
       const successPanel = feedback.querySelector('[data-mel-publish-success]');
       if (errorPanel) {
@@ -1723,7 +1739,11 @@
               renderPublishSuccessFeedback(shell, result.handoff);
             }
             else {
-              renderPublishFeedback(shell, result.message || Drupal.t('Your event is now live'), []);
+              const title = result.message || Drupal.t('Your event is now live');
+              renderPublishSuccessFeedback(shell, {
+                title,
+                message: title,
+              });
             }
             setPublishButtonState(button, 'published');
             updatePublishPanels(shell, true);
@@ -1796,7 +1816,11 @@
               renderPublishSuccessFeedback(shell, result.handoff);
             }
             else {
-              renderPublishFeedback(shell, result.message || Drupal.t('Your event is now live'), []);
+              const title = result.message || Drupal.t('Your event is now live');
+              renderPublishSuccessFeedback(shell, {
+                title,
+                message: title,
+              });
             }
             updatePublishPanels(shell, true);
             updateFormMetadata(shell, result);
@@ -1869,7 +1893,11 @@
               button.textContent = originalLabel || Drupal.t('Unpublish');
               return;
             }
-            renderPublishFeedback(shell, result.message || Drupal.t('Unpublished successfully'), []);
+            const title = result.message || Drupal.t('Unpublished successfully');
+            renderPublishSuccessFeedback(shell, {
+              title,
+              message: title,
+            });
             updatePublishPanels(shell, false);
             updateFormMetadata(shell, result);
             button.disabled = false;

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-workspace.html.twig
@@ -114,29 +114,40 @@
 
   {# Outcome zone — Launch Success Alternative A (VL-5A). Same panel for AJAX + ?mel_celebrate=1. #}
   <section
-    class="mel-event-studio-publish-feedback mel-launch-success"
-    aria-live="polite"
+    class="mel-event-studio-publish-feedback mel-outcome mel-launch-success"
     aria-atomic="true"
     data-mel-publish-feedback
     data-mel-launch-success
     hidden
   >
-    <div class="mel-event-studio-publish-feedback__error" data-mel-publish-error hidden>
-      <h2 class="mel-event-studio-publish-feedback__title" data-mel-publish-feedback-title>{{ 'Cannot publish yet'|t }}</h2>
-      <ul class="mel-event-studio-publish-feedback__list" data-mel-publish-feedback-list></ul>
-      <a class="mel-event-studio-publish-feedback__restore" href="#" data-mel-publish-restore hidden>{{ 'Restore draft'|t }}</a>
+    <div
+      class="mel-event-studio-publish-feedback__error mel-outcome__panel mel-outcome__panel--error"
+      role="alert"
+      aria-labelledby="mel-publish-feedback-title"
+      data-mel-publish-error
+      hidden
+    >
+      <h2
+        id="mel-publish-feedback-title"
+        class="mel-event-studio-publish-feedback__title mel-outcome__title"
+        data-mel-publish-feedback-title
+        tabindex="-1"
+      >{{ 'Cannot publish yet'|t }}</h2>
+      <ul class="mel-event-studio-publish-feedback__list mel-outcome__messages" data-mel-publish-feedback-list></ul>
+      <a class="mel-event-studio-publish-feedback__restore mel-outcome__action" href="#" data-mel-publish-restore hidden>{{ 'Restore draft'|t }}</a>
     </div>
     <div
-      class="mel-event-studio-publish-feedback__success mel-launch-success__panel"
+      class="mel-event-studio-publish-feedback__success mel-outcome__panel mel-outcome__panel--success mel-launch-success__panel"
       data-mel-publish-success
       hidden
       role="region"
       aria-labelledby="mel-publish-success-title"
+      aria-live="polite"
     >
       <p class="visually-hidden" data-mel-publish-success-announce></p>
       <h2
         id="mel-publish-success-title"
-        class="mel-event-studio-publish-feedback__title mel-launch-success__title"
+        class="mel-event-studio-publish-feedback__title mel-outcome__title mel-launch-success__title"
         data-mel-publish-success-title
         tabindex="-1"
       ></h2>

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioLaunchSuccessTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioLaunchSuccessTest.php
@@ -61,6 +61,10 @@ final class EventStudioLaunchSuccessTest extends UnitTestCase {
     $this->assertStringContainsString('data-mel-publish-success-view', $twig);
     $this->assertStringContainsString('data-mel-publish-success-boost', $twig);
     $this->assertStringContainsString('aria-live="polite"', $twig);
+    $this->assertStringContainsString('mel-outcome', $twig);
+    $this->assertStringContainsString('mel-outcome__panel--success', $twig);
+    $this->assertStringContainsString('mel-outcome__panel--error', $twig);
+    $this->assertStringContainsString('role="alert"', $twig);
     $this->assertStringContainsString('mel-publish-success-title', $twig);
     $this->assertStringContainsString('Share your event', $twig);
     $this->assertStringContainsString('Copy link', $twig);
@@ -96,6 +100,11 @@ final class EventStudioLaunchSuccessTest extends UnitTestCase {
     $js = file_get_contents(dirname(__DIR__, 3) . '/js/mel-event-studio-shell.js');
     $this->assertIsString($js);
     $this->assertStringContainsString('function renderPublishSuccessFeedback(shell, handoff)', $js);
+    $this->assertStringContainsString('function setOutcomeTone(feedback, tone)', $js);
+    $this->assertStringContainsString("setOutcomeTone(feedback, 'error')", $js);
+    $this->assertStringContainsString("setOutcomeTone(feedback, 'success')", $js);
+    $this->assertStringContainsString('heading.focus({ preventScroll: true })', $js);
+    $this->assertStringContainsString("Drupal.t('Unpublished successfully')", $js);
     $this->assertStringContainsString('people_can', $js);
     $this->assertStringContainsString('share_workspace_url', $js);
     $this->assertStringContainsString('[data-mel-publish-success-title]', $js);

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-event-studio-launch-success.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-event-studio-launch-success.scss
@@ -16,22 +16,6 @@
 @use '../tokens/shadows' as *;
 @use '../tokens/typography' as *;
 
-// ============================================================================
-// OUTCOME PANEL — calm white soft surface on Warm Cream (earned card)
-// ============================================================================
-
-.mel-vendor-console.mel-vendor-shell .mel-event-studio--workspace .mel-event-studio-publish-feedback.is-success,
-.mel-event-studio--workspace .mel-event-studio-publish-feedback.is-success,
-.mel-event-studio--workspace .mel-launch-success.is-success {
-  margin: 0 0 $mel-zone-gap-sm;
-  padding: $spacing-5 $spacing-5;
-  max-width: 42rem;
-  border: 1px solid $mel-ws-border-soft;
-  border-radius: 16px;
-  background: $mel-shell-surface;
-  box-shadow: $shadow-sm;
-}
-
 .mel-event-studio--workspace .mel-launch-success.is-success.mel-launch-success--enter {
   animation: mel-launch-success-enter 180ms ease-out;
 }
@@ -52,25 +36,6 @@
   .mel-event-studio--workspace .mel-launch-success.is-success.mel-launch-success--enter {
     animation: none;
   }
-}
-
-.mel-event-studio--workspace .mel-launch-success__title,
-.mel-event-studio--workspace .mel-event-studio-publish-feedback.is-success .mel-event-studio-publish-feedback__title {
-  margin: 0 0 $spacing-3;
-  font-size: 1.375rem;
-  font-weight: $font-weight-bold;
-  line-height: 1.25;
-  color: $text-primary;
-}
-
-.mel-event-studio--workspace .mel-launch-success__title:focus {
-  outline: none;
-}
-
-.mel-event-studio--workspace .mel-launch-success__title:focus-visible {
-  outline: 3px solid $mel-brand-coral;
-  outline-offset: 3px;
-  border-radius: 4px;
 }
 
 // ============================================================================

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-event-studio-outcome-states.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-event-studio-outcome-states.scss
@@ -1,0 +1,74 @@
+/**
+ * @file
+ * VL-5B — shared Vendor Studio Outcome states.
+ *
+ * Presentation only. State truth remains with existing services and AJAX.
+ */
+
+@use '../tokens/colors' as *;
+@use '../tokens/spacing' as *;
+@use '../tokens/shadows' as *;
+@use '../tokens/typography' as *;
+
+.mel-event-studio--workspace .mel-outcome {
+  width: min(100%, 42rem);
+  margin: $mel-zone-gap-md 0 0;
+  padding: $spacing-5;
+  border: 1px solid $mel-ws-border-soft;
+  border-radius: 16px;
+  background: $mel-shell-surface;
+  box-shadow: $shadow-sm;
+}
+
+.mel-event-studio--workspace .mel-outcome--success {
+  border-left: 4px solid $success;
+}
+
+.mel-event-studio--workspace .mel-outcome--error {
+  border-left: 4px solid $danger;
+}
+
+.mel-event-studio--workspace .mel-outcome__title {
+  margin: 0 0 $spacing-3;
+  color: $text-primary;
+  font-size: 1.375rem;
+  font-weight: $font-weight-bold;
+  line-height: 1.25;
+}
+
+.mel-event-studio--workspace .mel-outcome__title:focus {
+  outline: none;
+}
+
+.mel-event-studio--workspace .mel-outcome__title:focus-visible {
+  outline: 3px solid $mel-brand-coral;
+  outline-offset: 3px;
+  border-radius: 4px;
+}
+
+.mel-event-studio--workspace .mel-outcome__messages {
+  margin: 0 0 $spacing-4;
+  padding-left: $spacing-5;
+  color: $text-primary;
+}
+
+.mel-event-studio--workspace .mel-outcome__messages:empty {
+  display: none;
+}
+
+.mel-event-studio--workspace .mel-outcome__action {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  color: $text-secondary;
+  font-weight: $font-weight-semibold;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+@media (max-width: 767px) {
+  .mel-event-studio--workspace .mel-outcome {
+    margin-top: $mel-zone-gap-sm;
+    padding: $spacing-4;
+  }
+}

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
@@ -36,6 +36,7 @@
   @include meta.load-css('components/mel-event-studio-mission-control');
   @include meta.load-css('components/mel-event-studio-boost-quiet');
   @include meta.load-css('components/mel-event-studio-launch-centre');
+  @include meta.load-css('components/mel-event-studio-outcome-states');
   @include meta.load-css('components/mel-event-studio-launch-success');
   @include meta.load-css('components/cards');
   @include meta.load-css('components/tables');


### PR DESCRIPTION
## Summary

Implements VL-5B as a shared Vendor Studio Outcome presentation layer using the existing publish feedback shell and AJAX contracts.

## Zone map

Identity: Hero unchanged; authoritative primary action remains frozen.
Guidance: Mission Control unchanged; readiness truth remains service-owned.
Work: Workspace content, forms, tables, Empty State and Launch Centre unchanged.
Outcome: Shared success and error presentation; Launch Success remains specialised.

## Changes

- Add shared mel-outcome success/error semantics to the existing feedback shell.
- Keep success announcements polite and make failures role=alert.
- Move failure focus to its heading.
- Use the existing success renderer for publish fallback and successful unpublish outcomes.
- Add vendor-theme shared Outcome surface, tone, focus and mobile presentation.
- Retain Launch Success content, CTA hierarchy, soft motion and quiet Boost.
- Extend existing contract tests for shared Outcome semantics and renderer state handling.

## Frozen architecture

No changes to builders, ViewModels, controllers, routes, payload fields, AJAX contracts, eligibility, readiness, Hero, Mission Control, Launch Centre, Commerce, Stripe, Empty State, forms or tables.

## Validation

- npm run mel:lint
- npm run mel:build
- VL-5 PHPUnit: 5 tests, 86 assertions
- ddev drush cr
- git diff --check
- Product Owner approved VL-5B presentation

## Risk

Low. Existing rendering paths and state sources are retained; this change adds shared semantics and presentation while correcting successful fallback outcomes that previously used failure presentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and client-side outcome rendering only; publish/unpublish AJAX and server contracts are unchanged.
> 
> **Overview**
> Introduces **VL-5B**, a shared **Outcome** presentation layer on the existing publish feedback shell—same AJAX contracts, no backend changes.
> 
> The workspace outcome zone gains **`mel-outcome`** markup and classes: errors use **`role="alert"`** and focus moves to the error **heading**; success keeps **`aria-live="polite"`** on the success panel. Shell JS adds **`setOutcomeTone`** to centralize success/error styling instead of ad‑hoc class toggles.
> 
> **Behavior fix:** publish without a full handoff and successful **unpublish** now call **`renderPublishSuccessFeedback`** (minimal title/message) instead of the error-style **`renderPublishFeedback`**, so those cases show the success outcome.
> 
> Vendor theme adds **`_mel-event-studio-outcome-states.scss`** (shared card, tone borders, title/messages/actions, mobile spacing) and moves duplicated outcome surface styles out of launch-success SCSS; Launch Success–specific content and motion stay in the launch-success partial. Unit tests assert the new template/JS contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2daf828578b5dceeaa8e860c2cbd3aaec513f08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->