### PR TITLE
Fix first boosted event spotlight placement

### DIFF
--- a/web/modules/custom/myeventlane_front/phpunit.xml
+++ b/web/modules/custom/myeventlane_front/phpunit.xml
@@ -12,6 +12,7 @@
       <file>tests/src/Unit/BlogCtaTest.php</file>
       <file>tests/src/Unit/BlogReadingTimeTest.php</file>
       <file>tests/src/Unit/BlogStructuredDataAuthorTest.php</file>
+      <file>tests/src/Unit/HomepageSpotlightPlacementContractTest.php</file>
       <file>tests/src/Unit/OrganiserHubCoverageTest.php</file>
       <file>tests/src/Unit/PlaybookQueryServiceTest.php</file>
     </testsuite>

--- a/web/modules/custom/myeventlane_front/src/Service/HomepageMerchandising.php
+++ b/web/modules/custom/myeventlane_front/src/Service/HomepageMerchandising.php
@@ -16,10 +16,10 @@ use Drupal\views\ViewExecutableFactory;
 /**
  * Resolves homepage hero, spotlight, and cross-rail deduplication sets.
  *
- * Hero = top promoted upcoming event (same sort as front_featured_events).
- * Spotlight = Community Spotlight roster (front_featured_events:block_featured).
+ * Hero = branded Page Visual with no reserved event.
+ * Spotlight = all marketplace-ready boosted upcoming events.
  * Lower rails exclude higher-priority sections (cascade):
- * Hero → Tonight → Hidden Gems → Discover → Community Spotlight →
+ * Branded hero → Tonight → Hidden Gems → Discover → Community Spotlight →
  * Community Favourites → Upcoming Highlights → Free RSVP → More Events To Explore.
  *
  * Downstream exclusions use getFeaturedBlockEventIds() for the spotlight roster,
@@ -50,11 +50,6 @@ final class HomepageMerchandising {
       'block_1',
     ],
   ];
-
-  /**
-   * @var list<int>|null
-   */
-  private ?array $heroEventIds = NULL;
 
   /**
    * @var list<int>|null
@@ -198,22 +193,19 @@ final class HomepageMerchandising {
   }
 
   /**
-   * Hero event NIDs (single lead promoted event).
+   * Event NIDs used by the branded homepage hero.
+   *
+   * The homepage hero does not render an event, so it must not reserve one
+   * from Community Spotlight.
    *
    * @return list<int>
    */
   public function getHeroEventIds(): array {
-    if ($this->heroEventIds !== NULL) {
-      return $this->heroEventIds;
-    }
-
-    $promoted = $this->loadMarketplaceReadyPromotedUpcomingEventIds();
-    $this->heroEventIds = $promoted !== [] ? [(int) reset($promoted)] : [];
-    return $this->heroEventIds;
+    return [];
   }
 
   /**
-   * Spotlight event NIDs (all boosted except hero).
+   * Spotlight event NIDs (all marketplace-ready boosted upcoming events).
    *
    * @return list<int>
    */
@@ -222,12 +214,7 @@ final class HomepageMerchandising {
       return $this->spotlightEventIds;
     }
 
-    $promoted = $this->loadMarketplaceReadyPromotedUpcomingEventIds();
-    $hero = $this->getHeroEventIds();
-    if ($hero !== []) {
-      $promoted = array_values(array_diff($promoted, $hero));
-    }
-    $this->spotlightEventIds = $promoted;
+    $this->spotlightEventIds = $this->loadMarketplaceReadyPromotedUpcomingEventIds();
     return $this->spotlightEventIds;
   }
 

--- a/web/modules/custom/myeventlane_front/tests/src/Unit/HomepageSpotlightPlacementContractTest.php
+++ b/web/modules/custom/myeventlane_front/tests/src/Unit/HomepageSpotlightPlacementContractTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_front\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects boosted-event placement on the homepage.
+ *
+ * @group myeventlane_front
+ */
+final class HomepageSpotlightPlacementContractTest extends TestCase {
+
+  public function testBrandedHeroDoesNotReserveFirstSpotlightEvent(): void {
+    $moduleRoot = dirname(__DIR__, 3);
+    $merchandising = (string) file_get_contents(
+      $moduleRoot . '/src/Service/HomepageMerchandising.php',
+    );
+    $homeHero = (string) file_get_contents(
+      $moduleRoot . '/src/Plugin/Block/HomeHeroBlock.php',
+    );
+
+    $this->assertStringContainsString("'#featured_events' => NULL", $homeHero);
+    $this->assertStringContainsString(
+      "public function getHeroEventIds(): array {\n    return [];\n  }",
+      $merchandising,
+    );
+    $this->assertStringContainsString(
+      '$this->spotlightEventIds = $this->loadMarketplaceReadyPromotedUpcomingEventIds();',
+      $merchandising,
+    );
+    $this->assertStringNotContainsString(
+      '$hero = $this->getHeroEventIds();',
+      $merchandising,
+    );
+  }
+
+}


### PR DESCRIPTION
## What changed

- stopped the branded homepage hero from reserving the first eligible boosted event
- allowed all marketplace-ready boosted upcoming events into Community Spotlight
- added a regression contract test and registered it in the module test suite

## Why

The homepage hero renders a Page Visual and no event card. The merchandising service still reserved the first eligible boosted event for that hero, then removed it from Community Spotlight. When only one boosted event was eligible, the Spotlight rail had no results.

## Impact

The first eligible boosted event can now render in Community Spotlight. Worth checking out remains Spotlight overflow, and Hidden Gems remains controlled by its separate editorial flag.

## Validation

- PHP syntax checks passed for the changed service and new test
- focused homepage tests: 3 passed, 14 assertions
- diff whitespace check passed

Rendered staging verification remains pending deployment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes homepage rail deduplication and spotlight roster logic; wrong behavior would affect promoted event visibility on the front page, but scope is limited to merchandising helpers and is guarded by a contract test.
> 
> **Overview**
> Fixes a homepage merchandising bug where the **branded hero** (Page Visual, no event card) still **reserved the top boosted upcoming event**, then **Community Spotlight** excluded that NID—leaving an empty spotlight when only one boosted event was eligible.
> 
> **`HomepageMerchandising`** now treats the hero as non-event: `getHeroEventIds()` always returns `[]`, and `getSpotlightEventIds()` loads **all** marketplace-ready promoted upcoming events with no hero subtraction. Hero-specific caching/state for that reservation was removed; cascade docs note a branded hero instead of a promoted-event hero.
> 
> Adds **`HomepageSpotlightPlacementContractTest`** (string contract on `HomeHeroBlock` + merchandising) and registers it in **`phpunit.xml`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14030a51573068f58c9d04f8483d7c3c34093689. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->