### PR TITLE
fix duplicate booking expiry emails

### DIFF
--- a/config/sync/myeventlane_messaging.template.order_confirmation.yml
+++ b/config/sync/myeventlane_messaging.template.order_confirmation.yml
@@ -163,22 +163,14 @@ body_html: |
           <!--<![endif]-->
           {% if apple_wallet_url or google_wallet_url or pdf_url %}
             <div style="margin-top:20px;" role="group" aria-label="Pass actions">
-              {% if apple_wallet_url %}
-                <a href="{{ apple_wallet_url }}" style="display:inline-block;margin:6px 8px;text-decoration:none;line-height:0;vertical-align:middle;" aria-label="Add to Apple Wallet">
-                  {% if apple_wallet_badge_url %}
-                    <img src="{{ apple_wallet_badge_url }}" alt="Add to Apple Wallet" width="156" height="48" style="display:block;width:156px;height:auto;border:0;outline:none;">
-                  {% else %}
-                    <span style="display:inline-block;background-color:#1f1f1f;color:#ffffff !important;text-decoration:none;padding:12px 18px;border-radius:8px;font-weight:600;font-size:14px;line-height:1.25;">Add to Apple Wallet</span>
-                  {% endif %}
+              {% if apple_wallet_url and apple_wallet_badge_url %}
+                <a href="{{ apple_wallet_url }}" style="display:inline-block;margin:8px;text-decoration:none;line-height:0;vertical-align:middle;" aria-label="Add to Apple Wallet">
+                  <img src="{{ apple_wallet_badge_url }}" alt="Add to Apple Wallet" width="156" height="48" style="display:block;width:156px;height:48px;border:0;outline:none;">
                 </a>
               {% endif %}
-              {% if google_wallet_url %}
-                <a href="{{ google_wallet_url }}" style="display:inline-block;margin:6px 8px;text-decoration:none;line-height:0;vertical-align:middle;" aria-label="Add to Google Wallet">
-                  {% if google_wallet_badge_url %}
-                    <img src="{{ google_wallet_badge_url }}" alt="Add to Google Wallet" width="200" height="48" style="display:block;width:200px;height:auto;border:0;outline:none;">
-                  {% else %}
-                    <span style="display:inline-block;background-color:#1f1f1f;color:#ffffff !important;text-decoration:none;padding:12px 18px;border-radius:8px;font-weight:600;font-size:14px;line-height:1.25;">Add to Google Wallet</span>
-                  {% endif %}
+              {% if google_wallet_url and google_wallet_badge_url %}
+                <a href="{{ google_wallet_url }}" style="display:inline-block;margin:8px;text-decoration:none;line-height:0;vertical-align:middle;" aria-label="Add to Google Wallet">
+                  <img src="{{ google_wallet_badge_url }}" alt="Add to Google Wallet" width="272" height="48" style="display:block;width:272px;height:48px;border:0;outline:none;">
                 </a>
               {% endif %}
               {% if pdf_url %}

--- a/web/modules/custom/myeventlane_boost/myeventlane_boost.install
+++ b/web/modules/custom/myeventlane_boost/myeventlane_boost.install
@@ -628,3 +628,48 @@ function myeventlane_boost_update_10009(): string {
     '@stats_renamed' => $stats_renamed,
   ]);
 }
+
+/**
+ * Adds idempotent expiry notification state to Boost entitlements.
+ */
+function myeventlane_boost_update_10010(): string {
+  $definitions = \Drupal::service('entity_field.manager')
+    ->getFieldStorageDefinitions('myeventlane_boost_entitlement');
+  $update_manager = \Drupal::entityDefinitionUpdateManager();
+
+  foreach ([
+    'expiry_notification_status',
+    'expiry_notified_at',
+    'expiry_notification_attempts',
+  ] as $field_name) {
+    if (isset($definitions[$field_name])) {
+      $update_manager->installFieldStorageDefinition(
+        $field_name,
+        'myeventlane_boost_entitlement',
+        'myeventlane_boost',
+        $definitions[$field_name],
+      );
+    }
+  }
+
+  $database = \Drupal::database();
+  $database->update('myeventlane_boost_entitlement')
+    ->fields([
+      'expiry_notification_status' => 'pending',
+      'expiry_notification_attempts' => 0,
+    ])
+    ->execute();
+
+  $historical_expired = $database
+    ->update('myeventlane_boost_entitlement')
+    ->fields([
+      'expiry_notification_status' => 'sent',
+    ])
+    ->condition('status', 'expired')
+    ->execute();
+
+  return sprintf(
+    'Added Boost entitlement expiry notification state and marked %d historical expired entitlements as already handled.',
+    $historical_expired,
+  );
+}

--- a/web/modules/custom/myeventlane_boost/myeventlane_boost.install
+++ b/web/modules/custom/myeventlane_boost/myeventlane_boost.install
@@ -653,19 +653,23 @@ function myeventlane_boost_update_10010(): string {
   }
 
   $database = \Drupal::database();
+  // Initialise both states atomically so cron can never observe historical
+  // expired entitlements as pending and resend their notifications.
+  $historical_expired = (int) $database
+    ->select('myeventlane_boost_entitlement', 'entitlement')
+    ->condition('status', 'expired')
+    ->countQuery()
+    ->execute()
+    ->fetchField();
+
   $database->update('myeventlane_boost_entitlement')
     ->fields([
-      'expiry_notification_status' => 'pending',
       'expiry_notification_attempts' => 0,
     ])
-    ->execute();
-
-  $historical_expired = $database
-    ->update('myeventlane_boost_entitlement')
-    ->fields([
-      'expiry_notification_status' => 'sent',
-    ])
-    ->condition('status', 'expired')
+    ->expression(
+      'expiry_notification_status',
+      "CASE WHEN status = 'expired' THEN 'sent' ELSE 'pending' END",
+    )
     ->execute();
 
   return sprintf(

--- a/web/modules/custom/myeventlane_boost/myeventlane_boost.module
+++ b/web/modules/custom/myeventlane_boost/myeventlane_boost.module
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
-use Drupal\myeventlane_boost\Cron\BoostExpiryCron;
 use Drupal\myeventlane_boost\Cron\BoostExpiryReminderCron;
 use Drupal\myeventlane_boost\Entity\BoostEntitlementInterface;
 
@@ -184,9 +183,7 @@ function myeventlane_boost_page_attachments(array &$attachments): void {
  */
 function myeventlane_boost_cron(): void {
   // Process expired boosts.
-  \Drupal::service('class_resolver')
-    ->getInstanceFromDefinition(BoostExpiryCron::class)
-    ->process();
+  \Drupal::service('myeventlane_boost.cron.expiry')->process();
 
   // Send expiry reminder emails.
   \Drupal::service('class_resolver')

--- a/web/modules/custom/myeventlane_boost/myeventlane_boost.services.yml
+++ b/web/modules/custom/myeventlane_boost/myeventlane_boost.services.yml
@@ -33,6 +33,17 @@ services:
       - '@datetime.time'
       - '@logger.channel.myeventlane_boost'
 
+  myeventlane_boost.cron.expiry:
+    class: Drupal\myeventlane_boost\Cron\BoostExpiryCron
+    arguments:
+      - '@entity_type.manager'
+      - '@datetime.time'
+      - '@logger.channel.myeventlane_boost'
+      - '@plugin.manager.mail'
+      - '@myeventlane_boost.entitlement_manager'
+      - '@lock'
+      - '@?myeventlane_notifications.business_trigger'
+
   myeventlane_boost.purchase_success_resolver:
     class: Drupal\myeventlane_boost\Service\BoostPurchaseSuccessResolver
     arguments:

--- a/web/modules/custom/myeventlane_boost/src/Cron/BoostExpiryCron.php
+++ b/web/modules/custom/myeventlane_boost/src/Cron/BoostExpiryCron.php
@@ -30,6 +30,11 @@ final class BoostExpiryCron implements ContainerInjectionInterface {
   private const LOCK_TTL = 300.0;
 
   /**
+   * Maximum number of automatic expiry notification attempts.
+   */
+  private const MAX_NOTIFICATION_ATTEMPTS = 5;
+
+  /**
    * Constructs a BoostExpiryCron.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
@@ -90,6 +95,7 @@ final class BoostExpiryCron implements ContainerInjectionInterface {
       ->condition('status', BoostEntitlementInterface::STATUS_EXPIRED)
       ->condition('ends', $this->time->getRequestTime(), '<=')
       ->condition('expiry_notification_status', BoostEntitlementInterface::EXPIRY_NOTIFICATION_SENT, '<>')
+      ->condition('expiry_notification_attempts', self::MAX_NOTIFICATION_ATTEMPTS, '<')
       ->notExists('expiry_notified_at')
       ->range(0, 500)
       ->execute();
@@ -167,6 +173,11 @@ final class BoostExpiryCron implements ContainerInjectionInterface {
           'expiry_notification_status',
           BoostEntitlementInterface::EXPIRY_NOTIFICATION_SENT,
           '<>',
+        )
+        ->condition(
+          'expiry_notification_attempts',
+          self::MAX_NOTIFICATION_ATTEMPTS,
+          '<',
         )
         ->notExists('expiry_notified_at')
         ->execute();
@@ -249,6 +260,12 @@ final class BoostExpiryCron implements ContainerInjectionInterface {
           '@attempt' => $attempt,
           '@entitlement_count' => count($pendingEntitlements),
         ]);
+        if ($attempt >= self::MAX_NOTIFICATION_ATTEMPTS) {
+          $this->logger->critical('Boost expiry notification exhausted automatic retries for event @event_id after @attempt attempts.', [
+            '@event_id' => $event->id(),
+            '@attempt' => $attempt,
+          ]);
+        }
       }
     }
     finally {

--- a/web/modules/custom/myeventlane_boost/src/Cron/BoostExpiryCron.php
+++ b/web/modules/custom/myeventlane_boost/src/Cron/BoostExpiryCron.php
@@ -199,18 +199,22 @@ final class BoostExpiryCron implements ContainerInjectionInterface {
         $pendingEntitlement->save();
       }
 
+      // Persist the idempotency decision before invoking the external mail
+      // transport. A worker stopping after Postmark accepts the message must
+      // not leave a retryable row that can send the same email again.
+      foreach ($pendingEntitlements as $pendingEntitlement) {
+        $pendingEntitlement->set(
+          'expiry_notification_status',
+          BoostEntitlementInterface::EXPIRY_NOTIFICATION_SENT,
+        );
+        $pendingEntitlement->set(
+          'expiry_notified_at',
+          $this->time->getRequestTime(),
+        );
+        $pendingEntitlement->save();
+      }
+
       if ($this->notifyVendor($event)) {
-        foreach ($pendingEntitlements as $pendingEntitlement) {
-          $pendingEntitlement->set(
-            'expiry_notification_status',
-            BoostEntitlementInterface::EXPIRY_NOTIFICATION_SENT,
-          );
-          $pendingEntitlement->set(
-            'expiry_notified_at',
-            $this->time->getRequestTime(),
-          );
-          $pendingEntitlement->save();
-        }
         $this->logger->notice('Sent boost expiry notification once for @entitlement_count entitlement(s) on event @event_id, attempt @attempt.', [
           '@entitlement_id' => $entitlementId,
           '@event_id' => $event->id(),
@@ -224,6 +228,7 @@ final class BoostExpiryCron implements ContainerInjectionInterface {
             'expiry_notification_status',
             BoostEntitlementInterface::EXPIRY_NOTIFICATION_PENDING,
           );
+          $pendingEntitlement->set('expiry_notified_at', NULL);
           $pendingEntitlement->save();
         }
         $this->logger->error('Boost expiry notification failed for @entitlement_count entitlement(s) on event @event_id, attempt @attempt; retry remains pending.', [
@@ -275,7 +280,17 @@ final class BoostExpiryCron implements ContainerInjectionInterface {
 
     $sent = !empty($result['result']);
     if ($sent && $this->businessNotificationTrigger !== NULL) {
-      $this->businessNotificationTrigger->onBoostCompleted($node, (int) $owner->id());
+      try {
+        $this->businessNotificationTrigger->onBoostCompleted($node, (int) $owner->id());
+      }
+      catch (\Throwable $exception) {
+        // The email has already been accepted. Ancillary in-app notification
+        // failure must not make the email retryable.
+        $this->logger->error('Boost completion notification failed after expiry email was sent for event @event_id: @message', [
+          '@event_id' => $node->id(),
+          '@message' => $exception->getMessage(),
+        ]);
+      }
     }
 
     return $sent;

--- a/web/modules/custom/myeventlane_boost/src/Cron/BoostExpiryCron.php
+++ b/web/modules/custom/myeventlane_boost/src/Cron/BoostExpiryCron.php
@@ -80,15 +80,17 @@ final class BoostExpiryCron implements ContainerInjectionInterface {
    * Claims each expired entitlement before sending its notification.
    */
   public function process(): void {
+    // Expiry is not notification-batch limited: promotion state must be
+    // correct even when more than 500 notifications are awaiting delivery.
+    $this->entitlementManager->expireEndedEntitlements();
+
     $storage = $this->entityTypeManager->getStorage('myeventlane_boost_entitlement');
     $ids = $storage->getQuery()
       ->accessCheck(FALSE)
-      ->condition('status', [
-        BoostEntitlementInterface::STATUS_ACTIVE,
-        BoostEntitlementInterface::STATUS_EXPIRED,
-      ], 'IN')
+      ->condition('status', BoostEntitlementInterface::STATUS_EXPIRED)
       ->condition('ends', $this->time->getRequestTime(), '<=')
       ->condition('expiry_notification_status', BoostEntitlementInterface::EXPIRY_NOTIFICATION_SENT, '<>')
+      ->notExists('expiry_notified_at')
       ->range(0, 500)
       ->execute();
 
@@ -102,19 +104,33 @@ final class BoostExpiryCron implements ContainerInjectionInterface {
   }
 
   /**
-   * Expires and notifies one entitlement under an exclusive lock.
+   * Notifies once for all simultaneously ended entitlements on an event.
    */
   private function processEntitlement(int $entitlementId): void {
-    $lockName = 'myeventlane_boost.expiry_notification.' . $entitlementId;
+    $storage = $this->entityTypeManager
+      ->getStorage('myeventlane_boost_entitlement');
+    $entitlement = $storage->load($entitlementId);
+    if (!$entitlement instanceof BoostEntitlementInterface) {
+      return;
+    }
+    $eventId = (int) ($entitlement->get('event')->target_id ?? 0);
+    if ($eventId <= 0) {
+      $this->logger->error('Boost expiry notification failed: entitlement @entitlement_id has no event.', [
+        '@entitlement_id' => $entitlementId,
+      ]);
+      return;
+    }
+
+    $lockName = 'myeventlane_boost.expiry_notification.event.' . $eventId;
     if (!$this->lock->acquire($lockName, self::LOCK_TTL)) {
-      $this->logger->info('Boost expiry notification skipped because entitlement @entitlement_id is already being processed.', [
+      $this->logger->info('Boost expiry notification skipped because event @event_id is already being processed.', [
+        '@event_id' => $eventId,
         '@entitlement_id' => $entitlementId,
       ]);
       return;
     }
 
     try {
-      $storage = $this->entityTypeManager->getStorage('myeventlane_boost_entitlement');
       $storage->resetCache([$entitlementId]);
       $entitlement = $storage->load($entitlementId);
       if (!$entitlement instanceof BoostEntitlementInterface) {
@@ -131,6 +147,33 @@ final class BoostExpiryCron implements ContainerInjectionInterface {
         return;
       }
 
+      $activeIds = $storage->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('event', $eventId)
+        ->condition('status', BoostEntitlementInterface::STATUS_ACTIVE)
+        ->condition('ends', $this->time->getRequestTime(), '>')
+        ->range(0, 1)
+        ->execute();
+      if ($activeIds !== []) {
+        return;
+      }
+
+      $pendingIds = $storage->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('event', $eventId)
+        ->condition('status', BoostEntitlementInterface::STATUS_EXPIRED)
+        ->condition('ends', $this->time->getRequestTime(), '<=')
+        ->condition(
+          'expiry_notification_status',
+          BoostEntitlementInterface::EXPIRY_NOTIFICATION_SENT,
+          '<>',
+        )
+        ->notExists('expiry_notified_at')
+        ->execute();
+      if ($pendingIds === []) {
+        return;
+      }
+
       $event = $entitlement->get('event')->entity;
       if (!$event instanceof NodeInterface) {
         $this->logger->error('Boost expiry notification failed: entitlement @entitlement_id has no event.', [
@@ -139,30 +182,55 @@ final class BoostExpiryCron implements ContainerInjectionInterface {
         return;
       }
 
-      $attempt = (int) ($entitlement->get('expiry_notification_attempts')->value ?? 0) + 1;
-      $entitlement->set('status', BoostEntitlementInterface::STATUS_EXPIRED);
-      $entitlement->set('expiry_notification_status', BoostEntitlementInterface::EXPIRY_NOTIFICATION_PROCESSING);
-      $entitlement->set('expiry_notification_attempts', $attempt);
-      $entitlement->save();
-      $this->entitlementManager->refreshEventBoostState((int) $event->id());
+      $pendingEntitlements = $storage->loadMultiple($pendingIds);
+      $attempt = 0;
+      foreach ($pendingEntitlements as $pendingEntitlement) {
+        $nextAttempt = (int) ($pendingEntitlement
+          ->get('expiry_notification_attempts')->value ?? 0) + 1;
+        $attempt = max($attempt, $nextAttempt);
+        $pendingEntitlement->set(
+          'expiry_notification_status',
+          BoostEntitlementInterface::EXPIRY_NOTIFICATION_PROCESSING,
+        );
+        $pendingEntitlement->set(
+          'expiry_notification_attempts',
+          $nextAttempt,
+        );
+        $pendingEntitlement->save();
+      }
 
       if ($this->notifyVendor($event)) {
-        $entitlement->set('expiry_notification_status', BoostEntitlementInterface::EXPIRY_NOTIFICATION_SENT);
-        $entitlement->set('expiry_notified_at', $this->time->getRequestTime());
-        $entitlement->save();
-        $this->logger->notice('Sent boost expiry notification for entitlement @entitlement_id, event @event_id, attempt @attempt.', [
+        foreach ($pendingEntitlements as $pendingEntitlement) {
+          $pendingEntitlement->set(
+            'expiry_notification_status',
+            BoostEntitlementInterface::EXPIRY_NOTIFICATION_SENT,
+          );
+          $pendingEntitlement->set(
+            'expiry_notified_at',
+            $this->time->getRequestTime(),
+          );
+          $pendingEntitlement->save();
+        }
+        $this->logger->notice('Sent boost expiry notification once for @entitlement_count entitlement(s) on event @event_id, attempt @attempt.', [
           '@entitlement_id' => $entitlementId,
           '@event_id' => $event->id(),
           '@attempt' => $attempt,
+          '@entitlement_count' => count($pendingEntitlements),
         ]);
       }
       else {
-        $entitlement->set('expiry_notification_status', BoostEntitlementInterface::EXPIRY_NOTIFICATION_PENDING);
-        $entitlement->save();
-        $this->logger->error('Boost expiry notification failed for entitlement @entitlement_id, event @event_id, attempt @attempt; retry remains pending.', [
+        foreach ($pendingEntitlements as $pendingEntitlement) {
+          $pendingEntitlement->set(
+            'expiry_notification_status',
+            BoostEntitlementInterface::EXPIRY_NOTIFICATION_PENDING,
+          );
+          $pendingEntitlement->save();
+        }
+        $this->logger->error('Boost expiry notification failed for @entitlement_count entitlement(s) on event @event_id, attempt @attempt; retry remains pending.', [
           '@entitlement_id' => $entitlementId,
           '@event_id' => $event->id(),
           '@attempt' => $attempt,
+          '@entitlement_count' => count($pendingEntitlements),
         ]);
       }
     }

--- a/web/modules/custom/myeventlane_boost/src/Cron/BoostExpiryCron.php
+++ b/web/modules/custom/myeventlane_boost/src/Cron/BoostExpiryCron.php
@@ -7,20 +7,27 @@ namespace Drupal\myeventlane_boost\Cron;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Lock\LockBackendInterface;
 use Drupal\Core\Mail\MailManagerInterface;
-use Drupal\myeventlane_boost\BoostManager;
+use Drupal\myeventlane_boost\Entity\BoostEntitlementInterface;
 use Drupal\myeventlane_boost\Service\BoostEntitlementManager;
 use Drupal\myeventlane_notifications\Service\BusinessNotificationTriggerService;
 use Drupal\node\NodeInterface;
+use Drupal\user\UserInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Cron handler to expire boosted events and notify vendors.
  *
- * Uses canonical BoostManager to find expired boosts.
+ * Uses entitlement state as the notification idempotency authority.
  */
 final class BoostExpiryCron implements ContainerInjectionInterface {
+
+  /**
+   * Maximum lifetime of an expiry notification lock.
+   */
+  private const LOCK_TTL = 300.0;
 
   /**
    * Constructs a BoostExpiryCron.
@@ -33,18 +40,20 @@ final class BoostExpiryCron implements ContainerInjectionInterface {
    *   The logger.
    * @param \Drupal\Core\Mail\MailManagerInterface $mailManager
    *   The mail manager.
-   * @param \Drupal\myeventlane_boost\BoostManager $boostManager
-   *   The boost manager.
    * @param \Drupal\myeventlane_boost\Service\BoostEntitlementManager $entitlementManager
    *   The entitlement manager.
+   * @param \Drupal\Core\Lock\LockBackendInterface $lock
+   *   The lock backend.
+   * @param \Drupal\myeventlane_notifications\Service\BusinessNotificationTriggerService|null $businessNotificationTrigger
+   *   Optional business notification trigger.
    */
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly TimeInterface $time,
     private readonly LoggerInterface $logger,
     private readonly MailManagerInterface $mailManager,
-    private readonly BoostManager $boostManager,
     private readonly BoostEntitlementManager $entitlementManager,
+    private readonly LockBackendInterface $lock,
     private readonly ?BusinessNotificationTriggerService $businessNotificationTrigger = NULL,
   ) {}
 
@@ -57,8 +66,8 @@ final class BoostExpiryCron implements ContainerInjectionInterface {
       $container->get('datetime.time'),
       $container->get('logger.channel.myeventlane_boost'),
       $container->get('plugin.manager.mail'),
-      $container->get('myeventlane_boost.manager'),
       $container->get('myeventlane_boost.entitlement_manager'),
+      $container->get('lock'),
       $container->has('myeventlane_notifications.business_trigger')
         ? $container->get('myeventlane_notifications.business_trigger')
         : NULL,
@@ -68,59 +77,125 @@ final class BoostExpiryCron implements ContainerInjectionInterface {
   /**
    * Process expired boosts.
    *
-   * Uses canonical BoostManager to find expired boosts, then clears them.
+   * Claims each expired entitlement before sending its notification.
    */
   public function process(): void {
-    // Use canonical API to get expired boosted events.
-    $nids = $this->boostManager->getExpiredBoostedEventIdsForStore(NULL, [
-      'access_check' => FALSE,
-      'limit' => 500,
-    ]);
+    $storage = $this->entityTypeManager->getStorage('myeventlane_boost_entitlement');
+    $ids = $storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('status', [
+        BoostEntitlementInterface::STATUS_ACTIVE,
+        BoostEntitlementInterface::STATUS_EXPIRED,
+      ], 'IN')
+      ->condition('ends', $this->time->getRequestTime(), '<=')
+      ->condition('expiry_notification_status', BoostEntitlementInterface::EXPIRY_NOTIFICATION_SENT, '<>')
+      ->range(0, 500)
+      ->execute();
 
-    if (empty($nids)) {
+    if (empty($ids)) {
       return;
     }
 
-    /** @var \Drupal\node\NodeInterface[] $nodes */
-    $nodeStorage = $this->entityTypeManager->getStorage('node');
-    $nodes = $nodeStorage->loadMultiple($nids);
-
-    $count = $this->entitlementManager->expireEndedEntitlements();
-    foreach ($nodes as $node) {
-      // Notify vendor.
-      $this->notifyVendor($node);
-    }
-
-    if ($count > 0) {
-      $this->logger->notice('Unboosted @count expired event(s) via cron.', ['@count' => $count]);
+    foreach (array_map('intval', $ids) as $entitlementId) {
+      $this->processEntitlement($entitlementId);
     }
   }
 
   /**
-   * Send expiration notification to the event owner.
+   * Expires and notifies one entitlement under an exclusive lock.
+   */
+  private function processEntitlement(int $entitlementId): void {
+    $lockName = 'myeventlane_boost.expiry_notification.' . $entitlementId;
+    if (!$this->lock->acquire($lockName, self::LOCK_TTL)) {
+      $this->logger->info('Boost expiry notification skipped because entitlement @entitlement_id is already being processed.', [
+        '@entitlement_id' => $entitlementId,
+      ]);
+      return;
+    }
+
+    try {
+      $storage = $this->entityTypeManager->getStorage('myeventlane_boost_entitlement');
+      $storage->resetCache([$entitlementId]);
+      $entitlement = $storage->load($entitlementId);
+      if (!$entitlement instanceof BoostEntitlementInterface) {
+        return;
+      }
+
+      if ((string) $entitlement->get('expiry_notification_status')->value === BoostEntitlementInterface::EXPIRY_NOTIFICATION_SENT
+        || !$entitlement->get('expiry_notified_at')->isEmpty()) {
+        return;
+      }
+
+      if ((int) ($entitlement->get('ends')->value ?? 0) > $this->time->getRequestTime()
+        || (string) $entitlement->get('status')->value === BoostEntitlementInterface::STATUS_REVOKED) {
+        return;
+      }
+
+      $event = $entitlement->get('event')->entity;
+      if (!$event instanceof NodeInterface) {
+        $this->logger->error('Boost expiry notification failed: entitlement @entitlement_id has no event.', [
+          '@entitlement_id' => $entitlementId,
+        ]);
+        return;
+      }
+
+      $attempt = (int) ($entitlement->get('expiry_notification_attempts')->value ?? 0) + 1;
+      $entitlement->set('status', BoostEntitlementInterface::STATUS_EXPIRED);
+      $entitlement->set('expiry_notification_status', BoostEntitlementInterface::EXPIRY_NOTIFICATION_PROCESSING);
+      $entitlement->set('expiry_notification_attempts', $attempt);
+      $entitlement->save();
+      $this->entitlementManager->refreshEventBoostState((int) $event->id());
+
+      if ($this->notifyVendor($event)) {
+        $entitlement->set('expiry_notification_status', BoostEntitlementInterface::EXPIRY_NOTIFICATION_SENT);
+        $entitlement->set('expiry_notified_at', $this->time->getRequestTime());
+        $entitlement->save();
+        $this->logger->notice('Sent boost expiry notification for entitlement @entitlement_id, event @event_id, attempt @attempt.', [
+          '@entitlement_id' => $entitlementId,
+          '@event_id' => $event->id(),
+          '@attempt' => $attempt,
+        ]);
+      }
+      else {
+        $entitlement->set('expiry_notification_status', BoostEntitlementInterface::EXPIRY_NOTIFICATION_PENDING);
+        $entitlement->save();
+        $this->logger->error('Boost expiry notification failed for entitlement @entitlement_id, event @event_id, attempt @attempt; retry remains pending.', [
+          '@entitlement_id' => $entitlementId,
+          '@event_id' => $event->id(),
+          '@attempt' => $attempt,
+        ]);
+      }
+    }
+    finally {
+      $this->lock->release($lockName);
+    }
+  }
+
+  /**
+   * Sends an expiration notification to the event owner.
    *
    * @param \Drupal\node\NodeInterface $node
    *   The event node.
    */
-  private function notifyVendor(NodeInterface $node): void {
+  private function notifyVendor(NodeInterface $node): bool {
     $owner = $node->getOwner();
     if ($owner === NULL) {
-      return;
+      return FALSE;
     }
 
     $email = $owner->getEmail();
     if (empty($email)) {
-      return;
+      return FALSE;
     }
 
     $params = [
       'node' => $node,
-      'vendor_name' => $owner->getDisplayName(),
+      'vendor_name' => $this->preferredRecipientName($owner),
     ];
 
     $langcode = $owner->getPreferredLangcode() ?: 'en';
 
-    $this->mailManager->mail(
+    $result = $this->mailManager->mail(
       'myeventlane_boost',
       'boost_expired',
       $email,
@@ -130,9 +205,28 @@ final class BoostExpiryCron implements ContainerInjectionInterface {
       TRUE
     );
 
-    if ($this->businessNotificationTrigger !== NULL && $owner !== NULL) {
+    $sent = !empty($result['result']);
+    if ($sent && $this->businessNotificationTrigger !== NULL) {
       $this->businessNotificationTrigger->onBoostCompleted($node, (int) $owner->id());
     }
+
+    return $sent;
+  }
+
+  /**
+   * Returns a human-facing recipient name without exposing an account handle.
+   */
+  private function preferredRecipientName(UserInterface $owner): string {
+    if ($owner->hasField('field_display_name')
+      && !$owner->get('field_display_name')->isEmpty()) {
+      $name = trim((string) $owner->get('field_display_name')->value);
+      if ($name !== '') {
+        return $name;
+      }
+    }
+
+    $displayName = trim($owner->getDisplayName());
+    return $displayName !== '' ? $displayName : 'there';
   }
 
 }

--- a/web/modules/custom/myeventlane_boost/src/Cron/BoostExpiryCron.php
+++ b/web/modules/custom/myeventlane_boost/src/Cron/BoostExpiryCron.php
@@ -214,7 +214,19 @@ final class BoostExpiryCron implements ContainerInjectionInterface {
         $pendingEntitlement->save();
       }
 
-      if ($this->notifyVendor($event)) {
+      try {
+        $sent = $this->notifyVendor($event);
+      }
+      catch (\Throwable $exception) {
+        $sent = FALSE;
+        $this->logger->error('Boost expiry mail transport threw for event @event_id, attempt @attempt: @message', [
+          '@event_id' => $event->id(),
+          '@attempt' => $attempt,
+          '@message' => $exception->getMessage(),
+        ]);
+      }
+
+      if ($sent) {
         $this->logger->notice('Sent boost expiry notification once for @entitlement_count entitlement(s) on event @event_id, attempt @attempt.', [
           '@entitlement_id' => $entitlementId,
           '@event_id' => $event->id(),

--- a/web/modules/custom/myeventlane_boost/src/Entity/BoostEntitlement.php
+++ b/web/modules/custom/myeventlane_boost/src/Entity/BoostEntitlement.php
@@ -130,6 +130,27 @@ final class BoostEntitlement extends ContentEntityBase implements BoostEntitleme
       ->setLabel(new TranslatableMarkup('Amount paid'))
       ->setDescription(new TranslatableMarkup('Amount paid for this entitlement.'));
 
+    $fields['expiry_notification_status'] = BaseFieldDefinition::create('list_string')
+      ->setLabel(new TranslatableMarkup('Expiry notification status'))
+      ->setDescription(new TranslatableMarkup('Delivery state for the entitlement expiry notification.'))
+      ->setRequired(TRUE)
+      ->setDefaultValue(BoostEntitlementInterface::EXPIRY_NOTIFICATION_PENDING)
+      ->setSetting('allowed_values', [
+        BoostEntitlementInterface::EXPIRY_NOTIFICATION_PENDING => 'Pending',
+        BoostEntitlementInterface::EXPIRY_NOTIFICATION_PROCESSING => 'Processing',
+        BoostEntitlementInterface::EXPIRY_NOTIFICATION_SENT => 'Sent',
+      ]);
+
+    $fields['expiry_notified_at'] = BaseFieldDefinition::create('timestamp')
+      ->setLabel(new TranslatableMarkup('Expiry notified at'))
+      ->setDescription(new TranslatableMarkup('Timestamp when the expiry notification was sent successfully.'));
+
+    $fields['expiry_notification_attempts'] = BaseFieldDefinition::create('integer')
+      ->setLabel(new TranslatableMarkup('Expiry notification attempts'))
+      ->setDescription(new TranslatableMarkup('Number of attempted expiry notification deliveries.'))
+      ->setDefaultValue(0)
+      ->setSetting('unsigned', TRUE);
+
     $fields['created'] = BaseFieldDefinition::create('created')
       ->setLabel(new TranslatableMarkup('Created'));
 

--- a/web/modules/custom/myeventlane_boost/src/Entity/BoostEntitlementInterface.php
+++ b/web/modules/custom/myeventlane_boost/src/Entity/BoostEntitlementInterface.php
@@ -28,6 +28,21 @@ interface BoostEntitlementInterface extends ContentEntityInterface, EntityOwnerI
   public const STATUS_REVOKED = 'revoked';
 
   /**
+   * Expiry notification is eligible for delivery.
+   */
+  public const EXPIRY_NOTIFICATION_PENDING = 'pending';
+
+  /**
+   * Expiry notification delivery is currently being attempted.
+   */
+  public const EXPIRY_NOTIFICATION_PROCESSING = 'processing';
+
+  /**
+   * Expiry notification was sent successfully.
+   */
+  public const EXPIRY_NOTIFICATION_SENT = 'sent';
+
+  /**
    * Entitlement source generated from paid boost checkout.
    */
   public const SOURCE_ORDER = 'order';

--- a/web/modules/custom/myeventlane_boost/tests/src/Kernel/BoostExpiryCronKernelTest.php
+++ b/web/modules/custom/myeventlane_boost/tests/src/Kernel/BoostExpiryCronKernelTest.php
@@ -210,6 +210,29 @@ final class BoostExpiryCronKernelTest extends KernelTestBase {
   }
 
   /**
+   * Permanently undeliverable notifications stop after the retry limit.
+   */
+  public function testFailedSendStopsAfterRetryLimit(): void {
+    $entitlement = $this->createExpiredEntitlement();
+    $mail = $this->createMock(MailManagerInterface::class);
+    $mail->expects($this->exactly(5))
+      ->method('mail')
+      ->willReturn(['result' => FALSE]);
+    $cron = $this->createCron($mail);
+
+    for ($attempt = 0; $attempt < 6; $attempt++) {
+      $cron->process();
+    }
+
+    $failed = $this->reloadEntitlement((int) $entitlement->id());
+    $this->assertSame('5', $failed->get('expiry_notification_attempts')->value);
+    $this->assertSame(
+      BoostEntitlementInterface::EXPIRY_NOTIFICATION_PENDING,
+      $failed->get('expiry_notification_status')->value,
+    );
+  }
+
+  /**
    * A competing worker cannot deliver while the entitlement lock is held.
    */
   public function testConcurrentWorkerCannotSendDuplicate(): void {

--- a/web/modules/custom/myeventlane_boost/tests/src/Kernel/BoostExpiryCronKernelTest.php
+++ b/web/modules/custom/myeventlane_boost/tests/src/Kernel/BoostExpiryCronKernelTest.php
@@ -126,6 +126,28 @@ final class BoostExpiryCronKernelTest extends KernelTestBase {
   }
 
   /**
+   * The sent marker is durable before the external transport is invoked.
+   */
+  public function testSentMarkerPrecedesMailTransport(): void {
+    $entitlement = $this->createExpiredEntitlement();
+    $entitlementId = (int) $entitlement->id();
+    $mail = $this->createMock(MailManagerInterface::class);
+    $mail->expects($this->once())
+      ->method('mail')
+      ->willReturnCallback(function () use ($entitlementId): array {
+        $claimed = $this->reloadEntitlement($entitlementId);
+        $this->assertSame(
+          BoostEntitlementInterface::EXPIRY_NOTIFICATION_SENT,
+          $claimed->get('expiry_notification_status')->value,
+        );
+        $this->assertFalse($claimed->get('expiry_notified_at')->isEmpty());
+        return ['result' => TRUE];
+      });
+
+    $this->createCron($mail)->process();
+  }
+
+  /**
    * A confirmed send failure remains retryable on the same entitlement.
    */
   public function testFailedSendRetriesSameEntitlement(): void {

--- a/web/modules/custom/myeventlane_boost/tests/src/Kernel/BoostExpiryCronKernelTest.php
+++ b/web/modules/custom/myeventlane_boost/tests/src/Kernel/BoostExpiryCronKernelTest.php
@@ -206,9 +206,90 @@ final class BoostExpiryCronKernelTest extends KernelTestBase {
   }
 
   /**
+   * Multiple simultaneously ended entitlements produce one event notice.
+   */
+  public function testMultipleEndedEntitlementsForEventSendOnce(): void {
+    $first = $this->createExpiredEntitlement();
+    $second = $this->createExpiredEntitlement();
+    $mail = $this->createMock(MailManagerInterface::class);
+    $mail->expects($this->once())
+      ->method('mail')
+      ->willReturn(['result' => TRUE]);
+
+    $this->createCron($mail)->process();
+
+    foreach ([$first, $second] as $entitlement) {
+      $reloaded = $this->reloadEntitlement((int) $entitlement->id());
+      $this->assertSame(
+        BoostEntitlementInterface::EXPIRY_NOTIFICATION_SENT,
+        $reloaded->get('expiry_notification_status')->value,
+      );
+    }
+  }
+
+  /**
+   * Expiry notice waits until the event has no active overlapping boost.
+   */
+  public function testOverlappingBoostDefersExpiryNotice(): void {
+    $ended = $this->createExpiredEntitlement();
+    $active = $this->createExpiredEntitlement(time() + 3600);
+    $mail = $this->createMock(MailManagerInterface::class);
+    $mail->expects($this->once())
+      ->method('mail')
+      ->willReturn(['result' => TRUE]);
+    $cron = $this->createCron($mail);
+
+    $cron->process();
+    $this->assertSame(
+      BoostEntitlementInterface::EXPIRY_NOTIFICATION_PENDING,
+      $this->reloadEntitlement((int) $ended->id())
+        ->get('expiry_notification_status')->value,
+    );
+
+    $active->set('ends', time() - 1);
+    $active->save();
+    $cron->process();
+
+    foreach ([$ended, $active] as $entitlement) {
+      $this->assertSame(
+        BoostEntitlementInterface::EXPIRY_NOTIFICATION_SENT,
+        $this->reloadEntitlement((int) $entitlement->id())
+          ->get('expiry_notification_status')->value,
+      );
+    }
+  }
+
+  /**
+   * Entitlement expiry itself is not limited by the 500-notification batch.
+   */
+  public function testBulkExpiryIsNotNotificationBatchLimited(): void {
+    for ($i = 0; $i < 501; $i++) {
+      $entitlement = $this->createExpiredEntitlement();
+      $entitlement->set(
+        'expiry_notification_status',
+        BoostEntitlementInterface::EXPIRY_NOTIFICATION_SENT,
+      );
+      $entitlement->save();
+    }
+    $mail = $this->createMock(MailManagerInterface::class);
+    $mail->expects($this->never())->method('mail');
+
+    $this->createCron($mail)->process();
+
+    $activeCount = $this->container->get('entity_type.manager')
+      ->getStorage('myeventlane_boost_entitlement')
+      ->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('status', BoostEntitlementInterface::STATUS_ACTIVE)
+      ->count()
+      ->execute();
+    $this->assertSame(0, (int) $activeCount);
+  }
+
+  /**
    * Creates an expired active entitlement.
    */
-  private function createExpiredEntitlement(): BoostEntitlementInterface {
+  private function createExpiredEntitlement(?int $ends = NULL): BoostEntitlementInterface {
     $storage = $this->container->get('entity_type.manager')
       ->getStorage('myeventlane_boost_entitlement');
     $entitlement = $storage->create([
@@ -216,7 +297,7 @@ final class BoostExpiryCronKernelTest extends KernelTestBase {
       'uid' => $this->event->getOwnerId(),
       'event' => $this->event->id(),
       'starts' => time() - 3600,
-      'ends' => time() - 60,
+      'ends' => $ends ?? time() - 60,
       'status' => BoostEntitlementInterface::STATUS_ACTIVE,
       'source' => BoostEntitlementInterface::SOURCE_PRO,
     ]);

--- a/web/modules/custom/myeventlane_boost/tests/src/Kernel/BoostExpiryCronKernelTest.php
+++ b/web/modules/custom/myeventlane_boost/tests/src/Kernel/BoostExpiryCronKernelTest.php
@@ -176,6 +176,40 @@ final class BoostExpiryCronKernelTest extends KernelTestBase {
   }
 
   /**
+   * A mail transport exception restores retryable notification state.
+   */
+  public function testMailExceptionRetriesSameEntitlement(): void {
+    $entitlement = $this->createExpiredEntitlement();
+    $mail = $this->createMock(MailManagerInterface::class);
+    $calls = 0;
+    $mail->expects($this->exactly(2))
+      ->method('mail')
+      ->willReturnCallback(static function () use (&$calls): array {
+        if ($calls++ === 0) {
+          throw new \RuntimeException('Transport failed.');
+        }
+        return ['result' => TRUE];
+      });
+
+    $cron = $this->createCron($mail);
+    $cron->process();
+
+    $failed = $this->reloadEntitlement((int) $entitlement->id());
+    $this->assertSame(
+      BoostEntitlementInterface::EXPIRY_NOTIFICATION_PENDING,
+      $failed->get('expiry_notification_status')->value,
+    );
+    $this->assertTrue($failed->get('expiry_notified_at')->isEmpty());
+
+    $cron->process();
+    $sent = $this->reloadEntitlement((int) $entitlement->id());
+    $this->assertSame(
+      BoostEntitlementInterface::EXPIRY_NOTIFICATION_SENT,
+      $sent->get('expiry_notification_status')->value,
+    );
+  }
+
+  /**
    * A competing worker cannot deliver while the entitlement lock is held.
    */
   public function testConcurrentWorkerCannotSendDuplicate(): void {

--- a/web/modules/custom/myeventlane_boost/tests/src/Kernel/BoostExpiryCronKernelTest.php
+++ b/web/modules/custom/myeventlane_boost/tests/src/Kernel/BoostExpiryCronKernelTest.php
@@ -1,0 +1,294 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_boost\Kernel;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\Lock\LockBackendInterface;
+use Drupal\Core\Mail\MailManagerInterface;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\myeventlane_boost\Cron\BoostExpiryCron;
+use Drupal\myeventlane_boost\Entity\BoostEntitlementInterface;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\user\Entity\User;
+use Psr\Log\LoggerInterface;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * Tests idempotent Boost expiry notification processing.
+ *
+ * @group myeventlane_boost
+ */
+#[RunTestsInSeparateProcesses]
+final class BoostExpiryCronKernelTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'node',
+    'field',
+    'datetime',
+    'text',
+    'options',
+    'commerce',
+    'commerce_price',
+    'commerce_store',
+    'commerce_product',
+    'commerce_order',
+    'myeventlane_boost',
+  ];
+
+  /**
+   * The test event.
+   */
+  private Node $event;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container): void {
+    parent::register($container);
+    foreach ([
+      'myeventlane_analytics.data',
+      'myeventlane_event_state.resolver',
+      'myeventlane_vendor.access.vendor_console',
+      'myeventlane_vendor.service.boost_status',
+    ] as $serviceId) {
+      $container->setDefinition($serviceId, new Definition(\stdClass::class));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('myeventlane_boost_entitlement');
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig(['system', 'user', 'node']);
+    $this->ensureEventSchema();
+
+    $owner = User::create([
+      'name' => 'boost-owner',
+      'mail' => 'boost-owner@example.test',
+      'status' => 1,
+    ]);
+    $owner->save();
+
+    $this->event = Node::create([
+      'type' => 'event',
+      'title' => 'Expired Boost Event',
+      'status' => 1,
+      'uid' => $owner->id(),
+      'field_promoted' => 1,
+      'field_promo_expires' => gmdate('Y-m-d\TH:i:s', time() - 60),
+    ]);
+    $this->event->save();
+  }
+
+  /**
+   * Repeated cron execution sends and logs exactly once.
+   */
+  public function testRepeatedCronSendsOnce(): void {
+    $entitlement = $this->createExpiredEntitlement();
+    $mail = $this->createMock(MailManagerInterface::class);
+    $mail->expects($this->once())
+      ->method('mail')
+      ->willReturn(['result' => TRUE]);
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->once())
+      ->method('notice')
+      ->with(
+        $this->stringContains('Sent boost expiry notification'),
+        $this->callback(static fn (array $context): bool => $context['@attempt'] === 1),
+      );
+
+    $cron = $this->createCron($mail, $logger);
+    $cron->process();
+    $cron->process();
+
+    $entitlement = $this->reloadEntitlement((int) $entitlement->id());
+    $this->assertSame(BoostEntitlementInterface::STATUS_EXPIRED, $entitlement->get('status')->value);
+    $this->assertSame(BoostEntitlementInterface::EXPIRY_NOTIFICATION_SENT, $entitlement->get('expiry_notification_status')->value);
+    $this->assertSame('1', $entitlement->get('expiry_notification_attempts')->value);
+    $this->assertFalse($entitlement->get('expiry_notified_at')->isEmpty());
+  }
+
+  /**
+   * A confirmed send failure remains retryable on the same entitlement.
+   */
+  public function testFailedSendRetriesSameEntitlement(): void {
+    $entitlement = $this->createExpiredEntitlement();
+    $mail = $this->createMock(MailManagerInterface::class);
+    $mail->expects($this->exactly(2))
+      ->method('mail')
+      ->willReturnOnConsecutiveCalls(
+        ['result' => FALSE],
+        ['result' => TRUE],
+      );
+
+    $cron = $this->createCron($mail);
+    $cron->process();
+
+    $failed = $this->reloadEntitlement((int) $entitlement->id());
+    $this->assertSame(BoostEntitlementInterface::EXPIRY_NOTIFICATION_PENDING, $failed->get('expiry_notification_status')->value);
+    $this->assertSame('1', $failed->get('expiry_notification_attempts')->value);
+    $this->assertTrue($failed->get('expiry_notified_at')->isEmpty());
+
+    $cron->process();
+
+    $sent = $this->reloadEntitlement((int) $entitlement->id());
+    $this->assertSame(BoostEntitlementInterface::EXPIRY_NOTIFICATION_SENT, $sent->get('expiry_notification_status')->value);
+    $this->assertSame('2', $sent->get('expiry_notification_attempts')->value);
+  }
+
+  /**
+   * A competing worker cannot deliver while the entitlement lock is held.
+   */
+  public function testConcurrentWorkerCannotSendDuplicate(): void {
+    $entitlement = $this->createExpiredEntitlement();
+    $mail = $this->createMock(MailManagerInterface::class);
+    $mail->expects($this->once())
+      ->method('mail')
+      ->willReturn(['result' => TRUE]);
+    $lock = $this->createMock(LockBackendInterface::class);
+    $lock->expects($this->exactly(2))
+      ->method('acquire')
+      ->willReturnOnConsecutiveCalls(FALSE, TRUE);
+    $lock->expects($this->once())
+      ->method('release');
+
+    $cron = $this->createCron($mail, NULL, $lock);
+    $cron->process();
+    $locked = $this->reloadEntitlement((int) $entitlement->id());
+    $this->assertSame(BoostEntitlementInterface::EXPIRY_NOTIFICATION_PENDING, $locked->get('expiry_notification_status')->value);
+    $this->assertSame('0', $locked->get('expiry_notification_attempts')->value);
+
+    $cron->process();
+    $cron->process();
+
+    $sent = $this->reloadEntitlement((int) $entitlement->id());
+    $this->assertSame(BoostEntitlementInterface::EXPIRY_NOTIFICATION_SENT, $sent->get('expiry_notification_status')->value);
+    $this->assertSame('1', $sent->get('expiry_notification_attempts')->value);
+  }
+
+  /**
+   * A processing record stranded by worker termination is retryable.
+   */
+  public function testStrandedProcessingStateRetries(): void {
+    $entitlement = $this->createExpiredEntitlement();
+    $entitlement->set('expiry_notification_status', BoostEntitlementInterface::EXPIRY_NOTIFICATION_PROCESSING);
+    $entitlement->save();
+
+    $mail = $this->createMock(MailManagerInterface::class);
+    $mail->expects($this->once())
+      ->method('mail')
+      ->willReturn(['result' => TRUE]);
+
+    $cron = $this->createCron($mail);
+    $cron->process();
+    $cron->process();
+
+    $sent = $this->reloadEntitlement((int) $entitlement->id());
+    $this->assertSame(BoostEntitlementInterface::EXPIRY_NOTIFICATION_SENT, $sent->get('expiry_notification_status')->value);
+    $this->assertSame('1', $sent->get('expiry_notification_attempts')->value);
+  }
+
+  /**
+   * Creates an expired active entitlement.
+   */
+  private function createExpiredEntitlement(): BoostEntitlementInterface {
+    $storage = $this->container->get('entity_type.manager')
+      ->getStorage('myeventlane_boost_entitlement');
+    $entitlement = $storage->create([
+      'label' => 'Expired entitlement',
+      'uid' => $this->event->getOwnerId(),
+      'event' => $this->event->id(),
+      'starts' => time() - 3600,
+      'ends' => time() - 60,
+      'status' => BoostEntitlementInterface::STATUS_ACTIVE,
+      'source' => BoostEntitlementInterface::SOURCE_PRO,
+    ]);
+    $entitlement->save();
+    return $entitlement;
+  }
+
+  /**
+   * Creates the cron handler with controlled delivery collaborators.
+   */
+  private function createCron(
+    MailManagerInterface $mail,
+    ?LoggerInterface $logger = NULL,
+    ?LockBackendInterface $lock = NULL,
+  ): BoostExpiryCron {
+    return new BoostExpiryCron(
+      $this->container->get('entity_type.manager'),
+      $this->container->get('datetime.time'),
+      $logger ?? $this->createStub(LoggerInterface::class),
+      $mail,
+      $this->container->get('myeventlane_boost.entitlement_manager'),
+      $lock ?? $this->container->get('lock'),
+    );
+  }
+
+  /**
+   * Reloads an entitlement without the entity memory cache.
+   */
+  private function reloadEntitlement(int $id): BoostEntitlementInterface {
+    $storage = $this->container->get('entity_type.manager')
+      ->getStorage('myeventlane_boost_entitlement');
+    $storage->resetCache([$id]);
+    $entitlement = $storage->load($id);
+    $this->assertInstanceOf(BoostEntitlementInterface::class, $entitlement);
+    return $entitlement;
+  }
+
+  /**
+   * Creates the event bundle and denormalized Boost fields.
+   */
+  private function ensureEventSchema(): void {
+    NodeType::create([
+      'type' => 'event',
+      'name' => 'Event',
+    ])->save();
+
+    FieldStorageConfig::create([
+      'field_name' => 'field_promoted',
+      'entity_type' => 'node',
+      'type' => 'boolean',
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'field_promoted',
+      'entity_type' => 'node',
+      'bundle' => 'event',
+      'label' => 'Promoted',
+    ])->save();
+
+    FieldStorageConfig::create([
+      'field_name' => 'field_promo_expires',
+      'entity_type' => 'node',
+      'type' => 'datetime',
+      'settings' => [
+        'datetime_type' => 'datetime',
+      ],
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'field_promo_expires',
+      'entity_type' => 'node',
+      'bundle' => 'event',
+      'label' => 'Promo expires',
+    ])->save();
+  }
+
+}

--- a/web/modules/custom/myeventlane_messaging/config/install/myeventlane_messaging.template.order_confirmation.yml
+++ b/web/modules/custom/myeventlane_messaging/config/install/myeventlane_messaging.template.order_confirmation.yml
@@ -163,22 +163,14 @@ body_html: |
           <!--<![endif]-->
           {% if apple_wallet_url or google_wallet_url or pdf_url %}
             <div style="margin-top:20px;" role="group" aria-label="Pass actions">
-              {% if apple_wallet_url %}
-                <a href="{{ apple_wallet_url }}" style="display:inline-block;margin:6px 8px;text-decoration:none;line-height:0;vertical-align:middle;" aria-label="Add to Apple Wallet">
-                  {% if apple_wallet_badge_url %}
-                    <img src="{{ apple_wallet_badge_url }}" alt="Add to Apple Wallet" width="156" height="48" style="display:block;width:156px;height:auto;border:0;outline:none;">
-                  {% else %}
-                    <span style="display:inline-block;background-color:#1f1f1f;color:#ffffff !important;text-decoration:none;padding:12px 18px;border-radius:8px;font-weight:600;font-size:14px;line-height:1.25;">Add to Apple Wallet</span>
-                  {% endif %}
+              {% if apple_wallet_url and apple_wallet_badge_url %}
+                <a href="{{ apple_wallet_url }}" style="display:inline-block;margin:8px;text-decoration:none;line-height:0;vertical-align:middle;" aria-label="Add to Apple Wallet">
+                  <img src="{{ apple_wallet_badge_url }}" alt="Add to Apple Wallet" width="156" height="48" style="display:block;width:156px;height:48px;border:0;outline:none;">
                 </a>
               {% endif %}
-              {% if google_wallet_url %}
-                <a href="{{ google_wallet_url }}" style="display:inline-block;margin:6px 8px;text-decoration:none;line-height:0;vertical-align:middle;" aria-label="Add to Google Wallet">
-                  {% if google_wallet_badge_url %}
-                    <img src="{{ google_wallet_badge_url }}" alt="Add to Google Wallet" width="200" height="48" style="display:block;width:200px;height:auto;border:0;outline:none;">
-                  {% else %}
-                    <span style="display:inline-block;background-color:#1f1f1f;color:#ffffff !important;text-decoration:none;padding:12px 18px;border-radius:8px;font-weight:600;font-size:14px;line-height:1.25;">Add to Google Wallet</span>
-                  {% endif %}
+              {% if google_wallet_url and google_wallet_badge_url %}
+                <a href="{{ google_wallet_url }}" style="display:inline-block;margin:8px;text-decoration:none;line-height:0;vertical-align:middle;" aria-label="Add to Google Wallet">
+                  <img src="{{ google_wallet_badge_url }}" alt="Add to Google Wallet" width="272" height="48" style="display:block;width:272px;height:48px;border:0;outline:none;">
                 </a>
               {% endif %}
               {% if pdf_url %}

--- a/web/modules/custom/myeventlane_messaging/myeventlane_messaging.install
+++ b/web/modules/custom/myeventlane_messaging/myeventlane_messaging.install
@@ -358,3 +358,110 @@ function myeventlane_messaging_update_10006(): void {
     $schema->addUniqueKey($table, 'idempotency_key', ['idempotency_key']);
   }
 }
+
+/**
+ * Backfills canonical idempotency keys and normalizes legacy recipients.
+ */
+function myeventlane_messaging_update_10007(): string {
+  $database = \Drupal::database();
+  $schema = $database->schema();
+  $table = 'myeventlane_message';
+  if (!$schema->tableExists($table)
+    || !$schema->fieldExists($table, 'idempotency_key')) {
+    return 'Messaging table or idempotency field is unavailable; no backfill required.';
+  }
+
+  $rows = $database->select($table, 'm')
+    ->fields('m', [
+      'id',
+      'template',
+      'recipient',
+      'context',
+      'status',
+      'created',
+    ])
+    ->isNull('idempotency_key')
+    ->execute()
+    ->fetchAll();
+  if ($rows === []) {
+    return 'No legacy messaging rows required idempotency backfill.';
+  }
+
+  $groups = [];
+  foreach ($rows as $row) {
+    $recipient = strtolower(trim((string) $row->recipient));
+    $context = $row->context
+      ? unserialize($row->context, ['allowed_classes' => FALSE])
+      : [];
+    $context = is_array($context) ? $context : [];
+    unset(
+      $context['_attachments'],
+      $context['_mel_notification_context'],
+      $context['_mel_notification_domain'],
+      $context['_mel_notification_priority'],
+    );
+    $context_hash = hash('sha256', implode('|', [
+      (string) $row->template,
+      $recipient,
+      (string) json_encode(
+        $context,
+        JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES,
+      ),
+    ]));
+    $key = sprintf(
+      'message:%s:%s',
+      (string) $row->template,
+      $context_hash,
+    );
+    $row->normalized_recipient = $recipient;
+    $row->normalized_context_hash = $context_hash;
+    $groups[$key][] = $row;
+  }
+
+  $priority = [
+    'delivered' => 100,
+    'sent' => 90,
+    'bounced' => 90,
+    'suppressed' => 85,
+    'delivery_unknown' => 80,
+    'dispatching' => 70,
+    'processing' => 60,
+    'queued' => 50,
+    'failed' => 10,
+    'failed_permanent' => 5,
+  ];
+  $updated = 0;
+  foreach ($groups as $key => $candidates) {
+    $key_exists = (bool) $database->select($table, 'm')
+      ->condition('idempotency_key', $key)
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    usort($candidates, static function (object $a, object $b) use ($priority): int {
+      $status_order = ($priority[$b->status] ?? 0)
+        <=> ($priority[$a->status] ?? 0);
+      return $status_order !== 0
+        ? $status_order
+        : ((int) $a->created <=> (int) $b->created);
+    });
+    foreach ($candidates as $index => $row) {
+      $database->update($table)
+        ->fields([
+          'recipient' => $row->normalized_recipient,
+          'context_hash' => $row->normalized_context_hash,
+          'idempotency_key' => $index === 0 && !$key_exists
+            ? $key
+            : 'legacy-duplicate:' . $row->id,
+        ])
+        ->condition('id', $row->id)
+        ->isNull('idempotency_key')
+        ->execute();
+      $updated++;
+    }
+  }
+
+  return sprintf(
+    'Backfilled idempotency keys and normalized recipients for %d legacy messages.',
+    $updated,
+  );
+}

--- a/web/modules/custom/myeventlane_messaging/myeventlane_messaging.install
+++ b/web/modules/custom/myeventlane_messaging/myeventlane_messaging.install
@@ -62,6 +62,12 @@ function myeventlane_messaging_schema() {
         'default' => '',
         'description' => 'Deterministic hash for idempotency (template + recipient + context).',
       ],
+      'idempotency_key' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => FALSE,
+        'description' => 'Business occurrence key used to prevent duplicate messages.',
+      ],
       'scheduled_for' => [
         'type' => 'int',
         'size' => 'normal',
@@ -97,6 +103,13 @@ function myeventlane_messaging_schema() {
         'default' => 0,
         'description' => 'Unix timestamp when message was sent (0 if not sent).',
       ],
+      'claimed_at' => [
+        'type' => 'int',
+        'size' => 'normal',
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'Unix timestamp when a worker atomically claimed delivery.',
+      ],
       'provider' => [
         'type' => 'varchar',
         'length' => 32,
@@ -113,6 +126,9 @@ function myeventlane_messaging_schema() {
       ],
     ],
     'primary key' => ['id'],
+    'unique keys' => [
+      'idempotency_key' => ['idempotency_key'],
+    ],
     'indexes' => [
       'context_hash_recipient_template' => ['context_hash', 'recipient', 'template'],
       'status_created' => ['status', 'created'],
@@ -306,5 +322,39 @@ function myeventlane_messaging_update_10005(): void {
   if (!$schema->indexExists($table, 'provider_message_id')) {
     $full = myeventlane_messaging_schema();
     $schema->addIndex($table, 'provider_message_id', ['provider_message_id'], $full[$table]);
+  }
+}
+
+/**
+ * Adds atomic business idempotency and worker claim state.
+ */
+function myeventlane_messaging_update_10006(): void {
+  $schema = \Drupal::database()->schema();
+  $table = 'myeventlane_message';
+
+  if (!$schema->tableExists($table)) {
+    return;
+  }
+
+  if (!$schema->fieldExists($table, 'idempotency_key')) {
+    $schema->addField($table, 'idempotency_key', [
+      'type' => 'varchar',
+      'length' => 255,
+      'not null' => FALSE,
+      'description' => 'Business occurrence key used to prevent duplicate messages.',
+    ]);
+  }
+  if (!$schema->fieldExists($table, 'claimed_at')) {
+    $schema->addField($table, 'claimed_at', [
+      'type' => 'int',
+      'size' => 'normal',
+      'not null' => TRUE,
+      'default' => 0,
+      'description' => 'Unix timestamp when a worker atomically claimed delivery.',
+    ]);
+  }
+  if (!$schema->indexExists($table, 'idempotency_key')) {
+    $full = myeventlane_messaging_schema();
+    $schema->addUniqueKey($table, 'idempotency_key', ['idempotency_key']);
   }
 }

--- a/web/modules/custom/myeventlane_messaging/myeventlane_messaging.module
+++ b/web/modules/custom/myeventlane_messaging/myeventlane_messaging.module
@@ -120,17 +120,18 @@ function myeventlane_messaging_email_branding_logo_url(): string {
   $theme_logo = $theme_settings->getSetting('logo.url', $default_theme);
 
   $candidates = [];
-  if ($theme_logo !== NULL && $theme_logo !== '') {
-    $candidates[] = _myeventlane_messaging_absolute_logo_url_from_setting((string) $theme_logo, $base, $file_url_generator);
-  }
-
   $extension_list = \Drupal::service('extension.list.theme');
   $theme_path = $extension_list->getPath($default_theme ?: 'myeventlane_theme');
   $drupal_root = \Drupal::root();
+  // Prefer a release-owned raster asset. Configured managed files can remain
+  // referenced after the underlying file has been removed from shared storage.
   foreach (['images/mel-email-logo.png', 'images/logo.png'] as $rel) {
     if ($theme_path !== '' && is_readable($drupal_root . '/' . $theme_path . '/' . $rel)) {
       $candidates[] = $base . '/' . $theme_path . '/' . $rel;
     }
+  }
+  if ($theme_logo !== NULL && $theme_logo !== '') {
+    $candidates[] = _myeventlane_messaging_absolute_logo_url_from_setting((string) $theme_logo, $base, $file_url_generator);
   }
 
   foreach ($candidates as $url) {

--- a/web/modules/custom/myeventlane_messaging/myeventlane_messaging.services.yml
+++ b/web/modules/custom/myeventlane_messaging/myeventlane_messaging.services.yml
@@ -86,6 +86,8 @@ services:
       $entityTypeManager: '@entity_type.manager'
       $ticketLabelResolver: '@?myeventlane_core.ticket_label_resolver'
       $fileUrlGenerator: '@file_url_generator'
+      $currencyFormatter: '@commerce_price.currency_formatter'
+      $dateFormatter: '@date.formatter'
       $messagingManager: '@myeventlane_messaging.manager'
       $logger: '@logger.channel.myeventlane_messaging'
       $domainDetector: '@myeventlane_core.domain_detector'

--- a/web/modules/custom/myeventlane_messaging/src/Controller/PostmarkWebhookController.php
+++ b/web/modules/custom/myeventlane_messaging/src/Controller/PostmarkWebhookController.php
@@ -21,7 +21,7 @@ final class PostmarkWebhookController extends ControllerBase {
   /**
    * Constructs PostmarkWebhookController.
    *
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The config factory.
    * @param \Drupal\myeventlane_messaging\Service\MessageStorage $messageStorage
    *   The message storage.
@@ -70,11 +70,16 @@ final class PostmarkWebhookController extends ControllerBase {
     $recipient = $payload['Recipient'] ?? '';
 
     // Update message status if we can find it by provider message ID.
-    $message = $this->messageStorage->findByProviderMessageId($messageId);
+    $message = $this->resolveMessage($payload);
 
-    if ($message && $message->status === 'sent') {
-      // Update status to 'delivered'.
-      $this->messageStorage->update($message->id, ['status' => 'delivered']);
+    if ($message) {
+      $this->messageStorage->update($message->id, [
+        'status' => 'delivered',
+        'sent' => (int) ($message->sent ?: time()),
+        'claimed_at' => 0,
+        'provider' => 'postmark',
+        'provider_message_id' => $messageId,
+      ]);
     }
 
     $this->getLogger('myeventlane_messaging')->info('Postmark delivery webhook received. MessageID=@id, Recipient=@recipient', [
@@ -123,10 +128,15 @@ final class PostmarkWebhookController extends ControllerBase {
     }
 
     // Update message status if found.
-    $message = $this->messageStorage->findByProviderMessageId($messageId);
+    $message = $this->resolveMessage($payload);
 
     if ($message) {
-      $this->messageStorage->update($message->id, ['status' => 'bounced']);
+      $this->messageStorage->update($message->id, [
+        'status' => 'bounced',
+        'claimed_at' => 0,
+        'provider' => 'postmark',
+        'provider_message_id' => $messageId,
+      ]);
     }
 
     $this->getLogger('myeventlane_messaging')->info('Postmark bounce webhook received. MessageID=@id, Recipient=@recipient', [
@@ -161,6 +171,36 @@ final class PostmarkWebhookController extends ControllerBase {
     }
 
     return hash_equals($secret, $providedSecret);
+  }
+
+  /**
+   * Resolves a message by provider ID or trusted Postmark metadata.
+   */
+  private function resolveMessage(array $payload): ?object {
+    $messageId = (string) ($payload['MessageID'] ?? '');
+    $message = $this->messageStorage->findByProviderMessageId($messageId);
+    if ($message !== NULL) {
+      return $message;
+    }
+
+    $internalId = $payload['Metadata']['mel_message_id'] ?? '';
+    if (!is_string($internalId) || $internalId === '') {
+      return NULL;
+    }
+    $message = $this->messageStorage->load($internalId);
+    if ($message === NULL) {
+      return NULL;
+    }
+
+    $recipient = strtolower(trim((string) (
+      $payload['Recipient'] ?? $payload['Email'] ?? ''
+    )));
+    if ($recipient === ''
+      || strtolower((string) $message->recipient) !== $recipient) {
+      return NULL;
+    }
+
+    return $message;
   }
 
 }

--- a/web/modules/custom/myeventlane_messaging/src/Plugin/QueueWorker/MessagingQueueWorker.php
+++ b/web/modules/custom/myeventlane_messaging/src/Plugin/QueueWorker/MessagingQueueWorker.php
@@ -127,6 +127,7 @@ final class MessagingQueueWorker extends QueueWorkerBase implements ContainerFac
       $this->state->set(self::STATE_KEY_RUN_COUNT, $runCount + 1);
     }
     catch (\Throwable $e) {
+      $this->messagingManager->releaseFailedClaim($messageId);
       $this->logger->error('Messaging queue item failed. message_id=@id @message', [
         '@id' => $messageId,
         '@message' => $e->getMessage(),

--- a/web/modules/custom/myeventlane_messaging/src/Plugin/QueueWorker/MessagingQueueWorker.php
+++ b/web/modules/custom/myeventlane_messaging/src/Plugin/QueueWorker/MessagingQueueWorker.php
@@ -7,6 +7,7 @@ namespace Drupal\myeventlane_messaging\Plugin\QueueWorker;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Queue\QueueFactory;
+use Drupal\Core\Queue\RequeueException;
 use Drupal\Core\Queue\QueueWorkerBase;
 use Drupal\Core\State\StateInterface;
 use Drupal\myeventlane_messaging\Service\MessagingManager;
@@ -127,7 +128,9 @@ final class MessagingQueueWorker extends QueueWorkerBase implements ContainerFac
       $this->state->set(self::STATE_KEY_RUN_COUNT, $runCount + 1);
     }
     catch (\Throwable $e) {
-      $this->messagingManager->releaseFailedClaim($messageId);
+      if (!$e instanceof RequeueException) {
+        $this->messagingManager->releaseFailedClaim($messageId);
+      }
       $this->logger->error('Messaging queue item failed. message_id=@id @message', [
         '@id' => $messageId,
         '@message' => $e->getMessage(),

--- a/web/modules/custom/myeventlane_messaging/src/Service/Delivery/DeliveryProviderInterface.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/Delivery/DeliveryProviderInterface.php
@@ -18,6 +18,9 @@ interface DeliveryProviderInterface {
    *
    * @return bool
    *   TRUE if accepted/sent, FALSE otherwise.
+   *
+   * @throws \Throwable
+   *   When the provider outcome is uncertain and must not be retried blindly.
    */
   public function send(array $params): bool;
 

--- a/web/modules/custom/myeventlane_messaging/src/Service/Delivery/PostmarkDeliveryProvider.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/Delivery/PostmarkDeliveryProvider.php
@@ -30,7 +30,7 @@ final class PostmarkDeliveryProvider implements DeliveryProviderInterface {
    */
   public function __construct(
     private readonly ClientFactory $httpClientFactory,
-    private readonly \Drupal\Core\Config\ConfigFactoryInterface $configFactory,
+    private readonly ConfigFactoryInterface $configFactory,
     private readonly LoggerInterface $logger,
   ) {}
 
@@ -86,6 +86,11 @@ final class PostmarkDeliveryProvider implements DeliveryProviderInterface {
       'TextBody' => $textBody,
       'MessageStream' => $messageStream,
     ];
+    if (!empty($params['mel_message_id'])) {
+      $payload['Metadata'] = [
+        'mel_message_id' => (string) $params['mel_message_id'],
+      ];
+    }
 
     if (!empty($replyTo)) {
       $payload['ReplyTo'] = $replyTo;
@@ -174,10 +179,10 @@ final class PostmarkDeliveryProvider implements DeliveryProviderInterface {
       return FALSE;
     }
     catch (\Exception $e) {
-      $this->logger->error('Postmark send exception: @message', [
+      $this->logger->critical('Postmark dispatch outcome is unknown: @message', [
         '@message' => $e->getMessage(),
       ]);
-      return FALSE;
+      throw $e;
     }
   }
 

--- a/web/modules/custom/myeventlane_messaging/src/Service/MessageStorage.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/MessageStorage.php
@@ -249,6 +249,7 @@ final class MessageStorage {
    *   Rows with context as array; ordered by sent ascending (0 first).
    */
   public function findSentOrderConfirmationsForOrder(int $orderId, string $recipient): array {
+    $recipient = strtolower(trim($recipient));
     if ($orderId < 1 || $recipient === '') {
       return [];
     }

--- a/web/modules/custom/myeventlane_messaging/src/Service/MessageStorage.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/MessageStorage.php
@@ -26,7 +26,8 @@ final class MessageStorage {
    *
    * @param array $row
    *   Keys: template, channel, recipient, langcode, context (array), context_hash,
-   *   scheduled_for, status, attempts, created, sent, provider, provider_message_id.
+   *   scheduled_for, status, attempts, created, sent, claimed_at, provider,
+   *   provider_message_id.
    *
    * @return string
    *   The message UUID.
@@ -48,11 +49,13 @@ final class MessageStorage {
         'langcode' => $row['langcode'] ?? 'en',
         'context' => $serialized,
         'context_hash' => $row['context_hash'] ?? '',
+        'idempotency_key' => $row['idempotency_key'] ?? NULL,
         'scheduled_for' => (int) ($row['scheduled_for'] ?? 0),
         'status' => $row['status'] ?? 'queued',
         'attempts' => (int) ($row['attempts'] ?? 0),
         'created' => (int) ($row['created'] ?? 0),
         'sent' => (int) ($row['sent'] ?? 0),
+        'claimed_at' => (int) ($row['claimed_at'] ?? 0),
         'provider' => $row['provider'] ?? '',
         'provider_message_id' => $row['provider_message_id'] ?? '',
       ])
@@ -120,6 +123,100 @@ final class MessageStorage {
   }
 
   /**
+   * Finds a message by its business idempotency key.
+   */
+  public function findByIdempotencyKey(string $idempotencyKey): ?object {
+    if ($idempotencyKey === '') {
+      return NULL;
+    }
+    $row = $this->connection->select('myeventlane_message', 'm')
+      ->fields('m')
+      ->condition('m.idempotency_key', $idempotencyKey)
+      ->execute()
+      ->fetchObject();
+    if (!$row) {
+      return NULL;
+    }
+    $row->context = $row->context
+      ? unserialize($row->context, ['allowed_classes' => FALSE])
+      : [];
+    return $row;
+  }
+
+  /**
+   * Atomically claims a queued or retryable message for one worker.
+   */
+  public function claimForDelivery(string $id, int $claimedAt): bool {
+    return $this->connection->update('myeventlane_message')
+      ->fields([
+        'status' => 'processing',
+        'claimed_at' => $claimedAt,
+      ])
+      ->condition('id', $id)
+      ->condition('status', ['queued', 'failed'], 'IN')
+      ->execute() === 1;
+  }
+
+  /**
+   * Atomically renews an abandoned pre-dispatch processing claim.
+   */
+  public function reclaimStaleProcessing(
+    string $id,
+    int $staleBefore,
+    int $claimedAt,
+  ): bool {
+    return $this->connection->update('myeventlane_message')
+      ->fields(['claimed_at' => $claimedAt])
+      ->condition('id', $id)
+      ->condition('status', 'processing')
+      ->condition('claimed_at', $staleBefore, '<=')
+      ->execute() === 1;
+  }
+
+  /**
+   * Atomically records that provider dispatch is about to begin.
+   */
+  public function markDispatching(string $id, int $claimedAt): bool {
+    return $this->connection->update('myeventlane_message')
+      ->fields([
+        'status' => 'dispatching',
+        'claimed_at' => $claimedAt,
+      ])
+      ->condition('id', $id)
+      ->condition('status', 'processing')
+      ->execute() === 1;
+  }
+
+  /**
+   * Quarantines an abandoned provider dispatch for reconciliation.
+   */
+  public function markStaleDispatchUnknown(string $id, int $staleBefore): bool {
+    return $this->connection->update('myeventlane_message')
+      ->fields([
+        'status' => 'delivery_unknown',
+        'claimed_at' => 0,
+      ])
+      ->condition('id', $id)
+      ->condition('status', 'dispatching')
+      ->condition('claimed_at', $staleBefore, '<=')
+      ->execute() === 1;
+  }
+
+  /**
+   * Releases a processing claim after an unhandled worker failure.
+   */
+  public function releaseFailedClaim(string $id): bool {
+    return $this->connection->update('myeventlane_message')
+      ->fields([
+        'status' => 'failed',
+        'claimed_at' => 0,
+      ])
+      ->condition('id', $id)
+      ->condition('status', 'processing')
+      ->execute() === 1;
+  }
+
+  /**
    * Finds a message by provider-assigned message ID.
    *
    * @param string $messageId
@@ -180,13 +277,20 @@ final class MessageStorage {
    * @param string $id
    *   Message UUID.
    * @param array $updates
-   *   Keys: status, attempts, sent, provider, provider_message_id.
+   *   Keys: status, attempts, sent, claimed_at, provider, provider_message_id.
    *
    * @return int
    *   Number of rows updated.
    */
   public function update(string $id, array $updates): int {
-    $allowed = ['status', 'attempts', 'sent', 'provider', 'provider_message_id'];
+    $allowed = [
+      'status',
+      'attempts',
+      'sent',
+      'claimed_at',
+      'provider',
+      'provider_message_id',
+    ];
     $fields = array_intersect_key($updates, array_flip($allowed));
     if (empty($fields)) {
       return 0;

--- a/web/modules/custom/myeventlane_messaging/src/Service/MessagingManager.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/MessagingManager.php
@@ -320,7 +320,10 @@ final class MessagingManager {
           '@id' => $messageId,
           'queue_name' => self::QUEUE_NAME,
         ]);
-        return;
+        throw new RequeueException(sprintf(
+          'Message %s is already claimed for delivery.',
+          $messageId,
+        ));
       }
       $this->logger->warning('Reclaimed stale pre-dispatch message after worker interruption. message_id=@id', [
         '@id' => $messageId,
@@ -737,15 +740,27 @@ final class MessagingManager {
         'created' => $now,
         'sent' => 0,
       ]);
-      $this->sendMessage($id);
     }
     catch (\Throwable $e) {
+      $existing = $this->messageStorage
+        ->findByIdempotencyKey($idempotencyKey);
+      if ($existing) {
+        $this->logger->info('sendNow legacy: concurrent duplicate recovered.', [
+          'message_id' => $existing->id,
+          'queue_name' => self::QUEUE_NAME,
+          'message_type' => $type,
+        ]);
+        $this->sendMessage($existing->id);
+        return;
+      }
       $this->logger->error('sendNow legacy: failed to create message. @message', [
         '@message' => $e->getMessage(),
         'queue_name' => self::QUEUE_NAME,
         'message_type' => $type,
       ]);
+      throw $e;
     }
+    $this->sendMessage($id);
   }
 
   /**

--- a/web/modules/custom/myeventlane_messaging/src/Service/MessagingManager.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/MessagingManager.php
@@ -11,10 +11,11 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Queue\QueueFactory;
+use Drupal\Core\Queue\RequeueException;
 use Drupal\myeventlane_messaging\Service\Delivery\DeliveryProviderManager;
-use Drupal\myeventlane_messaging\Service\BrandResolverInterface;
 use Drupal\myeventlane_pro\Service\VendorCommsResolver;
 use Psr\Log\LoggerInterface;
+use Throwable;
 
 /**
  * Queues and sends transactional messages. Single entry point; idempotent.
@@ -25,6 +26,16 @@ final class MessagingManager {
    * The queue name used for message dispatch.
    */
   private const QUEUE_NAME = 'myeventlane_messaging';
+
+  /**
+   * Maximum provider delivery attempts before a terminal failure.
+   */
+  private const MAX_DELIVERY_ATTEMPTS = 5;
+
+  /**
+   * Seconds before an abandoned worker claim is considered stale.
+   */
+  private const DELIVERY_CLAIM_TTL = 900;
 
   /**
    * Templates that are always sent (transactional, not subject to opt-out).
@@ -89,6 +100,8 @@ final class MessagingManager {
    *   The preference storage.
    * @param \Drupal\myeventlane_messaging\Service\Delivery\DeliveryProviderManager $deliveryProviderManager
    *   The delivery provider manager.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
    * @param \Drupal\myeventlane_messaging\Service\UtmLinker|null $utmLinker
    *   Optional UTM linker (may be NULL if not yet in container).
    * @param \Drupal\myeventlane_messaging\Service\BrandResolverInterface|null $vendorBrandResolver
@@ -127,7 +140,8 @@ final class MessagingManager {
    * @param array $context
    *   The template context (must be serializable; no objects for hashing).
    * @param array $opts
-   *   Optional: langcode, attachments, scheduled_for, channel.
+   *   Optional: langcode, attachments, scheduled_for, channel, and
+   *   idempotency_key.
    *
    * @return string|null
    *   The message ID (UUID) if queued, NULL if skipped or failed. Caller may pass
@@ -136,9 +150,7 @@ final class MessagingManager {
   public function queue(string $type, string $to, array $context = [], array $opts = []): ?string {
     $eventId = isset($context['event_id']) && is_numeric($context['event_id']) ? (int) $context['event_id'] : NULL;
     $orderId = isset($context['order_id']) && is_numeric($context['order_id']) ? (int) $context['order_id'] : NULL;
-    $submissionId = isset($context['submission_id']) && is_numeric($context['submission_id']) ? (int) $context['submission_id'] : NULL;
-
-    $to = trim($to);
+    $to = strtolower(trim($to));
     if ($to === '') {
       $this->logger->warning('MessagingManager::queue: empty recipient skipped.', [
         'queue_name' => self::QUEUE_NAME,
@@ -156,7 +168,15 @@ final class MessagingManager {
     }
 
     $contextHash = $this->contextHash($type, $to, $context);
-    $existing = $this->messageStorage->findByContextHash($contextHash, $to, $type, ['queued', 'sent']);
+    $idempotencyKey = trim((string) ($opts['idempotency_key'] ?? ''));
+    if ($idempotencyKey === '') {
+      $idempotencyKey = sprintf('message:%s:%s', $type, $contextHash);
+    }
+    if (strlen($idempotencyKey) > 255) {
+      $idempotencyKey = 'sha256:' . hash('sha256', $idempotencyKey);
+    }
+
+    $existing = $this->messageStorage->findByIdempotencyKey($idempotencyKey);
     if ($existing) {
       $this->logger->info('MessagingManager::queue: duplicate skipped (idempotent).', [
         'queue_name' => self::QUEUE_NAME,
@@ -196,6 +216,7 @@ final class MessagingManager {
         'langcode' => $langcode,
         'context' => $storableContext,
         'context_hash' => $contextHash,
+        'idempotency_key' => $idempotencyKey,
         'scheduled_for' => $scheduledFor,
         'status' => 'queued',
         'attempts' => 0,
@@ -203,7 +224,18 @@ final class MessagingManager {
         'sent' => 0,
       ]);
     }
-    catch (\Throwable $e) {
+    catch (Throwable $e) {
+      // A concurrent producer may have won the unique-key insert race.
+      $existing = $this->messageStorage->findByIdempotencyKey($idempotencyKey);
+      if ($existing !== NULL) {
+        $this->logger->info('MessagingManager::queue: concurrent duplicate skipped (idempotent).', [
+          'queue_name' => self::QUEUE_NAME,
+          'message_type' => $type,
+          'existing_id' => $existing->id,
+          'idempotency_key' => $idempotencyKey,
+        ]);
+        return NULL;
+      }
       $this->logger->error('Failed to create message record. @message', [
         '@message' => $e->getMessage(),
         'queue_name' => self::QUEUE_NAME,
@@ -263,6 +295,75 @@ final class MessagingManager {
       ]);
       return;
     }
+    $now = time();
+    $staleBefore = $now - self::DELIVERY_CLAIM_TTL;
+    if ($message->status === 'processing') {
+      if ((int) $message->claimed_at <= 0
+        || (int) $message->claimed_at > $staleBefore
+        || !$this->messageStorage->reclaimStaleProcessing(
+          $messageId,
+          $staleBefore,
+          $now,
+        )) {
+        $this->logger->info('Message is already claimed by another worker. message_id=@id', [
+          '@id' => $messageId,
+          'queue_name' => self::QUEUE_NAME,
+        ]);
+        return;
+      }
+      $this->logger->warning('Reclaimed stale pre-dispatch message after worker interruption. message_id=@id', [
+        '@id' => $messageId,
+        'queue_name' => self::QUEUE_NAME,
+      ]);
+    }
+    elseif ($message->status === 'dispatching') {
+      if ((int) $message->claimed_at > 0
+        && (int) $message->claimed_at <= $staleBefore
+        && $this->messageStorage->markStaleDispatchUnknown(
+          $messageId,
+          $staleBefore,
+        )) {
+        $this->logger->critical('Stale provider dispatch quarantined without retry to prevent a duplicate. message_id=@id', [
+          '@id' => $messageId,
+          'queue_name' => self::QUEUE_NAME,
+        ]);
+      }
+      else {
+        $this->logger->info('Message provider dispatch is already in progress. message_id=@id', [
+          '@id' => $messageId,
+          'queue_name' => self::QUEUE_NAME,
+        ]);
+      }
+      return;
+    }
+    elseif ($message->status === 'delivery_unknown') {
+      $this->logger->warning('Message delivery remains unknown and requires provider reconciliation. message_id=@id', [
+        '@id' => $messageId,
+        'queue_name' => self::QUEUE_NAME,
+      ]);
+      return;
+    }
+    if ($message->status === 'failed_permanent'
+      || (int) $message->attempts >= self::MAX_DELIVERY_ATTEMPTS) {
+      $this->messageStorage->update($messageId, [
+        'status' => 'failed_permanent',
+        'claimed_at' => 0,
+      ]);
+      $this->logger->error('Message reached the maximum delivery attempts. message_id=@id attempts=@attempts', [
+        '@id' => $messageId,
+        '@attempts' => (int) $message->attempts,
+        'queue_name' => self::QUEUE_NAME,
+      ]);
+      return;
+    }
+    if ($message->status !== 'processing'
+      && !$this->messageStorage->claimForDelivery($messageId, $now)) {
+      $this->logger->info('Message delivery claim was not acquired. message_id=@id', [
+        '@id' => $messageId,
+        'queue_name' => self::QUEUE_NAME,
+      ]);
+      return;
+    }
 
     $type = $message->template;
     $to = $message->recipient;
@@ -295,7 +396,10 @@ final class MessagingManager {
         'queue_name' => self::QUEUE_NAME,
         'message_id' => $messageId,
       ]);
-      $this->messageStorage->update($messageId, ['status' => 'suppressed']);
+      $this->messageStorage->update($messageId, [
+        'status' => 'suppressed',
+        'claimed_at' => 0,
+      ]);
       return;
     }
 
@@ -306,7 +410,10 @@ final class MessagingManager {
         '@type' => $type,
         'queue_name' => self::QUEUE_NAME,
       ]);
-      $this->messageStorage->update($messageId, ['status' => 'suppressed']);
+      $this->messageStorage->update($messageId, [
+        'status' => 'suppressed',
+        'claimed_at' => 0,
+      ]);
       return;
     }
 
@@ -329,7 +436,10 @@ final class MessagingManager {
         '@len' => strlen($smsText),
         'queue_name' => self::QUEUE_NAME,
       ]);
-      $this->messageStorage->update($messageId, ['status' => 'suppressed']);
+      $this->messageStorage->update($messageId, [
+        'status' => 'suppressed',
+        'claimed_at' => 0,
+      ]);
       return;
     }
 
@@ -380,7 +490,10 @@ final class MessagingManager {
         'message_id' => $messageId,
         'message_type' => $type,
       ]);
-      $this->messageStorage->update($messageId, ['status' => 'failed']);
+      $this->messageStorage->update($messageId, [
+        'status' => 'failed',
+        'claimed_at' => 0,
+      ]);
       return;
     }
     $subject = Html::decodeEntities(strip_tags($subjectRaw));
@@ -393,7 +506,10 @@ final class MessagingManager {
         '@type' => $type,
         'queue_name' => self::QUEUE_NAME,
       ]);
-      $this->messageStorage->update($messageId, ['status' => 'failed']);
+      $this->messageStorage->update($messageId, [
+        'status' => 'failed',
+        'claimed_at' => 0,
+      ]);
       return;
     }
 
@@ -404,7 +520,10 @@ final class MessagingManager {
         '@type' => $type,
         'queue_name' => self::QUEUE_NAME,
       ]);
-      $this->messageStorage->update($messageId, ['status' => 'failed']);
+      $this->messageStorage->update($messageId, [
+        'status' => 'failed',
+        'claimed_at' => 0,
+      ]);
       return;
     }
 
@@ -426,7 +545,10 @@ final class MessagingManager {
         'message_id' => $messageId,
         'message_type' => $type,
       ]);
-      $this->messageStorage->update($messageId, ['status' => 'failed']);
+      $this->messageStorage->update($messageId, [
+        'status' => 'failed',
+        'claimed_at' => 0,
+      ]);
       return;
     }
 
@@ -447,6 +569,7 @@ final class MessagingManager {
       'langcode' => $message->langcode,
       'attachments' => $opts['attachments'] ?? [],
       'mel_template_key' => $type,
+      'mel_message_id' => $messageId,
     ];
     if ($orderId !== NULL) {
       $params['mel_order_id'] = $orderId;
@@ -461,13 +584,39 @@ final class MessagingManager {
       $params['reply_to'] = $brand['reply_to'];
     }
 
-    $sent = $provider->send($params);
+    if (!$this->messageStorage->markDispatching($messageId, time())) {
+      $this->logger->error('Message lost its delivery claim before provider dispatch. message_id=@id', [
+        '@id' => $messageId,
+        'queue_name' => self::QUEUE_NAME,
+      ]);
+      return;
+    }
+
+    try {
+      $sent = $provider->send($params);
+    }
+    catch (\Throwable $e) {
+      $this->messageStorage->incrementAttempts($messageId);
+      $this->messageStorage->update($messageId, [
+        'status' => 'delivery_unknown',
+        'claimed_at' => 0,
+        'provider' => $provider->id(),
+      ]);
+      $this->logger->critical('Provider dispatch outcome is unknown; automatic retry suppressed. message_id=@id provider=@provider @message', [
+        '@id' => $messageId,
+        '@provider' => $provider->id(),
+        '@message' => $e->getMessage(),
+        'queue_name' => self::QUEUE_NAME,
+      ]);
+      return;
+    }
 
     $this->messageStorage->incrementAttempts($messageId);
     if ($sent) {
       $updates = [
         'status' => 'sent',
         'sent' => (int) time(),
+        'claimed_at' => 0,
         'provider' => $provider->id(),
       ];
       $providerMessageId = $provider->getLastProviderMessageId();
@@ -485,7 +634,10 @@ final class MessagingManager {
       ]);
     }
     else {
-      $this->messageStorage->update($messageId, ['status' => 'failed']);
+      $this->messageStorage->update($messageId, [
+        'status' => 'failed',
+        'claimed_at' => 0,
+      ]);
       $this->logger->error('Failed sending message @type to @to. message_id=@id', [
         '@type' => $type,
         '@to' => $to,
@@ -493,6 +645,19 @@ final class MessagingManager {
         'queue_name' => self::QUEUE_NAME,
         'event_id' => $eventId,
         'order_id' => $orderId,
+      ]);
+      throw new RequeueException(sprintf('Delivery failed for message %s.', $messageId));
+    }
+  }
+
+  /**
+   * Releases a worker claim when delivery throws unexpectedly.
+   */
+  public function releaseFailedClaim(string $messageId): void {
+    if ($this->messageStorage->releaseFailedClaim($messageId)) {
+      $this->logger->warning('Released failed message delivery claim for retry. message_id=@id', [
+        '@id' => $messageId,
+        'queue_name' => self::QUEUE_NAME,
       ]);
     }
   }
@@ -514,7 +679,7 @@ final class MessagingManager {
     }
     // Legacy: no message_id. Create message and send once (no re-queue).
     $type = $payload['type'] ?? 'generic';
-    $to = $payload['to'] ?? '';
+    $to = strtolower(trim((string) ($payload['to'] ?? '')));
     $context = $payload['context'] ?? [];
     $opts = $payload['opts'] ?? [];
     if ($to === '') {
@@ -525,7 +690,14 @@ final class MessagingManager {
       return;
     }
     $contextHash = $this->contextHash($type, $to, $context);
-    $existing = $this->messageStorage->findByContextHash($contextHash, $to, $type, ['queued', 'sent']);
+    $idempotencyKey = trim((string) ($opts['idempotency_key'] ?? ''));
+    if ($idempotencyKey === '') {
+      $idempotencyKey = sprintf('message:%s:%s', $type, $contextHash);
+    }
+    if (strlen($idempotencyKey) > 255) {
+      $idempotencyKey = 'sha256:' . hash('sha256', $idempotencyKey);
+    }
+    $existing = $this->messageStorage->findByIdempotencyKey($idempotencyKey);
     if ($existing) {
       $this->sendMessage($existing->id);
       return;
@@ -543,6 +715,7 @@ final class MessagingManager {
         'langcode' => $langcode,
         'context' => $storableContext,
         'context_hash' => $contextHash,
+        'idempotency_key' => $idempotencyKey,
         'scheduled_for' => $now,
         'status' => 'queued',
         'attempts' => 0,

--- a/web/modules/custom/myeventlane_messaging/src/Service/MessagingManager.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/MessagingManager.php
@@ -596,11 +596,15 @@ final class MessagingManager {
     }
 
     if (!$this->messageStorage->markDispatching($messageId, time())) {
+      $this->messageStorage->releaseFailedClaim($messageId);
       $this->logger->error('Message lost its delivery claim before provider dispatch. message_id=@id', [
         '@id' => $messageId,
         'queue_name' => self::QUEUE_NAME,
       ]);
-      return;
+      throw new RequeueException(sprintf(
+        'Provider dispatch claim failed for message %s.',
+        $messageId,
+      ));
     }
 
     try {

--- a/web/modules/custom/myeventlane_messaging/src/Service/MessagingManager.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/MessagingManager.php
@@ -15,7 +15,6 @@ use Drupal\Core\Queue\RequeueException;
 use Drupal\myeventlane_messaging\Service\Delivery\DeliveryProviderManager;
 use Drupal\myeventlane_pro\Service\VendorCommsResolver;
 use Psr\Log\LoggerInterface;
-use Throwable;
 
 /**
  * Queues and sends transactional messages. Single entry point; idempotent.
@@ -178,6 +177,18 @@ final class MessagingManager {
 
     $existing = $this->messageStorage->findByIdempotencyKey($idempotencyKey);
     if ($existing) {
+      if ($existing->status === 'failed'
+        && (int) $existing->attempts < self::MAX_DELIVERY_ATTEMPTS) {
+        $this->queueFactory->get(self::QUEUE_NAME)->createItem([
+          'message_id' => $existing->id,
+        ]);
+        $this->logger->notice('MessagingManager::queue: retryable failed message requeued.', [
+          'queue_name' => self::QUEUE_NAME,
+          'message_type' => $type,
+          'existing_id' => $existing->id,
+        ]);
+        return $existing->id;
+      }
       $this->logger->info('MessagingManager::queue: duplicate skipped (idempotent).', [
         'queue_name' => self::QUEUE_NAME,
         'event_id' => $eventId,
@@ -224,7 +235,7 @@ final class MessagingManager {
         'sent' => 0,
       ]);
     }
-    catch (Throwable $e) {
+    catch (\Throwable $e) {
       // A concurrent producer may have won the unique-key insert race.
       $existing = $this->messageStorage->findByIdempotencyKey($idempotencyKey);
       if ($existing !== NULL) {

--- a/web/modules/custom/myeventlane_messaging/src/Service/MessagingManager.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/MessagingManager.php
@@ -347,6 +347,10 @@ final class MessagingManager {
           '@id' => $messageId,
           'queue_name' => self::QUEUE_NAME,
         ]);
+        throw new RequeueException(sprintf(
+          'Provider dispatch is already in progress for message %s.',
+          $messageId,
+        ));
       }
       return;
     }

--- a/web/modules/custom/myeventlane_messaging/src/Service/OrderConfirmationQueueBuilder.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/OrderConfirmationQueueBuilder.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_messaging\Service;
 
+use CommerceGuys\Intl\Formatter\CurrencyFormatterInterface;
 use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\Core\Session\AccountInterface;
@@ -37,6 +39,8 @@ final class OrderConfirmationQueueBuilder {
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly ?TicketLabelResolver $ticketLabelResolver,
     private readonly FileUrlGeneratorInterface $fileUrlGenerator,
+    private readonly CurrencyFormatterInterface $currencyFormatter,
+    private readonly DateFormatterInterface $dateFormatter,
     private readonly MessagingManager $messagingManager,
     private readonly LoggerInterface $logger,
     private readonly DomainDetector $domainDetector,
@@ -113,7 +117,10 @@ final class OrderConfirmationQueueBuilder {
     $invoice = $this->taxInvoicePresentation->build($order);
     $booking_total = $pricing['total_formatted'] !== ''
       ? $pricing['total_formatted']
-      : $this->formatPrice((float) $order->getTotalPrice()->getNumber());
+      : $this->formatPrice(
+        (float) $order->getTotalPrice()->getNumber(),
+        $order->getTotalPrice()->getCurrencyCode(),
+      );
 
     // Customer presentation only — Commerce label() is "Order {number}".
     $order_number = trim((string) $order->getOrderNumber());
@@ -153,7 +160,12 @@ final class OrderConfirmationQueueBuilder {
       'is_paid' => $is_paid,
       'events' => $this->formatEventsForEmail($events),
       'ticket_items' => $this->formatTicketItemsForEmail($ticket_items),
-      'donation_total' => $donation_total > 0 ? $this->formatPrice($donation_total) : NULL,
+      'donation_total' => $donation_total > 0
+        ? $this->formatPrice(
+          $donation_total,
+          $order->getTotalPrice()->getCurrencyCode(),
+      )
+        : NULL,
       'order_subtotal_formatted' => $pricing['subtotal_formatted'],
       'order_tax_rows' => $pricing['tax_rows'],
       'order_fee_rows' => $pricing['fee_rows'],
@@ -340,14 +352,14 @@ final class OrderConfirmationQueueBuilder {
 
       if ($event->hasField('field_event_start') && !$event->get('field_event_start')->isEmpty()) {
         $start_timestamp = strtotime($event->get('field_event_start')->value);
-        $start_date = date('j F Y', $start_timestamp);
-        $start_time = date('g:i a', $start_timestamp);
+        $start_date = $this->dateFormatter->format($start_timestamp, 'custom', 'j F Y');
+        $start_time = $this->dateFormatter->format($start_timestamp, 'custom', 'g:i a T');
       }
 
       if ($event->hasField('field_event_end') && !$event->get('field_event_end')->isEmpty()) {
         $end_timestamp = strtotime($event->get('field_event_end')->value);
-        $end_date = date('j F Y', $end_timestamp);
-        $end_time = date('g:i a', $end_timestamp);
+        $end_date = $this->dateFormatter->format($end_timestamp, 'custom', 'j F Y');
+        $end_time = $this->dateFormatter->format($end_timestamp, 'custom', 'g:i a T');
       }
 
       if ($event->hasField('field_event_image') && !$event->get('field_event_image')->isEmpty()) {
@@ -550,7 +562,12 @@ final class OrderConfirmationQueueBuilder {
       $formatted[] = [
         'title' => $label,
         'quantity' => (int) $item->getQuantity(),
-        'price' => $price ? $this->formatPrice((float) $price->getNumber()) : '$0.00',
+        'price' => $price
+          ? $this->formatPrice(
+            (float) $price->getNumber(),
+            $price->getCurrencyCode(),
+        )
+          : $this->formatPrice(0.0, 'AUD'),
         'attendees' => $attendees,
       ];
     }
@@ -971,8 +988,11 @@ final class OrderConfirmationQueueBuilder {
     return NULL;
   }
 
-  private function formatPrice(float $amount): string {
-    return '$' . number_format($amount, 2);
+  /**
+   * Formats an amount using the Commerce currency formatter.
+   */
+  private function formatPrice(float $amount, string $currencyCode): string {
+    return $this->currencyFormatter->format((string) $amount, $currencyCode);
   }
 
 }

--- a/web/modules/custom/myeventlane_messaging/src/Service/OrderConfirmationQueueBuilder.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/OrderConfirmationQueueBuilder.php
@@ -159,7 +159,10 @@ final class OrderConfirmationQueueBuilder {
       'is_guest' => $is_guest,
       'is_paid' => $is_paid,
       'events' => $this->formatEventsForEmail($events),
-      'ticket_items' => $this->formatTicketItemsForEmail($ticket_items),
+      'ticket_items' => $this->formatTicketItemsForEmail(
+        $ticket_items,
+        $order->getTotalPrice()->getCurrencyCode(),
+      ),
       'donation_total' => $donation_total > 0
         ? $this->formatPrice(
           $donation_total,
@@ -531,7 +534,10 @@ final class OrderConfirmationQueueBuilder {
     return $value !== '' ? $value : NULL;
   }
 
-  private function formatTicketItemsForEmail(array $ticket_items): array {
+  private function formatTicketItemsForEmail(
+    array $ticket_items,
+    string $orderCurrencyCode,
+  ): array {
     $formatted = [];
 
     foreach ($ticket_items as $item) {
@@ -567,7 +573,7 @@ final class OrderConfirmationQueueBuilder {
             (float) $price->getNumber(),
             $price->getCurrencyCode(),
         )
-          : $this->formatPrice(0.0, 'AUD'),
+          : $this->formatPrice(0.0, $orderCurrencyCode),
         'attendees' => $attendees,
       ];
     }

--- a/web/modules/custom/myeventlane_messaging/src/Service/VendorBrandResolver.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/VendorBrandResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_messaging\Service;
 
+use Drupal\Component\Utility\Html;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\file\FileInterface;
@@ -19,7 +20,7 @@ use Drupal\myeventlane_vendor\Service\CurrentVendorResolverInterface;
  * 2. Else if vendor entity provided → brand from vendor fields
  * 3. Else if event_id provided → load event → field_event_vendor → brand
  * 4. Else if order provided → resolve vendor via store/event → brand
- * 5. Else → MEL platform defaults
+ * 5. Else → MEL platform defaults.
  */
 final class VendorBrandResolver implements BrandResolverInterface {
 
@@ -80,6 +81,11 @@ final class VendorBrandResolver implements BrandResolverInterface {
     }
 
     $footerText = $this->getFieldValue($vendor, 'field_msg_footer');
+    $footerText = trim(preg_replace(
+      '/\s+/u',
+      ' ',
+      Html::decodeEntities(strip_tags($footerText)),
+    ) ?? '');
     if ($footerText === '') {
       $footerText = Brand::DEFAULT_FOOTER;
     }
@@ -172,6 +178,9 @@ final class VendorBrandResolver implements BrandResolverInterface {
 
     $file = $vendor->get($fieldName)->entity;
     if (!$file instanceof FileInterface) {
+      return '';
+    }
+    if (!is_readable($file->getFileUri())) {
       return '';
     }
 

--- a/web/modules/custom/myeventlane_messaging/tests/src/Kernel/MessageStorageTest.php
+++ b/web/modules/custom/myeventlane_messaging/tests/src/Kernel/MessageStorageTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\myeventlane_messaging\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\myeventlane_messaging\Service\MessageStorage;
+use Drupal\Core\Database\IntegrityConstraintViolationException;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
@@ -47,7 +48,7 @@ final class MessageStorageTest extends KernelTestBase {
   }
 
   /**
-   * create() persists provider and provider_message_id.
+   * Create() persists provider and provider_message_id.
    */
   public function testCreatePersistsProviderFields(): void {
     $id = $this->storage->create([
@@ -69,7 +70,7 @@ final class MessageStorageTest extends KernelTestBase {
   }
 
   /**
-   * update() can set provider and provider_message_id.
+   * Update() can set provider and provider_message_id.
    */
   public function testUpdateProviderFields(): void {
     $id = $this->storage->create([
@@ -96,7 +97,7 @@ final class MessageStorageTest extends KernelTestBase {
   }
 
   /**
-   * findByProviderMessageId() returns a hydrated row.
+   * FindByProviderMessageId() returns a hydrated row.
    */
   public function testFindByProviderMessageId(): void {
     $this->storage->create([
@@ -118,11 +119,90 @@ final class MessageStorageTest extends KernelTestBase {
   }
 
   /**
-   * findByProviderMessageId() returns NULL when not found.
+   * FindByProviderMessageId() returns NULL when not found.
    */
   public function testFindByProviderMessageIdNotFound(): void {
     $this->assertNull($this->storage->findByProviderMessageId('missing-id'));
     $this->assertNull($this->storage->findByProviderMessageId(''));
+  }
+
+  /**
+   * A business idempotency key can be inserted only once.
+   */
+  public function testIdempotencyKeyIsUnique(): void {
+    $row = [
+      'template' => 'boost_expired',
+      'channel' => 'email',
+      'recipient' => 'anna@example.com',
+      'context' => ['entitlement_id' => 42],
+      'context_hash' => hash('sha256', 'boost-expired-42'),
+      'idempotency_key' => 'boost_expired:entitlement:42',
+      'status' => 'queued',
+    ];
+
+    $this->storage->create($row);
+    $existing = $this->storage->findByIdempotencyKey(
+      'boost_expired:entitlement:42',
+    );
+    $this->assertNotNull($existing);
+
+    $this->expectException(IntegrityConstraintViolationException::class);
+    $this->storage->create($row);
+  }
+
+  /**
+   * Only one worker can atomically claim a message.
+   */
+  public function testClaimForDeliveryIsAtomicAndFailedCanRetry(): void {
+    $id = $this->storage->create([
+      'template' => 'test',
+      'channel' => 'email',
+      'recipient' => 'worker@example.com',
+      'context' => [],
+      'context_hash' => hash('sha256', 'claim-test'),
+      'idempotency_key' => 'test:claim:1',
+      'status' => 'queued',
+    ]);
+
+    $this->assertTrue($this->storage->claimForDelivery($id, 100));
+    $this->assertFalse($this->storage->claimForDelivery($id, 101));
+    $claimed = $this->storage->load($id);
+    $this->assertSame('processing', $claimed->status);
+    $this->assertSame('100', (string) $claimed->claimed_at);
+
+    $this->assertTrue($this->storage->releaseFailedClaim($id));
+    $this->assertFalse($this->storage->releaseFailedClaim($id));
+    $this->assertTrue($this->storage->claimForDelivery($id, 102));
+  }
+
+  /**
+   * Stale work is retried only before the provider-dispatch boundary.
+   */
+  public function testStaleClaimRecoveryQuarantinesProviderDispatch(): void {
+    $id = $this->storage->create([
+      'template' => 'test',
+      'channel' => 'email',
+      'recipient' => 'restart@example.com',
+      'context' => [],
+      'context_hash' => hash('sha256', 'restart-test'),
+      'idempotency_key' => 'test:restart:1',
+      'status' => 'queued',
+    ]);
+
+    $this->assertTrue($this->storage->claimForDelivery($id, 100));
+    $this->assertFalse($this->storage->reclaimStaleProcessing($id, 99, 200));
+    $this->assertTrue($this->storage->reclaimStaleProcessing($id, 100, 200));
+    $this->assertTrue($this->storage->markDispatching($id, 201));
+    $this->assertFalse($this->storage->markDispatching($id, 202));
+    $this->assertFalse($this->storage->releaseFailedClaim($id));
+    $this->assertFalse($this->storage->reclaimStaleProcessing($id, 300, 301));
+    $this->assertFalse($this->storage->markStaleDispatchUnknown($id, 200));
+    $this->assertTrue($this->storage->markStaleDispatchUnknown($id, 201));
+
+    $message = $this->storage->load($id);
+    $this->assertSame('delivery_unknown', $message->status);
+    $this->assertSame('0', (string) $message->claimed_at);
+    $this->assertFalse($this->storage->claimForDelivery($id, 302));
   }
 
 }

--- a/web/modules/custom/myeventlane_messaging/tests/src/Kernel/MessageStorageTest.php
+++ b/web/modules/custom/myeventlane_messaging/tests/src/Kernel/MessageStorageTest.php
@@ -4,10 +4,22 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\myeventlane_messaging\Kernel;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Queue\QueueFactory;
+use Drupal\Core\Queue\QueueInterface;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\myeventlane_messaging\Service\Delivery\DeliveryProviderManager;
+use Drupal\myeventlane_messaging\Service\MessagePreferenceStorage;
+use Drupal\myeventlane_messaging\Service\MessageRenderer;
 use Drupal\myeventlane_messaging\Service\MessageStorage;
+use Drupal\myeventlane_messaging\Service\MessagingManager;
 use Drupal\Core\Database\IntegrityConstraintViolationException;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use Psr\Log\LoggerInterface;
 
 /**
  * Tests MessageStorage provider tracking (create, update, lookup).
@@ -203,6 +215,114 @@ final class MessageStorageTest extends KernelTestBase {
     $this->assertSame('delivery_unknown', $message->status);
     $this->assertSame('0', (string) $message->claimed_at);
     $this->assertFalse($this->storage->claimForDelivery($id, 302));
+  }
+
+  /**
+   * Legacy backfill prefers a sent row and normalizes recipient casing.
+   */
+  public function testLegacyIdempotencyBackfillPrefersSentMessage(): void {
+    $context = ['order_id' => 42];
+    $failedId = $this->storage->create([
+      'template' => 'order_confirmation',
+      'channel' => 'email',
+      'recipient' => 'Anna@Example.com',
+      'context' => $context,
+      'context_hash' => 'legacy-failed-hash',
+      'status' => 'failed',
+      'created' => 1,
+    ]);
+    $sentId = $this->storage->create([
+      'template' => 'order_confirmation',
+      'channel' => 'email',
+      'recipient' => 'anna@example.com',
+      'context' => $context,
+      'context_hash' => 'legacy-sent-hash',
+      'status' => 'sent',
+      'created' => 2,
+      'sent' => 3,
+    ]);
+
+    myeventlane_messaging_update_10007();
+
+    $contextHash = hash(
+      'sha256',
+      'order_confirmation|anna@example.com|{"order_id":42}',
+    );
+    $canonicalKey = 'message:order_confirmation:' . $contextHash;
+    $failed = $this->storage->load($failedId);
+    $sent = $this->storage->load($sentId);
+    $this->assertSame('anna@example.com', $failed->recipient);
+    $this->assertSame('anna@example.com', $sent->recipient);
+    $this->assertSame($canonicalKey, $sent->idempotency_key);
+    $this->assertSame('legacy-duplicate:' . $failedId, $failed->idempotency_key);
+    $this->assertCount(
+      1,
+      $this->storage->findSentOrderConfirmationsForOrder(
+        42,
+        'ANNA@EXAMPLE.COM',
+      ),
+    );
+  }
+
+  /**
+   * Queueing a retryable failed occurrence reuses and requeues its row.
+   */
+  public function testFailedOccurrenceIsRequeuedWithoutDuplicateRow(): void {
+    $idempotencyKey = 'order_confirmation:order:42';
+    $id = $this->storage->create([
+      'template' => 'order_confirmation',
+      'channel' => 'email',
+      'recipient' => 'anna@example.com',
+      'context' => ['order_id' => 42],
+      'context_hash' => hash('sha256', 'failed-order-42'),
+      'idempotency_key' => $idempotencyKey,
+      'status' => 'failed',
+      'attempts' => 1,
+    ]);
+
+    $queue = $this->createMock(QueueInterface::class);
+    $queue->expects($this->once())
+      ->method('createItem')
+      ->with(['message_id' => $id]);
+    $queueFactory = $this->createMock(QueueFactory::class);
+    $queueFactory->method('get')
+      ->with('myeventlane_messaging')
+      ->willReturn($queue);
+    $config = $this->createMock(ImmutableConfig::class);
+    $config->method('get')->willReturn(NULL);
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')->willReturn($config);
+    $language = $this->createMock(LanguageInterface::class);
+    $language->method('getId')->willReturn('en');
+    $languageManager = $this->createMock(LanguageManagerInterface::class);
+    $languageManager->method('getDefaultLanguage')->willReturn($language);
+
+    $manager = new MessagingManager(
+      $configFactory,
+      $languageManager,
+      $queueFactory,
+      $this->createMock(LoggerInterface::class),
+      (new \ReflectionClass(MessageRenderer::class))
+        ->newInstanceWithoutConstructor(),
+      $this->storage,
+      new MessagePreferenceStorage($this->container->get('database')),
+      (new \ReflectionClass(DeliveryProviderManager::class))
+        ->newInstanceWithoutConstructor(),
+      $this->createMock(EntityTypeManagerInterface::class),
+    );
+
+    $this->assertSame($id, $manager->queue(
+      'order_confirmation',
+      'Anna@Example.com',
+      ['order_id' => 42],
+      ['idempotency_key' => $idempotencyKey],
+    ));
+    $count = $this->container->get('database')
+      ->select('myeventlane_message', 'm')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertSame(1, (int) $count);
   }
 
 }

--- a/web/modules/custom/myeventlane_messaging/tests/src/Kernel/PostmarkWebhookControllerTest.php
+++ b/web/modules/custom/myeventlane_messaging/tests/src/Kernel/PostmarkWebhookControllerTest.php
@@ -107,6 +107,64 @@ final class PostmarkWebhookControllerTest extends KernelTestBase {
   }
 
   /**
+   * Delivery metadata reconciles an uncertain provider dispatch.
+   */
+  public function testDeliveryMetadataReconcilesUnknownDispatch(): void {
+    $id = $this->messageStorage->create([
+      'template' => 'test',
+      'channel' => 'email',
+      'recipient' => 'reconcile@example.com',
+      'context' => [],
+      'context_hash' => hash('sha256', 'reconcile-test'),
+      'status' => 'delivery_unknown',
+      'provider' => 'postmark',
+    ]);
+
+    $request = $this->buildRequest([
+      'MessageID' => 'reconciled-provider-id',
+      'Recipient' => 'reconcile@example.com',
+      'Metadata' => ['mel_message_id' => $id],
+    ], self::WEBHOOK_SECRET);
+
+    $response = $this->controller->delivery($request);
+    $this->assertSame(200, $response->getStatusCode());
+
+    $row = $this->messageStorage->load($id);
+    $this->assertSame('delivered', $row->status);
+    $this->assertSame('postmark', $row->provider);
+    $this->assertSame('reconciled-provider-id', $row->provider_message_id);
+    $this->assertGreaterThan(0, (int) $row->sent);
+  }
+
+  /**
+   * Metadata cannot reconcile a message for another recipient.
+   */
+  public function testDeliveryMetadataRequiresMatchingRecipient(): void {
+    $id = $this->messageStorage->create([
+      'template' => 'test',
+      'channel' => 'email',
+      'recipient' => 'expected@example.com',
+      'context' => [],
+      'context_hash' => hash('sha256', 'recipient-test'),
+      'status' => 'delivery_unknown',
+      'provider' => 'postmark',
+    ]);
+
+    $request = $this->buildRequest([
+      'MessageID' => 'wrong-recipient-provider-id',
+      'Recipient' => 'other@example.com',
+      'Metadata' => ['mel_message_id' => $id],
+    ], self::WEBHOOK_SECRET);
+
+    $response = $this->controller->delivery($request);
+    $this->assertSame(200, $response->getStatusCode());
+    $this->assertSame(
+      'delivery_unknown',
+      $this->messageStorage->load($id)->status,
+    );
+  }
+
+  /**
    * Bounce webhook updates known message status to bounced.
    */
   public function testBounceUpdatesKnownMessage(): void {

--- a/web/modules/custom/myeventlane_messaging/tests/src/Unit/OrderConfirmationTemplateAceTest.php
+++ b/web/modules/custom/myeventlane_messaging/tests/src/Unit/OrderConfirmationTemplateAceTest.php
@@ -128,7 +128,7 @@ final class OrderConfirmationTemplateAceTest extends TestCase {
     $context = $this->sampleContext();
     $context['apple_wallet_url'] = 'https://example.test/wallet/apple/55';
     $context['google_wallet_url'] = 'https://example.test/wallet/google/55';
-    $context['apple_wallet_badge_url'] = NULL;
+    $context['apple_wallet_badge_url'] = 'https://example.test/modules/custom/myeventlane_wallet/assets/web/add-to-apple-wallet.svg';
     $context['google_wallet_badge_url'] = 'https://example.test/modules/custom/myeventlane_wallet/assets/web/add-to-google-wallet.png';
     $context['pdf_url'] = 'https://example.test/ticket/ABC123/pdf';
 
@@ -139,8 +139,27 @@ final class OrderConfirmationTemplateAceTest extends TestCase {
     $this->assertStringContainsString('Download PDF', $body);
     $this->assertStringContainsString('/wallet/apple/55', $body);
     $this->assertStringContainsString('/wallet/google/55', $body);
-    $this->assertStringNotContainsString('add-to-apple-wallet.svg', $body);
+    $this->assertStringContainsString('add-to-apple-wallet.svg', $body);
     $this->assertStringContainsString('add-to-google-wallet.png', $body);
+    $this->assertStringContainsString('width="156" height="48"', $body);
+    $this->assertStringContainsString('width="272" height="48"', $body);
+  }
+
+  /**
+   * Wallet CTAs are omitted when official badge artwork is unavailable.
+   */
+  public function testWalletCtaDoesNotImitateMissingOfficialBadge(): void {
+    $data = $this->loadTemplate();
+    $twig = new Environment(new ArrayLoader([]));
+    $context = $this->sampleContext();
+    $context['apple_wallet_url'] = 'https://example.test/wallet/apple/55';
+    $context['apple_wallet_badge_url'] = NULL;
+
+    $body = trim($twig->createTemplate((string) $data['body_html'])->render($context));
+
+    $this->assertStringNotContainsString('/wallet/apple/55', $body);
+    $this->assertStringNotContainsString('Add to Apple Wallet', $body);
+    $this->assertStringNotContainsString('mel-wallet-badge__fallback', $body);
   }
 
   /**

--- a/web/modules/custom/myeventlane_messaging/tests/src/Unit/PostmarkDeliveryProviderTest.php
+++ b/web/modules/custom/myeventlane_messaging/tests/src/Unit/PostmarkDeliveryProviderTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_messaging\Unit;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Http\ClientFactory;
+use Drupal\myeventlane_messaging\Service\Delivery\PostmarkDeliveryProvider;
+use Drupal\Tests\UnitTestCase;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests Postmark delivery metadata and uncertain outcomes.
+ *
+ * @coversDefaultClass \Drupal\myeventlane_messaging\Service\Delivery\PostmarkDeliveryProvider
+ *
+ * @group myeventlane_messaging
+ */
+final class PostmarkDeliveryProviderTest extends UnitTestCase {
+
+  /**
+   * @covers ::send
+   */
+  public function testInternalMessageIdIsSentAsMetadata(): void {
+    $history = [];
+    $provider = $this->provider([
+      new Response(200, [], json_encode([
+        'MessageID' => 'provider-message-id',
+      ], JSON_THROW_ON_ERROR)),
+    ], $history);
+
+    $this->assertTrue($provider->send($this->params()));
+    $this->assertSame('provider-message-id', $provider->getLastProviderMessageId());
+
+    $payload = json_decode(
+      (string) $history[0]['request']->getBody(),
+      TRUE,
+      flags: JSON_THROW_ON_ERROR,
+    );
+    $this->assertSame(
+      'internal-message-id',
+      $payload['Metadata']['mel_message_id'],
+    );
+  }
+
+  /**
+   * @covers ::send
+   */
+  public function testTransportExceptionIsNotReportedAsConfirmedFailure(): void {
+    $request = new Request('POST', 'https://api.postmarkapp.com/email');
+    $history = [];
+    $provider = $this->provider([
+      new RequestException('Connection interrupted', $request),
+    ], $history);
+
+    $this->expectException(RequestException::class);
+    $provider->send($this->params());
+  }
+
+  /**
+   * Builds a provider backed by a deterministic Guzzle handler.
+   *
+   * @param array $responses
+   *   Mock handler responses or exceptions.
+   * @param array $history
+   *   Captured Guzzle transactions.
+   */
+  private function provider(array $responses, array &$history): PostmarkDeliveryProvider {
+    $handler = HandlerStack::create(new MockHandler($responses));
+    $handler->push(Middleware::history($history));
+    $client = new Client(['handler' => $handler]);
+
+    $httpFactory = $this->createMock(ClientFactory::class);
+    $httpFactory->method('fromOptions')->willReturn($client);
+
+    $config = $this->createMock(ImmutableConfig::class);
+    $values = [
+      'postmark.server_token' => 'test-token',
+      'postmark.message_stream' => 'outbound',
+      'from_email' => 'hello@example.com',
+      'from_name' => 'MyEventLane',
+      'reply_to' => 'support@example.com',
+    ];
+    $config->method('get')->willReturnCallback(
+      static fn(string $key): mixed => $values[$key] ?? NULL,
+    );
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')
+      ->with('myeventlane_messaging.settings')
+      ->willReturn($config);
+
+    return new PostmarkDeliveryProvider(
+      $httpFactory,
+      $configFactory,
+      $this->createMock(LoggerInterface::class),
+    );
+  }
+
+  /**
+   * Returns a valid Postmark delivery payload.
+   */
+  private function params(): array {
+    return [
+      'to' => 'anna@example.com',
+      'subject' => 'Test message',
+      'html' => '<p>Test</p>',
+      'mel_message_id' => 'internal-message-id',
+    ];
+  }
+
+}

--- a/web/modules/custom/myeventlane_wallet/assets/web/README.md
+++ b/web/modules/custom/myeventlane_wallet/assets/web/README.md
@@ -26,4 +26,4 @@ Canonical Twig fragment: `wallet-buttons.html.twig` (theme hook `myeventlane_wal
 - Do not recreate, recolour, flip, animate, or shadow the badges.
 - Keep badges secondary to MEL product identity.
 - Maintain clear space; keep minimum height ~48px on interactive surfaces.
-- On very dark backgrounds, Apple artwork may sit on a light clear-space pad (see `css/wallet-badges.css`).
+- Do not add custom backgrounds, padding, shadows, or effects to either badge.

--- a/web/modules/custom/myeventlane_wallet/css/wallet-badges.css
+++ b/web/modules/custom/myeventlane_wallet/css/wallet-badges.css
@@ -8,7 +8,7 @@
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
-  gap: var(--mel-space-2, 8px);
+  gap: 0;
   align-items: stretch;
 }
 
@@ -26,7 +26,8 @@
   min-height: 48px;
   min-width: 44px;
   padding: 0;
-  margin: 0;
+  /* Google requires at least 8dp clear space around the official badge. */
+  margin: 8px;
   border: 0;
   background: transparent;
   border-radius: 0.5rem;
@@ -54,41 +55,6 @@
   width: auto;
   height: 48px;
   max-width: 100%;
-}
-
-/* Dark mode: Apple outline-friendly clear space; Google button stays black. */
-@media (prefers-color-scheme: dark) {
-  .mel-wallet-badge--apple {
-    background-color: #f5f5f7;
-    border-radius: 0.5rem;
-    padding: 0.25rem 0.35rem;
-  }
-
-  .mel-wallet-badge--google {
-    /* Official black button already contrasts on dark surfaces. */
-    background-color: transparent;
-  }
-}
-
-[data-theme="dark"] .mel-wallet-badge--apple,
-.mel-theme--dark .mel-wallet-badge--apple {
-  background-color: #f5f5f7;
-  border-radius: 0.5rem;
-  padding: 0.25rem 0.35rem;
-}
-
-.mel-wallet-badge__fallback {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 48px;
-  padding: 0.75rem 1.125rem;
-  border-radius: 0.5rem;
-  font-weight: 600;
-  font-size: 0.875rem;
-  line-height: 1.25;
-  color: #ffffff;
-  background-color: #1f1f1f;
 }
 
 .mel-wallet-buttons--confirmation {

--- a/web/modules/custom/myeventlane_wallet/templates/wallet-buttons.html.twig
+++ b/web/modules/custom/myeventlane_wallet/templates/wallet-buttons.html.twig
@@ -3,8 +3,8 @@
  * @file
  * Canonical Apple / Google Wallet CTA fragment.
  *
- * Consumes WalletActionBuilder action arrays. Prefer official badge artwork
- * under assets/web/; fall back to accessible text using official product names.
+ * Consumes WalletActionBuilder action arrays. A CTA is rendered only when its
+ * official badge artwork is available under assets/web/.
  *
  * Available variables:
  * - apple: action array|null from WalletActionBuilder
@@ -15,51 +15,45 @@
 {% set variant = variant|default('default') %}
 {% set apple_url = apple.url|default('') %}
 {% set google_url = google.url|default('') %}
-{% if apple_url or google_url %}
+{% set apple_badge = apple.badge.src|default('') %}
+{% set google_badge = google.badge.src|default('') %}
+{% if (apple_url and apple_badge) or (google_url and google_badge) %}
   {{ attach_library('myeventlane_wallet/wallet_badges') }}
   <div class="mel-wallet-buttons mel-wallet-buttons--{{ variant }}" role="group" aria-label="{{ 'Wallet'|t }}">
-    {% if apple_url %}
+    {% if apple_url and apple_badge %}
       <a
         href="{{ apple_url }}"
         class="mel-wallet-badge mel-wallet-badge--apple"
         download
         aria-label="{{ apple.aria_label|default(apple.label|default('Add to Apple Wallet'|t)) }}"
       >
-        {% if apple.badge.src|default('') %}
-          <img
-            class="mel-wallet-badge__img"
-            src="{{ apple.badge.src }}"
-            alt="{{ apple.badge.alt|default('Add to Apple Wallet'|t) }}"
-            width="156"
-            height="48"
-            loading="lazy"
-            decoding="async"
-          >
-        {% else %}
-          <span class="mel-wallet-badge__fallback">{{ apple.label|default('Add to Apple Wallet'|t) }}</span>
-        {% endif %}
+        <img
+          class="mel-wallet-badge__img"
+          src="{{ apple_badge }}"
+          alt="{{ apple.badge.alt|default('Add to Apple Wallet'|t) }}"
+          width="156"
+          height="48"
+          loading="lazy"
+          decoding="async"
+        >
       </a>
     {% endif %}
-    {% if google_url %}
+    {% if google_url and google_badge %}
       <a
         href="{{ google_url }}"
         class="mel-wallet-badge mel-wallet-badge--google"
         rel="noopener noreferrer"
         aria-label="{{ google.aria_label|default(google.label|default('Add to Google Wallet'|t)) }}"
       >
-        {% if google.badge.src|default('') %}
-          <img
-            class="mel-wallet-badge__img"
-            src="{{ google.badge.src }}"
-            alt="{{ google.badge.alt|default('Add to Google Wallet'|t) }}"
-            width="200"
-            height="48"
-            loading="lazy"
-            decoding="async"
-          >
-        {% else %}
-          <span class="mel-wallet-badge__fallback">{{ google.label|default('Add to Google Wallet'|t) }}</span>
-        {% endif %}
+        <img
+          class="mel-wallet-badge__img"
+          src="{{ google_badge }}"
+          alt="{{ google.badge.alt|default('Add to Google Wallet'|t) }}"
+          width="272"
+          height="48"
+          loading="lazy"
+          decoding="async"
+        >
       </a>
     {% endif %}
   </div>

--- a/web/modules/custom/myeventlane_wallet/tests/src/Unit/WalletActionBuilderTest.php
+++ b/web/modules/custom/myeventlane_wallet/tests/src/Unit/WalletActionBuilderTest.php
@@ -24,6 +24,26 @@ final class WalletActionBuilderTest extends UnitTestCase {
   private string $tempDir = '';
 
   /**
+   * Official wallet badge assets retain their required presentation contract.
+   */
+  public function testOfficialBadgePresentationContract(): void {
+    $moduleRoot = DRUPAL_ROOT . '/modules/custom/myeventlane_wallet';
+    $template = file_get_contents($moduleRoot . '/templates/wallet-buttons.html.twig');
+    $css = file_get_contents($moduleRoot . '/css/wallet-badges.css');
+    $googleSize = getimagesize($moduleRoot . '/assets/web/add-to-google-wallet.png');
+
+    $this->assertIsString($template);
+    $this->assertIsString($css);
+    $this->assertSame([283, 50], [$googleSize[0], $googleSize[1]]);
+    $this->assertStringContainsString('width="156"', $template);
+    $this->assertStringContainsString('width="272"', $template);
+    $this->assertSame(2, substr_count($template, 'height="48"'));
+    $this->assertStringContainsString('margin: 8px;', $css);
+    $this->assertStringNotContainsString('mel-wallet-badge__fallback', $template);
+    $this->assertStringNotContainsString('mel-wallet-badge__fallback', $css);
+  }
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {


### PR DESCRIPTION
## Summary

<!-- What changed and why (organiser outcome, not only technical delta). -->

## Zone map (Event Workspace — required before screenshots)

<!-- Required for any PR that changes Event Workspace / organiser Workspace UI.
     Remove only for PRs with zero Workspace UI impact (state N/A + rationale). -->

```text
Identity:   <!-- Where am I? -->
Guidance:   <!-- What should I do next? (one recommendation or omit) -->
Work:       <!-- How do I do it? -->
Outcome:    <!-- What happened? (or omit) -->
```

**Zone Gate:** If you cannot produce this map, the page has not been designed yet.  
Authority: `docs/design/vendor-studio-visual/07-workspace-zones.md`

## Vendor Studio Design System References

<!-- Required for any PR that changes Vendor Studio / organiser console experience or `docs/design/vendor-studio/`.
     Remove this section only for PRs with zero Vendor Studio impact. -->

This implementation follows:

- <!-- e.g. docs/design/vendor-studio-visual/07-workspace-zones.md -->
- <!-- e.g. docs/design/vendor-studio-visual/03-option-b5.md -->
- <!-- e.g. 02-information-architecture.md -->
- <!-- e.g. 05-component-library.md -->
- <!-- e.g. 11-design-tokens.md -->
- <!-- e.g. 16-design-review-checklist.md -->
- <!-- e.g. 21-definition-of-done.md -->
- <!-- e.g. ADR-0001 -->
- <!-- e.g. DDR-003 -->

**Build order:** PDS → Workspace Zones → Visual Language B.5 → Component Catalogue → Implementation  
**PDS home:** `docs/design/vendor-studio/` (Vendor Studio Product Design System v1.0 — FROZEN)

Please also apply the GitHub label: `design-system`

## Definition of Done / checklist

- [ ] Zone Gate map present (or N/A with rationale)
- [ ] Applicable gates in `docs/design/vendor-studio/21-definition-of-done.md`
- [ ] `docs/design/vendor-studio/16-design-review-checklist.md` completed (or N/A with rationale)
- [ ] No contradiction of higher-order PDS docs ([ADR-0001](../docs/design/vendor-studio/decisions/ADR-0001-design-authority.md))

## Test plan

- [ ] <!-- Manual / automated checks -->

## Risk

<!-- Access, Commerce, payments, cache, PII — or "None" -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cron email semantics, messaging DB schema with unique keys, and Postmark retry behavior—incorrect idempotency could suppress legitimate sends or leave messages stuck in delivery_unknown.
> 
> **Overview**
> Stops **duplicate boost expiry and booking-related emails** by making delivery idempotent at the entitlement layer and in the shared messaging pipeline.
> 
> **Boost expiry cron** now expires all ended entitlements first (not capped at 500), then sends **one vendor email per event** when every boost on that event has ended—using per-event locks, entitlement fields (`expiry_notification_status`, `expiry_notified_at`, `expiry_notification_attempts`), and marking rows **sent before** calling mail so retries cannot double-send. Historical expired entitlements are backfilled as already notified on update `10010`.
> 
> **Messaging (`myeventlane_message`)** gains a unique **`idempotency_key`**, **`claimed_at`**, and atomic **claim → dispatching → sent/failed/delivery_unknown** states in `MessagingManager` and `MessageStorage`. Queue workers release claims on hard failures; Postmark sends **`mel_message_id` metadata** and webhooks can reconcile **`delivery_unknown`** rows. Legacy rows are backfilled via updates `10006`/`10007`.
> 
> **Order confirmation** and wallet CTAs only show Apple/Google links when **official badge URLs** exist (no text fallbacks); email template and `wallet-buttons` twig/CSS align to fixed badge dimensions and 8px clear space. Minor email fixes: Commerce currency/date formatting, safer vendor logos, theme logo preference order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f18f6b3a86b6722528514ab0ba3b77cb5a0276f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->