### PR TITLE
Refine Vendor Studio ticket workspace flow

### DIFF
--- a/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
@@ -137,6 +137,13 @@ services:
       - '@logger.factory'
       - '@myeventlane_vendor.event_access_checker'
       - '@database'
+      - '@myeventlane_event.ticket_tier_deletion_guard'
+
+  myeventlane_event.ticket_tier_deletion_guard:
+    class: Drupal\myeventlane_event\Service\TicketTierDeletionGuard
+    arguments:
+      - '@entity_type.manager'
+      - '@logger.factory'
 
   myeventlane_event.booking_flow_resolver:
     class: Drupal\myeventlane_event\Service\BookingFlowResolver

--- a/web/modules/custom/myeventlane_event/src/Service/TicketTierDeletionGuard.php
+++ b/web/modules/custom/myeventlane_event/src/Service/TicketTierDeletionGuard.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event\Service;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\mel_ticket\Entity\TicketTypeInterface;
+
+/**
+ * Evaluates whether a ticket type can be permanently deleted safely.
+ */
+final class TicketTierDeletionGuard {
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly LoggerChannelFactoryInterface $loggerFactory,
+  ) {}
+
+  /**
+   * @return array{
+   *   allowed: bool,
+   *   blockers: list<string>,
+   *   counts: array<string, int>
+   * }
+   */
+  public function evaluate(TicketTypeInterface $ticket): array {
+    $ticket_id = (int) $ticket->id();
+    $counts = [
+      'order_items' => 0,
+      'issued_tickets' => 0,
+      'waitlist_entries' => 0,
+      'access_codes' => 0,
+    ];
+    $blockers = [];
+
+    try {
+      $variation_id = $ticket->hasField('commerce_variation') && !$ticket->get('commerce_variation')->isEmpty()
+        ? (int) $ticket->get('commerce_variation')->target_id
+        : 0;
+      if ($variation_id > 0) {
+        $counts['order_items'] = $this->countReferences(
+          'commerce_order_item',
+          'purchased_entity',
+          $variation_id,
+        );
+      }
+
+      $counts['issued_tickets'] = $this->countReferences(
+        'myeventlane_ticket',
+        'mel_ticket_type',
+        $ticket_id,
+      );
+      $counts['waitlist_entries'] = $this->countReferences(
+        'mel_ticket_waitlist_entry',
+        'ticket_type',
+        $ticket_id,
+      );
+      $counts['access_codes'] = $this->countReferences(
+        'mel_access_code',
+        'allowed_ticket_types',
+        $ticket_id,
+      );
+    }
+    catch (\Throwable $e) {
+      $this->loggerFactory->get('myeventlane_event')->error(
+        'Ticket deletion eligibility inspection failed for ticket @tid: @message',
+        [
+          '@tid' => (string) $ticket_id,
+          '@message' => $e->getMessage(),
+        ],
+      );
+      return [
+        'allowed' => FALSE,
+        'blockers' => ['inspection_failed'],
+        'counts' => $counts,
+      ];
+    }
+
+    foreach ($counts as $reference => $count) {
+      if ($count > 0) {
+        $blockers[] = $reference;
+      }
+    }
+
+    return [
+      'allowed' => $blockers === [],
+      'blockers' => $blockers,
+      'counts' => $counts,
+    ];
+  }
+
+  private function countReferences(string $entity_type_id, string $field_name, int $target_id): int {
+    if (!$this->entityTypeManager->hasDefinition($entity_type_id)) {
+      throw new \RuntimeException(sprintf(
+        'Required deletion reference entity type "%s" is unavailable.',
+        $entity_type_id,
+      ));
+    }
+
+    $storage = $this->entityTypeManager->getStorage($entity_type_id);
+    return (int) $storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition($field_name, $target_id)
+      ->count()
+      ->execute();
+  }
+
+}

--- a/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
+++ b/web/modules/custom/myeventlane_event/src/Service/TicketTierLifecycleService.php
@@ -30,8 +30,6 @@ final class TicketTierLifecycleService implements EventPaidTicketLoaderInterface
 
   public const CURRENCY_MISMATCH_MESSAGE = 'All tickets for an event must use the same currency.';
 
-  private const BEST_VALUE_REQUIRED_MESSAGE = 'Choose one Best value ticket when an event has more than one paid or RSVP ticket type.';
-
   private const SHORT_DESCRIPTION_MAX_LENGTH = 320;
 
   private const TICKET_TITLE_MAX_LENGTH = 255;
@@ -44,6 +42,7 @@ final class TicketTierLifecycleService implements EventPaidTicketLoaderInterface
     private readonly LoggerChannelFactoryInterface $loggerFactory,
     private readonly EventVendorAccessChecker $eventVendorAccessChecker,
     private readonly Connection $database,
+    private readonly TicketTierDeletionGuard $ticketTierDeletionGuard,
   ) {}
 
   /**
@@ -550,6 +549,64 @@ final class TicketTierLifecycleService implements EventPaidTicketLoaderInterface
   }
 
   /**
+   * @return array{
+   *   allowed: bool,
+   *   blockers: list<string>,
+   *   counts: array<string, int>
+   * }
+   */
+  public function evaluateTicketDeletion(TicketTypeInterface $ticket): array {
+    return $this->ticketTierDeletionGuard->evaluate($ticket);
+  }
+
+  /**
+   * Permanently deletes an unreferenced ticket and its unused variation.
+   *
+   * @throws \InvalidArgumentException
+   * @throws \Throwable
+   */
+  public function deleteTicketOnEvent(NodeInterface $event, TicketTypeInterface $ticket): void {
+    if (!$this->ticketBelongsToEvent($event, (int) $ticket->id())) {
+      throw new InvalidArgumentException('Ticket data could not be matched to this event.');
+    }
+
+    $eligibility = $this->evaluateTicketDeletion($ticket);
+    if (!$eligibility['allowed']) {
+      throw new InvalidArgumentException('This ticket has booking or operational history and cannot be permanently deleted.');
+    }
+
+    $variation_id = $ticket->hasField('commerce_variation') && !$ticket->get('commerce_variation')->isEmpty()
+      ? (int) $ticket->get('commerce_variation')->target_id
+      : 0;
+
+    $transaction = $this->database->startTransaction();
+    try {
+      $this->archiveTicketOnEvent($event, $ticket);
+
+      if ($variation_id > 0) {
+        $variation_storage = $this->entityTypeManager->getStorage('commerce_product_variation');
+        $variation_storage->resetCache([$variation_id]);
+        $variation = $variation_storage->load($variation_id);
+        if ($variation instanceof ProductVariationInterface) {
+          $product = $variation->getProduct();
+          if ($product instanceof ProductInterface && method_exists($product, 'hasVariation')
+            && $product->hasVariation($variation)) {
+            $product->removeVariation($variation);
+            $product->save();
+          }
+          $variation->delete();
+        }
+      }
+
+      $ticket->delete();
+    }
+    catch (\Throwable $e) {
+      $transaction->rollBack();
+      throw $e;
+    }
+  }
+
+  /**
    * Persists field changes on an existing ticket and syncs paid projections.
    *
    * @param array<string, mixed> $values
@@ -652,8 +709,6 @@ final class TicketTierLifecycleService implements EventPaidTicketLoaderInterface
         'title' => '',
       ];
     }
-
-    $this->assertBestValueSelectionForNewTicket($event, $payload);
 
     return $payload;
   }
@@ -785,8 +840,6 @@ final class TicketTierLifecycleService implements EventPaidTicketLoaderInterface
       );
     }
 
-    $this->assertBestValueSelectionForTicketUpdate($event, $ticket, $payload);
-
     return $payload;
   }
 
@@ -855,127 +908,7 @@ final class TicketTierLifecycleService implements EventPaidTicketLoaderInterface
       $errors[] = self::CURRENCY_MISMATCH_MESSAGE;
     }
 
-    $bestValueError = $this->validateBestValueSelectionForRows($event, $account, $rows);
-    if ($bestValueError !== NULL) {
-      $errors[] = $bestValueError;
-    }
-
     return array_merge($errors, $this->validateRsvpCapacityAgainstEvent($event, $eventKind, $rsvpCapSum));
-  }
-
-  /**
-   * Optional best-value guidance for newly created joinable ticket types.
-   *
-   * Previously enforced as a hard block; now advisory only so vendors can
-   * save tickets without designating a "best value" tier upfront.
-   *
-   * @param array<string, mixed> $payload
-   */
-  private function assertBestValueSelectionForNewTicket(NodeInterface $event, array $payload): void {
-  }
-
-  /**
-   * Enforces the MEL guided model when editing an existing joinable ticket type.
-   *
-   * @param array<string, mixed> $payload
-   */
-  private function assertBestValueSelectionForTicketUpdate(NodeInterface $event, TicketTypeInterface $ticket, array $payload): void {
-    if (!$ticket->hasField('field_is_best_value') && !array_key_exists('field_is_best_value', $payload)) {
-      return;
-    }
-
-    $analysis = $this->analyzeBestValueTickets($event, $ticket, $payload);
-    if ($analysis['joinable_count'] > 1 && !$analysis['has_best_value']) {
-      throw new InvalidArgumentException(self::BEST_VALUE_REQUIRED_MESSAGE);
-    }
-  }
-
-  /**
-   * Validates a complete Event Studio ticket rows payload against existing tickets.
-   *
-   * @param list<array<string, mixed>> $rows
-   */
-  private function validateBestValueSelectionForRows(NodeInterface $event, AccountInterface $account, array $rows): ?string {
-    $tickets = $this->ticketTypeManager->loadEventTicketTypesForDisplay($event);
-    $joinableCount = 0;
-    $hasBestValue = FALSE;
-    $seenIds = [];
-
-    foreach ($rows as $row) {
-      $ticketId = (int) ($row['id'] ?? 0);
-      if ($ticketId > 0) {
-        $ticket = $this->loadWritableTicketForEvent($event, $ticketId, $account);
-        if (!$ticket instanceof TicketTypeInterface) {
-          continue;
-        }
-        $seenIds[$ticketId] = TRUE;
-        if (!$this->isJoinableTicketKind($ticket->getTicketKind())) {
-          continue;
-        }
-        $joinableCount++;
-        $hasBestValue = $hasBestValue || $this->ticketWillBeBestValue($ticket, $row);
-        continue;
-      }
-
-      $kind = $this->normalizeTicketKind($row['ticket_kind'] ?? 'paid');
-      if (!$this->isJoinableTicketKind($kind)) {
-        continue;
-      }
-      $joinableCount++;
-      $hasBestValue = $hasBestValue || !empty($row['field_is_best_value']);
-    }
-
-    foreach ($tickets as $ticketId => $ticket) {
-      if (isset($seenIds[(int) $ticketId]) || !$this->isJoinableTicketKind($ticket->getTicketKind())) {
-        continue;
-      }
-      $joinableCount++;
-      $hasBestValue = $hasBestValue || ($ticket->hasField('field_is_best_value') && $ticket->isBestValueTicket());
-    }
-
-    return $joinableCount > 1 && !$hasBestValue ? self::BEST_VALUE_REQUIRED_MESSAGE : NULL;
-  }
-
-  /**
-   * @param array<string, mixed> $payload
-   *
-   * @return array{joinable_count: int, has_best_value: bool}
-   */
-  private function analyzeBestValueTickets(NodeInterface $event, ?TicketTypeInterface $overrideTicket = NULL, array $payload = []): array {
-    $joinableCount = 0;
-    $hasBestValue = FALSE;
-    $overrideId = $overrideTicket instanceof TicketTypeInterface ? (int) $overrideTicket->id() : 0;
-
-    foreach ($this->ticketTypeManager->loadEventTicketTypesForDisplay($event) as $ticket) {
-      if (!$this->isJoinableTicketKind($ticket->getTicketKind())) {
-        continue;
-      }
-      $joinableCount++;
-      if ($overrideId > 0 && (int) $ticket->id() === $overrideId) {
-        $hasBestValue = $hasBestValue || $this->ticketWillBeBestValue($ticket, $payload);
-        continue;
-      }
-      $hasBestValue = $hasBestValue || ($ticket->hasField('field_is_best_value') && $ticket->isBestValueTicket());
-    }
-
-    return [
-      'joinable_count' => $joinableCount,
-      'has_best_value' => $hasBestValue,
-    ];
-  }
-
-  /**
-   * @param array<string, mixed> $values
-   */
-  private function ticketWillBeBestValue(TicketTypeInterface $ticket, array $values): bool {
-    if (array_key_exists('field_is_best_value', $values)) {
-      return !empty($values['field_is_best_value']);
-    }
-    return $ticket->hasField('field_is_best_value') && $ticket->isBestValueTicket();
-  }
-
-  private function isJoinableTicketKind(string $kind): bool {
-    return in_array($kind, ['paid', 'rsvp'], TRUE);
   }
 
   /**

--- a/web/modules/custom/myeventlane_event/tests/src/Unit/TicketTierDeletionGuardTest.php
+++ b/web/modules/custom/myeventlane_event/tests/src/Unit/TicketTierDeletionGuardTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event\Unit;
+
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\mel_ticket\Entity\TicketTypeInterface;
+use Drupal\myeventlane_event\Service\TicketTierDeletionGuard;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_event\Service\TicketTierDeletionGuard
+ *
+ * @group myeventlane_event
+ */
+final class TicketTierDeletionGuardTest extends TestCase {
+
+  public function testAllowsDeletionWithoutOperationalReferences(): void {
+    $guard = $this->guardWithCounts([]);
+
+    $result = $guard->evaluate($this->ticket());
+
+    $this->assertTrue($result['allowed']);
+    $this->assertSame([], $result['blockers']);
+    $this->assertSame([
+      'order_items' => 0,
+      'issued_tickets' => 0,
+      'waitlist_entries' => 0,
+      'access_codes' => 0,
+    ], $result['counts']);
+  }
+
+  /**
+   * @param array<string, int> $counts
+   * @param list<string> $expectedBlockers
+   */
+  #[DataProvider('blockingReferenceProvider')]
+  public function testBlocksDeletionForOperationalReferences(array $counts, array $expectedBlockers): void {
+    $guard = $this->guardWithCounts($counts);
+
+    $result = $guard->evaluate($this->ticket());
+
+    $this->assertFalse($result['allowed']);
+    $this->assertSame($expectedBlockers, $result['blockers']);
+  }
+
+  /**
+   * @return iterable<string, array{array<string, int>, list<string>}>
+   */
+  public static function blockingReferenceProvider(): iterable {
+    yield 'order item' => [['commerce_order_item' => 1], ['order_items']];
+    yield 'issued ticket' => [['myeventlane_ticket' => 1], ['issued_tickets']];
+    yield 'waitlist entry' => [['mel_ticket_waitlist_entry' => 1], ['waitlist_entries']];
+    yield 'access code' => [['mel_access_code' => 1], ['access_codes']];
+  }
+
+  public function testFailsClosedWhenInspectionThrows(): void {
+    $entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $entityTypeManager->method('hasDefinition')->willReturn(TRUE);
+    $storage = $this->createMock(EntityStorageInterface::class);
+    $storage->method('getQuery')->willThrowException(new \RuntimeException('Storage unavailable.'));
+    $entityTypeManager->method('getStorage')->willReturn($storage);
+
+    $guard = new TicketTierDeletionGuard($entityTypeManager, $this->loggerFactory());
+    $result = $guard->evaluate($this->ticket());
+
+    $this->assertFalse($result['allowed']);
+    $this->assertSame(['inspection_failed'], $result['blockers']);
+  }
+
+  public function testFailsClosedWhenRequiredReferenceTypeIsUnavailable(): void {
+    $entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $entityTypeManager->method('hasDefinition')->willReturn(FALSE);
+
+    $guard = new TicketTierDeletionGuard($entityTypeManager, $this->loggerFactory());
+    $result = $guard->evaluate($this->ticket());
+
+    $this->assertFalse($result['allowed']);
+    $this->assertSame(['inspection_failed'], $result['blockers']);
+  }
+
+  /**
+   * @param array<string, int> $counts
+   */
+  private function guardWithCounts(array $counts): TicketTierDeletionGuard {
+    $entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $entityTypeManager->method('hasDefinition')->willReturn(TRUE);
+    $entityTypeManager->method('getStorage')->willReturnCallback(
+      function (string $entityTypeId) use ($counts): EntityStorageInterface {
+        $query = $this->createMock(QueryInterface::class);
+        $query->method('accessCheck')->willReturnSelf();
+        $query->method('condition')->willReturnSelf();
+        $query->method('count')->willReturnSelf();
+        $query->method('execute')->willReturn($counts[$entityTypeId] ?? 0);
+
+        $storage = $this->createMock(EntityStorageInterface::class);
+        $storage->method('getQuery')->willReturn($query);
+        return $storage;
+      },
+    );
+
+    return new TicketTierDeletionGuard($entityTypeManager, $this->loggerFactory());
+  }
+
+  private function ticket(): TicketTypeInterface {
+    $variation = $this->createMock(FieldItemListInterface::class);
+    $variation->method('isEmpty')->willReturn(FALSE);
+    $variation->method('__get')->with('target_id')->willReturn(501);
+
+    $ticket = $this->createMock(TicketTypeInterface::class);
+    $ticket->method('id')->willReturn(42);
+    $ticket->method('hasField')->with('commerce_variation')->willReturn(TRUE);
+    $ticket->method('get')->with('commerce_variation')->willReturn($variation);
+    return $ticket;
+  }
+
+  private function loggerFactory(): LoggerChannelFactoryInterface {
+    $factory = $this->createMock(LoggerChannelFactoryInterface::class);
+    $factory->method('get')->willReturn($this->createMock(LoggerChannelInterface::class));
+    return $factory;
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-tickets-app.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-tickets-app.js
@@ -35,8 +35,48 @@
     });
   }
 
+  /**
+   * Clears one ticket card's sales window without submitting the form.
+   */
+  function resetSalesWindow(button) {
+    const ticketId = button.dataset.melResetSalesWindow || '';
+    if (!ticketId) {
+      return;
+    }
+
+    const card = button.closest('.mel-event-studio-ticket-card');
+    if (!(card instanceof HTMLElement)) {
+      return;
+    }
+
+    const fields = card.querySelectorAll(
+      '[name^="tickets[' + ticketId + '][sales_window]"]',
+    );
+    fields.forEach((field) => {
+      if (field instanceof HTMLInputElement) {
+        field.value = '';
+        field.defaultValue = '';
+        field.removeAttribute('value');
+        field.setAttribute('autocomplete', 'off');
+        field.dispatchEvent(new Event('input', { bubbles: true }));
+        field.dispatchEvent(new Event('change', { bubbles: true }));
+        field.blur();
+      }
+    });
+
+    const status = document.getElementById('mel-ticket-sales-window-status-' + ticketId);
+    if (status instanceof HTMLElement) {
+      status.textContent = Drupal.t('Sales window cleared. Save tickets to keep this change.');
+    }
+
+  }
+
   Drupal.behaviors.melEventStudioTicketsApp = {
     attach(context) {
+      once('mel-tickets-delete-safe-default', 'input[name$="[actions][delete]"]', context).forEach((checkbox) => {
+        checkbox.checked = false;
+      });
+
       once('mel-tickets-advanced-tools', '.mel-event-studio-advanced-tools', context).forEach((details) => {
         details.addEventListener('toggle', () => {
           if (!details.open) {
@@ -69,6 +109,21 @@
           event.preventDefault();
           openAddTicketPanel(details);
         });
+      });
+
+      once('mel-tickets-reset-sales-window', '[data-mel-reset-sales-window]', context).forEach((button) => {
+        const ticketId = button.dataset.melResetSalesWindow || '';
+        const card = button.closest('.mel-event-studio-ticket-card');
+        if (ticketId && card instanceof HTMLElement) {
+          card.querySelectorAll(
+            '[name^="tickets[' + ticketId + '][sales_window]"]',
+          ).forEach((field) => {
+            if (field instanceof HTMLInputElement) {
+              field.setAttribute('autocomplete', 'off');
+            }
+          });
+        }
+        button.addEventListener('click', () => resetSalesWindow(button));
       });
     },
   };

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.libraries.yml
@@ -18,7 +18,7 @@ mel_event_studio:
     - myeventlane_event_studio/mel_event_studio_highlights
 
 mel_event_studio_tickets_app:
-  version: 1.1
+  version: 1.4
   js:
     js/mel-event-studio-tickets-app.js: {}
   dependencies:

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventCheckoutQuestionsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventCheckoutQuestionsForm.php
@@ -248,7 +248,9 @@ final class EventCheckoutQuestionsForm extends FormBase {
 
     $this->studioAutosaveService->clearDraft($event, 'questions');
     $this->messenger()->addStatus($this->t('Guest questions saved.'));
-    $form_state->setRebuild(TRUE);
+    $form_state->setRedirect('myeventlane_event_studio.workspace_questions', [
+      'node' => $event->id(),
+    ]);
   }
 
   /**

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioOperationalTicketsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioOperationalTicketsForm.php
@@ -389,21 +389,38 @@ final class EventStudioOperationalTicketsForm extends FormBase {
     }
 
     foreach ($this->submittedExistingTicketRows($form_state) as $ticket_id => $row) {
-      if (!empty($row['archive']) && !empty($row['duplicate'])) {
+      $selected_actions = array_filter([
+        'duplicate' => !empty($row['duplicate']),
+        'archive' => !empty($row['archive']),
+        'delete' => !empty($row['delete']),
+      ]);
+      if (count($selected_actions) > 1) {
         $form_state->setErrorByName(
-          'tickets][' . $ticket_id . '][actions][duplicate]',
-          $this->t('Choose either Duplicate ticket or Archive ticket, not both.'),
+          'tickets][' . $ticket_id . '][actions',
+          $this->t('Choose only one ticket action: Duplicate, Archive, or permanently delete.'),
         );
         continue;
       }
-      if (!empty($row['archive'])) {
-        continue;
-      }
+
       $ticket = $this->ticketTierLifecycle->loadWritableTicketForEvent($event, $ticket_id, $this->currentUser);
       if (!$ticket instanceof TicketTypeInterface) {
         $form_state->setErrorByName('tickets][' . $ticket_id, $this->t('Ticket data could not be matched to this event. Reload and try again.'));
         continue;
       }
+      if (!empty($row['delete'])) {
+        $eligibility = $this->ticketTierLifecycle->evaluateTicketDeletion($ticket);
+        if (!$eligibility['allowed']) {
+          $form_state->setErrorByName(
+            'tickets][' . $ticket_id . '][actions][delete]',
+            $this->deletionBlockedMessage($eligibility),
+          );
+        }
+        continue;
+      }
+      if (!empty($row['archive'])) {
+        continue;
+      }
+
       // Duplicate still applies the same-request inline edits to the source first.
       $row = $this->normalizeExistingTicketRowInput($ticket, $row);
       try {
@@ -451,6 +468,11 @@ final class EventStudioOperationalTicketsForm extends FormBase {
       foreach ($this->submittedExistingTicketRows($form_state) as $ticket_id => $row) {
         $ticket = $this->ticketTierLifecycle->loadWritableTicketForEvent($event, $ticket_id, $this->currentUser);
         if (!$ticket instanceof TicketTypeInterface) {
+          continue;
+        }
+        if (!empty($row['delete'])) {
+          $this->ticketTierLifecycle->deleteTicketOnEvent($event, $ticket);
+          $this->recordTicketAnalyticsEvent('ticket_deleted', $event, (int) $ticket->id());
           continue;
         }
         // Mutual exclusion is enforced in validateForm; never archive when
@@ -510,7 +532,9 @@ final class EventStudioOperationalTicketsForm extends FormBase {
     $this->persistDonationSettingsFromWorkspace($event);
 
     $this->messenger()->addStatus($this->t('Tickets saved and synced.'));
-    $form_state->setRebuild(TRUE);
+    $form_state->setRedirect('myeventlane_event_studio.workspace_tickets', [
+      'node' => $event->id(),
+    ]);
   }
 
   /**
@@ -545,6 +569,7 @@ final class EventStudioOperationalTicketsForm extends FormBase {
           : 'public'
       ] ?? $this->t('Public'),
     };
+    $deletion_eligibility = $this->ticketTierLifecycle->evaluateTicketDeletion($ticket);
 
     return [
       '#type' => 'container',
@@ -744,6 +769,32 @@ final class EventStudioOperationalTicketsForm extends FormBase {
             '#default_value' => $this->dateFieldDefault($ticket, 'sale_end'),
             '#parents' => ['tickets', $ticket_id, 'sales_window', 'sale_end'],
           ],
+          'reset' => [
+            '#type' => 'html_tag',
+            '#tag' => 'button',
+            '#value' => $this->t('Clear sales window'),
+            '#attributes' => [
+              'type' => 'button',
+              'class' => [
+                'mel-btn',
+                'mel-btn--tertiary',
+                'mel-event-studio-ticket-card__reset-sales-window',
+              ],
+              'data-mel-reset-sales-window' => (string) $ticket_id,
+              'aria-describedby' => 'mel-ticket-sales-window-status-' . $ticket_id,
+            ],
+          ],
+          'reset_status' => [
+            '#type' => 'html_tag',
+            '#tag' => 'span',
+            '#value' => '',
+            '#attributes' => [
+              'id' => 'mel-ticket-sales-window-status-' . $ticket_id,
+              'class' => ['mel-event-studio-ticket-card__reset-status'],
+              'role' => 'status',
+              'aria-live' => 'polite',
+            ],
+          ],
         ],
         'visibility_group' => [
           '#type' => 'container',
@@ -783,15 +834,6 @@ final class EventStudioOperationalTicketsForm extends FormBase {
             '#wrapper_attributes' => ['class' => ['mel-event-studio-ticket-card__checkbox']],
             '#parents' => ['tickets', $ticket_id, 'status', 'published'],
           ],
-          'best_value' => [
-            '#type' => 'checkbox',
-            '#title' => $this->t('Highlight as best value'),
-            '#description' => $this->t('Use sparingly when one ticket should be gently highlighted for attendees.'),
-            '#default_value' => $ticket->hasField('field_is_best_value') && $ticket->isBestValueTicket(),
-            '#disabled' => $ticket->isArchived() || !$ticket->hasField('field_is_best_value'),
-            '#wrapper_attributes' => ['class' => ['mel-event-studio-ticket-card__checkbox']],
-            '#parents' => ['tickets', $ticket_id, 'status', 'best_value'],
-          ],
         ],
       ],
       'quick_actions' => [
@@ -803,7 +845,7 @@ final class EventStudioOperationalTicketsForm extends FormBase {
         'hint' => [
           '#type' => 'html_tag',
           '#tag' => 'p',
-          '#value' => $this->t('Quick edit above, then save. Choose duplicate or archive — not both.'),
+          '#value' => $this->t('Quick edit above, then save. Choose only one ticket action.'),
           '#attributes' => ['class' => ['mel-event-studio-ticket-card__quick-actions-hint']],
         ],
         'duplicate' => [
@@ -827,10 +869,51 @@ final class EventStudioOperationalTicketsForm extends FormBase {
         '#attributes' => ['class' => ['mel-event-studio-ticket-card__advanced-content']],
         '#prefix' => '<details class="mel-event-studio-ticket-card__advanced"><summary>' . $this->t('Optional ticket settings') . '</summary>',
         '#suffix' => '</details>',
+        'best_value' => [
+          '#type' => 'checkbox',
+          '#title' => $this->t('Highlight as best value'),
+          '#description' => $this->t('Use sparingly when one ticket should be gently highlighted for attendees.'),
+          '#default_value' => $ticket->hasField('field_is_best_value') && $ticket->isBestValueTicket(),
+          '#disabled' => $ticket->isArchived() || !$ticket->hasField('field_is_best_value'),
+          '#wrapper_attributes' => ['class' => ['mel-event-studio-ticket-card__checkbox']],
+          '#parents' => ['tickets', $ticket_id, 'status', 'best_value'],
+        ],
         'ticket_kind' => [
           '#type' => 'hidden',
           '#value' => $kind,
           '#parents' => ['tickets', $ticket_id, 'actions', 'ticket_kind'],
+        ],
+      ],
+      'removal' => [
+        '#type' => 'details',
+        '#title' => $this->t('Remove ticket'),
+        '#open' => FALSE,
+        '#attributes' => [
+          'class' => ['mel-event-studio-ticket-card__removal'],
+        ],
+        'warning' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->t('Permanent deletion cannot be undone. Use Archive when you only need to stop future bookings.'),
+          '#access' => $deletion_eligibility['allowed'],
+          '#attributes' => ['class' => ['mel-event-studio-ticket-card__removal-warning']],
+        ],
+        'delete' => [
+          '#type' => 'checkbox',
+          '#title' => $this->t('Permanently delete this ticket when I save'),
+          '#description' => $this->t('The ticket and its unused Commerce variation will be removed when you select Save tickets.'),
+          '#default_value' => 0,
+          '#access' => $deletion_eligibility['allowed'],
+          '#attributes' => ['autocomplete' => 'off'],
+          '#wrapper_attributes' => ['class' => ['mel-event-studio-ticket-card__action', 'mel-event-studio-ticket-card__action--danger']],
+          '#parents' => ['tickets', $ticket_id, 'actions', 'delete'],
+        ],
+        'blocked' => [
+          '#type' => 'html_tag',
+          '#tag' => 'p',
+          '#value' => $this->deletionBlockedMessage($deletion_eligibility),
+          '#access' => !$deletion_eligibility['allowed'],
+          '#attributes' => ['class' => ['mel-event-studio-ticket-card__removal-blocked']],
         ],
       ],
     ];
@@ -929,10 +1012,21 @@ final class EventStudioOperationalTicketsForm extends FormBase {
         $row['ticket_kind'] = $row['actions']['ticket_kind'] ?? '';
         $row['archive'] = !empty($row['actions']['archive']) ? 1 : 0;
         $row['duplicate'] = !empty($row['actions']['duplicate']) ? 1 : 0;
+        $row['delete'] = !empty($row['actions']['delete']) ? 1 : 0;
       }
       $out[(int) $ticket_id] = $row;
     }
     return $out;
+  }
+
+  /**
+   * @param array{allowed: bool, blockers: list<string>, counts: array<string, int>} $eligibility
+   */
+  private function deletionBlockedMessage(array $eligibility): string {
+    if (in_array('inspection_failed', $eligibility['blockers'], TRUE)) {
+      return (string) $this->t('Deletion availability could not be verified. Archive this ticket or try again later.');
+    }
+    return (string) $this->t('This ticket has booking or operational history, so it cannot be permanently deleted. Archive it instead.');
   }
 
   private function dateFieldDefault(TicketTypeInterface $ticket, string $field_name): ?DrupalDateTime {

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioTicketsForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioTicketsForm.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_event_studio\Form;
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 
 /**
@@ -38,6 +39,21 @@ final class EventStudioTicketsForm extends EventStudioBaseForm {
    */
   protected function getCurrentStepId(): string {
     return 'tickets';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getContinueButtonLabel() {
+    return $this->t('Save booking settings');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function onWizardStepSaveSuccess(NodeInterface $saved, FormStateInterface $form_state): void {
+    $this->messenger()->addStatus($this->t('Booking settings saved.'));
+    $form_state->setRedirect('myeventlane_event_studio.workspace_tickets', ['node' => $saved->id()]);
   }
 
   /**
@@ -114,12 +130,42 @@ final class EventStudioTicketsForm extends EventStudioBaseForm {
       ],
     ];
 
-    $form['mel']['collect_attendee_questions'] = [
-      '#type' => 'checkbox',
-      '#title' => $this->t('Collect extra attendee details'),
-      '#description' => $this->t('Gather information per guest (beyond name and email).'),
-      '#default_value' => !empty($melDefaults['collect_attendee_questions']),
-      '#mel_option_card' => TRUE,
+    $form['mel']['attendee_questions_handoff'] = [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => ['mel-event-studio-attendee-questions-handoff'],
+        'role' => 'region',
+        'aria-labelledby' => 'mel-attendee-questions-handoff-title',
+      ],
+      'eyebrow' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('Attendee questions'),
+        '#attributes' => ['class' => ['mel-event-studio-attendee-questions-handoff__eyebrow']],
+      ],
+      'title' => [
+        '#type' => 'html_tag',
+        '#tag' => 'h4',
+        '#value' => $this->t('Need more than name and email?'),
+        '#attributes' => [
+          'id' => 'mel-attendee-questions-handoff-title',
+          'class' => ['mel-event-studio-attendee-questions-handoff__title'],
+        ],
+      ],
+      'copy' => [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => $this->t('Add short questions for attendees to answer while booking. Collection turns on automatically when an active question is saved.'),
+        '#attributes' => ['class' => ['mel-event-studio-attendee-questions-handoff__copy']],
+      ],
+      'action' => [
+        '#type' => 'link',
+        '#title' => $this->t('Manage attendee questions'),
+        '#url' => Url::fromRoute('myeventlane_event_studio.workspace_questions', ['node' => $node->id()]),
+        '#attributes' => [
+          'class' => ['mel-btn', 'mel-btn--secondary'],
+        ],
+      ],
       '#suffix' => '</div></section>',
     ];
 

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
@@ -794,6 +794,16 @@ final class EventStudioSectionRenderer {
    * @return array<string, mixed>
    */
   private function buildTicketsStack(NodeInterface $event): array {
+    $event_type = $event->hasField('field_event_type') && !$event->get('field_event_type')->isEmpty()
+      ? (string) $event->get('field_event_type')->value
+      : '';
+    $has_external_url = $event->hasField('field_external_url') && !$event->get('field_external_url')->isEmpty();
+    $has_ticket_setup = $event->hasField('field_ticket_types') && !$event->get('field_ticket_types')->isEmpty();
+    $uses_ticket_types = in_array($event_type, ['paid', 'both'], TRUE);
+    $preview_ready = $event_type === 'rsvp'
+      || ($event_type === 'external' && $has_external_url)
+      || ($uses_ticket_types && $has_ticket_setup);
+
     $build = [
       '#type' => 'container',
       '#attributes' => [
@@ -806,10 +816,12 @@ final class EventStudioSectionRenderer {
       'mode' => $this->formBuilder->getForm(EventStudioTicketsForm::class, $event),
     ];
 
-    $build['operational'] = $this->formBuilder->getForm(EventStudioOperationalTicketsForm::class, $event);
-    $build['operational']['#weight'] = 5;
+    if ($uses_ticket_types) {
+      $build['operational'] = $this->formBuilder->getForm(EventStudioOperationalTicketsForm::class, $event);
+      $build['operational']['#weight'] = 5;
+    }
 
-    if ($this->eventTicketPreviewBuilder instanceof EventTicketPreviewBuilder) {
+    if ($preview_ready && $this->eventTicketPreviewBuilder instanceof EventTicketPreviewBuilder) {
       $preview = $this->eventTicketPreviewBuilder->build($event);
       if ($preview !== []) {
         $build['ticket_preview'] = $preview;
@@ -817,8 +829,10 @@ final class EventStudioSectionRenderer {
       }
     }
 
-    $build['advanced'] = $this->buildAdvancedTicketTools($event);
-    $build['advanced']['#weight'] = 20;
+    if ($uses_ticket_types && $has_ticket_setup) {
+      $build['advanced'] = $this->buildAdvancedTicketTools($event);
+      $build['advanced']['#weight'] = 20;
+    }
 
     $support = $this->supportResolver->buildCard($event, 'tickets');
     if ($support !== NULL) {

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioTicketsAppContractTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioTicketsAppContractTest.php
@@ -40,6 +40,78 @@ final class EventStudioTicketsAppContractTest extends TestCase {
     $this->assertStringNotContainsString('SKU', $form);
   }
 
+  public function testSuccessfulTicketSaveReloadsTheCompleteWorkspace(): void {
+    $form = file_get_contents($this->moduleRoot() . '/src/Form/EventStudioOperationalTicketsForm.php');
+
+    $this->assertNotFalse($form);
+    $this->assertStringContainsString("'Tickets saved and synced.'", $form);
+    $this->assertStringContainsString(
+      "\$form_state->setRedirect('myeventlane_event_studio.workspace_tickets'",
+      $form,
+    );
+    $this->assertStringNotContainsString('$form_state->setRebuild(TRUE);', $form);
+  }
+
+  public function testTicketJourneyProgressesFromSavedBookingChoice(): void {
+    $ticketsForm = file_get_contents($this->moduleRoot() . '/src/Form/EventStudioTicketsForm.php');
+    $renderer = file_get_contents($this->moduleRoot() . '/src/Service/EventStudioSectionRenderer.php');
+
+    $this->assertNotFalse($ticketsForm);
+    $this->assertStringContainsString("return \$this->t('Save booking settings')", $ticketsForm);
+    $this->assertStringContainsString("'myeventlane_event_studio.workspace_tickets'", $ticketsForm);
+    $this->assertStringContainsString("'Booking settings saved.'", $ticketsForm);
+    $this->assertStringNotContainsString("'#title' => \$this->t('Collect extra attendee details')", $ticketsForm);
+    $this->assertStringContainsString("'myeventlane_event_studio.workspace_questions'", $ticketsForm);
+    $this->assertStringContainsString('Manage attendee questions', $ticketsForm);
+    $this->assertStringContainsString('Collection turns on automatically when an active question is saved.', $ticketsForm);
+
+    $this->assertNotFalse($renderer);
+    $this->assertStringContainsString("\$uses_ticket_types = in_array(\$event_type, ['paid', 'both'], TRUE)", $renderer);
+    $this->assertStringContainsString('if ($uses_ticket_types)', $renderer);
+    $this->assertStringContainsString('if ($preview_ready && $this->eventTicketPreviewBuilder', $renderer);
+    $this->assertStringContainsString('if ($uses_ticket_types && $has_ticket_setup)', $renderer);
+  }
+
+  public function testOptionalSettingsAndSalesWindowResetAreFunctional(): void {
+    $form = file_get_contents($this->moduleRoot() . '/src/Form/EventStudioOperationalTicketsForm.php');
+    $javascript = file_get_contents($this->moduleRoot() . '/js/mel-event-studio-tickets-app.js');
+
+    $this->assertNotFalse($form);
+    $optionalSettings = strpos($form, "'advanced' => [");
+    $bestValue = strpos($form, "'#title' => \$this->t('Highlight as best value')");
+    $this->assertNotFalse($optionalSettings);
+    $this->assertNotFalse($bestValue);
+    $this->assertGreaterThan($optionalSettings, $bestValue);
+    $this->assertStringContainsString("'#value' => \$this->t('Clear sales window')", $form);
+    $this->assertStringContainsString('data-mel-reset-sales-window', $form);
+    $this->assertStringContainsString("'type' => 'button'", $form);
+    $this->assertStringContainsString('mel-event-studio-ticket-card__reset-status', $form);
+
+    $this->assertNotFalse($javascript);
+    $this->assertStringContainsString('function resetSalesWindow(button)', $javascript);
+    $this->assertStringContainsString("field.value = ''", $javascript);
+    $this->assertStringContainsString("field.defaultValue = ''", $javascript);
+    $this->assertStringContainsString("field.removeAttribute('value')", $javascript);
+    $this->assertStringContainsString("field.setAttribute('autocomplete', 'off')", $javascript);
+    $this->assertStringContainsString("new Event('input', { bubbles: true })", $javascript);
+    $this->assertStringContainsString('field.blur()', $javascript);
+    $this->assertStringNotContainsString('firstField.focus()', $javascript);
+    $this->assertStringContainsString('Sales window cleared. Save tickets to keep this change.', $javascript);
+  }
+
+  public function testBestValueHighlightIsOptional(): void {
+    $lifecycle = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_event/src/Service/TicketTierLifecycleService.php');
+    $manager = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_event/src/Service/TicketTypeManager.php');
+
+    $this->assertNotFalse($lifecycle);
+    $this->assertStringNotContainsString('BEST_VALUE_REQUIRED_MESSAGE', $lifecycle);
+    $this->assertStringNotContainsString('Choose one Best value ticket', $lifecycle);
+    $this->assertStringNotContainsString('validateBestValueSelectionForRows', $lifecycle);
+
+    $this->assertNotFalse($manager);
+    $this->assertStringContainsString('normalizeBestValueTicketSelection', $manager);
+  }
+
   public function testDuplicateAppliesSameRequestEditsBeforeCopy(): void {
     $form = file_get_contents($this->moduleRoot() . '/src/Form/EventStudioOperationalTicketsForm.php');
     $this->assertNotFalse($form);
@@ -111,12 +183,45 @@ final class EventStudioTicketsAppContractTest extends TestCase {
     $this->assertStringContainsString("getTicketKind() === 'rsvp'", $form);
   }
 
-  public function testDuplicateAndArchiveAreMutuallyExclusive(): void {
+  public function testTicketActionsAreMutuallyExclusive(): void {
     $form = file_get_contents($this->moduleRoot() . '/src/Form/EventStudioOperationalTicketsForm.php');
     $this->assertNotFalse($form);
-    $this->assertStringContainsString('Choose either Duplicate ticket or Archive ticket, not both.', $form);
-    $this->assertStringContainsString("!empty(\$row['archive']) && !empty(\$row['duplicate'])", $form);
+    $this->assertStringContainsString('Choose only one ticket action: Duplicate, Archive, or permanently delete.', $form);
+    $this->assertStringContainsString("'delete' => !empty(\$row['delete'])", $form);
+    $this->assertStringContainsString('if (count($selected_actions) > 1)', $form);
     $this->assertStringContainsString("!empty(\$row['archive']) && empty(\$row['duplicate'])", $form);
+  }
+
+  public function testPermanentDeletionUsesLifecycleGuard(): void {
+    $form = file_get_contents($this->moduleRoot() . '/src/Form/EventStudioOperationalTicketsForm.php');
+    $lifecycle = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_event/src/Service/TicketTierLifecycleService.php');
+    $guard = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_event/src/Service/TicketTierDeletionGuard.php');
+
+    $this->assertNotFalse($form);
+    $this->assertStringContainsString('Permanently delete this ticket when I save', $form);
+    $this->assertStringContainsString('evaluateTicketDeletion', $form);
+    $this->assertStringContainsString('deleteTicketOnEvent', $form);
+    $this->assertStringContainsString('ticket_deleted', $form);
+    $this->assertStringContainsString('Choose only one ticket action', $form);
+    $this->assertStringContainsString("'#default_value' => 0", $form);
+
+    $this->assertNotFalse($lifecycle);
+    $this->assertStringContainsString('function evaluateTicketDeletion', $lifecycle);
+    $this->assertStringContainsString('function deleteTicketOnEvent', $lifecycle);
+    $this->assertStringContainsString('$this->archiveTicketOnEvent($event, $ticket)', $lifecycle);
+    $this->assertStringContainsString('$ticket->delete()', $lifecycle);
+
+    $this->assertNotFalse($guard);
+    $this->assertStringContainsString("'commerce_order_item'", $guard);
+    $this->assertStringContainsString("'myeventlane_ticket'", $guard);
+    $this->assertStringContainsString("'mel_ticket_waitlist_entry'", $guard);
+    $this->assertStringContainsString("'mel_access_code'", $guard);
+    $this->assertStringContainsString("'inspection_failed'", $guard);
+
+    $javascript = file_get_contents($this->moduleRoot() . '/js/mel-event-studio-tickets-app.js');
+    $this->assertNotFalse($javascript);
+    $this->assertStringContainsString('mel-tickets-delete-safe-default', $javascript);
+    $this->assertStringContainsString('checkbox.checked = false', $javascript);
   }
 
   public function testOperationalFormAttachesTicketsAppLibrary(): void {

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceLibraryAttachmentTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioWorkspaceLibraryAttachmentTest.php
@@ -66,6 +66,17 @@ final class EventStudioWorkspaceLibraryAttachmentTest extends TestCase {
     $this->assertStringContainsString('if (!_myeventlane_event_studio_is_workspace_route())', $form);
   }
 
+  public function testSuccessfulQuestionSaveRedirectsToEventScopedWorkspace(): void {
+    $form = file_get_contents($this->moduleRoot . '/src/Form/EventCheckoutQuestionsForm.php');
+    $this->assertIsString($form);
+    $this->assertStringContainsString(
+      "\$form_state->setRedirect('myeventlane_event_studio.workspace_questions'",
+      $form,
+    );
+    $this->assertStringContainsString("'node' => \$event->id()", $form);
+    $this->assertStringNotContainsString('$form_state->setRebuild(TRUE);', $form);
+  }
+
   public function testWorkspaceControllerStillAttachesShellOnly(): void {
     $controller = file_get_contents($this->moduleRoot . '/src/Controller/EventStudioController.php');
     $this->assertIsString($controller);

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.libraries.yml
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.libraries.yml
@@ -3,6 +3,7 @@
 
 # Canonical global bundle for vendor pages (attached via info.yml + page_attachments_alter).
 global:
+  version: 2.0.1
   css:
     theme:
       dist/main.css: {}

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-event-studio-ticket-hierarchy.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-event-studio-ticket-hierarchy.scss
@@ -1,0 +1,448 @@
+/**
+ * @file
+ * VL-5C.2B — Tickets setup hierarchy.
+ *
+ * Booking choice, ticket work, and customer preview remain distinct zones.
+ * Commerce, validation, autosave, and ticket lifecycle behaviour remain
+ * unchanged.
+ */
+
+@use '../tokens/colors' as *;
+@use '../tokens/radii' as *;
+@use '../tokens/spacing' as *;
+@use '../tokens/typography' as *;
+
+.mel-event-studio--workspace
+  [data-mel-event-studio-section='tickets']
+  .mel-es-field-group--booking {
+  margin: 0 0 $spacing-8;
+  padding: 0 0 $spacing-8;
+  border: 0;
+  border-bottom: 1px solid $mel-ws-border-soft;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.mel-event-studio--workspace
+  [data-mel-event-studio-section='tickets']
+  .mel-es-field-group--booking
+  .mel-es-field-group__header {
+  margin: 0 0 $spacing-5;
+  padding: 0;
+  border: 0;
+}
+
+.mel-event-studio--workspace
+  [data-mel-event-studio-section='tickets']
+  .mel-es-field-group--booking
+  .mel-es-field-group__title {
+  color: $text-primary;
+  font-size: $font-size-section-title;
+  font-weight: $font-weight-bold;
+  line-height: $line-height-tight;
+  letter-spacing: $letter-spacing-tight;
+}
+
+.mel-event-studio--workspace
+  [data-mel-event-studio-section='tickets']
+  .mel-es-field-group--booking
+  .mel-es-field-group__hint {
+  max-width: 38rem;
+  margin-top: $spacing-2;
+  color: $text-secondary;
+  font-size: $font-size-meta;
+  line-height: $line-height-normal;
+}
+
+.mel-event-studio--workspace
+  [data-mel-event-studio-section='tickets']
+  .mel-es-field-group--booking
+  .mel-es-field-group__body {
+  gap: $spacing-5;
+}
+
+.mel-event-studio--workspace .mel-event-studio-tickets-app {
+  display: grid;
+  gap: $spacing-8;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-tickets-app
+  > .myeventlane-event-studio-operational-tickets {
+  padding-top: $spacing-2;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-attendee-questions-handoff {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: $spacing-2 $spacing-5;
+  align-items: center;
+  padding: $spacing-5;
+  border: 1px solid $mel-ws-purple-border;
+  border-radius: $radius-lg;
+  background: $mel-ws-soft-sky;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-attendee-questions-handoff__eyebrow,
+.mel-event-studio--workspace
+  .mel-event-studio-attendee-questions-handoff__title,
+.mel-event-studio--workspace
+  .mel-event-studio-attendee-questions-handoff__copy {
+  grid-column: 1;
+  margin: 0;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-attendee-questions-handoff__eyebrow {
+  color: $mel-ws-purple;
+  font-size: $font-size-meta;
+  font-weight: $font-weight-bold;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-attendee-questions-handoff__title {
+  color: $text-primary;
+  font-size: $font-size-section-title;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-attendee-questions-handoff__copy {
+  max-width: 42rem;
+  color: $text-secondary;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-attendee-questions-handoff
+  .mel-btn {
+  grid-column: 2;
+  grid-row: 1 / span 3;
+  align-self: center;
+  white-space: nowrap;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-intro.mel-es-card {
+  padding: 0 0 $spacing-6;
+  border: 0;
+  border-bottom: 1px solid $mel-ws-border-soft;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-card {
+  gap: $spacing-5;
+  padding: $spacing-6;
+  border: 1px solid $mel-ws-border-soft;
+  border-radius: $radius-lg;
+  background: $ml-vendor-card;
+  box-shadow: 0 8px 24px rgba($text-primary, 0.05);
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-card__header {
+  gap: $spacing-4;
+  padding-bottom: $spacing-5;
+  border-bottom: 1px solid $mel-ws-border-soft;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-card__summary {
+  gap: $spacing-2;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-card__summary-price,
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-card__summary-status {
+  padding: $spacing-1 $spacing-3;
+  font-size: $font-size-meta;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-card__attendee-preview {
+  margin: 0;
+  padding: $spacing-4 0 $spacing-5;
+  border: 0;
+  border-bottom: 1px solid $mel-ws-border-soft;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-card__body {
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-card__field-group,
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-card__sales-window {
+  gap: $spacing-4;
+  padding: $spacing-5 0;
+  border: 0;
+  border-bottom: 1px solid $mel-ws-border-soft;
+  border-radius: 0;
+  background: transparent;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-card__field-group::before {
+  display: none;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-card__field-group
+  > .mel-event-studio-ticket-card__group-title {
+  min-height: auto;
+  margin: 0;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-card__sales-window
+  .mel-event-studio-ticket-card__reset-sales-window {
+  justify-self: start;
+  min-height: 44px;
+  padding-inline: 0;
+  color: $text-secondary;
+  background: transparent;
+  box-shadow: none;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-card__sales-window
+  .mel-event-studio-ticket-card__reset-sales-window:hover,
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-card__sales-window
+  .mel-event-studio-ticket-card__reset-sales-window:focus-visible {
+  color: $text-primary;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-card__reset-status {
+  grid-column: 1 / -1;
+  min-height: 1.25rem;
+  color: $text-secondary;
+  font-size: $font-size-meta;
+  line-height: $line-height-normal;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-card__advanced {
+  margin: 0;
+  padding-top: $spacing-3;
+  border-top: 1px solid $mel-ws-border-soft;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-card__advanced
+  > summary {
+  min-height: 44px;
+  padding: 0;
+  color: $text-secondary;
+  background: transparent;
+  font-weight: $font-weight-semibold;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-card__advanced
+  > summary::before {
+  display: none;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-card__advanced-content {
+  padding-top: $spacing-4;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-card__quick-actions {
+  margin: 0;
+  padding: $spacing-5 0;
+  border-bottom: 1px solid $mel-ws-border-soft;
+  background: transparent;
+  box-shadow: none;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-card__removal {
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid $mel-ws-border-soft;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  color: $text-secondary;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-card__removal
+  > summary {
+  min-height: 44px;
+  padding: 0;
+  color: $text-secondary;
+  font-weight: $font-weight-semibold;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-card__removal-warning,
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-card__removal-blocked {
+  max-width: 42rem;
+  margin: 0 0 $spacing-4;
+  color: $text-secondary;
+  font-size: $font-size-meta;
+  line-height: $line-height-normal;
+}
+
+.mel-event-studio--workspace
+  .mel-event-studio-ticket-card__action--danger {
+  padding: $spacing-4;
+  border: 1px solid rgba($danger, 0.28);
+  border-radius: $radius-md;
+  background: $danger-light;
+}
+
+.mel-event-studio--workspace
+  .mel-event-ticket-preview {
+  margin-top: $spacing-2;
+}
+
+@media all {
+  .mel-event-studio--workspace
+    .mel-event-studio-ticket-card__header {
+    grid-template-columns: minmax(0, 1fr) minmax(8rem, 0.42fr) minmax(9rem, 0.48fr);
+    align-items: start;
+  }
+
+  .mel-event-studio--workspace
+    .mel-event-studio-ticket-card__identity {
+    grid-column: 1;
+  }
+
+  .mel-event-studio--workspace
+    .mel-event-studio-ticket-card__pricing {
+    grid-column: 2;
+    max-width: none;
+  }
+
+  .mel-event-studio--workspace
+    .mel-event-studio-ticket-card__capacity {
+    grid-column: 3;
+  }
+
+  .mel-event-studio--workspace
+    .mel-event-studio-ticket-card__badges {
+    grid-column: 1 / -1;
+  }
+
+  .mel-event-studio--workspace
+    .mel-event-studio-ticket-card__body {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    column-gap: $spacing-6;
+  }
+
+  .mel-event-studio--workspace
+    .mel-event-studio-ticket-card__sales-window {
+    grid-column: 1 / -1;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    column-gap: $spacing-6;
+  }
+
+  .mel-event-studio--workspace
+    .mel-event-studio-ticket-card__sales-window
+    .mel-event-studio-ticket-card__group-title,
+  .mel-event-studio--workspace
+    .mel-event-studio-ticket-card__sales-window
+    .mel-event-studio-ticket-card__reset-sales-window,
+  .mel-event-studio--workspace
+    .mel-event-studio-ticket-card__sales-window
+    [role='status'] {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 767px) {
+  .mel-event-studio--workspace .mel-event-studio-tickets-app {
+    gap: $spacing-6;
+  }
+
+  .mel-event-studio--workspace
+    [data-mel-event-studio-section='tickets']
+    .mel-es-field-group--booking {
+    margin-bottom: $spacing-6;
+    padding-bottom: $spacing-6;
+  }
+
+  .mel-event-studio--workspace
+    [data-mel-event-studio-section='tickets']
+    .mel-es-field-group--booking
+    .mel-es-field-group__header {
+    margin-bottom: $spacing-4;
+  }
+
+  .mel-event-studio--workspace
+    [data-mel-event-studio-section='tickets']
+    .mel-es-field-group--booking
+    .mel-es-field-group__body {
+    gap: $spacing-4;
+  }
+
+  .mel-event-studio--workspace
+    .mel-event-studio-ticket-card {
+    padding: $spacing-5;
+  }
+
+  .mel-event-studio--workspace
+    .mel-event-studio-attendee-questions-handoff {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .mel-event-studio--workspace
+    .mel-event-studio-attendee-questions-handoff
+    .mel-btn {
+    grid-column: 1;
+    grid-row: auto;
+    justify-self: stretch;
+  }
+
+  .mel-event-studio--workspace
+    .mel-event-studio-ticket-card__header,
+  .mel-event-studio--workspace
+    .mel-event-studio-ticket-card__body,
+  .mel-event-studio--workspace
+    .mel-event-studio-ticket-card__sales-window {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .mel-event-studio--workspace
+    .mel-event-studio-ticket-card__identity,
+  .mel-event-studio--workspace
+    .mel-event-studio-ticket-card__pricing,
+  .mel-event-studio--workspace
+    .mel-event-studio-ticket-card__capacity,
+  .mel-event-studio--workspace
+    .mel-event-studio-ticket-card__badges,
+  .mel-event-studio--workspace
+    .mel-event-studio-ticket-card__sales-window,
+  .mel-event-studio--workspace
+    .mel-event-studio-ticket-card__sales-window
+    .mel-event-studio-ticket-card__group-title,
+  .mel-event-studio--workspace
+    .mel-event-studio-ticket-card__sales-window
+    .mel-event-studio-ticket-card__reset-sales-window,
+  .mel-event-studio--workspace
+    .mel-event-studio-ticket-card__sales-window
+    [role='status'] {
+    grid-column: auto;
+  }
+}

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
@@ -125,6 +125,9 @@
   @include meta.load-css('pages/settings-hub');
   @include meta.load-css('pages/support-hub');
   @include meta.load-css('pages/analytics-hub');
+
+  // Vendor Studio corrections load after shared Event Studio presentation.
+  @include meta.load-css('components/mel-event-studio-ticket-hierarchy');
 }
 
 // Klaro renders at document root (#klaro), outside .mel-vendor — reuse public theme styles.


### PR DESCRIPTION
## Summary

- refine the event-scoped Ticket Workspace hierarchy and progressive ticket setup
- keep common ticket properties accessible while moving optional controls into progressive disclosure
- make Best Value optional and add sales-window reset behaviour
- support duplicate, archive, and guarded permanent deletion actions
- replace the disconnected attendee-collection checkbox with an event-scoped attendee-question handoff
- reload the complete Tickets or Questions workspace after successful saves
- add vendor-theme presentation for the approved ticket-card hierarchy

## Why

Organisers need to understand which event and ticket they are changing, see the public booking outcome, and complete common work without being overwhelmed by advanced settings. Successful attendee-question saves also rebuilt the submitted form state, leaving the add-question editor populated and making a completed save look unfinished.

## Impact

The organiser journey remains portfolio → selected event → dedicated event workspace. Ticket, question, preview, and lifecycle behaviour remain scoped to the selected event. No new routes, ticketing features, Commerce projections, readiness logic, publish enforcement, CTA resolution, or global workspace architecture are introduced.

## Validation

- PHP syntax passed for the changed PHP implementation files
- 33 PHPUnit tests and 221 assertions passed
- vendor-theme production build passed
- Drupal cache rebuild passed
- `git diff --check` passed
- repository push validation passed, including Composer, config, webroot, and raw-card-data safety checks
- Product Owner live-tested attendee-question create, event-scoped reload, and cleared add editor on test event 1666

## Review notes

Codex browser control could not independently access the local DDEV hostname because of the browser network policy. Previously reported desktop/mobile and ticket lifecycle runtime checks were not rerun by Codex during the final audit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Permanent ticket deletion and Commerce variation removal touch ticketing/commerce data paths, though eligibility checks and transactions reduce exposure; lifecycle validation changes (optional best value) may affect checkout merchandising expectations.
> 
> **Overview**
> Refines the **Vendor Event Studio tickets journey** so booking mode, operational ticket editing, preview, and advanced tools appear in a clearer hierarchy based on event type (`paid`/`both` vs RSVP/external).
> 
> Introduces **`TicketTierDeletionGuard`** and lifecycle methods **`evaluateTicketDeletion`** / **`deleteTicketOnEvent`**, blocking permanent delete when order items, issued tickets, waitlist entries, or access codes exist; Event Studio exposes a **Remove ticket** action (mutually exclusive with duplicate/archive) and runs deletion in a transaction after archive/detach, including unused Commerce variation cleanup.
> 
> **Removes mandatory “best value” validation** from `TicketTierLifecycleService` and moves the highlight checkbox into optional ticket settings. Adds **Clear sales window** client-side reset (save still required) and forces delete checkboxes off on attach to avoid accidental submits.
> 
> **Booking settings step** drops the inline “collect attendee details” checkbox in favor of a link to the event-scoped **Questions** workspace; successful saves on tickets, questions, and booking settings **redirect** to the workspace route instead of rebuilding the form.
> 
> Vendor theme adds **`mel-event-studio-ticket-hierarchy`** SCSS and bumps library versions for cache busting; contract/unit tests cover deletion guard, redirects, and UI contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0be717f248ec3a5bc9342ee53fa607be1eff5b6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->