### PR TITLE
Fix account setup form submission

### DIFF
--- a/web/modules/custom/myeventlane_account/tests/modules/myeventlane_account_test/myeventlane_account_test.module
+++ b/web/modules/custom/myeventlane_account/tests/modules/myeventlane_account_test/myeventlane_account_test.module
@@ -14,5 +14,5 @@ use Drupal\Core\Form\FormStateInterface;
  */
 function myeventlane_account_test_form_user_form_alter(array &$form, FormStateInterface $form_state): void {
   require_once dirname(__DIR__, 3) . '/myeventlane_account.module';
-  _myeventlane_account_customer_settings_form_alter($form);
+  _myeventlane_account_customer_settings_form_alter($form, $form_state);
 }

--- a/web/modules/custom/myeventlane_account/tests/src/Functional/CustomerSettingsSaveTest.php
+++ b/web/modules/custom/myeventlane_account/tests/src/Functional/CustomerSettingsSaveTest.php
@@ -7,6 +7,7 @@ namespace Drupal\Tests\myeventlane_account\Functional;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\Tests\BrowserTestBase;
+use Drupal\user\UserInterface;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
@@ -60,7 +61,7 @@ final class CustomerSettingsSaveTest extends BrowserTestBase {
   }
 
   /**
-   * Ensures profile values persist and core account values stay top-level.
+   * Ensures profile and password values persist using top-level account inputs.
    */
   public function testCustomerSettingsSaveAndReload(): void {
     $account = $this->drupalCreateUser();
@@ -73,9 +74,13 @@ final class CustomerSettingsSaveTest extends BrowserTestBase {
     $this->assertSession()->fieldExists('name');
     $this->assertSession()->fieldNotExists('account[name]');
 
+    $password = 'MEL-functional-settings-save!';
     $this->submitForm([
       'field_display_name[0][value]' => 'Customer Test',
       'field_city[0][value]' => 'Sydney',
+      'current_pass' => $account->passRaw,
+      'pass[pass1]' => $password,
+      'pass[pass2]' => $password,
     ], 'Save');
 
     $this->assertSession()->pageTextContains('The changes have been saved.');
@@ -83,6 +88,19 @@ final class CustomerSettingsSaveTest extends BrowserTestBase {
     $this->drupalGet('/user/' . $account->id() . '/edit');
     $this->assertSession()->fieldValueEquals('field_display_name[0][value]', 'Customer Test');
     $this->assertSession()->fieldValueEquals('field_city[0][value]', 'Sydney');
+
+    $saved = $this->container->get('entity_type.manager')->getStorage('user')->loadUnchanged($account->id());
+    self::assertInstanceOf(UserInterface::class, $saved);
+    self::assertTrue(\Drupal::service('password')->check($password, $saved->getPassword()));
+
+    $this->drupalLogout();
+    $this->drupalGet('/user/login');
+    $this->submitForm([
+      'name' => $account->getAccountName(),
+      'pass' => $password,
+    ], 'Log in');
+    $this->drupalGet('/user/' . $account->id() . '/edit');
+    $this->assertSession()->statusCodeEquals(200);
   }
 
 }

--- a/web/modules/custom/myeventlane_account/tests/src/Unit/CustomerSettingsFormGroupingTest.php
+++ b/web/modules/custom/myeventlane_account/tests/src/Unit/CustomerSettingsFormGroupingTest.php
@@ -14,6 +14,19 @@ use PHPUnit\Framework\TestCase;
 final class CustomerSettingsFormGroupingTest extends TestCase {
 
   /**
+   * Ensures the settings form and its submit actions render exactly once.
+   */
+  public function testSettingsTemplateUsesCanonicalFormChildren(): void {
+    $template = file_get_contents(dirname(__DIR__, 7) . '/web/themes/custom/myeventlane_theme/templates/form/form--user-profile-form.html.twig');
+    self::assertIsString($template);
+
+    self::assertStringContainsString("{% if attributes.hasClass('mel-account-settings-form') %}\n    {{ children }}", $template);
+    self::assertSame(2, substr_count($template, '{{ children }}'));
+    self::assertStringNotContainsString('{{ element.', $template);
+    self::assertStringNotContainsString('{{ element|without', $template);
+  }
+
+  /**
    * Ensures visual grouping preserves entity field structure and parents.
    */
   public function testEntityFieldsRemainAtTheirOriginalKeys(): void {

--- a/web/themes/custom/myeventlane_theme/templates/form/form--user-profile-form.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/form/form--user-profile-form.html.twig
@@ -6,13 +6,8 @@
  */
 #}
 <form{{ attributes }}>
-  {{ element.form_build_id }}
-  {{ element.form_token }}
-  {{ element.form_id }}
-
   {% if attributes.hasClass('mel-account-settings-form') %}
-    {{ element|without('actions', 'form_id', 'form_token', 'form_build_id') }}
-    {{ element.actions }}
+    {{ children }}
   {% else %}
     <div class="mel-auth-card mel-auth-card--reset">
 
@@ -25,11 +20,7 @@
       </p>
 
       <div class="mel-auth-form">
-        {{ element|without('actions', 'form_id', 'form_token', 'form_build_id') }}
-      </div>
-
-      <div class="mel-auth-actions">
-        {{ element.actions }}
+        {{ children }}
       </div>
 
     </div>


### PR DESCRIPTION
## What changed

- Render the Drupal user profile form through its canonical `children` output in both settings and account-setup layouts.
- Remove the manual split rendering that emitted submit actions more than once.
- Extend the customer settings functional test to verify profile persistence, password hash persistence, and a fresh sign-in.
- Add a template contract test and correct the test form-alter call to pass Drupal's form state.

## Root cause

The custom user-profile Twig template rendered the form elements and action controls separately while Drupal also exposed them through the complete form render tree. This produced duplicate Save controls and broke the expected form submission contract on the account-setup/settings flow.

## Impact

Customer and organiser account setup use the same canonical Drupal form submission path. The page retains the MyEventLane presentation while hidden security fields and the Save action render exactly once.

## Validation

- Customer settings functional test: profile save, password hash change, logout, new-password sign-in, protected edit-page reload
- Template contract unit test: 3 tests, 19 assertions
- Theme CSS lint and hero variant check
- Public and vendor theme production builds
- PHP syntax and Git whitespace checks

Existing dependency audit warnings remain unchanged and are outside this fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Theme and test-only changes to form rendering and coverage; restores standard Drupal form submission with no new auth or data paths.
> 
> **Overview**
> Fixes broken account setup/settings submission caused by the user-profile Twig template rendering form fields and **Save** actions separately while Drupal also emitted them through the full render tree, which duplicated submit controls and violated the expected FAPI contract.
> 
> The template now outputs **`{{ children }}`** for both the settings (`mel-account-settings-form`) and password-reset layouts instead of manually printing hidden tokens and `element|without` / `element.actions`. Tests were tightened to match: the test form alter passes **`$form_state`** into `_myeventlane_account_customer_settings_form_alter`, the functional test covers password change, stored hash verification, logout, and login with the new password, and a unit test locks the template to canonical **`children`** usage (no `element.` / `element|without` splits).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0243af5a95981e72280a4aaa76b9ec215dd6374. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->