### PR TITLE
Protect account form values from language rewriting

### DIFF
--- a/web/modules/custom/myeventlane_core/tests/src/Unit/LanguageStyleFormPreprocessContractTest.php
+++ b/web/modules/custom/myeventlane_core/tests/src/Unit/LanguageStyleFormPreprocessContractTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_core\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects Drupal form machine values from display-language rewriting.
+ *
+ * @group myeventlane_core
+ */
+final class LanguageStyleFormPreprocessContractTest extends TestCase {
+
+  /**
+   * Ensures the generic theme preprocessor excludes form element hooks.
+   */
+  public function testFormElementHooksAreExcludedFromLanguageRewriting(): void {
+    $theme_file = dirname(__DIR__, 6) . '/themes/custom/myeventlane_theme/myeventlane_theme.theme';
+    $source = file_get_contents($theme_file);
+
+    self::assertIsString($source);
+    self::assertStringContainsString("'form',", $source);
+    self::assertStringContainsString("'input',", $source);
+    self::assertStringContainsString("'textarea',", $source);
+    self::assertStringContainsString("'select',", $source);
+    self::assertStringContainsString('$hook === $form_theme_hook', $source);
+    self::assertStringContainsString("str_starts_with(\$hook, \$form_theme_hook . '__')", $source);
+    self::assertStringContainsString('rewriting the hidden value user_form to member_form', $source);
+  }
+
+}

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -361,12 +361,27 @@ function myeventlane_theme_preprocess(array &$variables, string $hook): void {
     return;
   }
 
-  // Form templates carry Drupal render arrays and Attribute data; do not run the
-  // generic string walker here. Walking those trees has caused
-  // InvalidArgumentException for keys like data-drupal-selector (must live under
-  // #attributes only). Form strings already go through t().
-  if (str_starts_with($hook, 'form')) {
-    return;
+  // Form templates and their child elements carry submitted values as ordinary
+  // template variables. The generic language walker must not touch them: for
+  // example, rewriting the hidden value user_form to member_form prevents
+  // Drupal from recognising and submitting the form. Labels already go through
+  // t(), so form wording does not depend on this generic fallback.
+  $form_theme_hooks = [
+    'form',
+    'input',
+    'textarea',
+    'select',
+    'checkboxes',
+    'radios',
+    'form_element',
+    'form_element_label',
+    'fieldset',
+    'details',
+  ];
+  foreach ($form_theme_hooks as $form_theme_hook) {
+    if ($hook === $form_theme_hook || str_starts_with($hook, $form_theme_hook . '__')) {
+      return;
+    }
   }
 
   // Email wrappers carry rendered HTML with canonical hrefs (e.g. /vendors/…).


### PR DESCRIPTION
## What changed

- Exclude Drupal form controls from the global display-language preprocessor.
- Preserve submitted machine values such as `user_form` and user-entered input.
- Add regression coverage for the form-hook exclusion contract.

## Root cause

The global wording filter changed the hidden Drupal form identifier from `user_form` to `member_form`. Drupal could not recognise the POST, so the settings page rebuilt without running its save handler.

## Validation

- Language-style form contract: 1 test, 7 assertions
- Account settings grouping: 2 tests, 14 assertions
- PHP syntax check
- MyEventLane theme lint
- Git whitespace check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted early-return in theme preprocess with regression test; no auth or data-model changes beyond fixing broken form submission.
> 
> **Overview**
> Fixes account and other Drupal forms failing to save when the global **language-style** preprocessor rewrote machine values (e.g. hidden `user_form` → `member_form`), so Drupal no longer recognised the POST.
> 
> **`myeventlane_theme_preprocess()`** no longer runs the generic string walker on form-related theme hooks. The old guard only skipped hooks whose names started with `form`; child hooks like `input`, `textarea`, and `select` were still processed. The change uses an explicit list (`form`, `input`, `textarea`, `select`, `checkboxes`, `radios`, `form_element`, `form_element_label`, `fieldset`, `details`) and bails out on exact hook names or `hook__*` suggestions.
> 
> Adds **`LanguageStyleFormPreprocessContractTest`** to lock in that exclusion list and the documented `user_form` / `member_form` rationale in the theme file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27708b05dac1b54824f031eaa6825eaca9b649ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->