### PR TITLE
Add organiser status notifications

### DIFF
--- a/web/themes/custom/myeventlane_vendor_theme/js/mel-status-notifications.js
+++ b/web/themes/custom/myeventlane_vendor_theme/js/mel-status-notifications.js
@@ -1,0 +1,75 @@
+/**
+ * @file
+ * Dismissal and accessible timing for organiser status notifications.
+ */
+
+(function (Drupal, once) {
+  'use strict';
+
+  Drupal.behaviors.melStatusNotifications = {
+    attach(context) {
+      once('mel-status-notice', '[data-mel-status-notice]', context).forEach(
+        (notice) => {
+          const dismissButton = notice.querySelector('[data-mel-status-dismiss]');
+          const duration = Number.parseInt(
+            notice.getAttribute('data-mel-status-auto-dismiss') || '0',
+            10,
+          );
+          let remaining = Number.isFinite(duration) ? duration : 0;
+          let startedAt = 0;
+          let timer = null;
+          let removed = false;
+
+          const removeNotice = () => {
+            if (removed) {
+              return;
+            }
+            removed = true;
+            window.clearTimeout(timer);
+            notice.classList.add('is-leaving');
+
+            const finish = () => {
+              if (notice.isConnected) {
+                notice.remove();
+              }
+            };
+
+            notice.addEventListener('transitionend', finish, { once: true });
+            window.setTimeout(finish, 240);
+          };
+
+          const startTimer = () => {
+            if (remaining <= 0 || removed) {
+              return;
+            }
+            startedAt = Date.now();
+            timer = window.setTimeout(removeNotice, remaining);
+          };
+
+          const pauseTimer = () => {
+            if (!timer) {
+              return;
+            }
+            window.clearTimeout(timer);
+            timer = null;
+            remaining = Math.max(0, remaining - (Date.now() - startedAt));
+          };
+
+          dismissButton?.addEventListener('click', removeNotice);
+
+          if (remaining > 0) {
+            notice.addEventListener('pointerenter', pauseTimer);
+            notice.addEventListener('pointerleave', startTimer);
+            notice.addEventListener('focusin', pauseTimer);
+            notice.addEventListener('focusout', (event) => {
+              if (!notice.contains(event.relatedTarget)) {
+                startTimer();
+              }
+            });
+            startTimer();
+          }
+        },
+      );
+    },
+  };
+})(Drupal, once);

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.libraries.yml
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.libraries.yml
@@ -9,6 +9,7 @@ global:
       dist/main.css: {}
   js:
     dist/main.js: { attributes: { type: module } }
+    js/mel-status-notifications.js: {}
   dependencies:
     - core/drupal
     - core/once

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-status-notifications.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_mel-status-notifications.scss
@@ -1,0 +1,184 @@
+/**
+ * Organiser status notifications.
+ *
+ * Success/info messages float below the organiser header. Warning/error
+ * messages stay in normal page flow so important guidance is not lost.
+ */
+
+.mel-status-notifications {
+  --mel-notice-bg: #fffdfb;
+  --mel-notice-border: #dfe4ea;
+  --mel-notice-ink: #293241;
+  --mel-notice-accent: #6b7280;
+
+  position: relative;
+  z-index: 35;
+}
+
+.mel-status-notifications__toasts {
+  position: fixed;
+  top: calc(var(--drupal-displace-offset-top, 0px) + 5.25rem);
+  right: 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+  width: min(25rem, calc(100vw - 3rem));
+  pointer-events: none;
+  z-index: 510;
+}
+
+.mel-status-notifications__banners {
+  display: grid;
+  gap: 0.75rem;
+  width: 100%;
+  margin-block-end: 1rem;
+}
+
+.mel-status-notice {
+  display: grid;
+  grid-template-columns: 2.5rem minmax(0, 1fr) 2.75rem;
+  align-items: start;
+  gap: 0.75rem;
+  padding: 0.875rem 0.75rem 0.875rem 1rem;
+  color: var(--mel-notice-ink);
+  background: var(--mel-notice-bg);
+  border: 1px solid var(--mel-notice-border);
+  border-left: 4px solid var(--mel-notice-accent);
+  border-radius: 1rem;
+  box-shadow: 0 12px 32px rgb(41 50 65 / 12%);
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity 180ms ease, transform 180ms ease;
+  pointer-events: auto;
+
+  &--status {
+    --mel-notice-bg: #f3fbf6;
+    --mel-notice-border: #cce8d5;
+    --mel-notice-accent: #27844f;
+  }
+
+  &--info {
+    --mel-notice-bg: #eef6ff;
+    --mel-notice-border: #cfe1f6;
+    --mel-notice-accent: #3974a8;
+  }
+
+  &--warning {
+    --mel-notice-bg: #fff8e8;
+    --mel-notice-border: #efd7a0;
+    --mel-notice-accent: #a96612;
+  }
+
+  &--error {
+    --mel-notice-bg: #fff2ef;
+    --mel-notice-border: #f2c4ba;
+    --mel-notice-accent: #b13b2c;
+  }
+
+  &--banner {
+    width: 100%;
+    box-shadow: 0 6px 18px rgb(41 50 65 / 7%);
+  }
+
+  &.is-leaving {
+    opacity: 0;
+    transform: translateY(-0.5rem);
+  }
+}
+
+.mel-status-notice__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  color: #fff;
+  background: var(--mel-notice-accent);
+  border-radius: 999px;
+  font-size: 1rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.mel-status-notice__content {
+  min-width: 0;
+  padding-block: 0.125rem;
+}
+
+.mel-status-notice__label {
+  display: block;
+  margin-block-end: 0.125rem;
+  color: var(--mel-notice-accent);
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  line-height: 1.35;
+  text-transform: uppercase;
+}
+
+.mel-status-notice__message {
+  color: var(--mel-notice-ink);
+  font-size: 0.9375rem;
+  font-weight: 650;
+  line-height: 1.45;
+
+  a {
+    color: inherit;
+    text-decoration: underline !important;
+    text-underline-offset: 0.15em;
+  }
+}
+
+.mel-status-notice__dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  margin: -0.125rem -0.125rem 0 0;
+  padding: 0;
+  color: #536174;
+  background: transparent;
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 1.5rem;
+  line-height: 1;
+
+  &:hover {
+    color: #293241;
+    background: rgb(41 50 65 / 7%);
+  }
+
+  &:focus-visible {
+    outline: 3px solid #f26d5b;
+    outline-offset: 2px;
+  }
+}
+
+@media (max-width: 47.99rem) {
+  .mel-status-notifications__toasts {
+    top: calc(var(--drupal-displace-offset-top, 0px) + 4.5rem);
+    right: 0.75rem;
+    left: 0.75rem;
+    width: auto;
+  }
+
+  .mel-status-notice {
+    grid-template-columns: 2.25rem minmax(0, 1fr) 2.75rem;
+    gap: 0.625rem;
+    padding-left: 0.75rem;
+    border-radius: 0.875rem;
+  }
+
+  .mel-status-notice__icon {
+    width: 2.25rem;
+    height: 2.25rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mel-status-notice {
+    transition: none;
+  }
+}

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
@@ -67,6 +67,7 @@
   @include meta.load-css('components/stripe-panel');
   @include meta.load-css('components/best-event');
   @include meta.load-css('components/notifications');
+  @include meta.load-css('components/mel-status-notifications');
   @include meta.load-css('components/event-table');
   @include meta.load-css('components/support-panel');
   @include meta.load-css('components/account-summary');

--- a/web/themes/custom/myeventlane_vendor_theme/templates/misc/status-messages.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/misc/status-messages.html.twig
@@ -1,0 +1,82 @@
+{#
+/**
+ * @file
+ * MyEventLane organiser notifications.
+ *
+ * Status and information messages are short-lived toasts. Warnings and errors
+ * remain in the page until the organiser dismisses them.
+ */
+#}
+
+{% set toast_types = ['status', 'info'] %}
+{% set notification_labels = {
+  status: 'Done'|t,
+  info: 'Update'|t,
+  warning: 'Needs attention'|t,
+  error: 'Something went wrong'|t
+} %}
+
+<div data-drupal-messages class="mel-status-notifications">
+  <div class="mel-status-notifications__toasts" aria-label="{{ 'Notifications'|t }}">
+    {% for type, messages in message_list %}
+      {% if type in toast_types %}
+        {% for message in messages %}
+          <section
+            class="mel-status-notice mel-status-notice--{{ type }} mel-status-notice--toast"
+            role="status"
+            aria-atomic="true"
+            data-mel-status-notice
+            data-mel-status-auto-dismiss="6000"
+          >
+            <span class="mel-status-notice__icon" aria-hidden="true">
+              {% if type == 'status' %}✓{% else %}i{% endif %}
+            </span>
+            <div class="mel-status-notice__content">
+              <span class="mel-status-notice__label">{{ notification_labels[type] }}</span>
+              <div class="mel-status-notice__message">{{ message }}</div>
+            </div>
+            <button
+              class="mel-status-notice__dismiss"
+              type="button"
+              aria-label="{{ 'Dismiss notification'|t }}"
+              data-mel-status-dismiss
+            >
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </section>
+        {% endfor %}
+      {% endif %}
+    {% endfor %}
+  </div>
+
+  <div class="mel-status-notifications__banners">
+    {% for type, messages in message_list %}
+      {% if type not in toast_types %}
+        {% for message in messages %}
+          <section
+            class="mel-status-notice mel-status-notice--{{ type }} mel-status-notice--banner"
+            role="{{ type == 'error' ? 'alert' : 'status' }}"
+            aria-atomic="true"
+            data-mel-status-notice
+          >
+            <span class="mel-status-notice__icon" aria-hidden="true">
+              {% if type == 'error' %}!{% else %}⚠{% endif %}
+            </span>
+            <div class="mel-status-notice__content">
+              <span class="mel-status-notice__label">{{ notification_labels[type]|default('Notice'|t) }}</span>
+              <div class="mel-status-notice__message">{{ message }}</div>
+            </div>
+            <button
+              class="mel-status-notice__dismiss"
+              type="button"
+              aria-label="{{ 'Dismiss notification'|t }}"
+              data-mel-status-dismiss
+            >
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </section>
+        {% endfor %}
+      {% endif %}
+    {% endfor %}
+  </div>
+</div>


### PR DESCRIPTION
## What changed
- replaces default Drupal organiser messages with MEL-styled notifications
- shows success and information messages as dismissible six-second toasts
- keeps warning and error messages visible until dismissed
- adds accessible status/alert semantics, focus-aware timing, mobile layout, and reduced-motion support

## Why
Organisers need clear confirmation after actions such as resending an order email, without the default Drupal presentation interrupting the dashboard experience.

## Validation
- vendor theme production build passed
- Twig contract render passed for status, info, warning, and error variants
- JavaScript syntax check passed
- `git diff --check` passed
- component reviewed and approved in local DEV

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to Drupal messenger output; no auth, data, or API impact.
> 
> **Overview**
> Replaces default Drupal organiser **status messages** with a custom **MEL notification** experience on the vendor theme.
> 
> **Success** and **info** messages render as fixed **toasts** (six-second auto-dismiss, manual dismiss, timer pauses on hover/focus). **Warning** and **error** messages stay as in-flow **banners** until dismissed so critical guidance is not auto-hidden.
> 
> Adds `status-messages.html.twig`, themed SCSS (toast vs banner layout, severity variants, mobile and reduced-motion), and `mel-status-notifications.js` wired through the **global** library bundle alongside existing `main.css` / `main.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89bf351bbf831614e37edd2afb62e2027d39237d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->