### PR TITLE
Simplify organiser onboarding contract

### DIFF
--- a/web/modules/custom/myeventlane_legal/src/Service/LegalGatekeeper.php
+++ b/web/modules/custom/myeventlane_legal/src/Service/LegalGatekeeper.php
@@ -82,8 +82,19 @@ final class LegalGatekeeper {
    * Checks whether the current user's vendor has accepted vendor terms.
    */
   public function hasVendorAcceptedTerms(): bool {
+    return $this->getVendorTermsAcceptedAt() !== NULL;
+  }
+
+  /**
+   * Returns the authoritative vendor Terms acceptance timestamp.
+   */
+  public function getVendorTermsAcceptedAt(): ?int {
     $vendor = $this->getCurrentVendorOrNull();
-    return $vendor && $this->vendorHasAcceptedTerms($vendor);
+    if (!$vendor || !$this->vendorHasAcceptedTerms($vendor)) {
+      return NULL;
+    }
+
+    return (int) $vendor->get('field_vendor_terms_accepted_at')->value;
   }
 
   /**

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.routing.yml
@@ -207,7 +207,7 @@ myeventlane_vendor.onboard.account:
 myeventlane_vendor.onboard.profile:
   path: '/vendor/onboard/profile'
   defaults:
-    _form: '\Drupal\myeventlane_vendor\Form\VendorOnboardProfileForm'
+    _controller: '\Drupal\myeventlane_vendor\Controller\VendorOnboardProfileController::profile'
     _title: 'Set up your organiser profile'
   requirements:
     _permission: 'access content'

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorOnboardProfileController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorOnboardProfileController.php
@@ -4,200 +4,44 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_vendor\Controller;
 
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Url;
-use Drupal\myeventlane_vendor\Entity\Vendor;
-use Drupal\myeventlane_vendor\Service\UserVendorMembershipQuery;
+use Drupal\myeventlane_core\Service\OnboardingManager;
+use Drupal\myeventlane_vendor\Form\VendorOnboardProfileForm;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
- * Controller for vendor onboarding step 2: Profile setup.
+ * Owns entry to the mandatory organiser-details step.
  */
 final class VendorOnboardProfileController extends ControllerBase {
 
   public function __construct(
-    private readonly UserVendorMembershipQuery $userVendorMembershipQuery,
+    private readonly OnboardingManager $onboardingManager,
   ) {}
+
+  /**
+   * Builds organiser details or returns completed organisers to event creation.
+   */
+  public function profile(): array|RedirectResponse {
+    $account = $this->currentUser();
+    if ($account->isAnonymous()) {
+      return new RedirectResponse(Url::fromRoute('myeventlane_vendor.onboard.account')->toString());
+    }
+
+    $state = $this->onboardingManager->loadVendorStateByUid((int) $account->id());
+    if ($state !== NULL && $this->onboardingManager->isCompleted($state)) {
+      return new RedirectResponse(Url::fromRoute('myeventlane_vendor.create_event_gateway')->toString());
+    }
+
+    return $this->formBuilder()->getForm(VendorOnboardProfileForm::class);
+  }
 
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container): static {
-    return new static(
-      $container->get('myeventlane_vendor.user_vendor_membership_query'),
-    );
-  }
-
-  /**
-   * Step 2: Vendor profile setup.
-   *
-   * @return array|\Symfony\Component\HttpFoundation\RedirectResponse
-   *   Render array or redirect.
-   */
-  public function profile(): array|RedirectResponse {
-    $currentUser = $this->currentUser();
-
-    // Require authentication.
-    if ($currentUser->isAnonymous()) {
-      return new RedirectResponse(
-        Url::fromRoute('myeventlane_vendor.onboard.account')->toString()
-      );
-    }
-
-    // Check if user already has a vendor.
-    $vendorIds = $this->userVendorMembershipQuery->getVendorIdsForUser((int) $currentUser->id());
-
-    $vendor = NULL;
-    if (!empty($vendorIds)) {
-      // Load existing vendor.
-      $vendor = $this->entityTypeManager()
-        ->getStorage('myeventlane_vendor')
-        ->load(reset($vendorIds));
-    }
-    else {
-      // Create new vendor entity.
-      $vendor = Vendor::create([
-        'uid' => (int) $currentUser->id(),
-      ]);
-    }
-
-    // Get the vendor form.
-    $formObject = $this->entityTypeManager()
-      ->getFormObject('myeventlane_vendor', $vendor->isNew() ? 'add' : 'edit')
-      ->setEntity($vendor);
-
-    $form = $this->formBuilder()->getForm($formObject);
-
-    // Enhance form for onboarding context.
-    $this->enhanceFormForOnboarding($form, $vendor);
-
-    // Override submit redirect.
-    $form['actions']['submit']['#submit'][] = [$this, 'onboardFormSubmit'];
-
-    return [
-      '#theme' => 'vendor_onboard_step',
-      '#step_number' => 2,
-      '#total_steps' => 6,
-      '#step_title' => $this->t('Set up your organiser profile'),
-      '#step_description' => $this->t('Tell people about your organisation. This information will appear on your public organiser page.'),
-      '#content' => $form,
-      '#attached' => [
-        'library' => ['myeventlane_vendor/onboarding'],
-      ],
-    ];
-  }
-
-  /**
-   * Enhances the vendor form for onboarding context.
-   *
-   * @param array $form
-   *   The form array.
-   * @param \Drupal\myeventlane_vendor\Entity\Vendor $vendor
-   *   The vendor entity.
-   */
-  private function enhanceFormForOnboarding(array &$form, Vendor $vendor): void {
-    // Improve field labels and descriptions.
-    if (isset($form['name'])) {
-      $form['name']['widget'][0]['value']['#title'] = $this->t('Organiser name');
-      $form['name']['widget'][0]['value']['#description'] = $this->t('The public name for your organisation (e.g., "Sydney Music Festival").');
-      $form['name']['widget'][0]['value']['#attributes']['placeholder'] = $this->t('Enter your organiser name');
-    }
-
-    if (isset($form['field_vendor_logo'])) {
-      $form['field_vendor_logo']['widget'][0]['#title'] = $this->t('Logo');
-      $form['field_vendor_logo']['widget'][0]['#description'] = $this->t('Upload your organisation logo. This will appear on your public page and event listings.');
-    }
-
-    if (isset($form['field_vendor_bio'])) {
-      $form['field_vendor_bio']['widget'][0]['#title'] = $this->t('About your organisation');
-      $form['field_vendor_bio']['widget'][0]['value']['#description'] = $this->t('A brief description of your organisation. This helps attendees learn more about you.');
-      $form['field_vendor_bio']['widget'][0]['value']['#attributes']['placeholder'] = $this->t('Tell people about your organisation...');
-    }
-
-    // Also handle field_description if it exists (alternative to field_vendor_bio).
-    if (isset($form['field_description'])) {
-      $form['field_description']['widget'][0]['#title'] = $this->t('About your organisation');
-      $form['field_description']['widget'][0]['value']['#description'] = $this->t('A brief description of your organisation. This helps attendees learn more about you.');
-      $form['field_description']['widget'][0]['value']['#attributes']['placeholder'] = $this->t('Tell people about your organisation...');
-    }
-
-    // Improve contact field labels and descriptions.
-    if (isset($form['field_email'])) {
-      $form['field_email']['widget'][0]['value']['#title'] = $this->t('Contact email');
-      $form['field_email']['widget'][0]['value']['#description'] = $this->t('Your organisation\'s contact email address.');
-      $form['field_email']['widget'][0]['value']['#attributes']['placeholder'] = $this->t('contact@example.com');
-    }
-
-    if (isset($form['field_phone'])) {
-      $form['field_phone']['widget'][0]['value']['#title'] = $this->t('Phone number');
-      $form['field_phone']['widget'][0]['value']['#description'] = $this->t('Your organisation\'s contact phone number.');
-      $form['field_phone']['widget'][0]['value']['#attributes']['placeholder'] = $this->t('+61 2 1234 5678');
-    }
-
-    if (isset($form['field_website'])) {
-      $form['field_website']['widget'][0]['uri']['#title'] = $this->t('Website');
-      $form['field_website']['widget'][0]['uri']['#description'] = $this->t('Your organisation\'s website URL.');
-      $form['field_website']['widget'][0]['uri']['#attributes']['placeholder'] = $this->t('https://example.com');
-    }
-
-    // Hide advanced fields during onboarding.
-    if (isset($form['field_vendor_users'])) {
-      $form['field_vendor_users']['#access'] = FALSE;
-    }
-
-    // Hide store field (handled separately).
-    if (isset($form['field_vendor_store'])) {
-      $form['field_vendor_store']['#access'] = FALSE;
-    }
-
-    // Improve visibility toggles.
-    if (isset($form['field_public_show_email'])) {
-      $form['field_public_show_email']['widget']['value']['#title'] = $this->t('Show email on public page');
-    }
-    if (isset($form['field_public_show_phone'])) {
-      $form['field_public_show_phone']['widget']['value']['#title'] = $this->t('Show phone on public page');
-    }
-    if (isset($form['field_public_show_location'])) {
-      $form['field_public_show_location']['widget']['value']['#title'] = $this->t('Show location on public page');
-    }
-
-    // Update submit button text.
-    if (isset($form['actions']['submit'])) {
-      $form['actions']['submit']['#value'] = $this->t('Continue to payment setup');
-    }
-
-    // Add wrapper classes for styling.
-    $form['#attributes']['class'][] = 'mel-onboard-form';
-    $form['#attributes']['class'][] = 'mel-onboard-profile-form';
-  }
-
-  /**
-   * Submit handler for onboarding profile form.
-   *
-   * @param array $form
-   *   The form array.
-   * @param \Drupal\Core\Form\FormStateInterface $form_state
-   *   The form state.
-   */
-  public function onboardFormSubmit(array $form, FormStateInterface $form_state): void {
-    $vendor = $form_state->getFormObject()->getEntity();
-    $currentUser = $this->currentUser();
-
-    // Ensure the current user is associated with the vendor.
-    if ($vendor->hasField('field_vendor_users')) {
-      $currentUsers = $vendor->get('field_vendor_users')->getValue();
-      $userIds = array_column($currentUsers, 'target_id');
-      if (!in_array($currentUser->id(), $userIds, TRUE)) {
-        $vendor->get('field_vendor_users')->appendItem(['target_id' => $currentUser->id()]);
-      }
-    }
-
-    // Redirect to Stripe connect (use stripe/connect, not onboard/stripe).
-    $form_state->setRedirect('myeventlane_vendor.stripe_connect', [], [
-      'query' => ['destination' => '/vendor/onboard/first-event'],
-    ]);
+    return new static($container->get('myeventlane_onboarding.manager'));
   }
 
 }

--- a/web/modules/custom/myeventlane_vendor/src/Form/VendorOnboardProfileForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/VendorOnboardProfileForm.php
@@ -12,6 +12,7 @@ use Drupal\Core\Url;
 use Drupal\myeventlane_core\Entity\OnboardingStateInterface;
 use Drupal\myeventlane_core\Service\OnboardingManager;
 use Drupal\myeventlane_legal\Service\LegalSettingsService;
+use Drupal\myeventlane_legal\Service\LegalGatekeeper;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -52,6 +53,7 @@ final class VendorOnboardProfileForm extends FormBase {
     AccountProxyInterface $current_user,
     TimeInterface $time,
     LegalSettingsService $legal_settings,
+    private readonly LegalGatekeeper $legalGatekeeper,
   ) {
     $this->onboardingManager = $onboarding_manager;
     $this->currentUser = $current_user;
@@ -68,6 +70,7 @@ final class VendorOnboardProfileForm extends FormBase {
       $container->get('current_user'),
       $container->get('datetime.time'),
       $container->get('myeventlane_legal.settings'),
+      $container->get('myeventlane_legal.gatekeeper'),
     );
   }
 
@@ -98,7 +101,7 @@ final class VendorOnboardProfileForm extends FormBase {
     // and Form API submit processing is reliable (root #tree breaks POST rebuild).
     // Step metadata for form--organiser-onboard-profile-form.html.twig preprocess.
     $form['#step_number'] = 2;
-    $form['#total_steps'] = 7;
+    $form['#total_steps'] = 3;
     $form['#step_title'] = $this->t('Let’s get your organiser set up 👋');
     $form['#step_description'] = $this->t('This helps people trust your events.');
     $form['#attributes']['class'][] = 'mel-onboard-form';
@@ -141,10 +144,16 @@ final class VendorOnboardProfileForm extends FormBase {
       ],
     ];
 
+    $accepted_at = $this->legalGatekeeper->getVendorTermsAcceptedAt();
+    $vendor_terms_url = $this->legalSettings->getVendorTermsUrl();
     $form['terms_accepted'] = [
       '#type' => 'checkbox',
-      '#title' => $this->t('I agree to the Vendor Terms of Service'),
-      '#default_value' => !empty($flags['terms_accepted']) || (!empty($flags['vendor_terms_accepted_at']) && (int) $flags['vendor_terms_accepted_at'] > 0),
+      '#title' => $vendor_terms_url !== ''
+        ? $this->t('I agree to the <a href=":url" target="_blank" rel="noopener">Vendor Terms of Service</a>', [':url' => $vendor_terms_url])
+        : $this->t('I agree to the Vendor Terms of Service'),
+      '#default_value' => $accepted_at !== NULL
+        || !empty($flags['terms_accepted'])
+        || (!empty($flags['vendor_terms_accepted_at']) && (int) $flags['vendor_terms_accepted_at'] > 0),
       '#required' => TRUE,
     ];
 
@@ -196,7 +205,11 @@ final class VendorOnboardProfileForm extends FormBase {
     $flags['terms_accepted'] = !empty($values['terms_accepted']);
 
     if ($flags['terms_accepted']) {
-      $flags['vendor_terms_accepted_at'] = (int) $this->time->getRequestTime();
+      // The vendor entity is the legal source of truth. Preserve an existing
+      // acceptance timestamp instead of recording a misleading re-acceptance
+      // when a returning organiser submits this form.
+      $flags['vendor_terms_accepted_at'] = $this->legalGatekeeper->getVendorTermsAcceptedAt()
+        ?? (int) $this->time->getRequestTime();
       $flags['vendor_terms_version'] = $this->legalSettings->getVendorTermsVersion();
       if ($this->legalSettings->storeVendorIpUa()) {
         $request = $this->getRequest();

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorPublishRequirementsGate.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorPublishRequirementsGate.php
@@ -70,10 +70,6 @@ final class VendorPublishRequirementsGate {
       $reasons[] = (string) $this->t('Complete your organiser profile before publishing.');
     }
 
-    if (!$this->eventStudioCreate->isVendorStripeConnected($vendor, $uid, $account)) {
-      $reasons[] = (string) $this->t('Connect Stripe before publishing your event.');
-    }
-
     return $reasons;
   }
 

--- a/web/modules/custom/myeventlane_vendor/tests/src/Unit/OrganiserOnboardingContractTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Unit/OrganiserOnboardingContractTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_vendor\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the mandatory organiser journey and paid-only Stripe boundary.
+ */
+final class OrganiserOnboardingContractTest extends TestCase {
+
+  private string $root;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->root = dirname(__DIR__, 6);
+  }
+
+  public function testCompletedOrganisersLeaveOnboarding(): void {
+    $routing = $this->read('myeventlane_vendor/myeventlane_vendor.routing.yml');
+    $controller = $this->read('myeventlane_vendor/src/Controller/VendorOnboardProfileController.php');
+
+    self::assertStringContainsString('VendorOnboardProfileController::profile', $routing);
+    self::assertStringNotContainsString("_form: '\\Drupal\\myeventlane_vendor\\Form\\VendorOnboardProfileForm'", $routing);
+    self::assertStringContainsString('isCompleted($state)', $controller);
+    self::assertStringContainsString("myeventlane_vendor.create_event_gateway", $controller);
+  }
+
+  public function testVendorEntityIsTermsSourceOfTruth(): void {
+    $form = $this->read('myeventlane_vendor/src/Form/VendorOnboardProfileForm.php');
+    $gatekeeper = $this->read('myeventlane_legal/src/Service/LegalGatekeeper.php');
+
+    self::assertStringContainsString('getVendorTermsAcceptedAt()', $gatekeeper);
+    self::assertStringContainsString('$accepted_at = $this->legalGatekeeper->getVendorTermsAcceptedAt();', $form);
+    self::assertStringContainsString("'#total_steps'] = 3", $form);
+    self::assertStringContainsString('getVendorTermsUrl()', $form);
+    self::assertStringContainsString('?? (int) $this->time->getRequestTime()', $form);
+  }
+
+  public function testStripeIsRequiredOnlyByPaidEventChecks(): void {
+    $vendorGate = $this->read('myeventlane_vendor/src/Service/VendorPublishRequirementsGate.php');
+    $eligibility = $this->read('myeventlane_event_studio/src/Service/PublishEligibilityEvaluator.php');
+    $readiness = $this->read('myeventlane_event_studio/src/Service/EventReadinessService.php');
+
+    self::assertStringNotContainsString('Connect Stripe before publishing your event.', $vendorGate);
+    self::assertStringContainsString("in_array(\$eventType, ['paid', 'both'], TRUE)", $eligibility);
+    self::assertStringContainsString("in_array(\$event_type, ['paid', 'both'], TRUE)", $readiness);
+  }
+
+  public function testNavigationShowsThreeMandatorySteps(): void {
+    $theme = file_get_contents($this->root . '/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme');
+    self::assertIsString($theme);
+
+    self::assertStringContainsString("\$display_order = ['present', 'ask', 'complete'];", $theme);
+    self::assertStringContainsString("'present' => t('Organiser details')", $theme);
+    self::assertStringNotContainsString("\$display_order = ['present', 'ask', 'listen', 'complete'];", $theme);
+
+    $template = file_get_contents($this->root . '/themes/custom/myeventlane_vendor_theme/templates/form/form--organiser-onboard-profile-form.html.twig');
+    self::assertIsString($template);
+    self::assertStringContainsString('<h1>{{ step_title }}</h1>', $template);
+  }
+
+  private function read(string $relativePath): string {
+    $contents = file_get_contents($this->root . '/modules/custom/' . $relativePath);
+    self::assertIsString($contents);
+    return $contents;
+  }
+
+}

--- a/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
+++ b/web/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme
@@ -976,7 +976,7 @@ function myeventlane_vendor_theme_theme_suggestions_form_alter(array &$suggestio
 function myeventlane_vendor_theme_preprocess_form__organiser_onboard_profile_form(array &$variables): void {
   $element = $variables['element'];
   $variables['step_number'] = $element['#step_number'] ?? 2;
-  $variables['total_steps'] = $element['#total_steps'] ?? 7;
+  $variables['total_steps'] = $element['#total_steps'] ?? 3;
   $variables['step_title'] = $element['#step_title'] ?? '';
   $variables['step_description'] = $element['#step_description'] ?? NULL;
   $step_number = $variables['step_number'];
@@ -1022,8 +1022,8 @@ function myeventlane_vendor_theme_preprocess_vendor_onboard_step(array &$variabl
 /**
  * Builds onboarding stages array for progress indicator.
  *
- * Uses STAGE_ORDER, OnboardingManager, LegalGatekeeper. Applies Stripe + Terms
- * locking for steps after listen.
+ * Uses STAGE_ORDER, OnboardingManager and LegalGatekeeper. Later steps remain
+ * locked until the organiser details and Terms step is complete.
  *
  * @param string|\Drupal\myeventlane_core\Entity\OnboardingStateInterface $route_or_state
  *   Effective onboarding route, or a vendor onboarding state (e.g. Event Studio preprocess).
@@ -1033,8 +1033,9 @@ function myeventlane_vendor_theme_preprocess_vendor_onboard_step(array &$variabl
  */
 function _myeventlane_vendor_theme_build_onboarding_stages(string|OnboardingStateInterface $route_or_state): array {
   $stage_order = OnboardingStateInterface::STAGE_ORDER;
-  // Event-first checklist: Profile → Create event → Payments → Publish.
-  $display_order = ['present', 'ask', 'listen', 'complete'];
+  // Mandatory journey: organiser details → create event → publish. Payments
+  // are requested inside Event Studio only when paid tickets are selected.
+  $display_order = ['present', 'ask', 'complete'];
   $route_to_stage = [
     'myeventlane_legal.vendor_terms' => 'probe',
     'myeventlane_vendor.onboard.account' => 'probe',
@@ -1047,15 +1048,13 @@ function _myeventlane_vendor_theme_build_onboarding_stages(string|OnboardingStat
     'myeventlane_vendor.onboard.complete' => 'complete',
   ];
   $stage_labels = [
-    'present' => t('Profile'),
+    'present' => t('Organiser details'),
     'ask' => t('Create event'),
-    'listen' => t('Payments'),
     'complete' => t('Publish'),
   ];
   $stage_routes = [
     'present' => 'myeventlane_vendor.onboard.profile',
     'ask' => 'myeventlane_event_studio.create',
-    'listen' => 'myeventlane_vendor.onboard.stripe',
     'complete' => 'myeventlane_vendor.onboard.complete',
   ];
 
@@ -1108,12 +1107,10 @@ function _myeventlane_vendor_theme_build_onboarding_stages(string|OnboardingStat
     $terms_accepted = \Drupal::service('myeventlane_legal.gatekeeper')->hasVendorAcceptedTerms();
   }
 
-  $flags = $state ? $state->getFlags() : [];
-
   $checklist_current = match ($canonical_stage) {
     'probe' => 'present',
     'present' => 'present',
-    'listen' => 'listen',
+    'listen' => 'ask',
     'ask' => 'ask',
     'invite' => 'complete',
     'complete' => 'complete',
@@ -1123,7 +1120,6 @@ function _myeventlane_vendor_theme_build_onboarding_stages(string|OnboardingStat
   $state_idx = ($state !== NULL) ? array_search($state->getStage(), $stage_order, TRUE) : FALSE;
   $idx_present = array_search('present', $stage_order, TRUE);
   $idx_ask = array_search('ask', $stage_order, TRUE);
-  $idx_listen = array_search('listen', $stage_order, TRUE);
   $idx_complete = array_search('complete', $stage_order, TRUE);
 
   $stages = [];
@@ -1134,10 +1130,7 @@ function _myeventlane_vendor_theme_build_onboarding_stages(string|OnboardingStat
         $stage_complete = TRUE;
       }
       elseif ($state_idx !== FALSE) {
-        if ($key === 'listen') {
-          $stage_complete = !empty($flags['stripe_connected']);
-        }
-        elseif ($key === 'present') {
+        if ($key === 'present') {
           $stage_complete = $idx_present !== FALSE && $state_idx > $idx_present;
         }
         elseif ($key === 'ask') {
@@ -1149,17 +1142,15 @@ function _myeventlane_vendor_theme_build_onboarding_stages(string|OnboardingStat
       }
     }
 
-    $stripe_locked = FALSE;
     $row_stage = match ($key) {
       'present' => 'present',
       'ask' => 'ask',
-      'listen' => 'listen',
       'complete' => 'complete',
       default => 'present',
     };
     $row_idx = array_search($row_stage, $stage_order, TRUE);
     $terms_locked = ($row_idx !== FALSE && $row_idx > $present_index) && !$terms_accepted;
-    $is_locked = $stripe_locked || $terms_locked;
+    $is_locked = $terms_locked;
 
     $url = '';
     if (isset($stage_routes[$key])) {
@@ -1210,12 +1201,12 @@ function _myeventlane_vendor_theme_onboarding_journey_meta(?string $effective_ro
   ];
   $stage = $route_to_stage[$route] ?? 'probe';
   $stage_order = \Drupal\myeventlane_core\Entity\OnboardingStateInterface::STAGE_ORDER;
-  $display_order = ['present', 'ask', 'listen', 'complete'];
+  $display_order = ['present', 'ask', 'complete'];
   $current_index = array_search(
     match ($stage) {
       'probe' => 'present',
       'present' => 'present',
-      'listen' => 'listen',
+      'listen' => 'ask',
       'ask' => 'ask',
       'invite' => 'complete',
       'complete' => 'complete',
@@ -1241,8 +1232,6 @@ function _myeventlane_vendor_theme_onboarding_journey_meta(?string $effective_ro
     $state_idx = $state_idx !== FALSE ? (int) $state_idx : 0;
   }
 
-  $journey_flags = ($state !== NULL) ? $state->getFlags() : [];
-
   $steps = [];
   $completed_keys = [];
   foreach ($journey_ids as $i => $id) {
@@ -1253,11 +1242,7 @@ function _myeventlane_vendor_theme_onboarding_journey_meta(?string $effective_ro
       $is_complete = TRUE;
     }
     elseif ($state_idx !== NULL && $key_stage_index !== FALSE) {
-      // Match _myeventlane_vendor_theme_build_onboarding_stages(): listen is optional; ask vs listen order in UI.
-      if ($id === 'listen') {
-        $is_complete = !empty($journey_flags['stripe_connected']);
-      }
-      elseif ($id === 'ask') {
+      if ($id === 'ask') {
         $ask_index = array_search('ask', $stage_order, TRUE);
         $is_complete = ($ask_index !== FALSE && $state_idx > $ask_index);
       }
@@ -1273,8 +1258,7 @@ function _myeventlane_vendor_theme_onboarding_journey_meta(?string $effective_ro
       $is_complete = $i < $current_index;
     }
     $label = match ($id) {
-      'present' => t('Profile'),
-      'listen' => t('Payments'),
+      'present' => t('Organiser details'),
       'ask' => t('Create event'),
       'complete' => t('Publish'),
       default => $id,

--- a/web/themes/custom/myeventlane_vendor_theme/templates/form/form--organiser-onboard-profile-form.html.twig
+++ b/web/themes/custom/myeventlane_vendor_theme/templates/form/form--organiser-onboard-profile-form.html.twig
@@ -9,6 +9,18 @@
 
     <main class="mel-es-workspace__main">
 
+      <header class="mel-onboard-es__header">
+        {% if onboarding_progress_label %}
+          <p class="mel-onboard-es__progress">{{ onboarding_progress_label }}</p>
+        {% endif %}
+        {% if step_title %}
+          <h1>{{ step_title }}</h1>
+        {% endif %}
+        {% if step_description %}
+          <p>{{ step_description }}</p>
+        {% endif %}
+      </header>
+
       <div class="mel-es-card mel-onboard-es-form-card">
         <form{{ attributes }}>
           {{ children }}


### PR DESCRIPTION
## What changed

- reduces mandatory organiser setup to Organiser details, Create event and Publish
- sends completed organisers back to event creation instead of reopening onboarding
- uses the vendor entity Terms timestamp as the authoritative acceptance record
- preserves an existing Terms timestamp when a returning organiser continues
- links the Vendor Terms directly from the consent control
- restores the onboarding heading and progress message
- removes the unconditional Stripe blocker from general organiser readiness
- retains Stripe enforcement for paid and mixed-ticket event publication

## Why

The organiser flow described seven steps in code, rendered four steps in navigation and marked onboarding complete after organiser name and Terms. Returning organisers could also see an unchecked Terms control even when the vendor entity recorded acceptance. Stripe was duplicated in the general publication gate, which could block free RSVP events.

This PR defines one mandatory account-ready journey and leaves payment onboarding conditional on choosing paid tickets.

## User impact

New organisers provide their organiser name, accept the Vendor Terms and continue directly into their first event. Free RSVP organisers can publish without Stripe. Paid-ticket organisers still receive the existing Stripe requirement before publication.

## Validation

- new-organiser submit created the vendor and Terms timestamp, then opened Event Studio
- completed organiser revisiting onboarding was routed to event creation
- general organiser publication gate returned no Stripe denial for the completed preview organiser
- paid publication gate continued to return the Stripe requirement
- PHPUnit: 7 tests, 34 assertions passed
- PHP syntax, CSS lint, production builds and diff checks passed

## Review boundary

This PR corrects the onboarding contract only. It does not include the proposed dynamic organiser profile hub, merge approval or deployment approval.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes organiser routing, legal consent UX, and publish gates—areas that affect who can create or publish events—though Stripe remains enforced for paid flows and behaviour is locked by contract tests.
> 
> **Overview**
> **Aligns organiser onboarding** so the mandatory path is **Organiser details → Create event → Publish** (three steps in UI and progress), removing **Payments** from the default journey and Stripe-based step locking in the vendor theme.
> 
> **`/vendor/onboard/profile`** is served by `VendorOnboardProfileController` instead of routing straight to the form: anonymous users still go to account signup; **completed** onboarding state redirects to **`create_event_gateway`** instead of reopening profile setup. The old controller path that built the full vendor entity form inline is removed in favour of `VendorOnboardProfileForm`.
> 
> **Vendor Terms** are centralized via `LegalGatekeeper::getVendorTermsAcceptedAt()`; the profile form pre-checks acceptance from the vendor entity, links to the terms URL, and on submit **reuses an existing timestamp** instead of overwriting it. Step count metadata moves from 7 to **3**; the organiser profile Twig template restores the **header** (progress label, title, description).
> 
> **Publishing readiness** (`VendorPublishRequirementsGate`) no longer adds a blanket “Connect Stripe before publishing” reason; Stripe stays enforced elsewhere for **paid / mixed** ticket publication (covered by a new **OrganiserOnboardingContractTest**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efc01a840ec6981cc0475e02dd16d904ff8aef24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->