### PR TITLE
Build dynamic organiser profile hub

### DIFF
--- a/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorSettingsPresentationContractTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorSettingsPresentationContractTest.php
@@ -49,4 +49,27 @@ final class VendorSettingsPresentationContractTest extends TestCase {
     }
   }
 
+  /**
+   * Ensures the profile hub enhances rather than replaces the Drupal form.
+   */
+  public function testOrganiserProfileHubKeepsTheCanonicalFormContract(): void {
+    $module_root = dirname(__DIR__, 4) . '/myeventlane_vendor_settings';
+    $form = file_get_contents($module_root . '/src/Form/VendorSettingsForm.php');
+    $library = file_get_contents($module_root . '/myeventlane_vendor_settings.libraries.yml');
+    $script = file_get_contents($module_root . '/js/mel-organiser-profile-hub.js');
+    self::assertIsString($form);
+    self::assertIsString($library);
+    self::assertIsString($script);
+
+    foreach (['public', 'profile', 'visual', 'contact', 'venues', 'business', 'team', 'notifications'] as $card) {
+      self::assertStringContainsString("'data-mel-organiser-card' => '$card'", $form);
+    }
+
+    self::assertStringContainsString("'#type' => 'submit'", $form);
+    self::assertStringContainsString("'#value' => \$this->t('Save changes')", $form);
+    self::assertStringContainsString('js/mel-organiser-profile-hub.js', $library);
+    self::assertStringContainsString('input[name="public_page[published]"]', $script);
+    self::assertStringContainsString("actions.hidden = true", $script);
+  }
+
 }

--- a/web/modules/custom/myeventlane_vendor_settings/css/mel-vendor-settings.css
+++ b/web/modules/custom/myeventlane_vendor_settings/css/mel-vendor-settings.css
@@ -187,6 +187,47 @@
 .mel-vendor-settings-v2__status-copy {
   min-width: 0;
 }
+.mel-vendor-settings-v2__status-copy h2 {
+  margin: 0.25rem 0 0.75rem;
+  color: var(--mel-color-text, #293241);
+  font-size: clamp(1.35rem, 3vw, 1.75rem);
+}
+
+.mel-vendor-settings-v2__eyebrow {
+  color: var(--mel-color-text-secondary, #637185);
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mel-vendor-settings-v2__status-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.mel-vendor-settings-v2__completeness {
+  color: var(--mel-color-text-secondary, #637185);
+  font-size: 0.875rem;
+  font-weight: 700;
+}
+
+.mel-vendor-settings-v2__progress {
+  width: min(18rem, 100%);
+  height: 0.4rem;
+  margin-block-start: 0.75rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #ece6e1;
+}
+.mel-vendor-settings-v2__progress span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--mel-color-accent-coral, #f26d5b);
+}
 
 .mel-vendor-settings-v2__status-copy p {
   margin: var(--mel-space-2, 0.5rem) 0 0;
@@ -226,6 +267,127 @@
   margin-inline: var(--mel-space-6, 1.5rem);
 }
 
+/* Option B, tranche 2: summary-first organiser profile cards. */
+.mel-organiser-profile-hub details.mel-vendor-settings-v2__section {
+  padding: 0;
+  overflow: clip;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.mel-organiser-profile-hub details.mel-vendor-settings-v2__section[open] {
+  border-color: rgba(110, 126, 242, 0.48);
+  box-shadow: 0 12px 32px rgba(41, 50, 65, 0.08);
+}
+
+.mel-organiser-profile-hub details.mel-vendor-settings-v2__section > summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.5rem 1.25rem;
+  align-items: center;
+  min-height: 5.25rem;
+  padding: 1.15rem 1.5rem;
+  color: var(--mel-color-text, #293241);
+  font-size: 1.0625rem;
+  font-weight: 800;
+  cursor: pointer;
+  list-style: none;
+}
+
+.mel-organiser-profile-hub details.mel-vendor-settings-v2__section > summary::-webkit-details-marker {
+  display: none;
+}
+
+#vendor-settings-form.mel-organiser-profile-hub details.mel-vendor-settings-v2__section > summary::before {
+  display: none !important;
+  content: none !important;
+  width: 0 !important;
+  margin: 0 !important;
+  overflow: hidden !important;
+  color: transparent !important;
+  font-size: 0 !important;
+}
+
+.mel-organiser-profile-hub details.mel-vendor-settings-v2__section,
+.mel-organiser-profile-hub fieldset,
+.mel-organiser-profile-hub .fieldset-wrapper,
+.mel-organiser-profile-hub .form-item {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.mel-organiser-profile-hub input,
+.mel-organiser-profile-hub textarea,
+.mel-organiser-profile-hub select {
+  box-sizing: border-box;
+  max-width: 100%;
+}
+
+.mel-organiser-profile-card__meta {
+  display: grid;
+  grid-column: 1/-1;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+}
+
+.mel-organiser-profile-card__summary {
+  color: var(--mel-color-text-secondary, #637185);
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.mel-organiser-profile-card__action {
+  grid-column: 2;
+  grid-row: 1/span 2;
+  min-width: 4.25rem;
+  padding: 0.55rem 0.85rem;
+  border: 1px solid rgba(110, 126, 242, 0.35);
+  border-radius: 999px;
+  color: #5360bf;
+  font-size: 0.8125rem;
+  font-weight: 800;
+  text-align: center;
+}
+
+.mel-organiser-profile-hub .filter-wrapper,
+.mel-organiser-profile-hub .filter-guidelines,
+.mel-organiser-profile-hub .js-filter-wrapper > .form-item--filter-format {
+  display: none;
+}
+
+.mel-organiser-profile-hub__save {
+  position: sticky;
+  bottom: 1rem;
+  z-index: 30;
+  justify-content: flex-end;
+  padding: 0.75rem;
+  border: 1px solid rgba(110, 126, 242, 0.25);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 12px 32px rgba(41, 50, 65, 0.16);
+  backdrop-filter: blur(12px);
+}
+
+.mel-organiser-profile-hub__save[hidden] {
+  display: none !important;
+}
+
+.mel-organiser-profile-hub__save.is-visible {
+  display: flex;
+  animation: mel-profile-save-in 180ms ease-out;
+}
+
+@keyframes mel-profile-save-in {
+  from {
+    opacity: 0;
+    transform: translateY(0.5rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
 #vendor-settings-form details.mel-card > summary + * {
   margin-block-start: var(--mel-space-5, 1.25rem);
 }
@@ -322,6 +484,11 @@
 }
 
 @media (max-width: 47.99rem) {
+  .mel-vendor-shell__main:has(.mel-organiser-profile-hub),
+  .mel-vendor-shell__content:has(.mel-organiser-profile-hub) {
+    width: 100%;
+    min-width: 0;
+  }
   .mel-vendor-settings-v2__status-card {
     align-items: stretch;
     flex-direction: column;
@@ -338,5 +505,26 @@
   }
   #vendor-settings-form #edit-public-page-optional-details {
     padding: var(--mel-space-3, 0.75rem);
+  }
+  .mel-organiser-profile-hub details.mel-vendor-settings-v2__section > summary {
+    min-height: 4.75rem;
+    padding: 1rem;
+  }
+  .mel-organiser-profile-card__action {
+    min-width: 3.75rem;
+    padding-inline: 0.7rem;
+  }
+  .mel-organiser-profile-hub__save {
+    bottom: 0.5rem;
+  }
+  .mel-organiser-profile-hub__save .button {
+    width: 100%;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .mel-organiser-profile-hub details.mel-vendor-settings-v2__section,
+  .mel-organiser-profile-hub__save.is-visible {
+    transition: none;
+    animation: none;
   }
 }

--- a/web/modules/custom/myeventlane_vendor_settings/css/mel-vendor-settings.scss
+++ b/web/modules/custom/myeventlane_vendor_settings/css/mel-vendor-settings.scss
@@ -193,6 +193,49 @@
 
 .mel-vendor-settings-v2__status-copy {
   min-width: 0;
+
+  h2 {
+    margin: 0.25rem 0 0.75rem;
+    color: var(--mel-color-text, #293241);
+    font-size: clamp(1.35rem, 3vw, 1.75rem);
+  }
+}
+
+.mel-vendor-settings-v2__eyebrow {
+  color: var(--mel-color-text-secondary, #637185);
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mel-vendor-settings-v2__status-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.mel-vendor-settings-v2__completeness {
+  color: var(--mel-color-text-secondary, #637185);
+  font-size: 0.875rem;
+  font-weight: 700;
+}
+
+.mel-vendor-settings-v2__progress {
+  width: min(18rem, 100%);
+  height: 0.4rem;
+  margin-block-start: 0.75rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #ece6e1;
+
+  span {
+    display: block;
+    height: 100%;
+    border-radius: inherit;
+    background: var(--mel-color-accent-coral, #f26d5b);
+  }
 }
 
 .mel-vendor-settings-v2__status-copy p {
@@ -231,6 +274,122 @@
  */
 #vendor-settings-form details.mel-card > :not(summary) {
   margin-inline: var(--mel-space-6, 1.5rem);
+}
+
+/* Option B, tranche 2: summary-first organiser profile cards. */
+.mel-organiser-profile-hub details.mel-vendor-settings-v2__section {
+  padding: 0;
+  overflow: clip;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.mel-organiser-profile-hub details.mel-vendor-settings-v2__section[open] {
+  border-color: rgba(110, 126, 242, 0.48);
+  box-shadow: 0 12px 32px rgba(41, 50, 65, 0.08);
+}
+
+.mel-organiser-profile-hub details.mel-vendor-settings-v2__section > summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.5rem 1.25rem;
+  align-items: center;
+  min-height: 5.25rem;
+  padding: 1.15rem 1.5rem;
+  color: var(--mel-color-text, #293241);
+  font-size: 1.0625rem;
+  font-weight: 800;
+  cursor: pointer;
+  list-style: none;
+}
+
+.mel-organiser-profile-hub details.mel-vendor-settings-v2__section > summary::-webkit-details-marker {
+  display: none;
+}
+
+#vendor-settings-form.mel-organiser-profile-hub details.mel-vendor-settings-v2__section > summary::before {
+  display: none !important;
+  content: none !important;
+  width: 0 !important;
+  margin: 0 !important;
+  overflow: hidden !important;
+  color: transparent !important;
+  font-size: 0 !important;
+}
+
+.mel-organiser-profile-hub details.mel-vendor-settings-v2__section,
+.mel-organiser-profile-hub fieldset,
+.mel-organiser-profile-hub .fieldset-wrapper,
+.mel-organiser-profile-hub .form-item {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.mel-organiser-profile-hub input,
+.mel-organiser-profile-hub textarea,
+.mel-organiser-profile-hub select {
+  box-sizing: border-box;
+  max-width: 100%;
+}
+
+.mel-organiser-profile-card__meta {
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+}
+
+.mel-organiser-profile-card__summary {
+  color: var(--mel-color-text-secondary, #637185);
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.mel-organiser-profile-card__action {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  min-width: 4.25rem;
+  padding: 0.55rem 0.85rem;
+  border: 1px solid rgba(110, 126, 242, 0.35);
+  border-radius: 999px;
+  color: #5360bf;
+  font-size: 0.8125rem;
+  font-weight: 800;
+  text-align: center;
+}
+
+.mel-organiser-profile-hub .filter-wrapper,
+.mel-organiser-profile-hub .filter-guidelines,
+.mel-organiser-profile-hub .js-filter-wrapper > .form-item--filter-format {
+  display: none;
+}
+
+.mel-organiser-profile-hub__save {
+  position: sticky;
+  bottom: 1rem;
+  z-index: 30;
+  justify-content: flex-end;
+  padding: 0.75rem;
+  border: 1px solid rgba(110, 126, 242, 0.25);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 12px 32px rgba(41, 50, 65, 0.16);
+  backdrop-filter: blur(12px);
+}
+
+.mel-organiser-profile-hub__save[hidden] {
+  display: none !important;
+}
+
+.mel-organiser-profile-hub__save.is-visible {
+  display: flex;
+  animation: mel-profile-save-in 180ms ease-out;
+}
+
+@keyframes mel-profile-save-in {
+  from { opacity: 0; transform: translateY(0.5rem); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 #vendor-settings-form details.mel-card > summary + * {
@@ -329,6 +488,12 @@
 }
 
 @media (max-width: 47.99rem) {
+  .mel-vendor-shell__main:has(.mel-organiser-profile-hub),
+  .mel-vendor-shell__content:has(.mel-organiser-profile-hub) {
+    width: 100%;
+    min-width: 0;
+  }
+
   .mel-vendor-settings-v2__status-card {
     align-items: stretch;
     flex-direction: column;
@@ -349,5 +514,31 @@
 
   #vendor-settings-form #edit-public-page-optional-details {
     padding: var(--mel-space-3, 0.75rem);
+  }
+
+  .mel-organiser-profile-hub details.mel-vendor-settings-v2__section > summary {
+    min-height: 4.75rem;
+    padding: 1rem;
+  }
+
+  .mel-organiser-profile-card__action {
+    min-width: 3.75rem;
+    padding-inline: 0.7rem;
+  }
+
+  .mel-organiser-profile-hub__save {
+    bottom: 0.5rem;
+  }
+
+  .mel-organiser-profile-hub__save .button {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mel-organiser-profile-hub details.mel-vendor-settings-v2__section,
+  .mel-organiser-profile-hub__save.is-visible {
+    transition: none;
+    animation: none;
   }
 }

--- a/web/modules/custom/myeventlane_vendor_settings/js/mel-organiser-profile-hub.js
+++ b/web/modules/custom/myeventlane_vendor_settings/js/mel-organiser-profile-hub.js
@@ -1,0 +1,99 @@
+(function (Drupal, once) {
+  'use strict';
+
+  const copy = {
+    public: { empty: 'Private by default', ready: 'Choose what visitors can see' },
+    profile: { empty: 'Add your story and public details', ready: 'Profile details added' },
+    visual: { empty: 'Add a logo and banner', ready: 'Brand appearance set' },
+    contact: { empty: 'Add private contact details', ready: 'Contact details added' },
+    venues: { empty: 'Manage your reusable venues', ready: 'Manage your reusable venues' },
+    business: { empty: 'Add invoicing and payment details', ready: 'Business details added' },
+    team: { empty: 'Only you have access', ready: 'Team access configured' },
+    notifications: { empty: 'Choose when we contact you', ready: 'Notification choices set' },
+  };
+
+  function usefulValue(element) {
+    if (element.type === 'checkbox' || element.type === 'radio') {
+      return element.checked;
+    }
+    if (element.type === 'file') {
+      return element.files && element.files.length > 0;
+    }
+    if (element.type === 'hidden' || element.type === 'submit') {
+      return false;
+    }
+    return String(element.value || '').trim() !== '';
+  }
+
+  function updateCard(card) {
+    const key = card.dataset.melOrganiserCard;
+    const summary = card.querySelector(':scope > summary');
+    if (!summary || !copy[key]) return;
+
+    const published = card.querySelector('input[name="public_page[published]"]');
+    const inputs = Array.from(card.querySelectorAll('input, textarea, select'));
+    const hasValue = inputs.some(usefulValue);
+    let text = hasValue ? copy[key].ready : copy[key].empty;
+
+    if (key === 'public') {
+      const visibleCount = inputs.filter((input) =>
+        input.type === 'checkbox' && input !== published && input.checked
+      ).length;
+      text = published && published.checked
+        ? `Published · ${visibleCount} optional detail${visibleCount === 1 ? '' : 's'} visible`
+        : 'Private · only you and authorised staff can view it';
+    }
+    else if (key === 'profile') {
+      const storyFields = card.querySelectorAll('textarea, input[name*="summary"], input[name*="tagline"], input[name*="website"], input[name*="social_links"]');
+      text = Array.from(storyFields).some(usefulValue)
+        ? 'Story and public details added'
+        : 'Name saved · add your story and links';
+    }
+    else if (key === 'visual') {
+      text = card.querySelector('.file, .managed-file .file-link')
+        ? 'Brand images added'
+        : 'Choose a logo, banner and colour';
+    }
+    else if (key === 'team') {
+      text = card.querySelector('ul li') ? 'Team access configured' : 'Only you have access';
+    }
+
+    summary.querySelector('.mel-organiser-profile-card__summary').textContent = text;
+    summary.querySelector('.mel-organiser-profile-card__action').textContent = card.open ? 'Done' : 'Edit';
+  }
+
+  Drupal.behaviors.melOrganiserProfileHub = {
+    attach(context) {
+      once('mel-organiser-profile-hub', '#vendor-settings-form', context).forEach((form) => {
+        form.classList.add('mel-organiser-profile-hub');
+        const cards = form.querySelectorAll('[data-mel-organiser-card]');
+        const actions = form.querySelector('.mel-organiser-profile-hub__save');
+
+        cards.forEach((card) => {
+          const summary = card.querySelector(':scope > summary');
+          if (!summary) return;
+          summary.insertAdjacentHTML('beforeend', '<span class="mel-organiser-profile-card__meta"><span class="mel-organiser-profile-card__summary"></span><span class="mel-organiser-profile-card__action" aria-hidden="true"></span></span>');
+          card.addEventListener('toggle', () => updateCard(card));
+          card.querySelectorAll('input, textarea, select').forEach((input) => {
+            input.addEventListener('change', () => updateCard(card));
+            input.addEventListener('input', () => updateCard(card));
+          });
+          if (card.querySelector('.form-item--error-message, .messages--error, [aria-invalid="true"]')) {
+            card.open = true;
+          }
+          updateCard(card);
+        });
+
+        if (actions) {
+          actions.hidden = true;
+          const revealSave = () => {
+            actions.hidden = false;
+            actions.classList.add('is-visible');
+          };
+          form.addEventListener('input', revealSave, { once: true });
+          form.addEventListener('change', revealSave, { once: true });
+        }
+      });
+    },
+  };
+})(Drupal, once);

--- a/web/modules/custom/myeventlane_vendor_settings/myeventlane_vendor_settings.libraries.yml
+++ b/web/modules/custom/myeventlane_vendor_settings/myeventlane_vendor_settings.libraries.yml
@@ -1,10 +1,11 @@
 settings_form:
-  version: 1.x
+  version: 2.0.0
   css:
     theme:
       css/mel-vendor-settings.css: {}
   js:
     js/mel-disable-ajax.js: {}
+    js/mel-organiser-profile-hub.js: {}
   dependencies:
     - core/once
     - myeventlane_vendor_theme/global-styling

--- a/web/modules/custom/myeventlane_vendor_settings/src/Form/VendorSettingsForm.php
+++ b/web/modules/custom/myeventlane_vendor_settings/src/Form/VendorSettingsForm.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_vendor_settings\Form;
 
 use Drupal\commerce_store\Entity\StoreInterface;
+use Drupal\Component\Utility\Html;
 use Drupal\Core\Access\AccessManagerInterface;
 use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -330,13 +331,44 @@ class VendorSettingsForm extends FormBase {
       ? $this->t('Your organiser profile can appear in the public directory. Review the visibility choices below to control which optional details visitors can see.')
       : $this->t('Only you and authorised MyEventLane staff can view these organiser details. Publish the profile below when you are ready.');
 
+    $profile_checks = [
+      trim((string) $vendor->getName()) !== '',
+      trim((string) $this->getFieldValue($vendor, 'field_summary', '')) !== '',
+      trim((string) $this->getFieldValue($vendor, 'field_description', '')) !== '',
+      trim((string) $this->getFieldValue($vendor, 'field_website', '')) !== '',
+      !$vendor->hasField('field_email')
+      || trim((string) $this->getFieldValue($vendor, 'field_email', '')) !== '',
+    ];
+    $profile_complete = count(array_filter($profile_checks));
+    $profile_total = count($profile_checks);
+    $profile_percentage = (int) round(($profile_complete / $profile_total) * 100);
+
     $form['preview_link'] = [
       '#type' => 'container',
       '#attributes' => ['class' => ['vendor-preview-link-wrapper', 'mel-vendor-settings-v2__status-card']],
       '#weight' => -998,
     ];
+    $overview_markup = sprintf(
+      '<div class="mel-vendor-settings-v2__status-copy">'
+      . '<span class="mel-vendor-settings-v2__eyebrow">%s</span>'
+      . '<h2>%s</h2><div class="mel-vendor-settings-v2__status-row">'
+      . '<span class="mel-vendor-settings-v2__pill %s">%s</span>'
+      . '<span class="mel-vendor-settings-v2__completeness">%s</span></div>'
+      . '<div class="mel-vendor-settings-v2__progress" role="progressbar" '
+      . 'aria-label="%s" aria-valuemin="0" aria-valuemax="100" aria-valuenow="%d">'
+      . '<span style="width:%d%%"></span></div><p>%s</p></div>',
+      Html::escape((string) $this->t('Organiser profile')),
+      Html::escape($vendor->getName()),
+      $status_class,
+      Html::escape((string) $status_label),
+      Html::escape((string) $this->t('@percentage% complete', ['@percentage' => $profile_percentage])),
+      Html::escape((string) $this->t('Profile completeness')),
+      $profile_percentage,
+      $profile_percentage,
+      Html::escape((string) $status_message),
+    );
     $form['preview_link']['status'] = [
-      '#markup' => '<div class="mel-vendor-settings-v2__status-copy"><span class="mel-vendor-settings-v2__pill ' . $status_class . '">' . $status_label . '</span><p>' . $status_message . '</p></div>',
+      '#markup' => $overview_markup,
       '#weight' => -10,
     ];
 
@@ -424,7 +456,7 @@ class VendorSettingsForm extends FormBase {
     $form['actions'] = [
       '#type' => 'actions',
       '#weight' => 100,
-      '#attributes' => ['class' => ['mel-form__actions']],
+      '#attributes' => ['class' => ['mel-form__actions', 'mel-organiser-profile-hub__save']],
     ];
 
     $form['actions']['submit'] = [
@@ -471,7 +503,10 @@ class VendorSettingsForm extends FormBase {
       '#type' => 'details',
       '#title' => $this->t('Profile content'),
       '#open' => FALSE,
-      '#attributes' => ['class' => ['mel-card', 'mel-vendor-settings__card', 'mel-vendor-settings-v2__section']],
+      '#attributes' => [
+        'class' => ['mel-card', 'mel-vendor-settings__card', 'mel-vendor-settings-v2__section'],
+        'data-mel-organiser-card' => 'profile',
+      ],
     ];
     $form['profile']['_intro'] = [
       '#markup' => '<p class="mel-vendor-settings-v2__section-lede">' . $this->t('Add the name, story and links used on your organiser page. Visibility is controlled separately above.') . '</p>',
@@ -649,6 +684,7 @@ class VendorSettingsForm extends FormBase {
       '#attributes' => [
         'class' => ['mel-card', 'mel-vendor-settings__card', 'mel-vendor-settings-v2__section'],
         'id' => 'visual-assets',
+        'data-mel-organiser-card' => 'visual',
       ],
     ];
     $form['visual_assets']['_intro'] = [
@@ -725,7 +761,10 @@ class VendorSettingsForm extends FormBase {
       '#type' => 'details',
       '#title' => $this->t('Contact & email identity'),
       '#open' => FALSE,
-      '#attributes' => ['class' => ['mel-card', 'mel-vendor-settings__card', 'mel-vendor-settings-v2__section']],
+      '#attributes' => [
+        'class' => ['mel-card', 'mel-vendor-settings__card', 'mel-vendor-settings-v2__section'],
+        'data-mel-organiser-card' => 'contact',
+      ],
     ];
     $form['contact']['_intro'] = [
       '#markup' => '<p class="mel-vendor-settings-v2__section-lede">' . $this->t('How attendees reach you and how outgoing emails are addressed.') . '</p>',
@@ -829,8 +868,16 @@ class VendorSettingsForm extends FormBase {
     $form['public_page'] = [
       '#type' => 'details',
       '#title' => $this->t('Profile privacy & visibility'),
-      '#open' => TRUE,
-      '#attributes' => ['class' => ['mel-card', 'mel-vendor-settings__card', 'mel-vendor-settings-v2__section', 'mel-vendor-settings-v2__section--privacy']],
+      '#open' => FALSE,
+      '#attributes' => [
+        'class' => [
+          'mel-card',
+          'mel-vendor-settings__card',
+          'mel-vendor-settings-v2__section',
+          'mel-vendor-settings-v2__section--privacy',
+        ],
+        'data-mel-organiser-card' => 'public',
+      ],
     ];
     $form['public_page']['_intro'] = [
       '#markup' => '<p class="mel-vendor-settings-v2__section-lede">' . $this->t('Your profile stays private until you publish it. You remain in control and can change these choices at any time.') . '</p>',
@@ -938,6 +985,7 @@ class VendorSettingsForm extends FormBase {
       '#attributes' => [
         'class' => ['mel-card', 'mel-vendor-settings__card', 'mel-vendor-settings-v2__section'],
         'id' => 'venues',
+        'data-mel-organiser-card' => 'venues',
       ],
     ];
     $form['venues']['_intro'] = [
@@ -973,6 +1021,7 @@ class VendorSettingsForm extends FormBase {
       '#attributes' => [
         'class' => ['mel-card', 'mel-vendor-settings__card', 'mel-vendor-settings-v2__section'],
         'id' => 'business',
+        'data-mel-organiser-card' => 'business',
       ],
     ];
     $form['store']['_intro'] = [
@@ -1029,6 +1078,7 @@ class VendorSettingsForm extends FormBase {
       '#attributes' => [
         'class' => ['mel-card', 'mel-vendor-settings__card', 'mel-vendor-settings-v2__section'],
         'id' => 'mel-vendor-settings-team-ajax',
+        'data-mel-organiser-card' => 'team',
       ],
     ];
     $form['team']['_intro'] = [
@@ -1084,10 +1134,11 @@ class VendorSettingsForm extends FormBase {
     $form['preferences'] = [
       '#type' => 'details',
       '#title' => $this->t('Notifications'),
-      '#open' => TRUE,
+      '#open' => FALSE,
       '#attributes' => [
         'class' => ['mel-card', 'mel-vendor-settings__card', 'mel-vendor-settings-v2__section'],
         'id' => 'notifications',
+        'data-mel-organiser-card' => 'notifications',
       ],
     ];
     $form['preferences']['notifications'] = [


### PR DESCRIPTION
## What changed

- adds an organiser profile overview with publication state and completeness
- presents the existing organiser fields as eight summary-first Edit/Done cards
- adds dynamic card summaries and a dirty-state Save bar
- hides Drupal text-format selectors while retaining the canonical form fields
- improves narrow-screen sizing without changing the vendor entity save contract
- adds a focused presentation contract test

## Why

Option B tranche 2 replaces the raw Drupal-form experience with a clearer organiser profile hub while preserving privacy, field structure and the established native POST save path.

## Privacy and data behaviour

- organiser profiles remain private by default
- the master publication choice is unchanged
- all eight optional public-detail opt-ins remain independent and off unless selected
- vendor and authorised administrator access is unchanged

## Validation

- focused PHPUnit contract suite: 4 tests, 32 assertions
- real organiser save, redirect, hard reload and targeted value read passed on an isolated DDEV database copy
- publication and all eight optional public-detail values remained off during the persistence test
- desktop and narrow-screen rendered checks completed
- project `mel:lint`, PHP syntax and Git diff checks passed
- repository pre-push validation passed

## Approval boundary

The desktop and mobile presentation was visually approved before publication. This PR does not authorise staging or production deployment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI, CSS, and client-side presentation only; submit handlers and privacy field semantics are unchanged, with a contract test guarding the form structure.
> 
> **Overview**
> **Organiser profile hub (Option B tranche 2)** — presentation-only refresh of the vendor settings profile form; the same Drupal fields and native POST save path are unchanged.
> 
> The status area is expanded into an **overview** with organiser name, published/private pill, a **profile completeness** percentage and progress bar (name, summary, description, website, email), plus the existing guidance copy. **Eight** `details` sections are tagged with `data-mel-organiser-card` (public, profile, visual, contact, venues, business, team, notifications); **privacy** and **notifications** now default **closed** like the other long sections.
> 
> A new **`mel-organiser-profile-hub.js`** behavior (library bumped to **2.0.0**) adds the hub class, injects per-card summary/Edit–Done UI, updates copy from field state (including publish/visibility counts), opens cards with validation errors, **hides the save actions until the form is dirty**, and CSS hides text-format chrome on rich text fields. Styling covers summary-first cards, sticky save bar, mobile shell width, and reduced motion.
> 
> A **PHPUnit contract test** locks in the eight cards, submit button, library attachment, and JS save-bar behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52e3f6321aaa2fa03774e97698bc18da01399012. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->