### PR TITLE
fix(views): complete site view audit remediation

### DIFF
--- a/config/sync/commerce_payment.commerce_payment_gateway.mel_stripe_cc.yml
+++ b/config/sync/commerce_payment.commerce_payment_gateway.mel_stripe_cc.yml
@@ -23,5 +23,5 @@ conditions:
     configuration:
       matching_strategy: any
       roles:
-        administrator: administrator
+        - administrator
 conditionOperator: AND

--- a/config/sync/core.entity_form_display.node.event.studio_branding.yml
+++ b/config/sync/core.entity_form_display.node.event.studio_branding.yml
@@ -105,13 +105,6 @@ content:
       show_crop_area: true
       show_default_crop: true
     third_party_settings: {  }
-  field_mel_event_gallery:
-    type: media_library_widget
-    weight: 14
-    region: content
-    settings:
-      media_types: {  }
-    third_party_settings: {  }
   field_mel_event_cover_media:
     type: media_library_widget
     weight: 1
@@ -119,6 +112,13 @@ content:
     settings:
       media_types:
         - image
+    third_party_settings: {  }
+  field_mel_event_gallery:
+    type: media_library_widget
+    weight: 14
+    region: content
+    settings:
+      media_types: {  }
     third_party_settings: {  }
 hidden:
   body: true

--- a/config/sync/core.entity_view_display.node.event.full.yml
+++ b/config/sync/core.entity_view_display.node.event.full.yml
@@ -186,8 +186,8 @@ hidden:
   field_location_latitude: true
   field_location_longitude: true
   field_location_place_id: true
-  field_mel_event_gallery: true
   field_mel_event_cover_media: true
+  field_mel_event_gallery: true
   field_mel_extras_book_placement: true
   field_mel_op_capabilities: true
   field_mel_page_style: true

--- a/config/sync/klaro.klaro_app.ai_alt_text_generation.yml
+++ b/config/sync/klaro.klaro_app.ai_alt_text_generation.yml
@@ -8,6 +8,9 @@ id: ai_alt_text_generation
 label: 'Drupal AI Alt Text Generation'
 description: 'This service generates alt texts for images using AI vision models. The image and metadata are sent to the selected AI service.'
 default: false
+purposes:
+  - cms
+cookies: {  }
 required: false
 opt_out: false
 only_once: false
@@ -15,11 +18,8 @@ contextual_consent_only: false
 contextual_consent_text: 'Transfer image and meta data to chosen AI service?'
 info_url: ''
 privacy_policy_url: ''
-purposes:
-  - cms
-cookies: {  }
-callback_code: ''
 javascripts: {  }
+callback_code: ''
 wrapper_identifier:
   - .ai-alt-text-generation
 attachments: {  }

--- a/config/sync/klaro.klaro_app.bluesky.yml
+++ b/config/sync/klaro.klaro_app.bluesky.yml
@@ -8,6 +8,9 @@ id: bluesky
 label: Bluesky
 description: 'Bluesky is a social media platform by Bluesky, PBLLC (USA)'
 default: false
+purposes:
+  - external_content
+cookies: {  }
 required: false
 opt_out: false
 only_once: false
@@ -15,12 +18,9 @@ contextual_consent_only: null
 contextual_consent_text: null
 info_url: 'https://bsky.social/about/faq'
 privacy_policy_url: 'https://bsky.social/about/support/privacy-policy'
-purposes:
-  - external_content
-cookies: {  }
-callback_code: ''
 javascripts:
   - embed.bsky.app
+callback_code: ''
 wrapper_identifier:
   - .bluesky-embed
 attachments: {  }

--- a/config/sync/klaro.klaro_app.cms.yml
+++ b/config/sync/klaro.klaro_app.cms.yml
@@ -8,13 +8,6 @@ id: cms
 label: Functional
 description: 'Store data (e.g. cookie for user session) in your browser (required to use this website).'
 default: true
-required: true
-opt_out: false
-only_once: false
-contextual_consent_only: null
-contextual_consent_text: null
-info_url: 'https://www.drupal.org'
-privacy_policy_url: ''
 purposes:
   - cms
 cookies:
@@ -22,8 +15,15 @@ cookies:
     regex: '^[SESS|SSESS]'
     path: ''
     domain: ''
-callback_code: ''
+required: true
+opt_out: false
+only_once: false
+contextual_consent_only: null
+contextual_consent_text: null
+info_url: 'https://www.drupal.org'
+privacy_policy_url: ''
 javascripts: {  }
+callback_code: ''
 wrapper_identifier: {  }
 attachments: {  }
 weight: -1

--- a/config/sync/klaro.klaro_app.deepchat.yml
+++ b/config/sync/klaro.klaro_app.deepchat.yml
@@ -8,13 +8,6 @@ id: deepchat
 label: Deepchat
 description: 'Deepchat is a chatbot. Your data is passed on to external AI providers. Depending on the settings, a session cookie can be written for the chat history. See the privacy policy for more information.'
 default: false
-required: false
-opt_out: false
-only_once: false
-contextual_consent_only: true
-contextual_consent_text: 'Load service chatbot Deepchat (uses session cookie and sends data to external service)?'
-info_url: ''
-privacy_policy_url: ''
 purposes:
   - livechat
 cookies:
@@ -22,8 +15,15 @@ cookies:
     regex: '^deepChatState_.*$'
     path: ''
     domain: ''
-callback_code: ''
+required: false
+opt_out: false
+only_once: false
+contextual_consent_only: true
+contextual_consent_text: 'Load service chatbot Deepchat (uses session cookie and sends data to external service)?'
+info_url: ''
+privacy_policy_url: ''
 javascripts: {  }
+callback_code: ''
 wrapper_identifier:
   - deep-chat
 attachments: {  }

--- a/config/sync/klaro.klaro_app.facebook.yml
+++ b/config/sync/klaro.klaro_app.facebook.yml
@@ -8,6 +8,9 @@ id: facebook
 label: Facebook
 description: 'Facebook is a social media platform by Meta Platforms, Inc (USA).'
 default: false
+purposes:
+  - external_content
+cookies: {  }
 required: false
 opt_out: false
 only_once: false
@@ -15,12 +18,9 @@ contextual_consent_only: null
 contextual_consent_text: null
 info_url: 'https://about.meta.com/company-info'
 privacy_policy_url: 'https://www.facebook.com/privacy/policy/'
-purposes:
-  - external_content
-cookies: {  }
-callback_code: ''
 javascripts:
   - www.facebook.com
+callback_code: ''
 wrapper_identifier: {  }
 attachments: {  }
 weight: 0

--- a/config/sync/klaro.klaro_app.ga.yml
+++ b/config/sync/klaro.klaro_app.ga.yml
@@ -8,13 +8,6 @@ id: ga
 label: 'Google Analytics'
 description: 'Tracks online visits of the website as a service.'
 default: false
-required: false
-opt_out: false
-only_once: false
-contextual_consent_only: null
-contextual_consent_text: null
-info_url: 'https://marketingplatform.google.com/intl/de/about/analytics/'
-privacy_policy_url: 'https://policies.google.com/privacy'
 purposes:
   - analytics
 cookies:
@@ -30,9 +23,16 @@ cookies:
     regex: ^IDE
     path: ''
     domain: ''
-callback_code: ''
+required: false
+opt_out: false
+only_once: false
+contextual_consent_only: null
+contextual_consent_text: null
+info_url: 'https://marketingplatform.google.com/intl/de/about/analytics/'
+privacy_policy_url: 'https://policies.google.com/privacy'
 javascripts:
   - analytics.js
+callback_code: ''
 wrapper_identifier: {  }
 attachments:
   - ga4_google_analytics

--- a/config/sync/klaro.klaro_app.google_maps.yml
+++ b/config/sync/klaro.klaro_app.google_maps.yml
@@ -8,6 +8,9 @@ id: google_maps
 label: 'Google Maps'
 description: 'Google Maps is an online map service offered by Google.'
 default: false
+purposes:
+  - external_content
+cookies: {  }
 required: false
 opt_out: false
 only_once: false
@@ -15,13 +18,10 @@ contextual_consent_only: null
 contextual_consent_text: null
 info_url: 'https://www.google.com/maps/about'
 privacy_policy_url: 'https://policies.google.com/privacy'
-purposes:
-  - external_content
-cookies: {  }
-callback_code: ''
 javascripts:
   - 'https://www.google.com/maps/embed'
   - 'https://maps.googleapis.com/maps/api/staticmap'
+callback_code: ''
 wrapper_identifier: {  }
 attachments: {  }
 weight: 0

--- a/config/sync/klaro.klaro_app.google_recaptcha.yml
+++ b/config/sync/klaro.klaro_app.google_recaptcha.yml
@@ -8,6 +8,9 @@ id: google_recaptcha
 label: 'Google reCAPTCHA'
 description: 'reCAPTCHA is a CAPTCHA system owned by Google LLC.'
 default: false
+purposes:
+  - security
+cookies: {  }
 required: false
 opt_out: false
 only_once: false
@@ -15,14 +18,11 @@ contextual_consent_only: null
 contextual_consent_text: null
 info_url: 'https://www.google.com/recaptcha/about/'
 privacy_policy_url: 'https://policies.google.com/privacy'
-purposes:
-  - security
-cookies: {  }
-callback_code: ''
 javascripts:
   - 'https://www.google.com/recaptcha/api.js'
   - 'https://www.recaptcha.net/recaptcha/api.js'
   - recaptcha.js
+callback_code: ''
 wrapper_identifier:
   - .g-recaptcha
 attachments: {  }

--- a/config/sync/klaro.klaro_app.gtm.yml
+++ b/config/sync/klaro.klaro_app.gtm.yml
@@ -8,6 +8,9 @@ id: gtm
 label: 'Google Tag Manager'
 description: 'Manages and deploys marketing tags.'
 default: false
+purposes:
+  - advertising
+cookies: {  }
 required: false
 opt_out: false
 only_once: false
@@ -15,14 +18,11 @@ contextual_consent_only: null
 contextual_consent_text: null
 info_url: 'https://marketingplatform.google.com/intl/de/about/tag-manager/'
 privacy_policy_url: 'https://policies.google.com/privacy'
-purposes:
-  - advertising
-cookies: {  }
-callback_code: ''
 javascripts:
   - gtm.js
   - gtag.js
   - 'https://www.googletagmanager.com/ns.html'
+callback_code: ''
 wrapper_identifier: {  }
 attachments:
   - gtm

--- a/config/sync/klaro.klaro_app.instagram.yml
+++ b/config/sync/klaro.klaro_app.instagram.yml
@@ -8,6 +8,9 @@ id: instagram
 label: Instagram
 description: 'Instagram is a social media platform by Meta Platforms, Inc (USA).'
 default: false
+purposes:
+  - external_content
+cookies: {  }
 required: false
 opt_out: false
 only_once: false
@@ -15,12 +18,9 @@ contextual_consent_only: null
 contextual_consent_text: null
 info_url: 'https://about.instagram.com/'
 privacy_policy_url: 'https://privacycenter.instagram.com/policy'
-purposes:
-  - external_content
-cookies: {  }
-callback_code: ''
 javascripts:
   - www.instagram.com/embed.js
+callback_code: ''
 wrapper_identifier:
   - .instagram-media
 attachments: {  }

--- a/config/sync/klaro.klaro_app.klaro.yml
+++ b/config/sync/klaro.klaro_app.klaro.yml
@@ -8,13 +8,6 @@ id: klaro
 label: 'Consent manager'
 description: 'Klaro! Cookie & Consent manager saves your consent status in the browser.'
 default: true
-required: true
-opt_out: false
-only_once: false
-contextual_consent_only: null
-contextual_consent_text: null
-info_url: 'https://github.com/klaro-org/klaro-js/blob/master/README.md'
-privacy_policy_url: ''
 purposes:
   - cms
 cookies:
@@ -22,8 +15,15 @@ cookies:
     regex: klaro
     path: ''
     domain: ''
-callback_code: ''
+required: true
+opt_out: false
+only_once: false
+contextual_consent_only: null
+contextual_consent_text: null
+info_url: 'https://github.com/klaro-org/klaro-js/blob/master/README.md'
+privacy_policy_url: ''
 javascripts: {  }
+callback_code: ''
 wrapper_identifier: {  }
 attachments: {  }
 weight: 0

--- a/config/sync/klaro.klaro_app.leaflet.yml
+++ b/config/sync/klaro.klaro_app.leaflet.yml
@@ -8,6 +8,9 @@ id: leaflet
 label: 'External Map (Leaflet)'
 description: 'This service loads external maps via Leaflet. See privacy policy for more information about the chosen map provider.'
 default: false
+purposes:
+  - external_content
+cookies: {  }
 required: false
 opt_out: false
 only_once: false
@@ -15,11 +18,8 @@ contextual_consent_only: null
 contextual_consent_text: null
 info_url: ''
 privacy_policy_url: ''
-purposes:
-  - external_content
-cookies: {  }
-callback_code: ''
 javascripts: {  }
+callback_code: ''
 wrapper_identifier: {  }
 attachments: {  }
 weight: 0

--- a/config/sync/klaro.klaro_app.linkedin.yml
+++ b/config/sync/klaro.klaro_app.linkedin.yml
@@ -8,6 +8,9 @@ id: linkedin
 label: Linkedin
 description: 'Linkedin is a social media platform by Linkedin, Inc (USA), subsidiary of Microsoft Corp. (USA).'
 default: false
+purposes:
+  - external_content
+cookies: {  }
 required: false
 opt_out: false
 only_once: false
@@ -15,12 +18,9 @@ contextual_consent_only: null
 contextual_consent_text: null
 info_url: 'https://about.linkedin.com/'
 privacy_policy_url: 'https://www.linkedin.com/legal/privacy-policy'
-purposes:
-  - external_content
-cookies: {  }
-callback_code: ''
 javascripts:
   - www.linkedin.com
+callback_code: ''
 wrapper_identifier: {  }
 attachments: {  }
 weight: 0

--- a/config/sync/klaro.klaro_app.mastodon.yml
+++ b/config/sync/klaro.klaro_app.mastodon.yml
@@ -8,6 +8,9 @@ id: mastodon
 label: 'Mastodon social.bund.de (Example)'
 description: 'Mastodon for social.bund.de - you must adapt the URL for your preferred Mastodon server.'
 default: false
+purposes:
+  - external_content
+cookies: {  }
 required: false
 opt_out: false
 only_once: false
@@ -15,12 +18,9 @@ contextual_consent_only: null
 contextual_consent_text: null
 info_url: 'https://joinmastodon.org/'
 privacy_policy_url: ''
-purposes:
-  - external_content
-cookies: {  }
-callback_code: ''
 javascripts:
   - social.bund.de
+callback_code: ''
 wrapper_identifier:
   - .mastodon-embed
 attachments: {  }

--- a/config/sync/klaro.klaro_app.mastodon_module.yml
+++ b/config/sync/klaro.klaro_app.mastodon_module.yml
@@ -8,6 +8,9 @@ id: mastodon_module
 label: Mastodon
 description: "Mastodon module for Drupal connects to given Mastodon server and stores posts in user's browser. Personal data such as IP addresses are processed."
 default: false
+purposes:
+  - external_content
+cookies: {  }
 required: false
 opt_out: false
 only_once: false
@@ -15,12 +18,9 @@ contextual_consent_only: false
 contextual_consent_text: ''
 info_url: 'https://mastodon.social/'
 privacy_policy_url: 'https://mastodon.social/privacy-policy'
-purposes:
-  - external_content
-cookies: {  }
-callback_code: ''
 javascripts:
   - mastodon.fed_embed.js
+callback_code: ''
 wrapper_identifier:
   - fed-embed
 attachments: {  }

--- a/config/sync/klaro.klaro_app.matomo.yml
+++ b/config/sync/klaro.klaro_app.matomo.yml
@@ -8,13 +8,6 @@ id: matomo
 label: Matomo
 description: 'Tracks online visits of the website.'
 default: false
-required: false
-opt_out: false
-only_once: false
-contextual_consent_only: null
-contextual_consent_text: null
-info_url: 'https://matomo.org'
-privacy_policy_url: 'https://matomo.org/privacy-policy'
 purposes:
   - analytics
 cookies:
@@ -34,9 +27,16 @@ cookies:
     regex: piwik_ignore
     path: ''
     domain: ''
-callback_code: ''
+required: false
+opt_out: false
+only_once: false
+contextual_consent_only: null
+contextual_consent_text: null
+info_url: 'https://matomo.org'
+privacy_policy_url: 'https://matomo.org/privacy-policy'
 javascripts:
   - matomo.js
+callback_code: ''
 wrapper_identifier: {  }
 attachments:
   - matomo_tracking_script

--- a/config/sync/klaro.klaro_app.matomo_cookies.yml
+++ b/config/sync/klaro.klaro_app.matomo_cookies.yml
@@ -8,13 +8,6 @@ id: matomo_cookies
 label: 'Matomo (block cookies)'
 description: 'Tracks online visits of the website.'
 default: false
-required: false
-opt_out: false
-only_once: false
-contextual_consent_only: null
-contextual_consent_text: null
-info_url: 'https://matomo.org'
-privacy_policy_url: 'https://matomo.org/privacy-policy'
 purposes:
   - analytics
 cookies:
@@ -30,8 +23,15 @@ cookies:
     regex: mtm_cookie_consent
     path: ''
     domain: ''
-callback_code: "if (typeof _paq !== 'undefined') {\r\n  if (consent == true) {\r\n    _paq.push(['rememberCookieConsentGiven']);\r\n  } else {\r\n    _paq.push(['forgetCookieConsentGiven']);\r\n  }\r\n}"
+required: false
+opt_out: false
+only_once: false
+contextual_consent_only: null
+contextual_consent_text: null
+info_url: 'https://matomo.org'
+privacy_policy_url: 'https://matomo.org/privacy-policy'
 javascripts: {  }
+callback_code: "if (typeof _paq !== 'undefined') {\r\n  if (consent == true) {\r\n    _paq.push(['rememberCookieConsentGiven']);\r\n  } else {\r\n    _paq.push(['forgetCookieConsentGiven']);\r\n  }\r\n}"
 wrapper_identifier: {  }
 attachments: {  }
 weight: 3

--- a/config/sync/klaro.klaro_app.posthog.yml
+++ b/config/sync/klaro.klaro_app.posthog.yml
@@ -8,6 +8,9 @@ id: posthog
 label: Posthog
 description: 'Posthog description'
 default: false
+purposes:
+  - analytics
+cookies: {  }
 required: false
 opt_out: false
 only_once: false
@@ -15,11 +18,8 @@ contextual_consent_only: false
 contextual_consent_text: ''
 info_url: 'https://posthog.com/docs/privacy/data-collection'
 privacy_policy_url: 'https://posthog.com/privacy'
-purposes:
-  - analytics
-cookies: {  }
-callback_code: "// NOTE: \r\n// - On initial call window.posthog and its functions may not be initialized yet:\r\n// - The posthog module detects Klaro and initializes with cookieless_mode: 'on_reject'\r\nif (window.posthog) {\r\n  if (consent === true && window.posthog.opt_in_capturing) {\r\n    window.posthog.opt_in_capturing();\r\n  }\r\n  else if (consent === false && window.posthog.opt_out_capturing) {\r\n    window.posthog.opt_out_capturing();\r\n  }\r\n}"
 javascripts: {  }
+callback_code: "// NOTE: \r\n// - On initial call window.posthog and its functions may not be initialized yet:\r\n// - The posthog module detects Klaro and initializes with cookieless_mode: 'on_reject'\r\nif (window.posthog) {\r\n  if (consent === true && window.posthog.opt_in_capturing) {\r\n    window.posthog.opt_in_capturing();\r\n  }\r\n  else if (consent === false && window.posthog.opt_out_capturing) {\r\n    window.posthog.opt_out_capturing();\r\n  }\r\n}"
 wrapper_identifier: {  }
 attachments: {  }
 weight: 0

--- a/config/sync/klaro.klaro_app.simple_popup_blocks.yml
+++ b/config/sync/klaro.klaro_app.simple_popup_blocks.yml
@@ -8,13 +8,6 @@ id: simple_popup_blocks
 label: 'Simple Popup Blocks'
 description: 'Popups that will save into a cookie if they were already opened'
 default: false
-required: false
-opt_out: false
-only_once: false
-contextual_consent_only: false
-contextual_consent_text: ''
-info_url: ''
-privacy_policy_url: ''
 purposes:
   - cms
 cookies:
@@ -22,9 +15,16 @@ cookies:
     regex: 'spb_(_.*)?'
     path: ''
     domain: ''
-callback_code: "var block = document.querySelector('.simple-popup-blocks-global');\r\nif (false == consent && block) {\r\nblock.remove()\r\n}"
+required: false
+opt_out: false
+only_once: false
+contextual_consent_only: false
+contextual_consent_text: ''
+info_url: ''
+privacy_policy_url: ''
 javascripts:
   - /simple_popup_blocks/js/simple_popup_blocks.js
+callback_code: "var block = document.querySelector('.simple-popup-blocks-global');\r\nif (false == consent && block) {\r\nblock.remove()\r\n}"
 wrapper_identifier: {  }
 attachments: {  }
 weight: 0

--- a/config/sync/klaro.klaro_app.threads.yml
+++ b/config/sync/klaro.klaro_app.threads.yml
@@ -8,6 +8,9 @@ id: threads
 label: 'Threads by Instagram'
 description: 'Threads is a social media platform by Meta Platforms, Inc (USA).'
 default: false
+purposes:
+  - external_content
+cookies: {  }
 required: false
 opt_out: false
 only_once: false
@@ -15,12 +18,9 @@ contextual_consent_only: null
 contextual_consent_text: null
 info_url: 'https://about.instagram.com/threads'
 privacy_policy_url: 'https://about.instagram.com/safety/privacy'
-purposes:
-  - external_content
-cookies: {  }
-callback_code: ''
 javascripts:
   - www.threads.net
+callback_code: ''
 wrapper_identifier:
   - .text-post-media
 attachments: {  }

--- a/config/sync/klaro.klaro_app.tiktok.yml
+++ b/config/sync/klaro.klaro_app.tiktok.yml
@@ -8,6 +8,9 @@ id: tiktok
 label: TikTok
 description: 'TikTok is a social media platform by Bytedance Ltd. (China/Cayman Islands).'
 default: false
+purposes:
+  - external_content
+cookies: {  }
 required: false
 opt_out: false
 only_once: false
@@ -15,12 +18,9 @@ contextual_consent_only: null
 contextual_consent_text: null
 info_url: 'https://www.tiktok.com/about'
 privacy_policy_url: 'https://www.tiktok.com/legal/privacy-policy-row'
-purposes:
-  - external_content
-cookies: {  }
-callback_code: ''
 javascripts:
   - www.tiktok.com
+callback_code: ''
 wrapper_identifier:
   - .tiktok-embed
 attachments: {  }

--- a/config/sync/klaro.klaro_app.umami.yml
+++ b/config/sync/klaro.klaro_app.umami.yml
@@ -8,6 +8,9 @@ id: umami
 label: Umami
 description: 'Tracks online visits of the website.'
 default: false
+purposes:
+  - analytics
+cookies: {  }
 required: false
 opt_out: false
 only_once: false
@@ -15,12 +18,9 @@ contextual_consent_only: false
 contextual_consent_text: ''
 info_url: 'https://umami.is'
 privacy_policy_url: 'https://umami.is/privacy'
-purposes:
-  - analytics
-cookies: {  }
-callback_code: ''
 javascripts:
   - umami.js
+callback_code: ''
 wrapper_identifier: {  }
 attachments:
   - umami_analytics_tracking_script

--- a/config/sync/klaro.klaro_app.vimeo.yml
+++ b/config/sync/klaro.klaro_app.vimeo.yml
@@ -8,6 +8,9 @@ id: vimeo
 label: Vimeo
 description: 'Vimeo is a video sharing platform by Vimeo, LLC (USA).'
 default: false
+purposes:
+  - external_content
+cookies: {  }
 required: false
 opt_out: false
 only_once: false
@@ -15,12 +18,9 @@ contextual_consent_only: null
 contextual_consent_text: null
 info_url: 'https://vimeo.com/'
 privacy_policy_url: 'https://vimeo.com/privacy'
-purposes:
-  - external_content
-cookies: {  }
-callback_code: ''
 javascripts:
   - vimeo.com
+callback_code: ''
 wrapper_identifier: {  }
 attachments: {  }
 weight: 0

--- a/config/sync/klaro.klaro_app.x.yml
+++ b/config/sync/klaro.klaro_app.x.yml
@@ -8,6 +8,9 @@ id: x
 label: X
 description: 'X (formerly known as Twitter) is a social media platform by X Corp. (USA).'
 default: false
+purposes:
+  - external_content
+cookies: {  }
 required: false
 opt_out: false
 only_once: false
@@ -15,12 +18,9 @@ contextual_consent_only: null
 contextual_consent_text: null
 info_url: 'https://x.com/'
 privacy_policy_url: 'https://x.com/en/privacy'
-purposes:
-  - external_content
-cookies: {  }
-callback_code: ''
 javascripts:
   - platform.twitter.com/widgets.js
+callback_code: ''
 wrapper_identifier:
   - .twitter-tweet
 attachments: {  }

--- a/config/sync/klaro.klaro_app.youtube.yml
+++ b/config/sync/klaro.klaro_app.youtube.yml
@@ -8,6 +8,9 @@ id: youtube
 label: YouTube
 description: 'YouTube is an online video sharing platform owned by Google.'
 default: false
+purposes:
+  - external_content
+cookies: {  }
 required: false
 opt_out: false
 only_once: false
@@ -15,15 +18,12 @@ contextual_consent_only: null
 contextual_consent_text: null
 info_url: 'https://www.youtube.com/'
 privacy_policy_url: 'https://www.youtube.com/howyoutubeworks/our-commitments/protecting-user-data/'
-purposes:
-  - external_content
-cookies: {  }
-callback_code: ''
 javascripts:
   - youtube.com
   - youtu.be
   - youtube-nocookie.com
   - ytimg.com
+callback_code: ''
 wrapper_identifier: {  }
 attachments: {  }
 weight: 0

--- a/config/sync/user.role.vendor.yml
+++ b/config/sync/user.role.vendor.yml
@@ -105,8 +105,8 @@ permissions:
   - manage_refunds
   - 'purchase boost for events'
   - request_refunds
-  - 'resolve vendor escalations'
   - 'resend ticket emails'
+  - 'resolve vendor escalations'
   - 'reuse mel_ticket_type entities'
   - 'scan qr codes'
   - 'toggle check-in status'

--- a/config/sync/views.view.events_calendar.yml
+++ b/config/sync/views.view.events_calendar.yml
@@ -29,6 +29,7 @@ display:
     display_plugin: default
     position: 0
     display_options:
+      title: 'Events Calendar'
       fields:
         title:
           id: title

--- a/config/sync/views.view.mel_organiser_hub_admin.yml
+++ b/config/sync/views.view.mel_organiser_hub_admin.yml
@@ -128,64 +128,6 @@ display:
       query:
         type: views_query
         options: {  }
-  page_coverage:
-    id: page_coverage
-    display_title: Coverage
-    display_plugin: page
-    position: 3
-    display_options:
-      title: 'Organiser Hub coverage'
-      fields:
-        name:
-          id: name
-          table: taxonomy_term_field_data
-          field: name
-          entity_type: taxonomy_term
-          entity_field: name
-          plugin_id: term_name
-          label: Category
-          type: string
-          settings:
-            link_to_entity: false
-        organiser_hub_category_coverage:
-          id: organiser_hub_category_coverage
-          table: taxonomy_term_field_data
-          field: organiser_hub_category_coverage
-          plugin_id: organiser_hub_category_coverage
-          label: Coverage
-      pager:
-        type: none
-        options:
-          offset: 0
-      sorts:
-        name:
-          id: name
-          table: taxonomy_term_field_data
-          field: name
-          order: ASC
-      filters:
-        vid:
-          id: vid
-          table: taxonomy_term_field_data
-          field: vid
-          plugin_id: bundle
-          value:
-            organiser_hub_categories: organiser_hub_categories
-      defaults:
-        title: false
-        pager: false
-        fields: false
-        sorts: false
-        filters: false
-      display_extenders: {  }
-      path: admin/content/organiser-hub/coverage
-      menu:
-        type: tab
-        title: Coverage
-        weight: 5
-        menu_name: admin
-      base_table: taxonomy_term_field_data
-      base_field: tid
   page_editorial:
     id: page_editorial
     display_title: Editorial

--- a/config/sync/views.view.mel_organiser_hub_coverage.yml
+++ b/config/sync/views.view.mel_organiser_hub_coverage.yml
@@ -1,0 +1,93 @@
+uuid: 3b73e0f6-abf6-4ed7-8833-a3d07fa12adf
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.organiser_hub_categories
+  module:
+    - myeventlane_front
+    - taxonomy
+    - user
+id: mel_organiser_hub_coverage
+label: 'MEL Organiser Hub Coverage'
+module: views
+description: 'Category coverage report for the organiser hub.'
+tag: myeventlane_front
+base_table: taxonomy_term_field_data
+base_field: tid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Organiser Hub coverage'
+      fields:
+        name:
+          id: name
+          table: taxonomy_term_field_data
+          field: name
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: term_name
+          label: Category
+          type: string
+          settings:
+            link_to_entity: false
+        organiser_hub_category_coverage:
+          id: organiser_hub_category_coverage
+          table: taxonomy_term_field_data
+          field: organiser_hub_category_coverage
+          plugin_id: organiser_hub_category_coverage
+          label: Coverage
+      pager:
+        type: none
+        options:
+          offset: 0
+      access:
+        type: perm
+        options:
+          perm: 'access content overview'
+      cache:
+        type: tag
+        options: {  }
+      sorts:
+        name:
+          id: name
+          table: taxonomy_term_field_data
+          field: name
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: standard
+          order: ASC
+      filters:
+        vid:
+          id: vid
+          table: taxonomy_term_field_data
+          field: vid
+          entity_type: taxonomy_term
+          entity_field: vid
+          plugin_id: bundle
+          value:
+            organiser_hub_categories: organiser_hub_categories
+      style:
+        type: table
+      row:
+        type: fields
+      query:
+        type: views_query
+        options: {  }
+  page_coverage:
+    id: page_coverage
+    display_title: Coverage
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/content/organiser-hub/coverage
+      menu:
+        type: tab
+        title: Coverage
+        weight: 5
+        menu_name: admin

--- a/config/sync/views.view.myeventlane_vendor_rsvps.yml
+++ b/config/sync/views.view.myeventlane_vendor_rsvps.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   module:
     - myeventlane_rsvp
+    - node
 _core:
   default_config_hash: KGpDY6o5J9ozP542Ol6yWt9B2baiT_uW0LO99v62g10
 id: myeventlane_vendor_rsvps
@@ -46,6 +47,14 @@ display:
           field: changed
           plugin_id: date
           label: Updated
+        event_title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: event_id
+          plugin_id: field
+          label: Event
+          empty: 'Legacy / unknown event'
       pager:
         type: full
         options:
@@ -103,6 +112,7 @@ display:
             attendee_name: attendee_name
             status: status
             changed: changed
+            event_title: event_title
           default: changed
           info:
             id:
@@ -119,6 +129,11 @@ display:
               empty_column: false
             changed:
               sortable: true
+              default_sort_order: desc
+              align: ''
+              empty_column: false
+            event_title:
+              sortable: true
               align: ''
               empty_column: false
       row:
@@ -127,7 +142,24 @@ display:
       query:
         type: views_query
         options: {  }
+      relationships:
+        event_id:
+          id: event_id
+          table: rsvp_submission
+          field: event_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          required: false
       display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+      tags: {  }
   page_1:
     id: page_1
     display_title: Page
@@ -141,3 +173,10 @@ display:
       path: dashboard/rsvps
       menu:
         type: none
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+      tags: {  }

--- a/config/sync/views.view.upcoming_events.yml
+++ b/config/sync/views.view.upcoming_events.yml
@@ -2171,10 +2171,10 @@ display:
           plugin_id: mel_event_no_end_upcoming
           group: 2
           exposed: false
-        field_event_type:
-          id: field_event_type
+        field_event_type_value:
+          id: field_event_type_value
           table: node__field_event_type
-          field: field_event_type
+          field: field_event_type_value
           relationship: none
           group_type: group
           admin_label: ''
@@ -3143,10 +3143,10 @@ display:
           plugin_id: mel_event_no_end_upcoming
           group: 2
           exposed: false
-        field_event_type:
-          id: field_event_type
+        field_event_type_value:
+          id: field_event_type_value
           table: node__field_event_type
-          field: field_event_type
+          field: field_event_type_value
           relationship: none
           group_type: group
           admin_label: ''

--- a/web/modules/custom/myeventlane_attendee/src/Repository/TicketAttendeeRepository.php
+++ b/web/modules/custom/myeventlane_attendee/src/Repository/TicketAttendeeRepository.php
@@ -63,7 +63,10 @@ final class TicketAttendeeRepository implements AttendeeRepositoryInterface {
         ->accessCheck(FALSE)
         ->condition('event', $eventId)
         ->condition('source', EventAttendee::SOURCE_TICKET)
-        ->condition('status', EventAttendee::STATUS_CONFIRMED)
+        ->condition('status', [
+          EventAttendee::STATUS_CONFIRMED,
+          EventAttendee::STATUS_CHECKED_IN,
+        ], 'IN')
         ->execute();
 
       if (empty($ids)) {
@@ -111,7 +114,10 @@ final class TicketAttendeeRepository implements AttendeeRepositoryInterface {
         if ($attendee instanceof EventAttendee
           && $attendee->getEventId() === $eventId
           && $attendee->getSource() === EventAttendee::SOURCE_TICKET
-          && $attendee->getStatus() === EventAttendee::STATUS_CONFIRMED) {
+          && in_array($attendee->getStatus(), [
+            EventAttendee::STATUS_CONFIRMED,
+            EventAttendee::STATUS_CHECKED_IN,
+          ], TRUE)) {
           $vm = $this->vendorPresentation->buildVendorRowFromEventAttendee($attendee);
           return new TicketAttendee(
             $attendee,
@@ -128,7 +134,10 @@ final class TicketAttendeeRepository implements AttendeeRepositoryInterface {
         ->accessCheck(FALSE)
         ->condition('event', $eventId)
         ->condition('source', EventAttendee::SOURCE_TICKET)
-        ->condition('status', EventAttendee::STATUS_CONFIRMED)
+        ->condition('status', [
+          EventAttendee::STATUS_CONFIRMED,
+          EventAttendee::STATUS_CHECKED_IN,
+        ], 'IN')
         ->condition('ticket_code', $identifier)
         ->range(0, 1)
         ->execute();
@@ -151,7 +160,10 @@ final class TicketAttendeeRepository implements AttendeeRepositoryInterface {
         ->accessCheck(FALSE)
         ->condition('event', $eventId)
         ->condition('source', EventAttendee::SOURCE_TICKET)
-        ->condition('status', EventAttendee::STATUS_CONFIRMED)
+        ->condition('status', [
+          EventAttendee::STATUS_CONFIRMED,
+          EventAttendee::STATUS_CHECKED_IN,
+        ], 'IN')
         ->condition('email', $identifier)
         ->range(0, 1)
         ->execute();
@@ -192,7 +204,10 @@ final class TicketAttendeeRepository implements AttendeeRepositoryInterface {
         ->accessCheck(FALSE)
         ->condition('event', $eventId)
         ->condition('source', EventAttendee::SOURCE_TICKET)
-        ->condition('status', EventAttendee::STATUS_CONFIRMED)
+        ->condition('status', [
+          EventAttendee::STATUS_CONFIRMED,
+          EventAttendee::STATUS_CHECKED_IN,
+        ], 'IN')
         ->count()
         ->execute();
     }
@@ -217,8 +232,7 @@ final class TicketAttendeeRepository implements AttendeeRepositoryInterface {
         ->accessCheck(FALSE)
         ->condition('event', $eventId)
         ->condition('source', EventAttendee::SOURCE_TICKET)
-        ->condition('status', EventAttendee::STATUS_CONFIRMED)
-        ->condition('checked_in', TRUE)
+        ->condition('status', EventAttendee::STATUS_CHECKED_IN)
         ->count()
         ->execute();
     }

--- a/web/modules/custom/myeventlane_checkin/tests/src/Unit/CheckInRepositoryActiveStatusContractTest.php
+++ b/web/modules/custom/myeventlane_checkin/tests/src/Unit/CheckInRepositoryActiveStatusContractTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_checkin\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects legacy check-in visibility for active ticket attendees.
+ *
+ * @group myeventlane_checkin
+ */
+final class CheckInRepositoryActiveStatusContractTest extends TestCase {
+
+  public function testTicketRepositoryRetainsCheckedInAttendees(): void {
+    $root = dirname(__DIR__, 7);
+    $repository = file_get_contents($root . '/web/modules/custom/myeventlane_attendee/src/Repository/TicketAttendeeRepository.php');
+
+    self::assertIsString($repository);
+    self::assertGreaterThanOrEqual(
+      5,
+      substr_count($repository, 'EventAttendee::STATUS_CHECKED_IN'),
+    );
+    self::assertStringContainsString(
+      "EventAttendee::STATUS_CHECKED_IN,\n        ], 'IN')",
+      $repository,
+    );
+    self::assertStringContainsString(
+      "->condition('status', EventAttendee::STATUS_CHECKED_IN)",
+      $repository,
+    );
+    self::assertStringNotContainsString(
+      "->condition('checked_in', TRUE)",
+      $repository,
+    );
+  }
+
+}

--- a/web/modules/custom/myeventlane_event/tests/src/Unit/CalendarViewContractTest.php
+++ b/web/modules/custom/myeventlane_event/tests/src/Unit/CalendarViewContractTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects MyEventLane's calendar title and wall-clock datetime contract.
+ *
+ * @group myeventlane_event
+ */
+final class CalendarViewContractTest extends TestCase {
+
+  public function testCalendarHasDocumentTitleAndCanonicalTimeCorrection(): void {
+    $moduleRoot = dirname(__DIR__, 3);
+    $webRoot = dirname($moduleRoot, 3);
+    $viewConfig = (string) file_get_contents($webRoot . '/../config/sync/views.view.events_calendar.yml');
+    $theme = (string) file_get_contents($webRoot . '/themes/custom/myeventlane_theme/myeventlane_theme.theme');
+
+    $this->assertStringContainsString("title: 'Events Calendar'", $viewConfig);
+    $this->assertStringContainsString("\$event_times[\$entity->id()][]", $theme);
+    $this->assertStringContainsString("\$event['start'] = \$canonical_times['start'];", $theme);
+    $this->assertStringContainsString("\$event['end'] = \$canonical_times['end'];", $theme);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event/tests/src/Unit/PublicDiscoveryViewContractTest.php
+++ b/web/modules/custom/myeventlane_event/tests/src/Unit/PublicDiscoveryViewContractTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects public discovery filters and sparse-result placement.
+ *
+ * @group myeventlane_event
+ */
+final class PublicDiscoveryViewContractTest extends TestCase {
+
+  public function testTicketTypeUsesValidViewsFilterHandler(): void {
+    $moduleRoot = dirname(__DIR__, 3);
+    $webRoot = dirname($moduleRoot, 3);
+    $config = (string) file_get_contents($webRoot . '/../config/sync/views.view.upcoming_events.yml');
+
+    $this->assertSame(2, substr_count($config, "field_event_type_value:\n          id: field_event_type_value"));
+    $this->assertSame(2, substr_count($config, "field: field_event_type_value"));
+    $this->assertStringNotContainsString("field_event_type:\n          id: field_event_type", $config);
+    $this->assertStringContainsString('identifier: event_type', $config);
+  }
+
+  public function testSparseDiscoveryGridsHaveDeliberateDesktopPlacement(): void {
+    $moduleRoot = dirname(__DIR__, 3);
+    $webRoot = dirname($moduleRoot, 3);
+    $styles = (string) file_get_contents(
+      $webRoot . '/themes/custom/myeventlane_theme/src/scss/pages/_discovery.scss',
+    );
+
+    $this->assertStringContainsString(':has(> :only-child)', $styles);
+    $this->assertStringContainsString(':has(> :first-child:nth-last-child(2))', $styles);
+    $this->assertStringContainsString(':has(> :first-child:nth-last-child(3))', $styles);
+    $this->assertStringContainsString('justify-content: center;', $styles);
+  }
+
+  public function testBrowseResultGrammarAndResetStateAreExplicit(): void {
+    $moduleRoot = dirname(__DIR__, 3);
+    $webRoot = dirname($moduleRoot, 3);
+    $themeRoot = $webRoot . '/themes/custom/myeventlane_theme';
+    $preprocess = (string) file_get_contents($themeRoot . '/myeventlane_theme.theme');
+    $view = (string) file_get_contents(
+      $themeRoot . '/templates/views/views-view--upcoming-events--page-events.html.twig',
+    );
+
+    $this->assertStringContainsString('$variables[\'mel_browse_active_filters\'] = FALSE;', $preprocess);
+    $this->assertStringContainsString("formatPlural(\n      (int) \$total,\n      '1 event',", $preprocess);
+    $this->assertStringContainsString('mel_browse_result_count_label|default', $view);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioOrdersPresentationContractTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioOrdersPresentationContractTest.php
@@ -37,4 +37,17 @@ final class EventStudioOrdersPresentationContractTest extends TestCase {
     self::assertStringContainsString("{{ 'Fees'|t }} {{ row.fees }}", $template);
   }
 
+  public function testStudioOrdersDescribeAllEventLinkedItemsAccurately(): void {
+    $root = dirname(__DIR__, 7);
+    $template = file_get_contents($root . '/web/themes/custom/myeventlane_vendor_theme/templates/event/orders.html.twig');
+
+    self::assertIsString($template);
+    self::assertStringContainsString("{{ 'Items sold'|t }}", $template);
+    self::assertStringContainsString("{{ 'Gross sales'|t }}", $template);
+    self::assertStringContainsString("{{ 'Items'|t }}", $template);
+    self::assertStringNotContainsString("{{ 'Tickets sold'|t }}", $template);
+    self::assertStringNotContainsString("{{ 'Gross ticket sales'|t }}", $template);
+    self::assertStringNotContainsString("{{ 'Tickets'|t }}", $template);
+  }
+
 }

--- a/web/modules/custom/myeventlane_front/src/Plugin/views/field/OrganiserHubCategoryCoverage.php
+++ b/web/modules/custom/myeventlane_front/src/Plugin/views/field/OrganiserHubCategoryCoverage.php
@@ -44,7 +44,14 @@ final class OrganiserHubCategoryCoverage extends FieldPluginBase {
   /**
    * {@inheritdoc}
    */
-  public function render(ResultRow $values): string {
+  public function query() {
+    // This is a calculated presentation field, not a database column.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(ResultRow $values): array|string {
     $entity = $values->_entity ?? NULL;
     if (!$entity instanceof TermInterface) {
       return '';
@@ -54,11 +61,15 @@ final class OrganiserHubCategoryCoverage extends FieldPluginBase {
       return $this->t('No data');
     }
     $gap = !empty($row['gap']) ? ' <span class="status status--warning">' . $this->t('Gap') . '</span>' : '';
-    return $this->t('Playbooks: @p · Articles: @a · Downloads: @d', [
+    $summary = $this->t('Playbooks: @p · Articles: @a · Downloads: @d', [
       '@p' => (string) $row['playbook_count'],
       '@a' => (string) $row['article_count'],
       '@d' => (string) $row['download_count'],
-    ]) . $gap;
+    ]);
+    if ($gap === '') {
+      return (string) $summary;
+    }
+    return ['#markup' => $summary . $gap];
   }
 
   /**

--- a/web/modules/custom/myeventlane_front/src/Plugin/views/field/OrganiserHubCompleteness.php
+++ b/web/modules/custom/myeventlane_front/src/Plugin/views/field/OrganiserHubCompleteness.php
@@ -41,17 +41,24 @@ final class OrganiserHubCompleteness extends FieldPluginBase {
   /**
    * {@inheritdoc}
    */
-  public function render(ResultRow $values): string {
+  public function query() {
+    // This is a calculated presentation field, not a database column.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(ResultRow $values): array|string {
     $node = $this->getNode($values);
     if ($node === NULL) {
       return '';
     }
     $warnings = $this->editorial->getCompletenessWarnings($node);
     if ($warnings === []) {
-      return '<span class="status status--enabled">' . $this->t('Complete') . '</span>';
+      return ['#markup' => '<span class="status status--enabled">' . $this->t('Complete') . '</span>'];
     }
     $items = array_map(static fn (string $warning): string => '<li>' . htmlspecialchars($warning, ENT_QUOTES) . '</li>', $warnings);
-    return '<ul class="mel-organiser-hub-admin__warnings"><li class="visually-hidden">' . $this->t('Editorial warnings') . '</li>' . implode('', $items) . '</ul>';
+    return ['#markup' => '<ul class="mel-organiser-hub-admin__warnings"><li class="visually-hidden">' . $this->t('Editorial warnings') . '</li>' . implode('', $items) . '</ul>'];
   }
 
   private function getNode(ResultRow $values): ?NodeInterface {

--- a/web/modules/custom/myeventlane_front/src/Plugin/views/field/OrganiserHubDownloadCount.php
+++ b/web/modules/custom/myeventlane_front/src/Plugin/views/field/OrganiserHubDownloadCount.php
@@ -39,6 +39,13 @@ final class OrganiserHubDownloadCount extends FieldPluginBase {
   /**
    * {@inheritdoc}
    */
+  public function query() {
+    // This is a calculated presentation field, not a database column.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function render(ResultRow $values): string {
     $entity = $values->_entity ?? NULL;
     if (!$entity instanceof NodeInterface) {

--- a/web/modules/custom/myeventlane_front/src/Plugin/views/field/OrganiserHubLinkingIssues.php
+++ b/web/modules/custom/myeventlane_front/src/Plugin/views/field/OrganiserHubLinkingIssues.php
@@ -39,17 +39,24 @@ final class OrganiserHubLinkingIssues extends FieldPluginBase {
   /**
    * {@inheritdoc}
    */
-  public function render(ResultRow $values): string {
+  public function query() {
+    // This is a calculated presentation field, not a database column.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(ResultRow $values): array|string {
     $entity = $values->_entity ?? NULL;
     if (!$entity instanceof NodeInterface) {
       return '';
     }
     $issues = $this->editorial->getLinkingIssues($entity);
     if ($issues === []) {
-      return '<span class="status status--enabled">' . $this->t('OK') . '</span>';
+      return ['#markup' => '<span class="status status--enabled">' . $this->t('OK') . '</span>'];
     }
     $items = array_map(static fn (string $issue): string => '<li>' . htmlspecialchars($issue, ENT_QUOTES) . '</li>', $issues);
-    return '<ul class="mel-organiser-hub-admin__warnings">' . implode('', $items) . '</ul>';
+    return ['#markup' => '<ul class="mel-organiser-hub-admin__warnings">' . implode('', $items) . '</ul>'];
   }
 
 }

--- a/web/modules/custom/myeventlane_front/tests/src/Unit/HomepageSparseRailContractTest.php
+++ b/web/modules/custom/myeventlane_front/tests/src/Unit/HomepageSparseRailContractTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_front\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects empty and sparse homepage rail presentation.
+ *
+ * @group myeventlane_front
+ */
+final class HomepageSparseRailContractTest extends TestCase {
+
+  public function testLatestRailUsesRealResultsGate(): void {
+    $moduleRoot = dirname(__DIR__, 3);
+    $webRoot = dirname($moduleRoot, 3);
+    $themeRoot = $webRoot . '/themes/custom/myeventlane_theme';
+    $preprocess = (string) file_get_contents($themeRoot . '/myeventlane_theme.theme');
+    $frontPage = (string) file_get_contents($themeRoot . '/templates/page--front.html.twig');
+
+    $this->assertStringContainsString(
+      "viewDisplayHasResults('upcoming_events', 'homepage_latest')",
+      $preprocess,
+    );
+    $this->assertStringContainsString(
+      '{% if mel_home_show_latest|default(false) %}',
+      $frontPage,
+    );
+    $this->assertStringNotContainsString('{% if page.homepage_latest %}', $frontPage);
+  }
+
+  public function testSparseRailsRetainResponsiveLayoutContract(): void {
+    $moduleRoot = dirname(__DIR__, 3);
+    $webRoot = dirname($moduleRoot, 3);
+    $themeRoot = $webRoot . '/themes/custom/myeventlane_theme';
+    $styles = (string) file_get_contents($themeRoot . '/src/scss/pages/_front-page.scss');
+    $carousel = (string) file_get_contents($themeRoot . '/src/js/card-carousel.js');
+
+    $this->assertStringContainsString('&:has(> :only-child)', $styles);
+    $this->assertStringContainsString('&:has(> :first-child:nth-last-child(2))', $styles);
+    $this->assertStringContainsString('grid-template-columns: 1fr;', $styles);
+    $this->assertStringContainsString('centeredInsufficientSlides: true', $carousel);
+    $this->assertStringContainsString('watchOverflow: true', $carousel);
+
+    $featured = (string) file_get_contents(
+      $themeRoot . '/templates/views/views-view-unformatted--front-featured-events--block-featured.html.twig',
+    );
+    $this->assertStringContainsString(
+      "'mel-card-carousel--spotlight mel-card-carousel--count-' ~ carousel_items|length",
+      $featured,
+    );
+    $this->assertStringContainsString('.mel-card-carousel--count-2 .swiper-wrapper', $styles);
+  }
+
+}

--- a/web/modules/custom/myeventlane_front/tests/src/Unit/OrganiserHubAdminViewsContractTest.php
+++ b/web/modules/custom/myeventlane_front/tests/src/Unit/OrganiserHubAdminViewsContractTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_front\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Protects the Organiser Hub administration Views contract.
+ *
+ * @group myeventlane_front
+ */
+final class OrganiserHubAdminViewsContractTest extends TestCase {
+
+  public function testCoverageUsesItsOwnTaxonomyBasedView(): void {
+    $root = dirname(__DIR__, 7);
+    $editorial = Yaml::parseFile($root . '/config/sync/views.view.mel_organiser_hub_admin.yml');
+    $coverage = Yaml::parseFile($root . '/config/sync/views.view.mel_organiser_hub_coverage.yml');
+
+    self::assertSame('node_field_data', $editorial['base_table']);
+    self::assertArrayNotHasKey('page_coverage', $editorial['display']);
+    self::assertSame('taxonomy_term_field_data', $coverage['base_table']);
+    self::assertSame(
+      'admin/content/organiser-hub/coverage',
+      $coverage['display']['page_coverage']['display_options']['path'],
+    );
+    self::assertSame(
+      'access content overview',
+      $coverage['display']['default']['display_options']['access']['options']['perm'],
+    );
+  }
+
+  public function testCalculatedFieldsDoNotAddDatabaseColumns(): void {
+    $root = dirname(__DIR__, 7);
+    $pluginDirectory = $root . '/web/modules/custom/myeventlane_front/src/Plugin/views/field/';
+
+    foreach ([
+      'OrganiserHubCategoryCoverage.php',
+      'OrganiserHubCompleteness.php',
+      'OrganiserHubDownloadCount.php',
+      'OrganiserHubLinkingIssues.php',
+    ] as $plugin) {
+      $source = file_get_contents($pluginDirectory . $plugin);
+      self::assertIsString($source);
+      self::assertStringContainsString('public function query()', $source, $plugin);
+      self::assertStringNotContainsString('parent::query()', $source, $plugin);
+    }
+  }
+
+  public function testCalculatedMarkupUsesRenderArrays(): void {
+    $root = dirname(__DIR__, 7);
+    $pluginDirectory = $root . '/web/modules/custom/myeventlane_front/src/Plugin/views/field/';
+
+    foreach ([
+      'OrganiserHubCategoryCoverage.php',
+      'OrganiserHubCompleteness.php',
+      'OrganiserHubLinkingIssues.php',
+    ] as $plugin) {
+      $source = file_get_contents($pluginDirectory . $plugin);
+      self::assertIsString($source);
+      self::assertStringContainsString("return ['#markup' =>", $source, $plugin);
+    }
+  }
+
+}

--- a/web/modules/custom/myeventlane_rsvp/config/install/views.view.myeventlane_vendor_rsvps.yml
+++ b/web/modules/custom/myeventlane_rsvp/config/install/views.view.myeventlane_vendor_rsvps.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   module:
     - myeventlane_rsvp
+    - node
 id: myeventlane_vendor_rsvps
 label: 'Vendor RSVP Submissions'
 module: views
@@ -23,6 +24,17 @@ display:
 
       title: 'RSVP Submissions'
 
+      relationships:
+        event_id:
+          id: event_id
+          table: rsvp_submission
+          field: event_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          required: false
+
       access:
         type: myeventlane_rsvp_vendor_access
         options: { }
@@ -30,6 +42,19 @@ display:
       cache:
         type: tag
         options: { }
+
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: '<div class="mel-vendor-rsvps__empty" role="status"><h2>No RSVPs yet</h2><p>RSVPs will appear here as people respond. You can share your event link from the Event Editor.</p></div>'
+          tokenize: false
 
       query:
         type: views_query
@@ -46,12 +71,17 @@ display:
         options:
           columns:
             id: id
+            event_title: event_title
             attendee_name: attendee_name
             status: status
             changed: changed
           default: changed
           info:
             id:
+              sortable: true
+              align: ''
+              empty_column: false
+            event_title:
               sortable: true
               align: ''
               empty_column: false
@@ -65,6 +95,7 @@ display:
               empty_column: false
             changed:
               sortable: true
+              default_sort_order: desc
               align: ''
               empty_column: false
 
@@ -80,6 +111,15 @@ display:
           field: id
           label: 'RSVP ID'
           plugin_id: numeric
+
+        event_title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: event_id
+          label: 'Event'
+          empty: 'Legacy / unknown event'
+          plugin_id: field
 
         attendee_name:
           id: attendee_name

--- a/web/modules/custom/myeventlane_rsvp/tests/src/Unit/VendorRsvpViewConfigTest.php
+++ b/web/modules/custom/myeventlane_rsvp/tests/src/Unit/VendorRsvpViewConfigTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_rsvp\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects aggregate organiser RSVP View presentation and isolation.
+ *
+ * @group myeventlane_rsvp
+ */
+final class VendorRsvpViewConfigTest extends TestCase {
+
+  public function testAggregateViewShowsEventAndDefaultsToNewestFirst(): void {
+    $config = (string) file_get_contents(dirname(__DIR__, 3) . '/config/install/views.view.myeventlane_vendor_rsvps.yml');
+
+    $this->assertStringContainsString('organiser_owned:', $config);
+    $this->assertStringContainsString('relationship: event_id', $config);
+    $this->assertStringContainsString("empty: 'Legacy / unknown event'", $config);
+    $this->assertStringContainsString('No RSVPs yet', $config);
+    $this->assertStringContainsString('default_sort_order: desc', $config);
+  }
+
+}

--- a/web/modules/custom/myeventlane_surface/src/MelWorkflowRegistry.php
+++ b/web/modules/custom/myeventlane_surface/src/MelWorkflowRegistry.php
@@ -78,7 +78,7 @@ final class MelWorkflowRegistry {
         accessibilityNotes: 'Use clear heading hierarchy for saved lists; empty states describe next save action.',
         activationExactRoutes: ['view.mel_saved_events.page_1'],
         activationPathPrefixes: ['/my-saved-events'],
-        primaryCtaRouteName: 'view.mel_saved_events.page_1',
+        primaryCtaRouteName: 'view.upcoming_events.page_events',
         primaryCtaTitle: 'Browse events',
         delegateVendorNextStepToOnboardingManager: FALSE,
       ),

--- a/web/modules/custom/myeventlane_surface/tests/src/Unit/MelSavedEventsWorkflowContractTest.php
+++ b/web/modules/custom/myeventlane_surface/tests/src/Unit/MelSavedEventsWorkflowContractTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_surface\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the Saved Events continuation path.
+ *
+ * @group myeventlane_surface
+ */
+final class MelSavedEventsWorkflowContractTest extends TestCase {
+
+  public function testBrowseEventsActionDoesNotLoopBackToSavedEvents(): void {
+    $moduleRoot = dirname(__DIR__, 3);
+    $registry = (string) file_get_contents($moduleRoot . '/src/MelWorkflowRegistry.php');
+    $savedWorkflowStart = strpos($registry, "'first_saved_event' =>");
+    $this->assertNotFalse($savedWorkflowStart);
+    $savedWorkflowEnd = strpos($registry, "'calendar_connected' =>", $savedWorkflowStart);
+    $this->assertNotFalse($savedWorkflowEnd);
+    $savedWorkflow = substr($registry, $savedWorkflowStart, $savedWorkflowEnd - $savedWorkflowStart);
+
+    $this->assertStringContainsString(
+      "primaryCtaRouteName: 'view.upcoming_events.page_events'",
+      $savedWorkflow,
+    );
+    $this->assertStringContainsString("primaryCtaTitle: 'Browse events'", $savedWorkflow);
+    $this->assertStringNotContainsString(
+      "primaryCtaRouteName: 'view.mel_saved_events.page_1'",
+      $savedWorkflow,
+    );
+  }
+
+}

--- a/web/modules/custom/myeventlane_views/src/Controller/AttendeeCsvController.php
+++ b/web/modules/custom/myeventlane_views/src/Controller/AttendeeCsvController.php
@@ -7,6 +7,7 @@ namespace Drupal\myeventlane_views\Controller;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Routing\LocalRedirectResponse;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\myeventlane_event_attendees\Service\MelAttendeeExportBuilder;
 use Drupal\myeventlane_vendor\Service\EventVendorAccessCheckerInterface;
@@ -56,12 +57,13 @@ final class AttendeeCsvController extends ControllerBase {
    * Builds a CSV response for attendees on an event.
    *
    * @return \Symfony\Component\HttpFoundation\Response|array
-   *   A CSV download response when `download_csv` is set, or the embedded view.
+   *   A CSV download response when `download_csv` is set, or a redirect to the
+   *   canonical organiser event portfolio.
    */
   public function handle(Request $request): Response|array {
     $eventIdRaw = $request->query->get('download_csv');
     if (!$eventIdRaw) {
-      return views_embed_view('attendee_answer', 'page_1');
+      return new LocalRedirectResponse('/vendor/events');
     }
 
     $eventId = (int) $eventIdRaw;

--- a/web/modules/custom/myeventlane_views/tests/src/Unit/AttendeeCsvExportAccessTest.php
+++ b/web/modules/custom/myeventlane_views/tests/src/Unit/AttendeeCsvExportAccessTest.php
@@ -43,6 +43,12 @@ final class AttendeeCsvExportAccessTest extends TestCase {
     $this->assertStringNotContainsString("access content", $routing);
   }
 
+  public function testLegacyListRedirectsToCanonicalEventPortfolio(): void {
+    $controller = (string) file_get_contents(dirname(__DIR__, 3) . '/src/Controller/AttendeeCsvController.php');
+    $this->assertStringContainsString("new LocalRedirectResponse('/vendor/events')", $controller);
+    $this->assertStringNotContainsString("views_embed_view('attendee_answer'", $controller);
+  }
+
   /**
    * Mirrors AttendeeCsvExportAccess download branch.
    */

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -2097,6 +2097,21 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
     $variables['mel_discovery_hero'] = _myeventlane_theme_build_discovery_hero($variables);
     $variables['mel_discovery_display_id'] = _myeventlane_theme_discovery_display_id($route);
     $variables['mel_discovery_show_context_filters'] = _myeventlane_theme_discovery_shows_context_filters($route);
+    $variables['mel_browse_active_filters'] = FALSE;
+    if ($route === 'view.upcoming_events.page_events') {
+      $query_all = \Drupal::request()->query->all();
+      foreach (['category', 'search', 'event_type', 'accessibility'] as $key) {
+        if (!array_key_exists($key, $query_all)) {
+          continue;
+        }
+        $value = $query_all[$key];
+        $values = is_array($value) ? $value : [$value];
+        if (array_filter($values, static fn($item): bool => $item !== NULL && $item !== '') !== []) {
+          $variables['mel_browse_active_filters'] = TRUE;
+          break;
+        }
+      }
+    }
   }
 
   // Site header: compact global header (desktop + mobile).
@@ -2241,6 +2256,10 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
         && isset($variables['page']['homepage_tonight'])
         && is_array($variables['page']['homepage_tonight'])
         && count(Element::children($variables['page']['homepage_tonight'])) > 0;
+      $variables['mel_home_show_latest'] = $homepageVisibility->viewDisplayHasResults('upcoming_events', 'homepage_latest')
+        && isset($variables['page']['homepage_latest'])
+        && is_array($variables['page']['homepage_latest'])
+        && count(Element::children($variables['page']['homepage_latest'])) > 0;
       $variables['mel_home_show_hidden_gems'] = $homepageVisibility->hasHiddenGemEvents()
         && isset($variables['page']['homepage_hidden_gems'])
         && is_array($variables['page']['homepage_hidden_gems'])
@@ -2257,6 +2276,7 @@ function myeventlane_theme_preprocess_page(array &$variables): void {
       $variables['mel_home_show_free_rsvp'] = FALSE;
       $variables['mel_home_show_recommended'] = FALSE;
       $variables['mel_home_show_tonight'] = FALSE;
+      $variables['mel_home_show_latest'] = FALSE;
       $variables['mel_home_show_hidden_gems'] = FALSE;
       $variables['mel_home_show_community_favourites'] = FALSE;
     }
@@ -2623,11 +2643,49 @@ function myeventlane_theme_preprocess_views_view_fullcalendar(array &$variables)
 
   $entity_colors = _myeventlane_theme_calendar_entity_colors($view, $tax_field, $color_service);
 
+  // Event Studio stores these Commerce store datetime values as Sydney
+  // wall-clock values. fullcalendar_view assumes Drupal UTC storage and
+  // converts them a second time, shifting displayed event times. Restore the
+  // canonical raw values before FullCalendar receives its event payload.
+  $event_times = [];
+  foreach ($view->result as $row) {
+    if (!$row instanceof ResultRow || !isset($row->_entity)) {
+      continue;
+    }
+    $entity = $row->_entity;
+    if (!$entity instanceof NodeInterface || !$entity->hasField('field_event_start')) {
+      continue;
+    }
+    $starts = $entity->get('field_event_start')->getValue();
+    $ends = $entity->hasField('field_event_end')
+      ? $entity->get('field_event_end')->getValue()
+      : [];
+    foreach ($starts as $delta => $start) {
+      $event_times[$entity->id()][] = [
+        'start' => $start['value'] ?? NULL,
+        'end' => $ends[$delta]['value'] ?? NULL,
+      ];
+    }
+  }
+
+  $event_deltas = [];
   foreach ($options['events'] as &$event) {
     if (!is_array($event)) {
       continue;
     }
     $entity_id = $event['eid'] ?? NULL;
+    $delta = $event_deltas[$entity_id] ?? 0;
+    $canonical_times = $event_times[$entity_id][$delta] ?? NULL;
+    if (is_array($canonical_times) && !empty($canonical_times['start'])) {
+      $event['start'] = $canonical_times['start'];
+      if (!empty($canonical_times['end'])) {
+        $event['end'] = $canonical_times['end'];
+      }
+      else {
+        unset($event['end']);
+      }
+      $event_deltas[$entity_id] = $delta + 1;
+    }
     if ($entity_id === NULL || !isset($entity_colors[$entity_id])) {
       $palette = _myeventlane_theme_calendar_default_event_colors($color_service);
     }
@@ -3576,6 +3634,11 @@ function myeventlane_theme_preprocess_views_view(array &$variables): void {
       $total = is_countable($result) ? count($result) : 0;
     }
     $variables['mel_browse_result_count'] = (int) $total;
+    $variables['mel_browse_result_count_label'] = \Drupal::translation()->formatPlural(
+      (int) $total,
+      '1 event',
+      '@count events',
+    );
   }
 
   // Only process views on taxonomy term pages.

--- a/web/themes/custom/myeventlane_theme/src/js/card-carousel.js
+++ b/web/themes/custom/myeventlane_theme/src/js/card-carousel.js
@@ -121,9 +121,8 @@ function initMelCardCarousels(context) {
     createCarousel(carousel, {
       slidesPerView: 1.15,
       spaceBetween: 12,
-      // Keep swipe enabled whenever there is more than one slide; never fit all
-      // slides in view at desktop (slidesPerView: 4 + 4 slides => isLocked: true).
-      watchOverflow: false,
+      centeredInsufficientSlides: true,
+      watchOverflow: true,
       grabCursor: true,
       simulateTouch: true,
       touchEventsTarget: 'container',

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_discovery.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_discovery.scss
@@ -46,6 +46,12 @@
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: mel.$mel-ds-space-md;
   }
+
+  .mel-discovery .mel-event-grid.mel-grid--events:has(> :only-child),
+  .mel-browse__results .mel-event-grid.mel-grid--events:has(> :only-child) {
+    grid-template-columns: minmax(0, 360px);
+    justify-content: center;
+  }
 }
 
 @include breakpoints.mel-break(lg) {
@@ -55,5 +61,23 @@
   .mel-vendor__event-grid.mel-event-grid.mel-grid--events,
   .mel-home-discover .mel-event-grid.mel-grid--events {
     grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .mel-discovery .mel-event-grid.mel-grid--events:has(> :only-child),
+  .mel-browse__results .mel-event-grid.mel-grid--events:has(> :only-child) {
+    grid-template-columns: minmax(0, 320px);
+    justify-content: center;
+  }
+
+  .mel-discovery .mel-event-grid.mel-grid--events:has(> :first-child:nth-last-child(2)),
+  .mel-browse__results .mel-event-grid.mel-grid--events:has(> :first-child:nth-last-child(2)) {
+    grid-template-columns: repeat(2, minmax(0, 320px));
+    justify-content: center;
+  }
+
+  .mel-discovery .mel-event-grid.mel-grid--events:has(> :first-child:nth-last-child(3)),
+  .mel-browse__results .mel-event-grid.mel-grid--events:has(> :first-child:nth-last-child(3)) {
+    grid-template-columns: repeat(3, minmax(0, 320px));
+    justify-content: center;
   }
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/pages/_front-page.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/pages/_front-page.scss
@@ -558,6 +558,17 @@
   gap: clamp(16px, 2.5vw, 22px);
   align-items: stretch;
 
+  // Keep sparse rails visually intentional instead of leaving empty columns.
+  &:has(> :only-child) {
+    grid-template-columns: minmax(0, 320px);
+    justify-content: center;
+  }
+
+  &:has(> :first-child:nth-last-child(2)) {
+    grid-template-columns: repeat(2, minmax(0, 320px));
+    justify-content: center;
+  }
+
   @media (width <= 1024px) {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -851,6 +862,11 @@
   min-width: 0;
   overflow: visible;
 
+  .mel-card-carousel--count-1 .swiper-wrapper,
+  .mel-card-carousel--count-2 .swiper-wrapper {
+    justify-content: center;
+  }
+
   .mel-card-carousel-shell--nav-below {
     .mel-card-carousel {
       padding: 0.5rem 0 0;
@@ -860,6 +876,12 @@
       .mel-event-card__link {
         touch-action: pan-x pan-y;
       }
+    }
+  }
+
+  @media (width <= 767px) {
+    .mel-card-carousel--count-2 .swiper-wrapper {
+      justify-content: flex-start;
     }
   }
 

--- a/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/page--front.html.twig
@@ -106,7 +106,7 @@
       } %}
     {% endif %}
 
-    {% if page.homepage_latest %}
+    {% if mel_home_show_latest|default(false) %}
       {% include '@myeventlane_theme/components/layout/mel-section-shell.html.twig' with {
         section_class: 'mel-section--latest mel-section--discover',
         section_width_class: '',

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--page-events.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view--upcoming-events--page-events.html.twig
@@ -22,7 +22,7 @@
 
     {% if mel_browse_result_count is defined %}
       <p class="mel-browse-results-count" role="status">
-        {{ '@count events'|t({'@count': mel_browse_result_count}) }}
+        {{ mel_browse_result_count_label|default('@count events'|t({'@count': mel_browse_result_count})) }}
       </p>
     {% endif %}
 

--- a/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--front-featured-events--block-featured.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/views/views-view-unformatted--front-featured-events--block-featured.html.twig
@@ -78,7 +78,7 @@
       {% include '@myeventlane_theme/components/card-carousel/card-carousel.twig' with {
         items: carousel_items,
         carousel_id: 'mel-spotlight-carousel',
-        carousel_modifier: 'mel-card-carousel--spotlight',
+        carousel_modifier: 'mel-card-carousel--spotlight mel-card-carousel--count-' ~ carousel_items|length,
         nav_below: true,
       } only %}
     </div>

--- a/web/themes/custom/myeventlane_vendor_theme/templates/event/orders.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/event/orders.html.twig
@@ -28,11 +28,11 @@
           <strong>{{ orders|length }}</strong>
         </article>
         <article class="mel-studio-orders__metric">
-          <span>{{ 'Tickets sold'|t }}</span>
+          <span>{{ 'Items sold'|t }}</span>
           <strong>{{ totals.ticket_count }}</strong>
         </article>
         <article class="mel-studio-orders__metric">
-          <span>{{ 'Gross ticket sales'|t }}</span>
+          <span>{{ 'Gross sales'|t }}</span>
           <strong>{{ totals.net_sales }}</strong>
         </article>
         <article class="mel-studio-orders__metric mel-studio-orders__metric--accent">
@@ -45,7 +45,7 @@
       <div class="mel-table__head">
         <div>{{ 'Order'|t }}</div>
         <div>{{ 'Purchaser'|t }}</div>
-        <div>{{ 'Tickets'|t }}</div>
+        <div>{{ 'Items'|t }}</div>
         <div>{{ 'Sale'|t }}</div>
         <div>{{ 'Status'|t }}</div>
         <div>{{ 'Actions'|t }}</div>
@@ -61,7 +61,7 @@
               <strong>{{ row.purchaser_name }}</strong>
               <small>{{ row.purchaser_email }}</small>
             </div>
-            <div data-label="{{ 'Tickets'|t }}"><strong>{{ row.ticket_count }}</strong></div>
+            <div data-label="{{ 'Items'|t }}"><strong>{{ row.ticket_count }}</strong></div>
             <div data-label="{{ 'Sale'|t }}">
               <strong>{{ row.net_sales }}</strong>
               <small>{{ 'Fees'|t }} {{ row.fees }} · {{ 'Net'|t }} {{ row.total }}</small>
@@ -102,7 +102,7 @@
           <div class="mel-table__row">
             <div class="mel-text--bold" data-label="{{ 'Order'|t }}">{{ 'Total'|t }}</div>
             <div data-label="{{ 'Purchaser'|t }}"></div>
-            <div data-label="{{ 'Tickets'|t }}"><strong>{{ totals.ticket_count }}</strong></div>
+            <div data-label="{{ 'Items'|t }}"><strong>{{ totals.ticket_count }}</strong></div>
             <div data-label="{{ 'Sale'|t }}">
               <strong>{{ totals.net_sales }}</strong>
               <small>{{ 'Fees'|t }} {{ totals.fees }} · {{ 'Net'|t }} {{ totals.total }}</small>


### PR DESCRIPTION
## What changed

- audited MyEventLane public discovery, calendar, saved-event, RSVP, customer, organiser, Event Studio, check-in and custom administration views
- corrected public event filtering, sparse homepage rails and carousel behaviour
- restored event-scoped RSVP and attendee export behaviour
- aligned saved-event workflow routing
- corrected Orders labels so all event-linked items are not misreported as tickets
- retained checked-in attendees in the legacy staff check-in repository
- repaired Organiser Hub editorial, coverage and linking administration views
- normalised Drupal configuration ordering and corrected the Commerce role-condition schema
- added focused regression contracts for the corrected surfaces

## Why

The audit found several rendering, filtering, event-isolation and presentation defects. The most severe failures were an attendee export access gap, checked-in guests disappearing from the legacy check-in view, and all three Organiser Hub administration views crashing because calculated fields were queried as physical database columns.

## User impact

Public event discovery now presents the intended event set and behaves correctly with sparse content. Organisers receive consistent event-isolated RSVP, attendee, order and check-in information. Staff administration reports render correctly and retain their existing access boundaries.

## Validation

- complete staging release validator: `READY FOR STAGING`
- 195 governance tests passed with 2,675 assertions
- 30 focused view-audit tests passed with 142 assertions
- Drupal bootstrap and database connectivity passed
- configuration status clean
- no database updates pending
- Composer, configuration, webroot and raw-card-data safety checks passed
- theme lint and both production frontend builds passed
- rendered browser verification completed across populated events and custom administration views

## Notes

- No database content was changed by the audit verification.
- Existing npm audit warnings remain outside this pull request’s scope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches vendor attendee/check-in queries, attendee export routing, and many synced Views/config surfaces; behaviour is well covered by contract tests but deploy still needs config import validation.
> 
> **Overview**
> This PR remediates a broad **Views and presentation audit**: broken admin reports, organiser/customer surfaces, and public discovery/calendar behaviour, plus config hygiene and regression contracts.
> 
> **Organiser Hub admin** no longer crashes: calculated Views fields skip SQL in `query()` and return render arrays. Coverage moves from a mixed node/taxonomy display into **`mel_organiser_hub_coverage`** on taxonomy terms at the same admin path.
> 
> **Vendor/organiser data** is tightened: aggregate RSVPs gain an **Event** column (node relationship), default **newest-first** sort, and empty-state copy; legacy attendee CSV without `download_csv` **redirects to `/vendor/events`** instead of embedding a view; Event Studio orders copy says **Items / gross sales** rather than tickets-only; **`TicketAttendeeRepository`** treats **checked-in** attendees as active and counts check-ins by `status` instead of `checked_in`.
> 
> **Public UX** fixes include **`upcoming_events`** event-type filter handler (`field_event_type_value`), browse **active-filter** detection and plural result labels, sparse **homepage/discovery grids** and spotlight carousel centering, **latest** rail gated on view results, calendar **title** plus theme hook restoring **Sydney wall-clock** times for FullCalendar, and saved-events workflow CTA routing to **browse events** instead of looping saved list.
> 
> **Config-only** changes reorder Klaro app YAML, fix Commerce gateway **roles** list shape, and minor display ordering; **unit contract tests** lock the above behaviour.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a4c64fdf23db25a9cf238062be17100e1777c6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->