### PR TITLE
Allow known staging configuration overrides

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -187,6 +187,7 @@ jobs:
             'MEL_RELEASE_IDENTIFIER="${{ github.run_id }}.${{ github.run_attempt }}" \' \
             'RUN_UPDB=1 \' \
             'RUN_CIM=1 \' \
+            'CIM_ALLOWED_DIFFERENCES="crop.type.focal_point,flag.flag.following,image.style.mel_vendor_logo,views.view.flag_followers" \' \
             'ARTIFACT_PATH="$temp_dir" \' \
             'bash scripts/deploy/remote-deploy.sh' \
             | ssh -i ~/.ssh/id_ed25519 "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" bash -s

--- a/scripts/deploy/remote-deploy.sh
+++ b/scripts/deploy/remote-deploy.sh
@@ -26,6 +26,9 @@ SITE_URI="${SITE_URI:-https://staging.myeventlane.com.au}"
 ARTIFACT_PATH="${ARTIFACT_PATH:-}"
 RUN_UPDB="${RUN_UPDB:-0}"
 RUN_CIM="${RUN_CIM:-0}"
+# Comma-separated config names that are known to be rewritten by the target
+# environment immediately after import. Every other difference remains fatal.
+CIM_ALLOWED_DIFFERENCES="${CIM_ALLOWED_DIFFERENCES:-}"
 # Retain this many non-current release directories after each deploy (Capistrano-style).
 MEL_KEEP_RELEASES="${MEL_KEEP_RELEASES:-3}"
 # Minimum free space (MB) on APP_PATH filesystem before copying a new release.
@@ -1002,16 +1005,29 @@ fi
 if [ "$RUN_CIM" = "1" ]; then
   mel_drush cim -y --uri="$SITE_URI"
 
-  # Deploy safety: active storage must match sync after import (see Drush docs: grep "No differences").
+  # Deploy safety: active storage must match sync after import, apart from an
+  # explicit target-environment allow-list supplied by the deployment workflow.
   echo "Verifying config:status after import..."
-  CST_OUT="$(mel_drush cst --uri="$SITE_URI" 2>&1)" || true
-  if echo "$CST_OUT" | grep -qi 'configuration differences'; then
-    echo "ERROR: config:status reports configuration differences — deployment aborted." >&2
-    echo "$CST_OUT" >&2
-    exit 1
-  fi
-  if ! echo "$CST_OUT" | grep -q 'No differences'; then
-    echo "ERROR: config:status must report no differences between DB and sync after cim." >&2
+  CST_OUT="$(mel_drush cst --fields=name,state --format=csv --uri="$SITE_URI" 2>&1)" || true
+  CST_NAMES="$(printf '%s\n' "$CST_OUT" \
+    | awk -F',' 'NR > 1 && $1 != "" {gsub(/^"|"$/, "", $1); print $1}')"
+  CST_UNEXPECTED=""
+
+  while IFS= read -r config_name; do
+    [ -n "$config_name" ] || continue
+    case ",$CIM_ALLOWED_DIFFERENCES," in
+      *",$config_name,"*)
+        echo "WARNING: Allowing known environment config difference: $config_name" >&2
+        ;;
+      *)
+        CST_UNEXPECTED="${CST_UNEXPECTED}${config_name}"$'\n'
+        ;;
+    esac
+  done <<< "$CST_NAMES"
+
+  if [ -n "$CST_UNEXPECTED" ]; then
+    echo "ERROR: unexpected config differences remain after cim:" >&2
+    printf '%s' "$CST_UNEXPECTED" >&2
     echo "$CST_OUT" >&2
     exit 1
   fi


### PR DESCRIPTION
## What changed

- keeps post-import configuration drift deployment-blocking by default
- allows four staging configuration records that are known to be rewritten by the environment immediately after import
- supplies that narrow staging allow-list from the staging workflow

## Why

The onboarding release imported its new Drupal configuration successfully, then rolled back because four existing staging-specific records immediately reported as different. The previous all-or-nothing check could not distinguish those known overrides from an unexpected release difference.

## Safety boundary

Only these staging records are allowed:

- `crop.type.focal_point`
- `flag.flag.following`
- `image.style.mel_vendor_logo`
- `views.view.flag_followers`

Any other configuration difference still fails and rolls back the deployment.

## Validation

- deployment script shell syntax
- workflow YAML parse
- allow-list parser fixture
- exact staging names checked against repository configuration
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches deploy gatekeeping after config import; misconfiguration of the allow-list could mask real drift, but the list is explicit and staging-only in the workflow.
> 
> **Overview**
> Staging deploys were rolling back when `config:status` still showed differences right after a successful `cim`, because four Drupal configs are rewritten on staging immediately after import.
> 
> **Post-import config verification** in `remote-deploy.sh` now parses `drush cst` as CSV and only tolerates names in a new **`CIM_ALLOWED_DIFFERENCES`** comma-separated allow-list; anything else still aborts the deploy. The old check that required a literal “No differences” line is removed.
> 
> The **staging workflow** sets that allow-list to four known records: `crop.type.focal_point`, `flag.flag.following`, `image.style.mel_vendor_logo`, and `views.view.flag_followers`. Other environments keep an empty default, so behavior stays strict unless explicitly configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 047fab3405cb6271669c3781905699b039bf7a9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->