### PR TITLE
Redesign customer profile settings hub

### DIFF
--- a/web/modules/custom/myeventlane_account/myeventlane_account.module
+++ b/web/modules/custom/myeventlane_account/myeventlane_account.module
@@ -470,6 +470,11 @@ function _myeventlane_account_customer_settings_form_alter(array &$form): void {
   if (isset($form['account']['roles'])) {
     $form['account']['roles']['#access'] = FALSE;
   }
+  // Commerce store ownership is managed through Organiser Studio. It is an
+  // internal relationship and must not leak into the customer settings UI.
+  if (isset($form['field_vendor_store'])) {
+    $form['field_vendor_store']['#access'] = FALSE;
+  }
 
   if (isset($form['account']['name'])) {
     $form['account']['name']['#title'] = t('Sign-in username');
@@ -486,11 +491,14 @@ function _myeventlane_account_customer_settings_form_alter(array &$form): void {
     $form['account']['pass']['#description'] = t('Leave blank to keep your current password.');
   }
 
-  $card_attr = ['class' => ['mel-account-settings__card']];
+  $card_attr = ['class' => ['mel-account-settings__card', 'mel-account-settings__section']];
 
   $form['mel_settings_profile'] = [
     '#type' => 'container',
-    '#attributes' => $card_attr + ['aria-labelledby' => 'mel-settings-profile-title'],
+    '#attributes' => $card_attr + [
+      'aria-labelledby' => 'mel-settings-profile-title',
+      'data-mel-settings-card' => 'profile',
+    ],
     '#weight' => -200,
   ];
   $form['mel_settings_profile']['_title'] = [
@@ -510,22 +518,18 @@ function _myeventlane_account_customer_settings_form_alter(array &$form): void {
     'mel_settings_profile',
   );
 
-  _myeventlane_account_group_nested_fields(
-    $form,
-    'account',
-    ['mail', 'name'],
-    'mel_settings_profile',
-  );
-
   $form['mel_settings_security'] = [
     '#type' => 'container',
-    '#attributes' => $card_attr + ['aria-labelledby' => 'mel-settings-security-title'],
+    '#attributes' => $card_attr + [
+      'aria-labelledby' => 'mel-settings-security-title',
+      'data-mel-settings-card' => 'security',
+    ],
     '#weight' => -190,
   ];
   $form['mel_settings_security']['_title'] = [
     '#type' => 'html_tag',
     '#tag' => 'h2',
-    '#value' => t('Security'),
+    '#value' => t('Account & security'),
     '#attributes' => [
       'id' => 'mel-settings-security-title',
       'class' => ['mel-account-settings__heading'],
@@ -536,7 +540,13 @@ function _myeventlane_account_customer_settings_form_alter(array &$form): void {
   _myeventlane_account_group_nested_fields(
     $form,
     'account',
-    ['current_pass', 'pass'],
+    ['mail', 'name', 'current_pass', 'pass'],
+    'mel_settings_security',
+  );
+
+  _myeventlane_account_group_entity_fields(
+    $form,
+    ['social_auth'],
     'mel_settings_security',
   );
 
@@ -569,7 +579,10 @@ function _myeventlane_account_customer_settings_form_alter(array &$form): void {
   if (isset($form['contact']) || $prefs_link !== []) {
     $form['mel_settings_notifications'] = [
       '#type' => 'container',
-      '#attributes' => $card_attr + ['aria-labelledby' => 'mel-settings-notify-title'],
+      '#attributes' => $card_attr + [
+        'aria-labelledby' => 'mel-settings-notify-title',
+        'data-mel-settings-card' => 'notifications',
+      ],
       '#weight' => -180,
     ];
     $form['mel_settings_notifications']['_title'] = [
@@ -597,7 +610,10 @@ function _myeventlane_account_customer_settings_form_alter(array &$form): void {
 
   $form['mel_settings_preferences'] = [
     '#type' => 'container',
-    '#attributes' => $card_attr + ['aria-labelledby' => 'mel-settings-prefs-title'],
+    '#attributes' => $card_attr + [
+      'aria-labelledby' => 'mel-settings-prefs-title',
+      'data-mel-settings-card' => 'preferences',
+    ],
     '#weight' => -170,
   ];
   $form['mel_settings_preferences']['_title'] = [
@@ -648,9 +664,17 @@ function _myeventlane_account_customer_settings_form_alter(array &$form): void {
 
   _myeventlane_account_group_entity_fields(
     $form,
-    ['field_accessibility_preferences', 'social_auth'],
+    ['field_accessibility_preferences'],
     'mel_settings_preferences',
   );
+  if (isset($form['field_accessibility_preferences']['#attributes']['class'])) {
+    $classes = &$form['field_accessibility_preferences']['#attributes']['class'];
+    $classes = is_array($classes) ? $classes : [$classes];
+    $classes[] = 'mel-account-settings__accessibility';
+  }
+  elseif (isset($form['field_accessibility_preferences'])) {
+    $form['field_accessibility_preferences']['#attributes']['class'] = ['mel-account-settings__accessibility'];
+  }
 
   $prefs_more = _myeventlane_account_customer_settings_preference_links();
   if ($prefs_more !== []) {
@@ -668,7 +692,10 @@ function _myeventlane_account_customer_settings_form_alter(array &$form): void {
   if ($support !== []) {
     $form['mel_settings_support'] = [
       '#type' => 'container',
-      '#attributes' => $card_attr + ['aria-labelledby' => 'mel-settings-support-title'],
+      '#attributes' => [
+        'class' => ['mel-account-settings__card', 'mel-account-settings__support'],
+        'aria-labelledby' => 'mel-settings-support-title',
+      ],
       '#weight' => -160,
     ];
     $form['mel_settings_support']['_title'] = [
@@ -687,6 +714,7 @@ function _myeventlane_account_customer_settings_form_alter(array &$form): void {
   if (isset($form['actions'])) {
     $form['actions']['#weight'] = 200;
     $form['actions']['#attributes']['class'][] = 'mel-account-settings__actions';
+    $form['actions']['#attributes']['aria-live'] = 'polite';
   }
 }
 

--- a/web/modules/custom/myeventlane_account/src/Controller/MyAccountController.php
+++ b/web/modules/custom/myeventlane_account/src/Controller/MyAccountController.php
@@ -173,7 +173,10 @@ final class MyAccountController extends ControllerBase {
       '#intro' => $this->t('Personal details, sign-in security, and how we stay in touch.'),
       '#form' => $form,
       '#attached' => [
-        'library' => ['myeventlane_theme/global-styling'],
+        'library' => [
+          'myeventlane_theme/global-styling',
+          'myeventlane_theme/account-settings-hub',
+        ],
       ],
     ];
     $cache->applyTo($build);

--- a/web/themes/custom/myeventlane_theme/js/account-settings-hub.js
+++ b/web/themes/custom/myeventlane_theme/js/account-settings-hub.js
@@ -1,0 +1,174 @@
+(function (Drupal, once) {
+  'use strict';
+
+  const fieldValue = (form, selector) => {
+    const field = form.querySelector(selector);
+    return field && typeof field.value === 'string' ? field.value.trim() : '';
+  };
+
+  const selectedLabel = (form, selector) => {
+    const field = form.querySelector(selector);
+    if (!field || field.selectedIndex < 0) {
+      return '';
+    }
+    return field.options[field.selectedIndex].text.trim();
+  };
+
+  const summaries = {
+    profile(form) {
+      return [
+        fieldValue(form, '[name="field_display_name[0][value]"]'),
+        fieldValue(form, '[name="field_city[0][value]"]'),
+      ].filter(Boolean).join(' · ') || Drupal.t('Add your personal details');
+    },
+    security(form) {
+      const email = fieldValue(form, '[name="mail"]');
+      return email ? Drupal.t('@email · Password protected', {'@email': email}) : Drupal.t('Password protected');
+    },
+    notifications(form) {
+      const contact = form.querySelector('[name="contact"]');
+      return contact && contact.checked
+        ? Drupal.t('Personal contact form is on')
+        : Drupal.t('Personal contact form is off');
+    },
+    preferences(form) {
+      return [
+        selectedLabel(form, '[name="preferred_langcode"]'),
+        selectedLabel(form, '[name="timezone"]'),
+      ].filter(Boolean).join(' · ') || Drupal.t('Choose language and region');
+    },
+  };
+
+  const updateOverview = (root, form) => {
+    const summary = root.querySelector('[data-mel-settings-overview]');
+    if (summary) {
+      summary.textContent = summaries.profile(form);
+    }
+
+    const avatar = root.querySelector('[data-mel-settings-avatar]');
+    const source = document.querySelector('.mel-my-account__avatar');
+    if (avatar && source && !avatar.hasChildNodes()) {
+      avatar.append(source.cloneNode(true));
+    }
+  };
+
+  Drupal.behaviors.melAccountSettingsHub = {
+    attach(context) {
+      once('mel-account-settings-hub', '.mel-account-settings', context).forEach((root) => {
+        const form = root.querySelector('.mel-account-settings-form');
+        if (!form) {
+          return;
+        }
+
+        const cards = Array.from(form.querySelectorAll('[data-mel-settings-card]'));
+
+        const closeCard = (card) => {
+          card.classList.remove('is-editing');
+          const button = card.querySelector('[data-mel-settings-toggle]');
+          const editor = card.querySelector('[data-mel-settings-editor]');
+          if (button) {
+            button.setAttribute('aria-expanded', 'false');
+            button.textContent = Drupal.t('Edit');
+          }
+          if (editor) {
+            editor.hidden = true;
+          }
+        };
+
+        const refreshCard = (card) => {
+          const key = card.dataset.melSettingsCard;
+          const summary = card.querySelector('[data-mel-settings-summary]');
+          if (summary && summaries[key]) {
+            summary.textContent = summaries[key](form);
+          }
+        };
+
+        cards.forEach((card) => {
+          const heading = card.querySelector('.mel-account-settings__heading');
+          if (!heading) {
+            return;
+          }
+
+          const summary = document.createElement('p');
+          summary.className = 'mel-account-settings__summary';
+          summary.dataset.melSettingsSummary = '';
+
+          const toggle = document.createElement('button');
+          toggle.type = 'button';
+          toggle.className = 'mel-account-settings__toggle';
+          toggle.dataset.melSettingsToggle = '';
+          toggle.setAttribute('aria-expanded', 'false');
+          toggle.textContent = Drupal.t('Edit');
+
+          const editor = document.createElement('div');
+          editor.className = 'mel-account-settings__editor';
+          editor.dataset.melSettingsEditor = '';
+          Array.from(card.children).forEach((child) => {
+            if (child !== heading) {
+              editor.append(child);
+            }
+          });
+
+          heading.after(toggle);
+          heading.after(summary);
+          card.append(editor);
+          refreshCard(card);
+          closeCard(card);
+
+          toggle.addEventListener('click', () => {
+            const opening = !card.classList.contains('is-editing');
+            cards.forEach(closeCard);
+            if (opening) {
+              card.classList.add('is-editing');
+              toggle.setAttribute('aria-expanded', 'true');
+              toggle.textContent = Drupal.t('Done');
+              editor.hidden = false;
+              const firstControl = editor.querySelector('input:not([type="hidden"]), select, textarea, button, a');
+              if (firstControl) {
+                firstControl.focus({preventScroll: true});
+              }
+            }
+          });
+        });
+
+        // Core's account container and contrib's social-auth details can remain
+        // as root-level siblings even when their children use #group. Rehome the
+        // intact DOM containers after render; their input names and Drupal form
+        // parents are unchanged.
+        const securityEditor = form.querySelector('[data-mel-settings-card="security"] [data-mel-settings-editor]');
+        if (securityEditor) {
+          ['#edit-account', '#edit-social-auth'].forEach((selector) => {
+            const orphan = form.querySelector(selector);
+            if (orphan && !securityEditor.contains(orphan)) {
+              securityEditor.append(orphan);
+            }
+          });
+        }
+
+        const invalidCard = cards.find((card) => card.querySelector('.error, [aria-invalid="true"]'));
+        if (invalidCard) {
+          const toggle = invalidCard.querySelector('[data-mel-settings-toggle]');
+          if (toggle) {
+            toggle.click();
+          }
+        }
+
+        const markDirty = () => {
+          form.classList.add('is-dirty');
+          const actions = form.querySelector('.mel-account-settings__actions');
+          if (actions) {
+            actions.classList.add('is-visible');
+          }
+          cards.forEach(refreshCard);
+          updateOverview(root, form);
+        };
+
+        form.addEventListener('input', markDirty);
+        form.addEventListener('change', markDirty);
+        form.addEventListener('submit', () => form.classList.remove('is-dirty'));
+        updateOverview(root, form);
+        root.classList.add('is-enhanced');
+      });
+    },
+  };
+})(Drupal, once);

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.libraries.yml
@@ -15,6 +15,13 @@ global-styling:
     - core/once
     - myeventlane_theme/skeleton
 
+account-settings-hub:
+  js:
+    js/account-settings-hub.js: { attributes: { defer: true } }
+  dependencies:
+    - core/drupal
+    - core/once
+
 # Event card grid: skeleton → content swap (see src/js/skeleton.js).
 skeleton:
   js:

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_account-settings.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_account-settings.scss
@@ -1,16 +1,17 @@
-// Customer settings (/my-settings/{user}) — canonical user entity form, MEL presentation.
-// Mobile-first; complements mel-form-system tokens.
+// Profile hub (/my-settings/{user}) — progressive enhancement over Drupal's
+// canonical user entity form. Field names and submission structure stay intact.
 
+@use 'sass:color';
 @use '../tokens/spacing';
 @use '../tokens/colors';
 @use '../tokens/typography';
 @use '../tokens/radii';
-
-$mel-account-settings-radius: radii.$mel-radius-md;
+@use '../tokens/shadows';
+@use '../tokens/breakpoints';
 
 .mel-account-settings {
   width: 100%;
-  max-width: 42rem;
+  max-width: 68rem;
 }
 
 .mel-my-account__header--settings-compact {
@@ -25,13 +26,195 @@ $mel-account-settings-radius: radii.$mel-radius-md;
   }
 }
 
+.mel-account-settings__overview {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: spacing.mel-space(4);
+  margin-block-end: spacing.mel-space(5);
+  padding: spacing.mel-space(4);
+  overflow: hidden;
+  border: 1px solid color.adjust(colors.$mel-color-primary, $alpha: -0.78);
+  border-radius: radii.$mel-radius-xl;
+  background:
+    radial-gradient(circle at 92% 10%, color.adjust(colors.$mel-color-accent, $alpha: -0.82), transparent 36%),
+    linear-gradient(135deg, colors.$mel-color-surface 0%, color.adjust(colors.$mel-color-primary, $alpha: -0.93) 100%);
+  box-shadow: shadows.$mel-shadow-sm;
+
+  @include breakpoints.mel-break(md) {
+    gap: spacing.mel-space(5);
+    padding: spacing.mel-space(5);
+  }
+}
+
+.mel-account-settings__overview-avatar {
+  display: grid;
+  width: 68px;
+  height: 68px;
+  flex: 0 0 68px;
+  place-items: center;
+  overflow: hidden;
+  border: 4px solid colors.$mel-color-surface;
+  border-radius: 50%;
+  background: color.adjust(colors.$mel-color-primary, $alpha: -0.84);
+  box-shadow: shadows.$mel-shadow-sm;
+
+  .mel-my-account__avatar {
+    width: 100%;
+    height: 100%;
+  }
+}
+
+.mel-account-settings__overview-copy {
+  min-width: 0;
+
+  h2 {
+    margin: spacing.mel-space(1) 0;
+    color: colors.$mel-color-text;
+    font-size: typography.mel-font-size(xl);
+    font-weight: typography.$mel-font-bold;
+    letter-spacing: -0.02em;
+  }
+
+  p {
+    margin: 0;
+    color: colors.$mel-color-text-muted;
+    line-height: 1.5;
+  }
+}
+
+.mel-account-settings__privacy-badge {
+  display: inline-flex;
+  min-height: 28px;
+  align-items: center;
+  padding-inline: spacing.mel-space(3);
+  border-radius: radii.$mel-radius-full;
+  background: colors.$mel-color-surface;
+  color: colors.$mel-color-text-muted;
+  font-size: typography.mel-font-size(xs);
+  font-weight: typography.$mel-font-semibold;
+  box-shadow: shadows.$mel-shadow-sm;
+}
+
+.mel-account-settings-form.mel-form,
+.mel-account-settings-form.mel-account-user-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: spacing.mel-space(4);
+
+  @include breakpoints.mel-break(lg) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.mel-account-settings__card {
+  position: relative;
+  min-width: 0;
+  padding: spacing.mel-space(4);
+  border: 1px solid var(--mel-color-border-subtle, #{colors.$mel-color-border});
+  border-radius: radii.$mel-radius-xl;
+  background: colors.$mel-color-surface;
+  box-shadow: shadows.$mel-shadow-sm;
+  transition: border-color 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+
+  &:hover {
+    border-color: color.adjust(colors.$mel-color-accent, $alpha: -0.7);
+    box-shadow: shadows.$mel-shadow-md;
+  }
+
+  &.is-editing {
+    border-color: color.adjust(colors.$mel-color-accent, $alpha: -0.25);
+    box-shadow: 0 12px 30px color.adjust(colors.$mel-color-accent, $alpha: -0.86);
+  }
+
+  @include breakpoints.mel-break(md) {
+    padding: spacing.mel-space(5);
+  }
+}
+
+.mel-account-settings__section[data-mel-settings-card='profile'],
+.mel-account-settings__support,
+.mel-account-settings__actions,
+.mel-account-settings-form > [data-drupal-selector='edit-actions'] {
+  @include breakpoints.mel-break(lg) {
+    grid-column: 1 / -1;
+  }
+}
+
+.mel-account-settings__heading {
+  max-width: calc(100% - 5rem);
+  margin: 0;
+  color: colors.$mel-color-text;
+  font-size: typography.mel-font-size(lg);
+  font-weight: typography.$mel-font-semibold;
+  letter-spacing: -0.01em;
+}
+
+.mel-account-settings__summary {
+  max-width: calc(100% - 5rem);
+  margin: spacing.mel-space(2) 0 0;
+  color: colors.$mel-color-text-muted;
+  font-size: typography.mel-font-size(sm);
+  line-height: 1.45;
+}
+
+.mel-account-settings__toggle {
+  position: absolute;
+  inset-block-start: spacing.mel-space(4);
+  inset-inline-end: spacing.mel-space(4);
+  min-width: 64px;
+  min-height: 40px;
+  padding: spacing.mel-space(2) spacing.mel-space(3);
+  border: 1px solid color.adjust(colors.$mel-color-primary, $alpha: -0.55);
+  border-radius: radii.$mel-radius-full;
+  background: color.adjust(colors.$mel-color-primary, $alpha: -0.91);
+  color: colors.$mel-color-primary-hover;
+  font: inherit;
+  font-size: typography.mel-font-size(sm);
+  font-weight: typography.$mel-font-semibold;
+  cursor: pointer;
+
+  &:hover {
+    background: color.adjust(colors.$mel-color-primary, $alpha: -0.84);
+  }
+
+  &:focus-visible {
+    outline: 3px solid color.adjust(colors.$mel-color-primary, $alpha: -0.55);
+    outline-offset: 2px;
+  }
+}
+
+.mel-account-settings__editor {
+  margin-block-start: spacing.mel-space(5);
+  padding-block-start: spacing.mel-space(4);
+  border-block-start: 1px solid colors.$mel-color-border;
+  animation: mel-settings-reveal 180ms ease-out;
+}
+
+@keyframes mel-settings-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 .mel-account-settings__inline-link {
   display: inline-flex;
   min-height: 44px;
   align-items: center;
-  font-weight: typography.$mel-font-medium;
-  text-decoration: underline;
-  text-underline-offset: 2px;
+  color: colors.$mel-color-accent;
+  font-weight: typography.$mel-font-semibold;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
 
   &:focus-visible {
     outline: 2px solid colors.$mel-focus-ring-color;
@@ -40,79 +223,61 @@ $mel-account-settings-radius: radii.$mel-radius-md;
   }
 }
 
-.mel-account-settings__intro {
-  margin: 0 0 spacing.mel-space(4);
-  font-size: typography.mel-font-size(md);
-  line-height: 1.5;
-  color: colors.$mel-color-text-muted;
-}
-
-.mel-account-settings-form.mel-form,
-.mel-account-settings-form.mel-account-user-form {
-  display: flex;
-  flex-direction: column;
-  gap: spacing.mel-space(4);
-}
-
-.mel-account-settings__card {
-  padding: spacing.mel-space(4);
-  border-radius: $mel-account-settings-radius;
-  background: var(--mel-color-surface-raised, #{colors.$mel-color-surface});
-  border: 1px solid var(--mel-color-border-subtle, rgba(0, 0, 0, 0.08));
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
-}
-
-.mel-account-settings__heading {
-  margin: 0 0 spacing.mel-space(3);
-  font-size: typography.mel-font-size(lg);
-  font-weight: typography.$mel-font-semibold;
-  color: colors.$mel-color-text;
-  letter-spacing: -0.01em;
-}
-
-.mel-account-settings__card-body {
-  display: flex;
-  flex-direction: column;
-  gap: spacing.mel-space(3);
-}
-
 .mel-account-settings__subheading {
-  margin: spacing.mel-space(2) 0 spacing.mel-space(2);
-  font-size: typography.mel-font-size(sm);
-  font-weight: typography.$mel-font-semibold;
-  color: colors.$mel-color-text-muted;
+  margin: spacing.mel-space(4) 0 spacing.mel-space(2);
+  color: colors.$mel-color-text-light;
+  font-size: typography.mel-font-size(xs);
+  font-weight: typography.$mel-font-bold;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+}
+
+.mel-account-settings__support {
+  padding-block: spacing.mel-space(4);
+
+  .mel-account-settings__heading {
+    margin-block-end: spacing.mel-space(2);
+  }
 }
 
 .mel-account-settings__support-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: spacing.mel-space(2);
   margin: 0;
   padding: 0;
   list-style: none;
 
   li {
-    margin-block-end: spacing.mel-space(2);
+    margin: 0;
   }
 
   a {
     display: inline-flex;
     min-height: 44px;
     align-items: center;
+    padding-inline: spacing.mel-space(3);
+    border-radius: radii.$mel-radius-full;
+    background: colors.$mel-color-surface-alt;
+    color: colors.$mel-color-text;
+    font-size: typography.mel-font-size(sm);
     font-weight: typography.$mel-font-medium;
-    text-decoration: underline;
-    text-underline-offset: 2px;
+    text-decoration: none;
+
+    &:hover {
+      background: color.adjust(colors.$mel-color-accent, $alpha: -0.88);
+    }
 
     &:focus-visible {
       outline: 2px solid colors.$mel-focus-ring-color;
       outline-offset: 2px;
-      border-radius: radii.$mel-radius-sm;
     }
   }
 }
 
 .mel-account-settings-form {
-  // Replace Drupal details/fieldset chrome inside customer settings cards.
-  details {
+  details,
+  fieldset:not(.fieldgroup) {
     margin: 0;
     padding: 0;
     border: 0;
@@ -120,17 +285,12 @@ $mel-account-settings-radius: radii.$mel-radius-md;
   }
 
   summary {
+    min-height: 44px;
     list-style: none;
 
     &::-webkit-details-marker {
       display: none;
     }
-  }
-
-  fieldset:not(.fieldgroup) {
-    margin: 0;
-    padding: 0;
-    border: 0;
   }
 
   .fieldset-wrapper {
@@ -145,35 +305,132 @@ $mel-account-settings-radius: radii.$mel-radius-md;
     }
   }
 
+  input:not([type='checkbox'], [type='radio'], [type='submit']),
+  select,
+  textarea {
+    width: 100%;
+    min-height: 48px;
+    border-color: colors.$mel-color-border;
+    border-radius: radii.$mel-radius-md;
+    background: colors.$mel-color-surface;
+
+    &:focus {
+      border-color: colors.$mel-color-primary;
+      box-shadow: 0 0 0 3px color.adjust(colors.$mel-color-primary, $alpha: -0.82);
+    }
+  }
+
   .description,
   .help-text,
   .form-item__description {
     margin-top: spacing.mel-space(1);
+    color: colors.$mel-color-text-light;
     font-size: typography.mel-font-size(sm);
     line-height: 1.45;
-    color: colors.$mel-color-text-muted;
   }
 
-  .form-actions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: spacing.mel-space(3);
-    margin-top: spacing.mel-space(2);
+  .mel-account-settings__accessibility {
+    .ck-toolbar,
+    .filter-wrapper,
+    .filter-guidelines,
+    .form-type-select {
+      display: none;
+    }
 
-    .button,
-    .mel-btn {
-      min-height: 44px;
-      padding-inline: spacing.mel-space(4);
+    .ck-editor__editable {
+      min-height: 8rem;
+      border-radius: radii.$mel-radius-md;
     }
   }
 
-  .mel-account-settings__prefs-links {
-    margin-top: spacing.mel-space(2);
+  .social-auth,
+  [data-drupal-selector*='social-auth'] {
+    table {
+      width: 100%;
+      border: 0;
+      border-collapse: separate;
+      border-spacing: 0;
+      border-radius: radii.$mel-radius-md;
+      background: colors.$mel-color-surface-alt;
+    }
+
+    th {
+      font-size: typography.mel-font-size(xs);
+    }
   }
 }
 
-@media (width >= 48rem) {
+.mel-account-settings__actions {
+  display: flex;
+  z-index: 20;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: spacing.mel-space(3);
+  margin: 0;
+  padding: spacing.mel-space(3);
+  border: 1px solid colors.$mel-color-border;
+  border-radius: radii.$mel-radius-xl;
+  background: color.adjust(colors.$mel-color-surface, $alpha: -0.04);
+  box-shadow: shadows.$mel-shadow-md;
+
+  .is-enhanced & {
+    position: sticky;
+    inset-block-end: spacing.mel-space(3);
+    visibility: hidden;
+    opacity: 0;
+    transform: translateY(8px);
+    transition: opacity 160ms ease, transform 160ms ease, visibility 160ms;
+  }
+
+  .is-enhanced &.is-visible {
+    visibility: visible;
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  .button,
+  .mel-btn {
+    min-width: 150px;
+    min-height: 48px;
+    padding-inline: spacing.mel-space(5);
+    border-radius: radii.$mel-radius-full;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mel-account-settings__card,
+  .mel-account-settings__editor,
+  .mel-account-settings__actions {
+    animation: none;
+    transition: none;
+  }
+}
+
+@media (width < 48rem) {
+  .mel-account-settings__overview {
+    align-items: flex-start;
+  }
+
+  .mel-account-settings__overview-avatar {
+    width: 56px;
+    height: 56px;
+    flex-basis: 56px;
+  }
+
+  .mel-account-settings__overview-copy h2 {
+    font-size: typography.mel-font-size(lg);
+  }
+
   .mel-account-settings__card {
-    padding: spacing.mel-space(5);
+    border-radius: radii.$mel-radius-lg;
+  }
+
+  .mel-account-settings__actions {
+    inset-inline: spacing.mel-space(3);
+
+    .button,
+    .mel-btn {
+      width: 100%;
+    }
   }
 }

--- a/web/themes/custom/myeventlane_theme/templates/account/mel-account-settings.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/account/mel-account-settings.html.twig
@@ -10,8 +10,13 @@
  */
 #}
 <div class="mel-account-settings mel-form-system mel-form-system--customer-settings">
-  {% if intro %}
-    <p class="mel-account-settings__intro">{{ intro }}</p>
-  {% endif %}
+  <section class="mel-account-settings__overview" aria-labelledby="mel-account-overview-title">
+    <div class="mel-account-settings__overview-avatar" data-mel-settings-avatar aria-hidden="true"></div>
+    <div class="mel-account-settings__overview-copy">
+      <span class="mel-account-settings__privacy-badge">{{ 'Private account'|t }}</span>
+      <h2 id="mel-account-overview-title">{{ 'Your profile'|t }}</h2>
+      <p data-mel-settings-overview>{{ 'Keep your details current for smoother bookings and relevant event suggestions.'|t }}</p>
+    </div>
+  </section>
   {{ form }}
 </div>


### PR DESCRIPTION
## What changed

- redesigns customer Profile & Settings as a compact profile hub
- adds progressive Edit and Done controls for profile, security, notification and preference cards
- adds an account overview and sticky Save action after changes
- keeps Drupal's canonical user form field names and submission structure intact
- hides the internal vendor store relationship from customer settings
- improves mobile spacing, accessible focus states and reduced-motion behaviour

## Why

The existing page exposed too much of Drupal's default form presentation. This change gives customers a clearer summary-first experience while preserving the entity-form contract that saves account information.

## Impact

Customers see private-by-default profile information in a more approachable layout. They can open only the section they need, update it and use the existing Drupal save flow. Organiser Studio and vendor profile settings are unchanged.

## Validation

- real customer-form submit, success confirmation and hard reload retained display name and city in the isolated DDEV preview
- desktop and 390 px mobile layouts checked
- PHP syntax checks passed
- JavaScript syntax check passed
- CSS lint passed
- both production theme builds passed
- PHPUnit: 3 tests, 22 assertions passed

## Review boundary

This PR covers the customer `/my-settings/{user}` presentation only. It does not deploy to staging or alter vendor onboarding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches customer account email/password grouping and post-render DOM moves for security fields; submission contract is preserved but auth UX regressions are worth a quick save/validation pass.
> 
> **Overview**
> Redesigns **customer** `/my-settings/{user}` as a summary-first **profile hub** while keeping Drupal’s canonical user entity form (field names and submit flow unchanged).
> 
> **Form structure (PHP):** Hides `field_vendor_store` from customers. Re-groups **email, username, password, and social auth** into **Account & security** (moved off Profile). Settings cards get `data-mel-settings-card` hooks; save actions gain `aria-live="polite"`.
> 
> **UI layer:** Twig replaces the intro paragraph with an **overview** (avatar slot, “Private account”, live profile summary). New **`account-settings-hub`** library and **`account-settings-hub.js`** progressively enhance cards with **Edit/Done**, collapsed editors, live section summaries, auto-open on validation errors, DOM rehome for orphaned `#edit-account` / social-auth blocks, and a **sticky Save** bar after edits.
> 
> **Styling:** `_account-settings.scss` shifts to a wider two-column card grid, overview hero, toggle/summary/editor patterns, simplified accessibility field chrome, and reduced-motion support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd28e3a93baf522806d568c04ae2a9e2f2040797. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->