### PR TITLE
Align Mission Control actions

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -5994,7 +5994,9 @@ body.mel-vendor .mel-event-studio-mission-control__next-title,
 .mel-event-studio-mission-control__cta {
   align-self: center;
   min-height: 44px;
+  min-width: 9rem;
   margin: 0;
+  justify-content: center;
 }
 
 .mel-event-studio-mission-control__publish-hint {
@@ -6009,8 +6011,22 @@ body.mel-vendor .mel-event-studio-mission-control__next-title,
   margin: 0;
   border: 0;
   padding: 0;
-  flex: 1 1 8rem;
-  min-width: 7rem;
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 100%;
+  overflow: visible;
+}
+
+/* Neutralise the global vendor details-card chrome for this compact action. */
+body.mel-vendor details.mel-event-studio-mission-control__details {
+  align-self: center;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  overflow: visible;
 }
 
 .mel-event-studio-mission-control__details[open] {
@@ -6022,23 +6038,34 @@ body.mel-vendor .mel-event-studio-mission-control__details > .mel-event-studio-m
 .mel-event-studio-mission-control__details > .mel-event-studio-mission-control__details-summary {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
+  width: auto;
+  min-width: 9rem;
+  max-width: 100%;
   min-height: 44px;
   margin: 0;
-  padding: 0.15rem 0;
+  padding: 0.625rem 0.875rem;
   cursor: pointer;
   list-style: none;
-  font-size: 0.875rem;
+  white-space: nowrap;
+  font-size: 0.9375rem;
   font-weight: 600;
-  line-height: 1.3;
-  color: var(--mel-text-muted, #64748b);
-  background: transparent;
-  border: 0;
-  border-radius: 8px;
+  line-height: 1.25;
+  color: var(--mel-text, #24303a);
+  background: var(--mel-surface, #fff);
+  border: 1px solid rgba(36, 48, 58, 0.1);
+  border-radius: 20px;
   box-shadow: none;
+  box-sizing: border-box;
 }
 
 .mel-event-studio-mission-control__details-summary::-webkit-details-marker {
   display: none;
+}
+
+.mel-event-studio-mission-control__details-summary::before {
+  display: none !important;
+  content: none !important;
 }
 
 .mel-event-studio-mission-control__details-summary::after {

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioLaunchCentreTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioLaunchCentreTest.php
@@ -148,6 +148,20 @@ final class EventStudioLaunchCentreTest extends UnitTestCase {
     $this->assertStringContainsString('@media (max-width: 767px)', $scss);
   }
 
+  public function testMissionControlActionsRemainCompactAndAligned(): void {
+    $scss = file_get_contents(dirname(__DIR__, 6) . '/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-event-studio-mission-control.scss');
+    $this->assertIsString($scss);
+    $this->assertStringContainsString('.mel-event-studio-mission-control__details {', $scss);
+    $this->assertStringContainsString('flex: 0 1 auto', $scss);
+    $this->assertStringContainsString('width: auto', $scss);
+    $this->assertStringContainsString('min-width: 9rem', $scss);
+    $this->assertStringContainsString('white-space: nowrap', $scss);
+    $this->assertStringContainsString('body.mel-vendor details.mel-event-studio-mission-control__details', $scss);
+    $this->assertStringContainsString('align-self: center', $scss);
+    $this->assertStringContainsString('.mel-event-studio-mission-control__details-summary::before', $scss);
+    $this->assertStringContainsString('content: none !important', $scss);
+  }
+
   public function testThemeHookRegistersLaunchCentre(): void {
     $module = file_get_contents(dirname(__DIR__, 3) . '/myeventlane_event_studio.module');
     $this->assertIsString($module);

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-event-studio-mission-control.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-event-studio-mission-control.scss
@@ -133,6 +133,7 @@ body.mel-vendor .mel-event-studio-mission-control__next-title,
 }
 
 .mel-event-studio-mission-control__actions {
+  align-items: center;
   gap: $spacing-2 $spacing-4;
   margin-top: $spacing-1;
 }
@@ -149,6 +150,8 @@ body.mel-vendor .mel-event-studio-mission-control__next-title,
 .mel-event-studio-mission-control__cta.mel-btn--secondary,
 .mel-event-studio-mission-control__cta {
   min-height: 44px;
+  min-width: 9rem;
+  justify-content: center;
   background-color: $mel-shell-surface;
   border-color: $mel-ws-border-soft;
   color: $text-primary;
@@ -174,13 +177,47 @@ body.mel-vendor .mel-event-studio-mission-control__next-title,
 
 body.mel-vendor .mel-event-studio-mission-control__details > .mel-event-studio-mission-control__details-summary,
 .mel-event-studio-mission-control__details > .mel-event-studio-mission-control__details-summary {
+  width: auto;
+  min-width: 9rem;
+  max-width: 100%;
+  justify-content: center;
   min-height: 44px;
-  font-size: $font-size-meta;
+  padding: 0.625rem 0.875rem;
+  white-space: nowrap;
+  font-size: 0.9375rem;
   font-weight: $font-weight-semibold;
-  color: $text-secondary;
-  background: transparent;
-  border: 0;
+  color: $text-primary;
+  background: $mel-shell-surface;
+  border: 1px solid $mel-ws-border-soft;
+  border-radius: 20px;
   box-shadow: none;
+}
+
+.mel-event-studio-mission-control__details {
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 100%;
+  overflow: visible;
+}
+
+body.mel-vendor details.mel-event-studio-mission-control__details {
+  align-self: center;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  overflow: visible;
+}
+
+.mel-event-studio-mission-control__details[open] {
+  flex: 1 1 100%;
+}
+
+.mel-event-studio-mission-control__details-summary::before {
+  display: none !important;
+  content: none !important;
 }
 
 .mel-event-studio-mission-control__details-summary:focus-visible {


### PR DESCRIPTION
## Summary
- match the Mission Control primary and details controls at 144 x 44px
- remove inherited details-card margin, border and shadow
- keep labels aligned, centred and non-wrapping
- add regression coverage for the compact action pair

## Validation
- 17 Event Studio component tests passed
- vendor theme production build passed in the main DDEV workspace
- live visual measurement confirmed matching dimensions and baseline

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS and a unit test; no PHP, Twig, or behavior changes to Mission Control logic.
> 
> **Overview**
> **Mission Control** action row styling is updated so the secondary CTA and the checklist **details** toggle read as a matched pair instead of mismatched chrome.
> 
> Both controls get **9rem min-width**, **44px min-height**, centered labels, and **nowrap** text. The details **summary** is restyled from a muted text link into a pill button (surface background, border, 20px radius) aligned with the CTA. Global **vendor** `details` card styling (margin, border, shadow, peach **summary** `::before`) is overridden for `mel-event-studio-mission-control__details` so the disclosure stays compact and vertically centered in the actions flex row; when open, the details block still spans full width.
> 
> The same rules are applied in module shell CSS and vendor theme SCSS. A unit test **`testMissionControlActionsRemainCompactAndAligned`** asserts the theme SCSS keeps these contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc4a1f4d6113c8969bce6d9cdbf7a0396b97991a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->