### PR TITLE
Add editable discovery and homepage visuals

### DIFF
--- a/config/sync/myeventlane_page_visuals.page_visual.free_events_hero.yml
+++ b/config/sync/myeventlane_page_visuals.page_visual.free_events_hero.yml
@@ -1,0 +1,12 @@
+uuid: 39409b4f-b655-4f01-8cfc-c4713f4ad630
+langcode: en
+status: true
+dependencies: {  }
+id: free_events_hero
+label: 'Free Events Hero'
+route_name: view.upcoming_events.page_free
+media_uuid_desktop: 536b5dbf-e2f9-4f3b-8e45-a47cf923649d
+media_uuid_mobile: 536b5dbf-e2f9-4f3b-8e45-a47cf923649d
+hide_on_mobile: false
+alt_text: 'Free events on MyEventLane'
+enabled: true

--- a/config/sync/myeventlane_page_visuals.page_visual.hidden_gems_hero.yml
+++ b/config/sync/myeventlane_page_visuals.page_visual.hidden_gems_hero.yml
@@ -5,8 +5,8 @@ dependencies: {  }
 id: hidden_gems_hero
 label: 'Hidden Gems Hero'
 route_name: view.upcoming_events.page_hidden_gems
-media_uuid_desktop: 02d27bad-4790-4dce-8b91-9e09d9c48836
-media_uuid_mobile: bd727d04-bb71-48e1-8061-a1f9aa92a72e
+media_uuid_desktop: 6978d7ac-da52-4a05-9dd7-2a77243d75d8
+media_uuid_mobile: 6978d7ac-da52-4a05-9dd7-2a77243d75d8
 hide_on_mobile: false
-alt_text: 'Hidden gems on MyEventLane'
+alt_text: 'Hidden gem events on MyEventLane'
 enabled: true

--- a/config/sync/myeventlane_page_visuals.page_visual.home_hero.yml
+++ b/config/sync/myeventlane_page_visuals.page_visual.home_hero.yml
@@ -5,8 +5,8 @@ dependencies: {  }
 id: home_hero
 label: 'Home Hero'
 route_name: system.front_page
-media_uuid_desktop: a0f88922-e659-4b97-90c9-5475d8731ab2
-media_uuid_mobile: null
+media_uuid_desktop: f7c407ab-d61f-4ddb-8aa0-a6351e3139ea
+media_uuid_mobile: aab99776-7bba-475c-a2a6-822aadaa263c
 hide_on_mobile: false
-alt_text: 'Community festival with live music, markets, and families enjoying local events.'
+alt_text: 'Discover community events on MyEventLane'
 enabled: true

--- a/config/sync/myeventlane_page_visuals.page_visual.this_weekend_hero.yml
+++ b/config/sync/myeventlane_page_visuals.page_visual.this_weekend_hero.yml
@@ -1,0 +1,12 @@
+uuid: 6f244f55-33b4-482e-9db7-9c71ea493173
+langcode: en
+status: true
+dependencies: {  }
+id: this_weekend_hero
+label: 'This Weekend Hero'
+route_name: view.upcoming_events.page_this_weekend
+media_uuid_desktop: 52c0caf3-fb35-4971-a536-ec89d4578f76
+media_uuid_mobile: 52c0caf3-fb35-4971-a536-ec89d4578f76
+hide_on_mobile: false
+alt_text: 'Events happening this weekend on MyEventLane'
+enabled: true

--- a/config/sync/myeventlane_page_visuals.page_visual.today_hero.yml
+++ b/config/sync/myeventlane_page_visuals.page_visual.today_hero.yml
@@ -1,0 +1,12 @@
+uuid: 7a5d0d70-91a5-43f0-902f-710f3ccac401
+langcode: en
+status: true
+dependencies: {  }
+id: today_hero
+label: 'Today Hero'
+route_name: view.upcoming_events.page_today
+media_uuid_desktop: 37c50ac5-fca4-4c9d-a6fb-18a76dd1b623
+media_uuid_mobile: 37c50ac5-fca4-4c9d-a6fb-18a76dd1b623
+hide_on_mobile: false
+alt_text: 'Events happening today on MyEventLane'
+enabled: true

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_discovery-hero.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_discovery-hero.scss
@@ -27,14 +27,6 @@
 
 .mel-home-hero--discovery {
   margin-bottom: 0;
-
-  // Page Visual artwork is authored as a panorama. Keep the right-side brand
-  // mark in frame and avoid the homepage's decorative zoom.
-  .mel-home-hero__media-img {
-    object-position: right center;
-    transform: none;
-    transform-origin: right center;
-  }
 }
 
 .mel-home-hero__text--subtitle {

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_home-hero.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_home-hero.scss
@@ -48,14 +48,14 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
-  object-position: 34% 44%;
-  transform: scale(1.12);
-  transform-origin: 34% 44%;
+  object-position: right center;
+  transform: none;
+  transform-origin: right center;
 
   @include breakpoints.mel-break(md, max) {
-    object-position: 42% 48%;
-    transform: scale(1.08);
-    transform-origin: 42% 48%;
+    object-position: right center;
+    transform: none;
+    transform-origin: right center;
   }
 }
 


### PR DESCRIPTION
## What changed

- adds editable Page Visual records for Today, This Weekend and Free Events
- updates Hidden Gems to the approved new media UUID
- adds separate approved desktop and mobile Homepage media UUIDs
- applies the confirmed no-zoom, right-edge-protected treatment to the shared homepage/discovery hero image

Movies and Markets remain taxonomy content updates and are intentionally not hard-coded in this PR. Their staging files will be assigned through Drupal with new cache-busting URLs after deployment.

## Why

The new page artwork needs to remain changeable through Drupal Page Visual administration. Movies and Markets reused year-cached public URLs, so their correct replacement files could still appear stale in browsers. The homepage also retained the old decorative zoom and cropped its bottom-right MEL logo.

## Impact

All supplied artwork remains editable. No event-cover crop behaviour changes.

## Validation

- Product Owner visually approved the DDEV homepage correction and additional image set
- all five Page Visual routes resolve the approved desktop/mobile media
- Movies and Markets resolve new unique DDEV file URLs
- Vite theme build passed
- MEL hero contract check passed
- DDEV configuration import and cache rebuild passed
- Drupal reports no configuration drift
- git diff --check passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config and presentation-only SCSS for hero artwork; no auth, data, or event-card crop behavior changes.
> 
> **Overview**
> Adds **Drupal Page Visual** config for **Today**, **This Weekend**, and **Free Events** discovery routes, each wired to approved desktop/mobile media and alt text so heroes stay editable in admin.
> 
> Updates **Home** and **Hidden Gems** heroes to new media UUIDs (home gets distinct desktop vs mobile assets) and refreshed alt copy.
> 
> **Hero image treatment** moves to the shared `.mel-home-hero__media-img` styles: removes decorative zoom/crop and uses **right-center** framing so panorama artwork and the MEL mark stay visible on homepage and discovery pages alike; the discovery-only duplicate rules are dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cee17350c69fb0d2d5b1e84e53c61667b5f514b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->