### PR TITLE
Fix customer settings field saving

### DIFF
--- a/web/modules/custom/myeventlane_account/myeventlane_account.module
+++ b/web/modules/custom/myeventlane_account/myeventlane_account.module
@@ -505,16 +505,11 @@ function _myeventlane_account_customer_settings_form_alter(array &$form): void {
     '#weight' => -50,
   ];
 
-  foreach (['field_display_name', 'user_picture', 'field_pronouns', 'field_city'] as $key) {
-    if (!isset($form[$key])) {
-      continue;
-    }
-    $element = $form[$key];
-    unset($form[$key]);
-    $element['#parents'] = [$key];
-    $element['#weight'] = $element['#weight'] ?? 0;
-    $form['mel_settings_profile'][$key] = $element;
-  }
+  _myeventlane_account_group_entity_fields(
+    $form,
+    ['field_display_name', 'user_picture', 'field_pronouns', 'field_city'],
+    'mel_settings_profile',
+  );
 
   if (!empty($form['account']) && is_array($form['account'])) {
     foreach (['mail', 'name'] as $key) {
@@ -662,15 +657,11 @@ function _myeventlane_account_customer_settings_form_alter(array &$form): void {
     $form['mel_settings_preferences']['timezone'] = $element;
   }
 
-  foreach (['field_accessibility_preferences', 'social_auth'] as $key) {
-    if (!isset($form[$key])) {
-      continue;
-    }
-    $element = $form[$key];
-    unset($form[$key]);
-    $element['#parents'] = [$key];
-    $form['mel_settings_preferences'][$key] = $element;
-  }
+  _myeventlane_account_group_entity_fields(
+    $form,
+    ['field_accessibility_preferences', 'social_auth'],
+    'mel_settings_preferences',
+  );
 
   $prefs_more = _myeventlane_account_customer_settings_preference_links();
   if ($prefs_more !== []) {
@@ -717,6 +708,31 @@ function _myeventlane_account_customer_settings_form_alter(array &$form): void {
   if (isset($form['actions'])) {
     $form['actions']['#weight'] = 200;
     $form['actions']['#attributes']['class'][] = 'mel-account-settings__actions';
+  }
+}
+
+/**
+ * Visually groups top-level entity fields without breaking value extraction.
+ *
+ * EntityFormDisplay expects configurable field widgets to remain at their
+ * original top-level keys when it extracts submitted values. Drupal's #group
+ * API renders those same elements inside the requested card while preserving
+ * their form structure and #parents.
+ *
+ * @param array<string, mixed> $form
+ *   The complete user entity form.
+ * @param string[] $field_keys
+ *   Top-level form element keys to group when present.
+ * @param string $group
+ *   The top-level container key that should render the elements.
+ */
+function _myeventlane_account_group_entity_fields(array &$form, array $field_keys, string $group): void {
+  foreach ($field_keys as $key) {
+    if (!isset($form[$key]) || !is_array($form[$key])) {
+      continue;
+    }
+
+    $form[$key]['#group'] = $group;
   }
 }
 

--- a/web/modules/custom/myeventlane_account/tests/src/Unit/CustomerSettingsFormGroupingTest.php
+++ b/web/modules/custom/myeventlane_account/tests/src/Unit/CustomerSettingsFormGroupingTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_account\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards customer settings fields against save-breaking reparenting.
+ *
+ * @group myeventlane_account
+ */
+final class CustomerSettingsFormGroupingTest extends TestCase {
+
+  /**
+   * Ensures visual grouping preserves entity field structure and parents.
+   */
+  public function testEntityFieldsRemainAtTheirOriginalKeys(): void {
+    require_once dirname(__DIR__, 3) . '/myeventlane_account.module';
+
+    $form = [
+      'mel_settings_profile' => [
+        '#type' => 'container',
+      ],
+      'field_display_name' => [
+        '#type' => 'textfield',
+        '#parents' => ['field_display_name'],
+      ],
+      'field_city' => [
+        '#type' => 'textfield',
+        '#parents' => ['field_city'],
+      ],
+    ];
+
+    _myeventlane_account_group_entity_fields(
+      $form,
+      ['field_display_name', 'field_city', 'field_missing'],
+      'mel_settings_profile',
+    );
+
+    $this->assertArrayHasKey('field_display_name', $form);
+    $this->assertArrayHasKey('field_city', $form);
+    $this->assertSame(['field_display_name'], $form['field_display_name']['#parents']);
+    $this->assertSame(['field_city'], $form['field_city']['#parents']);
+    $this->assertSame('mel_settings_profile', $form['field_display_name']['#group']);
+    $this->assertSame('mel_settings_profile', $form['field_city']['#group']);
+    $this->assertArrayNotHasKey('field_missing', $form);
+  }
+
+}


### PR DESCRIPTION
## What changed

- Keep configurable customer account fields at their original top-level form keys.
- Use Drupal's `#group` API to render those fields inside the designed settings cards.
- Add regression coverage confirming field parents and entity-form structure are preserved.

## Why

Customer information entered at `/my-settings/{user}` returned to its previous values after Save. The form alteration moved entity widgets beneath visual containers. Drupal's entity form display extracts configurable values from the widgets at their expected form locations, so the submitted profile values were not persisted.

## Impact

Customer profile and preference fields can be extracted and saved while retaining the existing card-based presentation. No configuration or database update is included.

## Validation

- PHP syntax checks passed for both changed files.
- Drupal and DrupalPractice coding-standard checks passed.
- Focused account unit suite passed: 3 tests, 15 assertions.
- `git diff --check` passed.

## Staging acceptance check

After deployment, sign in as the staging customer and verify that changes made at `/my-settings/48` remain after Save and a full page reload. Also confirm the profile and preferences cards still render correctly on desktop and mobile.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches user entity form value extraction on the customer settings route; wrong grouping could still break profile persistence, but the change is narrow and guarded by a regression test.
> 
> **Overview**
> Fixes customer profile and preference values reverting after Save on `/my-settings/{user}` by **stopping physical reparenting** of configurable entity widgets into settings card containers.
> 
> Entity fields (`field_display_name`, `user_picture`, `field_pronouns`, `field_city`, `field_accessibility_preferences`, `social_auth`) now stay at their **original top-level form keys** and only get `#group` set via new helper `_myeventlane_account_group_entity_fields`, so **EntityFormDisplay** can still extract submitted values while cards render unchanged.
> 
> Adds unit coverage in `CustomerSettingsFormGroupingTest` asserting keys, `#parents`, and `#group` are preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d10a445e9fc2c2f0ee673c9ebe0d00a403eaaa0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->