### PR TITLE
Fix account settings validation and saving

### DIFF
--- a/web/modules/custom/myeventlane_account/myeventlane_account.module
+++ b/web/modules/custom/myeventlane_account/myeventlane_account.module
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
-use Drupal\Core\Render\Element;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
 use Drupal\myeventlane_surface\MelCustomerRouteCatalog;
@@ -511,17 +510,12 @@ function _myeventlane_account_customer_settings_form_alter(array &$form): void {
     'mel_settings_profile',
   );
 
-  if (!empty($form['account']) && is_array($form['account'])) {
-    foreach (['mail', 'name'] as $key) {
-      if (!isset($form['account'][$key])) {
-        continue;
-      }
-      $element = $form['account'][$key];
-      unset($form['account'][$key]);
-      $element['#parents'] = ['account', $key];
-      $form['mel_settings_profile'][$key] = $element;
-    }
-  }
+  _myeventlane_account_group_nested_fields(
+    $form,
+    'account',
+    ['mail', 'name'],
+    'mel_settings_profile',
+  );
 
   $form['mel_settings_security'] = [
     '#type' => 'container',
@@ -539,17 +533,12 @@ function _myeventlane_account_customer_settings_form_alter(array &$form): void {
     '#weight' => -50,
   ];
 
-  if (!empty($form['account']) && is_array($form['account'])) {
-    foreach (['current_pass', 'pass'] as $key) {
-      if (!isset($form['account'][$key])) {
-        continue;
-      }
-      $element = $form['account'][$key];
-      unset($form['account'][$key]);
-      $element['#parents'] = ['account', $key];
-      $form['mel_settings_security'][$key] = $element;
-    }
-  }
+  _myeventlane_account_group_nested_fields(
+    $form,
+    'account',
+    ['current_pass', 'pass'],
+    'mel_settings_security',
+  );
 
   try {
     $reset_url = Url::fromRoute('user.pass');
@@ -695,16 +684,6 @@ function _myeventlane_account_customer_settings_form_alter(array &$form): void {
     $form['mel_settings_support']['body'] = $support + ['#weight' => 0];
   }
 
-  if (isset($form['account'])) {
-    $account_children = Element::children($form['account']);
-    if ($account_children === []) {
-      unset($form['account']);
-    }
-    else {
-      $form['account']['#access'] = FALSE;
-    }
-  }
-
   if (isset($form['actions'])) {
     $form['actions']['#weight'] = 200;
     $form['actions']['#attributes']['class'][] = 'mel-account-settings__actions';
@@ -733,6 +712,33 @@ function _myeventlane_account_group_entity_fields(array &$form, array $field_key
     }
 
     $form[$key]['#group'] = $group;
+  }
+}
+
+/**
+ * Visually groups nested controls while preserving their submitted values.
+ *
+ * Drupal's user account container is not a tree, so controls such as mail and
+ * name submit as top-level values. Moving them and assigning new #parents
+ * changes those values to account[mail] and account[name], which prevents the
+ * core user form from validating and saving the entity.
+ *
+ * @param array<string, mixed> $form
+ *   The complete user entity form.
+ * @param string $parent_key
+ *   The original parent container key.
+ * @param string[] $field_keys
+ *   Child form element keys to group when present.
+ * @param string $group
+ *   The top-level container key that should render the elements.
+ */
+function _myeventlane_account_group_nested_fields(array &$form, string $parent_key, array $field_keys, string $group): void {
+  foreach ($field_keys as $key) {
+    if (!isset($form[$parent_key][$key]) || !is_array($form[$parent_key][$key])) {
+      continue;
+    }
+
+    $form[$parent_key][$key]['#group'] = $group;
   }
 }
 

--- a/web/modules/custom/myeventlane_account/tests/modules/myeventlane_account_test/myeventlane_account_test.info.yml
+++ b/web/modules/custom/myeventlane_account/tests/modules/myeventlane_account_test/myeventlane_account_test.info.yml
@@ -1,0 +1,8 @@
+name: 'MyEventLane Account Test'
+type: module
+description: 'Test-only integration hooks for MyEventLane account forms.'
+package: Testing
+core_version_requirement: ^11
+
+dependencies:
+  - drupal:user

--- a/web/modules/custom/myeventlane_account/tests/modules/myeventlane_account_test/myeventlane_account_test.module
+++ b/web/modules/custom/myeventlane_account/tests/modules/myeventlane_account_test/myeventlane_account_test.module
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @file
+ * Applies the production settings layout to the core user form in tests.
+ */
+
+declare(strict_types=1);
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ */
+function myeventlane_account_test_form_user_form_alter(array &$form, FormStateInterface $form_state): void {
+  require_once dirname(__DIR__, 3) . '/myeventlane_account.module';
+  _myeventlane_account_customer_settings_form_alter($form);
+}

--- a/web/modules/custom/myeventlane_account/tests/modules/myeventlane_account_test/myeventlane_account_test.routing.yml
+++ b/web/modules/custom/myeventlane_account/tests/modules/myeventlane_account_test/myeventlane_account_test.routing.yml
@@ -1,0 +1,6 @@
+myeventlane_notifications.preferences:
+  path: '/account-test/notifications'
+  defaults:
+    _controller: '\Drupal\myeventlane_account_test\Controller\TestController::page'
+  requirements:
+    _access: 'TRUE'

--- a/web/modules/custom/myeventlane_account/tests/modules/myeventlane_account_test/src/Controller/TestController.php
+++ b/web/modules/custom/myeventlane_account/tests/modules/myeventlane_account_test/src/Controller/TestController.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_account_test\Controller;
+
+/**
+ * Supplies inert routes required while rendering the settings form in tests.
+ */
+final class TestController {
+
+  /**
+   * Returns an empty test page.
+   *
+   * @return array<string, mixed>
+   *   An empty render array.
+   */
+  public function page(): array {
+    return [];
+  }
+
+}

--- a/web/modules/custom/myeventlane_account/tests/src/Functional/CustomerSettingsSaveTest.php
+++ b/web/modules/custom/myeventlane_account/tests/src/Functional/CustomerSettingsSaveTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_account\Functional;
+
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\Tests\BrowserTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Verifies customer settings retain Drupal's account form contract and save.
+ *
+ * @group myeventlane_account
+ */
+#[RunTestsInSeparateProcesses]
+final class CustomerSettingsSaveTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'field',
+    'text',
+    'user',
+    'myeventlane_account_test',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    foreach (['field_display_name', 'field_city'] as $field_name) {
+      FieldStorageConfig::create([
+        'field_name' => $field_name,
+        'entity_type' => 'user',
+        'type' => 'string',
+      ])->save();
+      FieldConfig::create([
+        'field_name' => $field_name,
+        'entity_type' => 'user',
+        'bundle' => 'user',
+        'label' => $field_name === 'field_display_name' ? 'Display name' : 'City',
+      ])->save();
+    }
+
+    $this->container->get('entity_display.repository')
+      ->getFormDisplay('user', 'user', 'default')
+      ->setComponent('field_display_name', ['type' => 'string_textfield'])
+      ->setComponent('field_city', ['type' => 'string_textfield'])
+      ->save();
+  }
+
+  /**
+   * Ensures profile values persist and core account values stay top-level.
+   */
+  public function testCustomerSettingsSaveAndReload(): void {
+    $account = $this->drupalCreateUser();
+    $this->drupalLogin($account);
+
+    $this->drupalGet('/user/' . $account->id() . '/edit');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->fieldExists('mail');
+    $this->assertSession()->fieldNotExists('account[mail]');
+    $this->assertSession()->fieldExists('name');
+    $this->assertSession()->fieldNotExists('account[name]');
+
+    $this->submitForm([
+      'field_display_name[0][value]' => 'Customer Test',
+      'field_city[0][value]' => 'Sydney',
+    ], 'Save');
+
+    $this->assertSession()->pageTextContains('The changes have been saved.');
+
+    $this->drupalGet('/user/' . $account->id() . '/edit');
+    $this->assertSession()->fieldValueEquals('field_display_name[0][value]', 'Customer Test');
+    $this->assertSession()->fieldValueEquals('field_city[0][value]', 'Sydney');
+  }
+
+}

--- a/web/modules/custom/myeventlane_account/tests/src/Unit/CustomerSettingsFormGroupingTest.php
+++ b/web/modules/custom/myeventlane_account/tests/src/Unit/CustomerSettingsFormGroupingTest.php
@@ -48,4 +48,43 @@ final class CustomerSettingsFormGroupingTest extends TestCase {
     $this->assertArrayNotHasKey('field_missing', $form);
   }
 
+  /**
+   * Ensures core account controls retain their original submitted parents.
+   */
+  public function testNestedAccountFieldsRetainTheirOriginalParents(): void {
+    require_once dirname(__DIR__, 3) . '/myeventlane_account.module';
+
+    $form = [
+      'mel_settings_profile' => [
+        '#type' => 'container',
+      ],
+      'account' => [
+        '#type' => 'container',
+        'mail' => [
+          '#type' => 'email',
+          '#parents' => ['mail'],
+        ],
+        'name' => [
+          '#type' => 'textfield',
+          '#parents' => ['name'],
+        ],
+      ],
+    ];
+
+    _myeventlane_account_group_nested_fields(
+      $form,
+      'account',
+      ['mail', 'name', 'missing'],
+      'mel_settings_profile',
+    );
+
+    $this->assertArrayHasKey('mail', $form['account']);
+    $this->assertArrayHasKey('name', $form['account']);
+    $this->assertSame(['mail'], $form['account']['mail']['#parents']);
+    $this->assertSame(['name'], $form['account']['name']['#parents']);
+    $this->assertSame('mel_settings_profile', $form['account']['mail']['#group']);
+    $this->assertSame('mel_settings_profile', $form['account']['name']['#group']);
+    $this->assertArrayNotHasKey('missing', $form['account']);
+  }
+
 }


### PR DESCRIPTION
## What changed

- Keep Drupal core account controls at their original form locations and submitted names.
- Render email, username and password controls inside the existing settings cards with Drupal's `#group` mechanism.
- Remove the account-container suppression that prevented core validation and saving.
- Add structural and browser-level regression coverage.

## Root cause

The customer settings layout moved Drupal's account controls and reassigned their `#parents`. The browser therefore submitted `account[mail]` and `account[name]`, while Drupal's user form validates and saves top-level `mail` and `name`. Required account values appeared missing, entity validation blocked the complete save, and the errors could not attach to the relocated controls.

## Impact

Customer and organiser account settings can retain the existing card presentation while using Drupal's standard user validation and entity-save path.

## Validation

- Account unit suite passed: 4 tests, 22 assertions.
- Drupal browser test passed: 1 test, 12 assertions.
- The browser test confirms top-level account field names, submits display name and city, receives the standard save confirmation, reloads and confirms both values persisted.
- PHP syntax, Drupal and DrupalPractice coding standards, and `git diff --check` passed.

## Staging acceptance check

After deployment, test `/my-settings/48` as the customer and `/my-settings/49` as the organiser. Change display name and city, save, perform a full reload, and confirm both values persist and the Profile and Security cards still render correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches user account form structure and submit field names; incorrect grouping could still break sign-in credential updates, though the new tests specifically guard the Drupal account form contract.
> 
> **Overview**
> Fixes customer account settings so **saves and validation work again** while keeping email, username, and password inside the Profile and Security cards.
> 
> The layout previously **moved** core `account` fields into card containers and rewrote `#parents`, so the browser posted `account[mail]` / `account[name]` instead of Drupal’s expected top-level `mail` / `name`. That broke core user form validation and blocked entity saves. The change **stops relocating** those elements and only sets `#group` on nested account controls via a new `_myeventlane_account_group_nested_fields()` helper (same idea as top-level entity fields). It also **drops** hiding or removing the empty `account` container after grouping.
> 
> Regression coverage adds a unit test for nested account `#parents` / `#group`, a functional test that asserts top-level field names and profile field persistence, and a small `myeventlane_account_test` module to apply the production settings alter on the core user edit form in tests (plus a stub notifications preferences route for form rendering).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ccd3ebd03e57c4a94076fd30db28506dbaaf978. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->