### PR TITLE
feat(vendor-workspace): refine details form hierarchy

### DIFF
--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-event-studio-form-hierarchy.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-event-studio-form-hierarchy.scss
@@ -1,0 +1,117 @@
+/**
+ * @file
+ * VL-5C.2A — Details form grouping and field hierarchy.
+ *
+ * Presentation only. Form fields, validation, save behaviour, autosave,
+ * location handling, and section ownership remain unchanged.
+ */
+
+@use '../tokens/colors' as *;
+@use '../tokens/spacing' as *;
+@use '../tokens/typography' as *;
+
+.mel-event-studio--workspace
+  [data-mel-event-studio-section='information']
+  .mel-es-field-group {
+  margin: 0;
+  padding: 0 0 $spacing-8;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.mel-event-studio--workspace
+  [data-mel-event-studio-section='information']
+  .mel-es-field-group
+  + .mel-es-field-group {
+  padding-top: $spacing-8;
+  border-top: 1px solid $mel-ws-border-soft;
+}
+
+.mel-event-studio--workspace
+  [data-mel-event-studio-section='information']
+  .mel-es-field-group:last-child {
+  padding-bottom: 0;
+}
+
+.mel-event-studio--workspace
+  [data-mel-event-studio-section='information']
+  .mel-es-field-group__header {
+  margin: 0 0 $spacing-5;
+  padding: 0;
+  border: 0;
+}
+
+.mel-event-studio--workspace
+  [data-mel-event-studio-section='information']
+  .mel-es-field-group__title {
+  color: $text-primary;
+  font-size: $font-size-section-title;
+  font-weight: $font-weight-bold;
+  line-height: $line-height-tight;
+  letter-spacing: $letter-spacing-tight;
+}
+
+.mel-event-studio--workspace
+  [data-mel-event-studio-section='information']
+  .mel-es-field-group__hint {
+  max-width: 38rem;
+  margin-top: $spacing-2;
+  color: $text-secondary;
+  font-size: $font-size-meta;
+  line-height: $line-height-normal;
+}
+
+.mel-event-studio--workspace
+  [data-mel-event-studio-section='information']
+  .mel-es-field-group__body {
+  gap: $spacing-5;
+}
+
+.mel-event-studio--workspace
+  [data-mel-event-studio-section='information']
+  .mel-es-field-group__body--datetime {
+  column-gap: $spacing-6;
+}
+
+.mel-event-studio--workspace
+  [data-mel-event-studio-section='information']
+  .mel-es-location-summary {
+  margin-bottom: $spacing-2;
+  border: 1px solid $mel-ws-border-soft;
+  border-radius: 14px;
+  background: $mel-ws-soft-sky;
+  box-shadow: none;
+}
+
+@media (max-width: 767px) {
+  .mel-event-studio--workspace
+    [data-mel-event-studio-section='information']
+    .mel-es-field-group {
+    padding-bottom: $spacing-6;
+  }
+
+  .mel-event-studio--workspace
+    [data-mel-event-studio-section='information']
+    .mel-es-field-group
+    + .mel-es-field-group {
+    padding-top: $spacing-6;
+  }
+
+  .mel-event-studio--workspace
+    [data-mel-event-studio-section='information']
+    .mel-es-field-group__header {
+    margin-bottom: $spacing-4;
+  }
+
+  .mel-event-studio--workspace
+    [data-mel-event-studio-section='information']
+    .mel-es-field-group__body,
+  .mel-event-studio--workspace
+    [data-mel-event-studio-section='information']
+    .mel-es-field-group__body--datetime {
+    grid-template-columns: minmax(0, 1fr);
+    gap: $spacing-4;
+  }
+}

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
@@ -39,6 +39,7 @@
   @include meta.load-css('components/mel-event-studio-outcome-states');
   @include meta.load-css('components/mel-event-studio-launch-success');
   @include meta.load-css('components/mel-event-studio-empty-states');
+  @include meta.load-css('components/mel-event-studio-form-hierarchy');
   @include meta.load-css('components/cards');
   @include meta.load-css('components/tables');
   @include meta.load-css('components/tabs');


### PR DESCRIPTION
## Summary
- implement VL-5C.2A presentation for the existing Details form groups
- replace the repeated elevated card stack with a flat editorial workflow
- retain the canonical Basics, Timing, Visibility, and Location regions
- scope styling to the information section only

## Validation
- npm run mel:lint
- npm run mel:build
- ddev drush cr
- focused PHPUnit: 23 tests, 126 assertions
- git diff --check
- rendered checks at 1280px, 768px, and 390px

## Scope
Presentation only. No PHP, Twig, JavaScript, routes, services, Builders, ViewModels, autosave, validation, location logic, Commerce, or Stripe changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Vendor-theme SCSS only, narrowly scoped to the information section; no form logic, markup, or backend changes.
> 
> **Overview**
> Adds **VL-5C.2A** presentation for the Event Studio **Details** (`information`) section: existing `.mel-es-field-group` regions (Basics, Timing, Visibility, Location) are restyled from stacked elevated cards to a **flat editorial layout**—transparent groups, soft dividers between groups, section-title typography for headers, and tuned spacing on bodies and datetime grids.
> 
> The **location summary** block gets a light bordered panel (`mel-es-location-summary`) without card shadow. Rules are scoped to `.mel-event-studio--workspace [data-mel-event-studio-section='information']` only; a new partial `_mel-event-studio-form-hierarchy.scss` is loaded from `main.scss` ahead of generic card/form styles so it overrides prior card-like grouping.
> 
> Mobile (≤767px) tightens padding and forces single-column field bodies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2b592c5ec72be7139939fa60b164eb2f548ce53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->