### PR TITLE
Fix panoramic Page Visual cropping

### DIFF
--- a/config/sync/image.style.mel_page_visual_hero_desktop.yml
+++ b/config/sync/image.style.mel_page_visual_hero_desktop.yml
@@ -1,0 +1,18 @@
+uuid: cb483947-8f68-46ea-9097-9b9224ed9b25
+langcode: en
+status: true
+dependencies:
+  module:
+    - image
+name: mel_page_visual_hero_desktop
+label: 'MEL page visual hero (desktop panorama)'
+effects:
+  d70e7e8a-2d90-4ea8-be2b-9592d0a7f7bf:
+    uuid: d70e7e8a-2d90-4ea8-be2b-9592d0a7f7bf
+    id: image_scale
+    weight: 0
+    data:
+      width: 2048
+      height: null
+      upscale: false
+pipeline: __default__

--- a/config/sync/image.style.mel_page_visual_hero_mobile.yml
+++ b/config/sync/image.style.mel_page_visual_hero_mobile.yml
@@ -1,0 +1,18 @@
+uuid: 4265b25c-165d-46bc-b0f5-e7472da38b75
+langcode: en
+status: true
+dependencies:
+  module:
+    - image
+name: mel_page_visual_hero_mobile
+label: 'MEL page visual hero (mobile panorama)'
+effects:
+  75fd8511-27ae-4ec3-a18d-0d82cc5a1fa7:
+    uuid: 75fd8511-27ae-4ec3-a18d-0d82cc5a1fa7
+    id: image_scale
+    weight: 0
+    data:
+      width: 960
+      height: null
+      upscale: false
+pipeline: __default__

--- a/config/sync/myeventlane_page_visuals.page_visual.calendar_hero.yml
+++ b/config/sync/myeventlane_page_visuals.page_visual.calendar_hero.yml
@@ -5,8 +5,8 @@ dependencies: {  }
 id: calendar_hero
 label: 'Calendar Hero '
 route_name: view.events_calendar.page_calendar
-media_uuid_desktop: f4d2cbae-0193-4e89-afe8-3c6c68c74436
-media_uuid_mobile: eceaab72-191d-4eef-83e6-b1f617fb2083
+media_uuid_desktop: b502d32e-ac30-445e-99e6-db2178a721b9
+media_uuid_mobile: b502d32e-ac30-445e-99e6-db2178a721b9
 hide_on_mobile: false
-alt_text: 'My EvenLane Calendar '
+alt_text: 'Browse the MyEventLane events calendar'
 enabled: true

--- a/config/sync/myeventlane_page_visuals.page_visual.community_hero.yml
+++ b/config/sync/myeventlane_page_visuals.page_visual.community_hero.yml
@@ -5,8 +5,8 @@ dependencies: {  }
 id: community_hero
 label: 'Community Favourites Hero'
 route_name: view.upcoming_events.page_popular
-media_uuid_desktop: 02d27bad-4790-4dce-8b91-9e09d9c48836
-media_uuid_mobile: bd727d04-bb71-48e1-8061-a1f9aa92a72e
+media_uuid_desktop: 210e8304-8fde-4c4b-88a5-a6fe4ba6e51f
+media_uuid_mobile: 210e8304-8fde-4c4b-88a5-a6fe4ba6e51f
 hide_on_mobile: false
-alt_text: 'Community favourites on MyEventLane'
+alt_text: 'Popular community events on MyEventLane'
 enabled: true

--- a/config/sync/myeventlane_page_visuals.page_visual.events_hero.yml
+++ b/config/sync/myeventlane_page_visuals.page_visual.events_hero.yml
@@ -5,8 +5,8 @@ dependencies: {  }
 id: events_hero
 label: 'Events Hero'
 route_name: view.upcoming_events.page_events
-media_uuid_desktop: 02d27bad-4790-4dce-8b91-9e09d9c48836
-media_uuid_mobile: bd727d04-bb71-48e1-8061-a1f9aa92a72e
+media_uuid_desktop: bad6f206-739e-4276-8054-d6b1b9645c03
+media_uuid_mobile: bad6f206-739e-4276-8054-d6b1b9645c03
 hide_on_mobile: false
-alt_text: 'My EvenLane Events '
+alt_text: 'Browse all events on MyEventLane'
 enabled: true

--- a/config/sync/myeventlane_page_visuals.page_visual.vendors_hero.yml
+++ b/config/sync/myeventlane_page_visuals.page_visual.vendors_hero.yml
@@ -5,8 +5,8 @@ dependencies: {  }
 id: vendors_hero
 label: 'Vendors Directory Hero'
 route_name: myeventlane_vendor.public_list
-media_uuid_desktop: 02d27bad-4790-4dce-8b91-9e09d9c48836
-media_uuid_mobile: bd727d04-bb71-48e1-8061-a1f9aa92a72e
+media_uuid_desktop: e256728a-7f74-4d72-a560-2a020afe5890
+media_uuid_mobile: e256728a-7f74-4d72-a560-2a020afe5890
 hide_on_mobile: false
 alt_text: 'Event organisers on MyEventLane'
 enabled: true

--- a/web/modules/custom/myeventlane_page_visuals/src/Service/PageVisualResolver.php
+++ b/web/modules/custom/myeventlane_page_visuals/src/Service/PageVisualResolver.php
@@ -23,14 +23,14 @@ use Drupal\myeventlane_page_visuals\Entity\PageVisualInterface;
 final class PageVisualResolver {
 
   /**
-   * Desktop discovery hero derivative (16:9, max 1600×900).
+   * Desktop Page Visual derivative; preserves panoramic artwork composition.
    */
-  private const STYLE_HERO_DESKTOP = 'mel_event_hero_featured';
+  private const STYLE_HERO_DESKTOP = 'mel_page_visual_hero_desktop';
 
   /**
-   * Mobile discovery hero derivative (16:9, 800×450).
+   * Mobile Page Visual derivative; preserves composition at a smaller width.
    */
-  private const STYLE_HERO_MOBILE = 'mel_event_card_featured';
+  private const STYLE_HERO_MOBILE = 'mel_page_visual_hero_mobile';
 
   /**
    * The entity type manager.

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_discovery-hero.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_discovery-hero.scss
@@ -27,6 +27,14 @@
 
 .mel-home-hero--discovery {
   margin-bottom: 0;
+
+  // Page Visual artwork is authored as a panorama. Keep the right-side brand
+  // mark in frame and avoid the homepage's decorative zoom.
+  .mel-home-hero__media-img {
+    object-position: right center;
+    transform: none;
+    transform-origin: right center;
+  }
 }
 
 .mel-home-hero__text--subtitle {


### PR DESCRIPTION
## What changed

- adds Page Visual-specific desktop and mobile image styles that scale without forcing a 16:9 crop
- switches the Page Visual resolver to those panorama-preserving styles
- removes the homepage decorative zoom from discovery heroes only
- right-aligns discovery artwork so the bottom-right MEL brand mark stays in frame
- records the approved media UUIDs for Events, Calendar, Community Favourites and Organisers

## Why

The shared event-cover image style cropped the sides of the new panoramic Page Visual artwork before CSS positioning. The Organisers hero therefore lost part of the MEL logo. The additional discovery image zoom removed more of the right edge.

## Impact

Page Visual images remain editable through Drupal. Event Studio and public event-cover cropping are unchanged.

## Validation

- Product Owner visually confirmed the corrected DDEV Organisers hero
- PHP lint passed
- Vite theme build passed
- MEL hero contract check passed
- DDEV configuration import and cache rebuild passed
- Drupal configuration status reports no drift
- desktop Organisers derivative verified at 2041 x 770
- mobile Organisers derivative verified at 960 x 362
- all four Page Visual routes resolve the new style URLs
- git diff --check passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and Drupal config changes limited to Page Visual heroes; event-cover and booking flows still use the existing hero image styles.
> 
> **Overview**
> Fixes **Page Visual** discovery heroes cropping panoramic artwork and clipping the MEL brand mark on the right.
> 
> Adds **`mel_page_visual_hero_desktop`** (max width 2048) and **`mel_page_visual_hero_mobile`** (max width 960) image styles that **scale by width only** instead of the shared 16:9 event-cover styles. **`PageVisualResolver`** now builds hero URLs from those styles.
> 
> Sync config points **Events, Calendar, Community Favourites, and Organisers** heroes at approved media UUIDs (same asset for desktop/mobile where noted) and refreshes alt text on several routes.
> 
> Discovery-only CSS on **`.mel-home-hero--discovery`** sets **`object-position: right center`**, drops the homepage decorative zoom on the hero image, so composition stays intact in the hero frame.
> 
> Event Studio and public **event-cover** derivatives are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0041c0702dfc14285d5d748035f278d7b13326b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->