### PR TITLE
Fix first-use account setup journey

### DIFF
--- a/config/sync/user.mail.yml
+++ b/config/sync/user.mail.yml
@@ -32,15 +32,15 @@ password_reset:
 
     --  [site:name] team
 register_admin_created:
-  subject: 'An administrator created an account for you at [site:name]'
+  subject: 'Set up your [site:name] account'
   body: |-
     [user:display-name],
 
-    A site administrator at [site:name] has created an account for you. You may now log in by clicking this link or copying and pasting it into your browser:
+    A MyEventLane administrator has created your account. Use this secure link to choose your password and finish setting up your account:
 
-    [user:one-time-login-url]
+    [user:one-time-login-url]?mel_flow=account_setup
 
-    This link can only be used once to log in and will lead you to a page where you can set your password.
+    This setup link can only be used once.
 
     After setting your password, you will be able to log in at [site:login-url] in the future using:
 
@@ -49,15 +49,15 @@ register_admin_created:
 
     --  [site:name] team
 register_no_approval_required:
-  subject: 'Account details for [user:display-name] at [site:name]'
+  subject: 'Set up your [site:name] account'
   body: |-
     [user:display-name],
 
-    Thank you for registering at [site:name]. You may now log in by clicking this link or copying and pasting it into your browser:
+    Thank you for joining [site:name]. Use this secure link to choose your password and finish setting up your account:
 
-    [user:one-time-login-url]
+    [user:one-time-login-url]?mel_flow=account_setup
 
-    This link can only be used once to log in and will lead you to a page where you can set your password.
+    This setup link can only be used once.
 
     After setting your password, you will be able to log in at [site:login-url] in the future using:
 

--- a/web/modules/custom/myeventlane_account/myeventlane_account.module
+++ b/web/modules/custom/myeventlane_account/myeventlane_account.module
@@ -450,7 +450,7 @@ function myeventlane_account_form_user_form_alter(array &$form, FormStateInterfa
 
   if ($is_customer_settings) {
     $form['#attributes']['class'][] = 'mel-account-settings-form';
-    _myeventlane_account_customer_settings_form_alter($form);
+    _myeventlane_account_customer_settings_form_alter($form, $form_state);
     return;
   }
 
@@ -466,7 +466,7 @@ function myeventlane_account_form_user_form_alter(array &$form, FormStateInterfa
  *
  * Preserves user entity form submit/validate by keeping original #parents on moved elements.
  */
-function _myeventlane_account_customer_settings_form_alter(array &$form): void {
+function _myeventlane_account_customer_settings_form_alter(array &$form, FormStateInterface $form_state): void {
   if (isset($form['account']['roles'])) {
     $form['account']['roles']['#access'] = FALSE;
   }
@@ -488,7 +488,9 @@ function _myeventlane_account_customer_settings_form_alter(array &$form): void {
     $form['account']['current_pass']['#description'] = t('Required when you change your email or password.');
   }
   if (isset($form['account']['pass'])) {
-    $form['account']['pass']['#description'] = t('Leave blank to keep your current password.');
+    $form['account']['pass']['#description'] = $form_state->get('user_pass_reset')
+      ? t('Choose a strong password and enter it twice.')
+      : t('Leave blank to keep your current password.');
   }
 
   $card_attr = ['class' => ['mel-account-settings__card', 'mel-account-settings__section']];
@@ -537,6 +539,21 @@ function _myeventlane_account_customer_settings_form_alter(array &$form): void {
     '#weight' => -50,
   ];
 
+  if ($form_state->get('user_pass_reset')) {
+    $form['#attributes']['data-mel-password-setup'] = 'true';
+    $form['mel_settings_security']['_password_setup_notice'] = [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => ['mel-account-settings__setup-notice'],
+        'role' => 'status',
+      ],
+      '#weight' => -40,
+      'message' => [
+        '#markup' => '<p>' . t('Choose and confirm your new password to continue. You do not need to enter a current password.') . '</p>',
+      ],
+    ];
+  }
+
   _myeventlane_account_group_nested_fields(
     $form,
     'account',
@@ -558,7 +575,9 @@ function _myeventlane_account_customer_settings_form_alter(array &$form): void {
       $reset_link['#attributes'] = [];
     }
     $reset_link['#attributes']['class'][] = 'mel-account-settings__inline-link';
-    $form['mel_settings_security']['_reset_link'] = $reset_link;
+    if (!$form_state->get('user_pass_reset')) {
+      $form['mel_settings_security']['_reset_link'] = $reset_link;
+    }
   }
   catch (\Throwable) {
   }

--- a/web/modules/custom/myeventlane_account/src/EventSubscriber/CustomerAccountRouteRedirectSubscriber.php
+++ b/web/modules/custom/myeventlane_account/src/EventSubscriber/CustomerAccountRouteRedirectSubscriber.php
@@ -67,8 +67,21 @@ final class CustomerAccountRouteRedirectSubscriber implements EventSubscriberInt
     }
 
     if ($route === 'entity.user.edit_form') {
-      $url = Url::fromRoute('myeventlane_account.settings', ['user' => $parameterUser->id()])->toString();
-      $event->setResponse(new RedirectResponse($url, 301));
+      $request = $event->getRequest();
+      $query = [];
+      foreach (['pass-reset-token', 'check_logged_in'] as $key) {
+        $value = $request->query->get($key);
+        if (is_string($value) && $value !== '') {
+          $query[$key] = $value;
+        }
+      }
+      $url = Url::fromRoute(
+        'myeventlane_account.settings',
+        ['user' => $parameterUser->id()],
+        ['query' => $query],
+      )->toString();
+      // A one-time password token must never be cached as a permanent redirect.
+      $event->setResponse(new RedirectResponse($url, 302));
       return;
     }
 

--- a/web/modules/custom/myeventlane_auth/myeventlane_auth.module
+++ b/web/modules/custom/myeventlane_auth/myeventlane_auth.module
@@ -14,6 +14,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\user\UserInterface;
 use Drupal\Core\Site\Settings;
+use Drupal\myeventlane_auth\EventSubscriber\AccountSetupFlowSubscriber;
 use Drupal\myeventlane_auth\EventSubscriber\MelPostLoginSessionRedirectSubscriber;
 use Drupal\myeventlane_auth\Service\IdentityIntentResolver;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -474,7 +475,7 @@ function myeventlane_auth_form_user_pass_reset_alter(
   string $form_id,
 ): void {
   if (
-    \Drupal::request()->getSession()->get('mel_account_setup_uid') !== (string) \Drupal::routeMatch()->getParameter('uid')
+    \Drupal::request()->getSession()->get(AccountSetupFlowSubscriber::SESSION_KEY) !== (string) \Drupal::routeMatch()->getParameter('uid')
     || $form_id !== 'user_pass_reset'
   ) {
     return;
@@ -504,11 +505,10 @@ function myeventlane_auth_preprocess_ginlogin(array &$variables): void {
   $uid = (string) \Drupal::routeMatch()->getParameter('uid');
   if (
     \Drupal::routeMatch()->getRouteName() === 'user.reset.form'
-    && $request->getSession()->get('mel_account_setup_uid') === $uid
+    && $request->getSession()->get(AccountSetupFlowSubscriber::SESSION_KEY) === $uid
   ) {
     $variables['title'] = t('Set up your account');
     $variables['mel_account_setup'] = TRUE;
-    $request->getSession()->remove('mel_account_setup_uid');
   }
 
   $config = \Drupal::config('gin_login.settings');
@@ -857,6 +857,12 @@ function myeventlane_auth_form_user_login_form_alter(array &$form, FormStateInte
  */
 function myeventlane_auth_user_login(UserInterface $account): void {
   $request = \Drupal::request();
+  if ($request->hasSession()) {
+    $session = $request->getSession();
+    if ($session->get(AccountSetupFlowSubscriber::SESSION_KEY) === (string) $account->id()) {
+      $session->remove(AccountSetupFlowSubscriber::SESSION_KEY);
+    }
+  }
   if (myeventlane_auth_is_password_reset_flow($request)) {
     \Drupal::logger('myeventlane_auth')->notice('Skipping MEL post-login routing for password reset flow.');
     return;

--- a/web/modules/custom/myeventlane_auth/myeventlane_auth.module
+++ b/web/modules/custom/myeventlane_auth/myeventlane_auth.module
@@ -38,6 +38,61 @@ function myeventlane_auth_cron(): void {
 }
 
 /**
+ * Implements hook_mail_alter().
+ *
+ * Registration and password recovery share Drupal's one-time-login route. Add
+ * an explicit presentation marker only to first-use registration emails.
+ */
+function myeventlane_auth_mail_alter(array &$message): void {
+  if (
+    ($message['module'] ?? '') !== 'user'
+    || !in_array($message['key'] ?? '', [
+      'register_admin_created',
+      'register_no_approval_required',
+    ], TRUE)
+  ) {
+    return;
+  }
+
+  $body = is_array($message['body'] ?? NULL)
+    ? implode("\n", $message['body'])
+    : (string) ($message['body'] ?? '');
+  preg_match_all('~https?://[^\s<]+~i', $body, $matches);
+  $urls = $matches[0] ?? [];
+  $setup_url = rtrim((string) ($urls[0] ?? ''), '.,;:!?)');
+  if ($setup_url === '') {
+    return;
+  }
+  if (!str_contains($setup_url, 'mel_flow=account_setup')) {
+    $setup_url .= str_contains($setup_url, '?') ? '&mel_flow=account_setup' : '?mel_flow=account_setup';
+  }
+
+  $site_name = (string) Drupal::config('system.site')->get('name');
+  $site_name = $site_name !== '' ? $site_name : 'MyEventLane';
+  $account = $message['params']['account'] ?? NULL;
+  $display_name = $account instanceof AccountInterface
+    ? $account->getDisplayName()
+    : '';
+  $intro = ($message['key'] ?? '') === 'register_admin_created'
+    ? t('A MyEventLane administrator has created your account.')
+    : t('Thank you for joining @site.', ['@site' => $site_name]);
+
+  $message['subject'] = (string) t('Set up your @site account', ['@site' => $site_name]);
+  $message['body'] = [implode("\n\n", array_filter([
+    $display_name !== '' ? $display_name . ',' : '',
+    (string) $intro . ' ' . (string) t('Use this secure link to choose your password and finish setting up your account:'),
+    $setup_url,
+    (string) t('This setup link can only be used once.'),
+    (string) t('After setting your password, you can log in at @url.', [
+      '@url' => Url::fromRoute('user.login', [], ['absolute' => TRUE])->toString(),
+    ]),
+    (string) t('-- MyEventLane team'),
+  ]))];
+  $message['params']['mel_account_setup'] = TRUE;
+  $message['params']['account_setup_url'] = $setup_url;
+}
+
+/**
  * Resolves raw MEL intent for the login request (GET or POST).
  *
  * Priority: mel_intent (query/POST), intent (query/POST), then destination
@@ -408,6 +463,95 @@ function myeventlane_auth_form_user_register_form_alter(array &$form, FormStateI
   ])));
 
   $form['actions']['submit']['#submit'][] = 'myeventlane_auth_user_register_form_post_save_redirect';
+}
+
+/**
+ * Presents first-use registration links as account setup, not password reset.
+ */
+function myeventlane_auth_form_user_pass_reset_alter(
+  array &$form,
+  FormStateInterface $form_state,
+  string $form_id,
+): void {
+  if (
+    \Drupal::request()->getSession()->get('mel_account_setup_uid') !== (string) \Drupal::routeMatch()->getParameter('uid')
+    || $form_id !== 'user_pass_reset'
+  ) {
+    return;
+  }
+
+  $form['#title'] = t('Set up your account');
+  $form['message'] = [
+    '#markup' => '<p>' . t('Welcome to MyEventLane. Continue to choose your password and finish setting up your account.') . '</p>',
+  ];
+  $form['help'] = [
+    '#markup' => '<p>' . t('For your security, this setup link can only be used once.') . '</p>',
+  ];
+  if (isset($form['actions']['submit'])) {
+    $form['actions']['submit']['#value'] = t('Continue');
+  }
+  $form['#attributes']['class'][] = 'mel-account-setup-form';
+}
+
+/**
+ * Implements hook_preprocess_ginlogin().
+ *
+ * Applies account-setup language and release-owned image fallbacks to the Gin
+ * Login shell. Admin-managed images remain authoritative while they exist.
+ */
+function myeventlane_auth_preprocess_ginlogin(array &$variables): void {
+  $request = \Drupal::request();
+  $uid = (string) \Drupal::routeMatch()->getParameter('uid');
+  if (
+    \Drupal::routeMatch()->getRouteName() === 'user.reset.form'
+    && $request->getSession()->get('mel_account_setup_uid') === $uid
+  ) {
+    $variables['title'] = t('Set up your account');
+    $variables['mel_account_setup'] = TRUE;
+    $request->getSession()->remove('mel_account_setup_uid');
+  }
+
+  $config = \Drupal::config('gin_login.settings');
+  $base = rtrim($request->getSchemeAndHttpHost() . $request->getBasePath(), '/');
+  $theme_path = \Drupal::service('extension.list.theme')->getPath('myeventlane_theme');
+
+  $logo_uri = (string) $config->get('logo.path');
+  if (!$config->get('logo.use_default') && $logo_uri !== '' && !file_exists($logo_uri)) {
+    $variables['icon_path'] = $base . '/' . $theme_path . '/images/myeventlane-logo.png';
+  }
+
+  $brand_uri = (string) $config->get('brand_image.path');
+  if (!$config->get('brand_image.use_default') && $brand_uri !== '' && !file_exists($brand_uri)) {
+    $variables['brand_image'] = [
+      '#theme' => 'image',
+      '#uri' => $base . '/' . $theme_path . '/images/mel/mel-mascot-round.png',
+      '#attributes' => [
+        'loading' => 'lazy',
+        'alt' => '',
+      ],
+    ];
+  }
+}
+
+/**
+ * Implements hook_gin_login_route_definitions_alter().
+ */
+function myeventlane_auth_gin_login_route_definitions_alter(array &$route_definitions): void {
+  foreach ($route_definitions as &$definition) {
+    $definition['preprocess functions'][] = 'myeventlane_auth_preprocess_ginlogin';
+  }
+}
+
+/**
+ * Implements hook_theme_registry_alter().
+ */
+function myeventlane_auth_theme_registry_alter(array &$theme_registry): void {
+  if (!isset($theme_registry['page__user__password'])) {
+    return;
+  }
+  $theme_registry['page__user__password']['template'] = 'page--user--password-mel';
+  $theme_registry['page__user__password']['path'] = \Drupal::service('extension.list.module')
+    ->getPath('myeventlane_auth') . '/templates';
 }
 
 /**

--- a/web/modules/custom/myeventlane_auth/myeventlane_auth.services.yml
+++ b/web/modules/custom/myeventlane_auth/myeventlane_auth.services.yml
@@ -63,6 +63,11 @@ services:
     tags:
       - { name: event_subscriber }
 
+  myeventlane_auth.account_setup_flow_subscriber:
+    class: Drupal\myeventlane_auth\EventSubscriber\AccountSetupFlowSubscriber
+    tags:
+      - { name: event_subscriber }
+
   # Disabled: hub wrap moved to MelPostLoginSessionRedirectSubscriber (request phase after session commit).
   myeventlane_auth.post_login_hub_redirect_subscriber:
     class: Drupal\myeventlane_auth\EventSubscriber\PostLoginHubRedirectSubscriber

--- a/web/modules/custom/myeventlane_auth/src/EventSubscriber/AccountSetupFlowSubscriber.php
+++ b/web/modules/custom/myeventlane_auth/src/EventSubscriber/AccountSetupFlowSubscriber.php
@@ -34,8 +34,14 @@ final class AccountSetupFlowSubscriber implements EventSubscriberInterface {
     $route = $request->attributes->get('_route');
     $uid = (string) $request->attributes->get('uid', '');
 
-    if ($route === 'user.reset' && $request->query->get('mel_flow') === 'account_setup' && $uid !== '') {
-      $request->getSession()->set(self::SESSION_KEY, $uid);
+    if ($route === 'user.reset' && $uid !== '') {
+      $session = $request->getSession();
+      if ($request->query->get('mel_flow') === 'account_setup') {
+        $session->set(self::SESSION_KEY, $uid);
+      }
+      else {
+        $session->remove(self::SESSION_KEY);
+      }
       return;
     }
 

--- a/web/modules/custom/myeventlane_auth/src/EventSubscriber/AccountSetupFlowSubscriber.php
+++ b/web/modules/custom/myeventlane_auth/src/EventSubscriber/AccountSetupFlowSubscriber.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_auth\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Carries account-setup presentation through Drupal's secure reset redirect.
+ */
+final class AccountSetupFlowSubscriber implements EventSubscriberInterface {
+
+  private const SESSION_KEY = 'mel_account_setup_uid';
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [KernelEvents::REQUEST => ['onRequest', 28]];
+  }
+
+  /**
+   * Stores first-use intent without changing Drupal's token validation.
+   */
+  public function onRequest(RequestEvent $event): void {
+    if (!$event->isMainRequest()) {
+      return;
+    }
+
+    $request = $event->getRequest();
+    $route = $request->attributes->get('_route');
+    $uid = (string) $request->attributes->get('uid', '');
+
+    if ($route === 'user.reset' && $request->query->get('mel_flow') === 'account_setup' && $uid !== '') {
+      $request->getSession()->set(self::SESSION_KEY, $uid);
+      return;
+    }
+
+    if ($route === 'user.reset.form' && $request->getSession()->get(self::SESSION_KEY) === $uid) {
+      $request->attributes->get('_route_object')?->setDefault('_title', 'Set up your account');
+    }
+  }
+
+}

--- a/web/modules/custom/myeventlane_auth/src/EventSubscriber/AccountSetupFlowSubscriber.php
+++ b/web/modules/custom/myeventlane_auth/src/EventSubscriber/AccountSetupFlowSubscriber.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
  */
 final class AccountSetupFlowSubscriber implements EventSubscriberInterface {
 
-  private const SESSION_KEY = 'mel_account_setup_uid';
+  public const SESSION_KEY = 'mel_account_setup_uid';
 
   /**
    * {@inheritdoc}

--- a/web/modules/custom/myeventlane_auth/templates/page--user--password-mel.html.twig
+++ b/web/modules/custom/myeventlane_auth/templates/page--user--password-mel.html.twig
@@ -1,0 +1,7 @@
+{% extends '@gin_login/page--user--login.html.twig' %}
+
+{% block title %}
+  <h1 class="page-title user-form-page__page-title">
+    {{ mel_account_setup|default(false) ? 'Set up your account'|t : 'Reset your password'|t }}
+  </h1>
+{% endblock %}

--- a/web/modules/custom/myeventlane_auth/tests/src/Unit/AccountSetupPresentationContractTest.php
+++ b/web/modules/custom/myeventlane_auth/tests/src/Unit/AccountSetupPresentationContractTest.php
@@ -32,11 +32,13 @@ final class AccountSetupPresentationContractTest extends TestCase {
     $module = file_get_contents(dirname(__DIR__, 3) . '/myeventlane_auth.module');
     self::assertIsString($module);
 
-    self::assertStringContainsString("get('mel_account_setup_uid')", $module);
+    self::assertStringContainsString('get(AccountSetupFlowSubscriber::SESSION_KEY)', $module);
     self::assertStringContainsString("t('Set up your account')", $module);
     self::assertStringContainsString("t('Continue')", $module);
     self::assertStringContainsString('function myeventlane_auth_mail_alter', $module);
     self::assertStringContainsString("'register_no_approval_required'", $module);
+    self::assertStringNotContainsString("remove('mel_account_setup_uid')", $module);
+    self::assertStringContainsString('remove(AccountSetupFlowSubscriber::SESSION_KEY)', $module);
 
     $subscriber = file_get_contents(dirname(__DIR__, 3) . '/src/EventSubscriber/AccountSetupFlowSubscriber.php');
     self::assertIsString($subscriber);
@@ -47,6 +49,10 @@ final class AccountSetupPresentationContractTest extends TestCase {
     self::assertIsString($template);
     self::assertStringContainsString("mel_account_setup|default(false)", $template);
     self::assertStringContainsString("'Reset your password'|t", $template);
+
+    $hub_script = file_get_contents(dirname(__DIR__, 7) . '/web/themes/custom/myeventlane_theme/js/account-settings-hub.js');
+    self::assertIsString($hub_script);
+    self::assertStringContainsString("toggle && !invalidCard.classList.contains('is-editing')", $hub_script);
   }
 
 }

--- a/web/modules/custom/myeventlane_auth/tests/src/Unit/AccountSetupPresentationContractTest.php
+++ b/web/modules/custom/myeventlane_auth/tests/src/Unit/AccountSetupPresentationContractTest.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\myeventlane_auth\Unit;
 
+use Drupal\myeventlane_auth\EventSubscriber\AccountSetupFlowSubscriber;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
  * Protects the distinction between account setup and password reset.
@@ -53,6 +59,29 @@ final class AccountSetupPresentationContractTest extends TestCase {
     $hub_script = file_get_contents(dirname(__DIR__, 7) . '/web/themes/custom/myeventlane_theme/js/account-settings-hub.js');
     self::assertIsString($hub_script);
     self::assertStringContainsString("toggle && !invalidCard.classList.contains('is-editing')", $hub_script);
+  }
+
+  /**
+   * A normal recovery link clears abandoned account-setup presentation state.
+   */
+  public function testPasswordRecoveryClearsStaleAccountSetupIntent(): void {
+    $session = new Session(new MockArraySessionStorage());
+    $kernel = $this->createMock(HttpKernelInterface::class);
+    $subscriber = new AccountSetupFlowSubscriber();
+
+    $setup_request = Request::create('/user/reset/123?mel_flow=account_setup');
+    $setup_request->setSession($session);
+    $setup_request->attributes->set('_route', 'user.reset');
+    $setup_request->attributes->set('uid', '123');
+    $subscriber->onRequest(new RequestEvent($kernel, $setup_request, HttpKernelInterface::MAIN_REQUEST));
+    self::assertSame('123', $session->get(AccountSetupFlowSubscriber::SESSION_KEY));
+
+    $recovery_request = Request::create('/user/reset/123');
+    $recovery_request->setSession($session);
+    $recovery_request->attributes->set('_route', 'user.reset');
+    $recovery_request->attributes->set('uid', '123');
+    $subscriber->onRequest(new RequestEvent($kernel, $recovery_request, HttpKernelInterface::MAIN_REQUEST));
+    self::assertFalse($session->has(AccountSetupFlowSubscriber::SESSION_KEY));
   }
 
 }

--- a/web/modules/custom/myeventlane_auth/tests/src/Unit/AccountSetupPresentationContractTest.php
+++ b/web/modules/custom/myeventlane_auth/tests/src/Unit/AccountSetupPresentationContractTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_auth\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the distinction between account setup and password reset.
+ *
+ * @group myeventlane_auth
+ */
+final class AccountSetupPresentationContractTest extends TestCase {
+
+  /**
+   * Registration mail marks only first-use links as account setup.
+   */
+  public function testRegistrationMailUsesAccountSetupLanguage(): void {
+    $mail = file_get_contents(dirname(__DIR__, 7) . '/config/sync/user.mail.yml');
+    self::assertIsString($mail);
+
+    self::assertStringContainsString("subject: 'Set up your [site:name] account'", $mail);
+    self::assertSame(2, substr_count($mail, '?mel_flow=account_setup'));
+    self::assertStringContainsString("password_reset:\n  subject: 'Replacement login information", $mail);
+  }
+
+  /**
+   * The one-time-login form changes language only for the explicit marker.
+   */
+  public function testResetFormHasExplicitAccountSetupPresentation(): void {
+    $module = file_get_contents(dirname(__DIR__, 3) . '/myeventlane_auth.module');
+    self::assertIsString($module);
+
+    self::assertStringContainsString("get('mel_account_setup_uid')", $module);
+    self::assertStringContainsString("t('Set up your account')", $module);
+    self::assertStringContainsString("t('Continue')", $module);
+    self::assertStringContainsString('function myeventlane_auth_mail_alter', $module);
+    self::assertStringContainsString("'register_no_approval_required'", $module);
+
+    $subscriber = file_get_contents(dirname(__DIR__, 3) . '/src/EventSubscriber/AccountSetupFlowSubscriber.php');
+    self::assertIsString($subscriber);
+    self::assertStringContainsString("query->get('mel_flow') === 'account_setup'", $subscriber);
+    self::assertStringContainsString("\$route === 'user.reset.form'", $subscriber);
+
+    $template = file_get_contents(dirname(__DIR__, 3) . '/templates/page--user--password-mel.html.twig');
+    self::assertIsString($template);
+    self::assertStringContainsString("mel_account_setup|default(false)", $template);
+    self::assertStringContainsString("'Reset your password'|t", $template);
+  }
+
+}

--- a/web/modules/custom/myeventlane_messaging/myeventlane_messaging.module
+++ b/web/modules/custom/myeventlane_messaging/myeventlane_messaging.module
@@ -125,7 +125,7 @@ function myeventlane_messaging_email_branding_logo_url(): string {
   $drupal_root = \Drupal::root();
   // Prefer a release-owned raster asset. Configured managed files can remain
   // referenced after the underlying file has been removed from shared storage.
-  foreach (['images/mel-email-logo.png', 'images/logo.png'] as $rel) {
+  foreach (['images/myeventlane-logo.png', 'images/mel-email-logo.png', 'images/logo.png'] as $rel) {
     if ($theme_path !== '' && is_readable($drupal_root . '/' . $theme_path . '/' . $rel)) {
       $candidates[] = $base . '/' . $theme_path . '/' . $rel;
     }

--- a/web/modules/custom/myeventlane_messaging/src/Service/MelEmailLayoutService.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/MelEmailLayoutService.php
@@ -209,6 +209,7 @@ final class MelEmailLayoutService {
       return $trim;
     }
     $escaped = Html::escape($trim);
+    $escaped = $this->linkifyUrls($escaped);
     $paragraphs = preg_split("/\r\n\r\n|\n\n/", $escaped, -1, PREG_SPLIT_NO_EMPTY);
     if ($paragraphs === FALSE) {
       return '<p class="mel-body" style="margin:0 0 16px 0;font-size:16px;line-height:1.6;color:#293241;">' . nl2br($escaped) . '</p>';
@@ -218,6 +219,23 @@ final class MelEmailLayoutService {
       $blocks[] = '<p class="mel-body" style="margin:0 0 16px 0;font-size:16px;line-height:1.6;color:#293241;">' . nl2br(trim((string) $p)) . '</p>';
     }
     return implode("\n", $blocks);
+  }
+
+  /**
+   * Converts escaped plain-text URLs into safe HTML links.
+   */
+  private function linkifyUrls(string $escaped): string {
+    return (string) preg_replace_callback(
+      '~https?://[^\s<]+~i',
+      static function (array $matches): string {
+        $candidate = (string) ($matches[0] ?? '');
+        $url = rtrim($candidate, '.,;:!?)');
+        $suffix = substr($candidate, strlen($url));
+        return '<a href="' . $url . '" style="color:#5360bf;text-decoration:underline;word-break:break-all;">'
+          . $url . '</a>' . $suffix;
+      },
+      $escaped,
+    );
   }
 
   private function isLikelyHtml(string $s): bool {

--- a/web/modules/custom/myeventlane_messaging/tests/src/Unit/MelEmailLayoutServiceTest.php
+++ b/web/modules/custom/myeventlane_messaging/tests/src/Unit/MelEmailLayoutServiceTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_messaging\Unit;
+
+use Drupal\myeventlane_messaging\Service\MelEmailLayoutService;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * Tests shared plain-text email formatting.
+ *
+ * @group myeventlane_messaging
+ */
+final class MelEmailLayoutServiceTest extends TestCase {
+
+  /**
+   * Plain URLs become clickable without losing surrounding punctuation.
+   */
+  public function testPlainTextUrlsBecomeSafeLinks(): void {
+    require_once dirname(__DIR__, 3) . '/src/Service/MelEmailLayoutService.php';
+    $reflection = new ReflectionClass(MelEmailLayoutService::class);
+    $service = $reflection->newInstanceWithoutConstructor();
+    $method = new ReflectionMethod($service, 'htmlOrPlainToInnerHtml');
+    $method->setAccessible(TRUE);
+
+    $html = (string) $method->invoke(
+      $service,
+      'Set up: https://example.com/user/reset/1/token/login?mel_flow=account_setup.',
+    );
+
+    self::assertStringContainsString(
+      'href="https://example.com/user/reset/1/token/login?mel_flow=account_setup"',
+      $html,
+    );
+    self::assertStringContainsString('</a>.', $html);
+  }
+
+}

--- a/web/themes/custom/myeventlane_theme/js/account-settings-hub.js
+++ b/web/themes/custom/myeventlane_theme/js/account-settings-hub.js
@@ -145,6 +145,13 @@
           });
         }
 
+        if (form.dataset.melPasswordSetup === 'true') {
+          const securityToggle = form.querySelector('[data-mel-settings-card="security"] [data-mel-settings-toggle]');
+          if (securityToggle) {
+            securityToggle.click();
+          }
+        }
+
         const invalidCard = cards.find((card) => card.querySelector('.error, [aria-invalid="true"]'));
         if (invalidCard) {
           const toggle = invalidCard.querySelector('[data-mel-settings-toggle]');

--- a/web/themes/custom/myeventlane_theme/js/account-settings-hub.js
+++ b/web/themes/custom/myeventlane_theme/js/account-settings-hub.js
@@ -155,7 +155,7 @@
         const invalidCard = cards.find((card) => card.querySelector('.error, [aria-invalid="true"]'));
         if (invalidCard) {
           const toggle = invalidCard.querySelector('[data-mel-settings-toggle]');
-          if (toggle) {
+          if (toggle && !invalidCard.classList.contains('is-editing')) {
             toggle.click();
           }
         }

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -5280,6 +5280,38 @@ function myeventlane_theme_preprocess_mimemail_message(array &$variables): void 
   $variables['logo_path'] = function_exists('myeventlane_messaging_email_branding_logo_url')
     ? myeventlane_messaging_email_branding_logo_url()
     : '';
+
+  // Mime Mail does not provide a generic `url` Twig variable. Registration
+  // links are part of the user mail body, so expose the one-time link to the
+  // dedicated account-setup template explicitly.
+  $registration_keys = [
+    'register_admin_created',
+    'register_no_approval_required',
+    'register-admin-created',
+    'register-no-approval-required',
+  ];
+  if (($variables['module'] ?? '') !== 'user'
+    || !in_array($variables['key'] ?? '', $registration_keys, TRUE)) {
+    return;
+  }
+
+  $body = $variables['body'] ?? '';
+  if (is_array($body)) {
+    $body = implode("\n", array_map(
+      static fn ($part): string => is_scalar($part) || $part instanceof \Stringable
+        ? (string) $part
+        : '',
+      $body,
+    ));
+  }
+
+  $variables['account_setup_url'] = (string) ($variables['params']['account_setup_url'] ?? '');
+  if ($variables['account_setup_url'] !== '') {
+    return;
+  }
+  if (preg_match('~https?://[^\s<>"\']+/user/reset/[^\s<>"\']+~', (string) $body, $matches)) {
+    $variables['account_setup_url'] = rtrim($matches[0], '.,);');
+  }
 }
 
 /**

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_account-settings.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_account-settings.scss
@@ -141,6 +141,19 @@
   }
 }
 
+// Password setup is a required onboarding step, not a secondary settings edit.
+// Give it the full content column so labels, guidance, and password controls do
+// not collapse into the narrow half-width desktop card.
+.mel-account-settings-form[data-mel-password-setup='true'] {
+  [data-mel-settings-card='security'] {
+    grid-column: 1 / -1;
+  }
+
+  [data-mel-settings-card='security'] .mel-account-settings__editor {
+    max-width: 46rem;
+  }
+}
+
 .mel-account-settings__heading {
   max-width: calc(100% - 5rem);
   margin: 0;

--- a/web/themes/custom/myeventlane_theme/templates/email/mimemail-message--user--register-no-approval-required.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/email/mimemail-message--user--register-no-approval-required.html.twig
@@ -1,125 +1,66 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <title>Welcome to MyEventLane</title>
-</head>
-<body style="margin:0; padding:0; background:#fef5ec; font-family: Arial, sans-serif;">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="x-apple-disable-message-reformatting" />
+    <title>{{ subject|striptags }}</title>
+  </head>
+  <body style="margin:0; padding:0; background:#fef5ec;">
+    {% set setup_url = params.account_setup_url|default(account_setup_url|default('')) %}
+    <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background:#fef5ec; padding:24px 0;">
+      <tr>
+        <td align="center" style="padding:0 12px;">
+          <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="600" style="width:600px; max-width:600px; background:#ffffff; border-radius:16px; overflow:hidden; box-shadow:0 12px 28px rgba(0,0,0,0.08);">
+            {% if logo_path|default('') %}
+              <tr>
+                <td style="padding:24px 28px 8px; text-align:left;">
+                  <img src="{{ logo_path }}" alt="MyEventLane" width="140" style="display:block; height:auto; border:0; outline:none; text-decoration:none;" />
+                </td>
+              </tr>
+            {% endif %}
 
-  <table width="100%" cellpadding="0" cellspacing="0" style="background:#fef5ec; padding:20px;">
-    <tr>
-      <td align="center">
+            <tr>
+              <td style="padding:18px 28px 8px; font-family:Nunito, Arial, sans-serif; color:#293241;">
+                <div style="font-size:24px; line-height:1.25; font-weight:700;">Set up your MyEventLane account</div>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:0 28px 22px; font-family:Nunito, Arial, sans-serif; font-size:15px; line-height:1.55; color:#4b5563;">
+                Set your password to finish creating your account. This secure link can only be used once.
+              </td>
+            </tr>
 
-        <table width="480" cellpadding="0" cellspacing="0" style="background:#ffffff; border-radius:16px; padding:24px; box-shadow:0 4px 12px rgba(0,0,0,0.06);">
+            {% if setup_url %}
+              <tr>
+                <td style="padding:0 28px 24px;">
+                  <a href="{{ setup_url }}" style="display:inline-block; background:#f26d5b; color:#ffffff; padding:14px 24px; border-radius:999px; text-decoration:none; font-family:Nunito, Arial, sans-serif; font-weight:700; font-size:16px;">
+                    Set up my account
+                  </a>
+                </td>
+              </tr>
+              <tr>
+                <td style="padding:0 28px 26px; font-family:Nunito, Arial, sans-serif; font-size:12px; line-height:1.5; color:#6b7280;">
+                  If the button does not work, copy and paste this link into your browser:<br />
+                  <a href="{{ setup_url }}" style="color:#6e7ef2; word-break:break-all;">{{ setup_url }}</a>
+                </td>
+              </tr>
+            {% else %}
+              <tr>
+                <td style="padding:0 28px 26px; font-family:Nunito, Arial, sans-serif; font-size:14px; line-height:1.5; color:#9b1c1c;">
+                  We could not create your secure setup link. Please request a new account email or contact MyEventLane support.
+                </td>
+              </tr>
+            {% endif %}
 
-          <!-- Logo -->
-          <tr>
-            <td align="center" style="padding-bottom:16px;">
-              <img src="https://myeventlane.com.au/themes/custom/myeventlane_theme/logo.png" width="160" alt="MyEventLane">
-            </td>
-          </tr>
-
-          <!-- Headline -->
-          <tr>
-            <td align="center" style="font-size:22px; font-weight:700; color:#2c3e50; padding-bottom:8px;">
-              Welcome to MyEventLane 🎉
-            </td>
-          </tr>
-
-          <!-- Subtext -->
-          <tr>
-            <td align="center" style="font-size:15px; color:#555; padding-bottom:24px;">
-              You’re one step away from discovering and creating amazing events.
-            </td>
-          </tr>
-
-          <!-- CTA BUTTON -->
-          <tr>
-            <td align="center" style="padding-bottom:24px;">
-              <a href="{{ url }}" style="
-                display:inline-block;
-                background:#f26d5b;
-                color:#ffffff;
-                padding:14px 24px;
-                border-radius:999px;
-                text-decoration:none;
-                font-weight:600;
-                font-size:16px;
-              ">
-                Continue to MyEventLane
-              </a>
-            </td>
-          </tr>
-
-          <!-- Info -->
-          <tr>
-            <td style="font-size:14px; color:#666; text-align:center; padding-bottom:16px;">
-              This secure link will log you in instantly and let you set your password.
-            </td>
-          </tr>
-
-          <!-- Divider -->
-          <tr>
-            <td style="border-top:1px solid #eee; padding-top:16px;"></td>
-          </tr>
-
-          <!-- Next Steps -->
-          <tr>
-            <td style="font-size:14px; color:#2c3e50; text-align:center; padding-bottom:12px;">
-              What would you like to do next?
-            </td>
-          </tr>
-
-          <tr>
-            <td align="center" style="padding-bottom:20px;">
-
-              <a href="https://myeventlane.com.au/events" style="
-                display:inline-block;
-                margin:6px;
-                padding:10px 16px;
-                border-radius:999px;
-                background:#f4f4f4;
-                color:#333;
-                text-decoration:none;
-                font-size:14px;
-              ">Browse Events</a>
-
-              <a href="https://myeventlane.com.au/create-event" style="
-                display:inline-block;
-                margin:6px;
-                padding:10px 16px;
-                border-radius:999px;
-                background:#6e7ef2;
-                color:#ffffff;
-                text-decoration:none;
-                font-size:14px;
-              ">Create an Event</a>
-
-            </td>
-          </tr>
-
-          <!-- Fallback -->
-          <tr>
-            <td style="font-size:12px; color:#999; text-align:center;">
-              Or copy and paste this link into your browser:<br>
-              <span style="word-break:break-all;">{{ url }}</span>
-            </td>
-          </tr>
-
-        </table>
-
-        <!-- Footer -->
-        <table width="480" style="margin-top:16px;">
-          <tr>
-            <td style="font-size:12px; color:#aaa; text-align:center;">
-              MyEventLane — Discover. Create. Connect.
-            </td>
-          </tr>
-        </table>
-
-      </td>
-    </tr>
-  </table>
-
-</body>
+            <tr>
+              <td style="padding:16px 28px; font-family:Nunito, Arial, sans-serif; font-size:12px; line-height:1.4; color:#6b7280; border-top:1px solid rgba(0,0,0,0.06);">
+                You are receiving this email because a MyEventLane account was created for this address.
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
 </html>

--- a/web/themes/custom/myeventlane_theme/templates/form/form--user-profile-form.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/form/form--user-profile-form.html.twig
@@ -9,23 +9,29 @@
   {{ element.form_build_id }}
   {{ element.form_token }}
   {{ element.form_id }}
-  <div class="mel-auth-card mel-auth-card--reset">
 
-    <h1 class="mel-auth-title">
-      {{ '✨ Set your password'|t }}
-    </h1>
+  {% if attributes.hasClass('mel-account-settings-form') %}
+    {{ element|without('actions', 'form_id', 'form_token', 'form_build_id') }}
+    {{ element.actions }}
+  {% else %}
+    <div class="mel-auth-card mel-auth-card--reset">
 
-    <p class="mel-auth-subtitle">
-      {{ "You’re one step away from creating your event."|t }}
-    </p>
+      <h1 class="mel-auth-title">
+        {{ '✨ Set your password'|t }}
+      </h1>
 
-    <div class="mel-auth-form">
-      {{ element|without('actions', 'form_id', 'form_token', 'form_build_id') }}
+      <p class="mel-auth-subtitle">
+        {{ "You’re one step away from creating your event."|t }}
+      </p>
+
+      <div class="mel-auth-form">
+        {{ element|without('actions', 'form_id', 'form_token', 'form_build_id') }}
+      </div>
+
+      <div class="mel-auth-actions">
+        {{ element.actions }}
+      </div>
+
     </div>
-
-    <div class="mel-auth-actions">
-      {{ element.actions }}
-    </div>
-
-  </div>
+  {% endif %}
 </form>


### PR DESCRIPTION
## What changed

- gives registration emails clear account-setup wording, a working CTA, and a clickable fallback URL
- distinguishes first-use account setup from genuine password recovery while retaining Drupal core token validation
- preserves the one-time password token when redirecting from the Drupal user edit route to MyEventLane settings
- opens the Account & security card with required password fields and no current-password requirement
- fixes the narrow password form layout and supplies release-owned fallbacks for missing login imagery
- keeps genuine password-reset wording and behaviour unchanged

## Root cause

The registration template expected a URL variable that Mime Mail does not supply. MyEventLane also redirected the core user edit route to `/my-settings/{user}` without forwarding `pass-reset-token`, which removed Drupal’s one-time permission to set a password. A password-reset form wrapper then constrained the Profile Hub to a narrow authentication card.

## User impact

New customers and organisers receive a clickable setup email, see account-setup language, and are taken directly to an expanded, readable password form. Existing password-recovery links retain their reset language and behaviour.

## Validation

- focused PHPUnit: 5 tests, 32 assertions passed
- PHP syntax checks passed
- `git diff --check` passed
- MyEventLane theme build passed
- CSS lint and locked hero check passed
- real Drupal registration and password-reset emails generated through Mailpit
- browser verified setup email, setup page, token-preserving redirect, required password fields, genuine reset path, working imagery, and corrected desktop width

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches one-time login tokens, redirects, and registration mail across auth and account modules; core token validation is unchanged but mis-forwarded query params could break password setup.
> 
> **Overview**
> This PR fixes the **first-use account setup** path so new users get clear emails, working links, and a usable password form—without changing how genuine password recovery works.
> 
> **Registration emails** now use “Set up your account” copy, append `?mel_flow=account_setup` to one-time login URLs (config + `hook_mail_alter`), and expose `account_setup_url` for Mime Mail. The registration HTML template is rebuilt around that CTA instead of a missing `url` variable, and plain-text bodies get **clickable links** via `MelEmailLayoutService::linkifyUrls`.
> 
> **`mel_flow=account_setup`** is tracked in session by `AccountSetupFlowSubscriber` so Gin Login and the one-time-login step show setup wording; normal reset links clear that state. Login imagery falls back to theme assets when Gin config files are missing.
> 
> **Customer redirect** from `entity.user.edit_form` to `/my-settings` now forwards `pass-reset-token` and `check_logged_in`, uses **302** (not 301) for token URLs, and the settings hub auto-opens **Account & security** with setup notice, full-width layout, and no “email me a reset” link during `user_pass_reset`.
> 
> The profile form template skips the narrow auth card when `mel-account-settings-form` is active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6705b2888ff40bb8f4a6c8f06b69b483325cac82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->