### PR TITLE
Fix organiser account setup redirect

### DIFF
--- a/web/modules/custom/myeventlane_auth/myeventlane_auth.module
+++ b/web/modules/custom/myeventlane_auth/myeventlane_auth.module
@@ -719,7 +719,7 @@ function myeventlane_auth_reset_redirect_submit(array &$form, FormStateInterface
     return;
   }
   $form_state->setRedirect(
-    'myeventlane_event_studio.create',
+    'myeventlane_vendor.create_event_gateway',
     [],
     [
       'query' => [

--- a/web/modules/custom/myeventlane_auth/tests/src/Unit/AccountSetupPresentationContractTest.php
+++ b/web/modules/custom/myeventlane_auth/tests/src/Unit/AccountSetupPresentationContractTest.php
@@ -62,6 +62,23 @@ final class AccountSetupPresentationContractTest extends TestCase {
   }
 
   /**
+   * Create-event setup returns through the public organiser gateway.
+   */
+  public function testCreateEventPasswordSetupUsesOrganiserGateway(): void {
+    $module = file_get_contents(dirname(__DIR__, 3) . '/myeventlane_auth.module');
+    self::assertIsString($module);
+
+    $start = strpos($module, 'function myeventlane_auth_reset_redirect_submit');
+    $end = strpos($module, 'function myeventlane_auth_form_user_login_form_alter', $start);
+    self::assertIsInt($start);
+    self::assertIsInt($end);
+    $handler = substr($module, $start, $end - $start);
+
+    self::assertStringContainsString("'myeventlane_vendor.create_event_gateway'", $handler);
+    self::assertStringNotContainsString("'myeventlane_event_studio.create'", $handler);
+  }
+
+  /**
    * A normal recovery link clears abandoned account-setup presentation state.
    */
   public function testPasswordRecoveryClearsStaleAccountSetupIntent(): void {


### PR DESCRIPTION
## What changed

- Send create-event password setup through the public `/create-event` gateway.
- Add a regression contract proving account setup cannot redirect directly to the protected Event Studio create route.

## Root cause

The one-time password setup submit handler redirected create-event intent to `myeventlane_event_studio.create`. A newly registered organiser has only the authenticated role and no vendor entity at that point, so Vendor Studio correctly returned HTTP 403.

## Impact

After choosing a password, a new organiser now returns through the canonical gateway. The gateway detects that no vendor exists and sends the account to organiser details and Vendor Terms onboarding before event creation.

## Validation

- Account setup presentation contract: 4 tests, 27 assertions
- Post-login route policy: 3 tests, 9 assertions
- Direct form-handler runtime check resolved `myeventlane_vendor.create_event_gateway`
- Disposable authenticated non-vendor account reached `/vendor/onboard/profile?destination=/create-event`
- Organiser details and Vendor Terms step rendered without HTTP 403
- Theme lint and both production theme builds passed
- PHP syntax, Git whitespace, cache rebuild and database-update status passed

The isolated DDEV override and disposable local account are not included in this PR. No staging data or roles were changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted redirect change in auth onboarding aligned with existing post-login policy; low blast radius with a new contract test.
> 
> **Overview**
> Fixes **403 after first-time password setup** for new organisers with `create_event` intent by no longer sending them to the protected Event Studio create route.
> 
> In `myeventlane_auth_reset_redirect_submit`, the post–one-time-password redirect changes from `myeventlane_event_studio.create` to **`myeventlane_vendor.create_event_gateway`**, still passing `mel_intent=create_event`, so onboarding (vendor profile / terms) can run before event creation.
> 
> Adds **`testCreateEventPasswordSetupUsesOrganiserGateway`** in `AccountSetupPresentationContractTest` to lock in the gateway route and forbid a direct `myeventlane_event_studio.create` redirect in that handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6edd9b85f49696b4868e6ecb4e1b6b5ee127094f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->