### PR TITLE
Open profile and security during account setup

### DIFF
--- a/web/modules/custom/myeventlane_account/myeventlane_account.module
+++ b/web/modules/custom/myeventlane_account/myeventlane_account.module
@@ -467,6 +467,8 @@ function myeventlane_account_form_user_form_alter(array &$form, FormStateInterfa
  * Preserves user entity form submit/validate by keeping original #parents on moved elements.
  */
 function _myeventlane_account_customer_settings_form_alter(array &$form, FormStateInterface $form_state): void {
+  $is_first_use_setup = _myeventlane_account_is_first_use_setup($form, $form_state);
+
   if (isset($form['account']['roles'])) {
     $form['account']['roles']['#access'] = FALSE;
   }
@@ -479,10 +481,19 @@ function _myeventlane_account_customer_settings_form_alter(array &$form, FormSta
   if (isset($form['account']['name'])) {
     $form['account']['name']['#title'] = t('Sign-in username');
     $form['account']['name']['#description'] = t('Your unique username for signing in.');
+    if ($is_first_use_setup) {
+      $form['account']['name']['#access'] = FALSE;
+    }
   }
   if (isset($form['account']['mail'])) {
-    $form['account']['mail']['#title'] = t('Email');
-    $form['account']['mail']['#description'] = t('Used for bookings, receipts, and updates you opt into.');
+    $form['account']['mail']['#title'] = $is_first_use_setup ? t('Sign-in email') : t('Email');
+    $form['account']['mail']['#description'] = $is_first_use_setup
+      ? t('Your verified email for signing in, bookings, and receipts.')
+      : t('Used for bookings, receipts, and updates you opt into.');
+    if ($is_first_use_setup) {
+      $form['account']['mail']['#attributes']['readonly'] = 'readonly';
+      $form['account']['mail']['#attributes']['aria-readonly'] = 'true';
+    }
   }
   if (isset($form['account']['current_pass'])) {
     $form['account']['current_pass']['#description'] = t('Required when you change your email or password.');
@@ -520,6 +531,10 @@ function _myeventlane_account_customer_settings_form_alter(array &$form, FormSta
     'mel_settings_profile',
   );
 
+  if ($is_first_use_setup && isset($form['field_display_name']['widget'][0]['value'])) {
+    $form['field_display_name']['widget'][0]['value']['#required'] = TRUE;
+  }
+
   $form['mel_settings_security'] = [
     '#type' => 'container',
     '#attributes' => $card_attr + [
@@ -552,6 +567,10 @@ function _myeventlane_account_customer_settings_form_alter(array &$form, FormSta
         '#markup' => '<p>' . t('Choose and confirm your new password to continue. You do not need to enter a current password.') . '</p>',
       ],
     ];
+  }
+
+  if ($is_first_use_setup) {
+    $form['#attributes']['data-mel-account-setup'] = 'true';
   }
 
   _myeventlane_account_group_nested_fields(
@@ -734,7 +753,32 @@ function _myeventlane_account_customer_settings_form_alter(array &$form, FormSta
     $form['actions']['#weight'] = 200;
     $form['actions']['#attributes']['class'][] = 'mel-account-settings__actions';
     $form['actions']['#attributes']['aria-live'] = 'polite';
+    if ($is_first_use_setup && isset($form['actions']['submit'])) {
+      $form['actions']['submit']['#value'] = t('Finish account setup');
+    }
   }
+}
+
+/**
+ * Whether this user form is the explicit first-use account setup journey.
+ */
+function _myeventlane_account_is_first_use_setup(array $form, FormStateInterface $form_state): bool {
+  if (!$form_state->get('user_pass_reset')) {
+    return FALSE;
+  }
+
+  $form_object = $form_state->getFormObject();
+  if (!is_object($form_object) || !method_exists($form_object, 'getEntity')) {
+    return FALSE;
+  }
+  $account = $form_object->getEntity();
+  if (!$account instanceof \Drupal\user\UserInterface || $account->id() === NULL) {
+    return FALSE;
+  }
+
+  $request = \Drupal::request();
+  return $request->hasSession()
+    && (string) $request->getSession()->get('mel_account_setup_uid') === (string) $account->id();
 }
 
 /**

--- a/web/modules/custom/myeventlane_auth/myeventlane_auth.module
+++ b/web/modules/custom/myeventlane_auth/myeventlane_auth.module
@@ -678,6 +678,7 @@ function myeventlane_auth_form_user_form_alter(array &$form, FormStateInterface 
       ];
     }
     $form['actions']['submit']['#submit'][] = 'myeventlane_auth_reset_redirect_submit';
+    $form['actions']['submit']['#submit'][] = 'myeventlane_auth_account_setup_complete_submit';
   }
 }
 
@@ -727,6 +728,32 @@ function myeventlane_auth_reset_redirect_submit(array &$form, FormStateInterface
       ],
     ],
   );
+}
+
+/**
+ * Clears first-use presentation state after the account form saves.
+ */
+function myeventlane_auth_account_setup_complete_submit(array &$form, FormStateInterface $form_state): void {
+  $form_object = $form_state->getFormObject();
+  if (!$form_object instanceof EntityFormInterface) {
+    return;
+  }
+  $account = $form_object->getEntity();
+  if (!$account instanceof UserInterface || $account->id() === NULL) {
+    return;
+  }
+
+  $request = \Drupal::request();
+  if (!$request->hasSession()) {
+    return;
+  }
+  $session = $request->getSession();
+  if ($session->get(AccountSetupFlowSubscriber::SESSION_KEY) === (string) $account->id()) {
+    $session->remove(AccountSetupFlowSubscriber::SESSION_KEY);
+    if ($form_state->getRedirect() === NULL) {
+      $form_state->setRedirect('myeventlane_account.dashboard');
+    }
+  }
 }
 
 /**
@@ -857,12 +884,6 @@ function myeventlane_auth_form_user_login_form_alter(array &$form, FormStateInte
  */
 function myeventlane_auth_user_login(UserInterface $account): void {
   $request = \Drupal::request();
-  if ($request->hasSession()) {
-    $session = $request->getSession();
-    if ($session->get(AccountSetupFlowSubscriber::SESSION_KEY) === (string) $account->id()) {
-      $session->remove(AccountSetupFlowSubscriber::SESSION_KEY);
-    }
-  }
   if (myeventlane_auth_is_password_reset_flow($request)) {
     \Drupal::logger('myeventlane_auth')->notice('Skipping MEL post-login routing for password reset flow.');
     return;

--- a/web/modules/custom/myeventlane_auth/src/EventSubscriber/AccountSetupFlowSubscriber.php
+++ b/web/modules/custom/myeventlane_auth/src/EventSubscriber/AccountSetupFlowSubscriber.php
@@ -39,7 +39,7 @@ final class AccountSetupFlowSubscriber implements EventSubscriberInterface {
       if ($request->query->get('mel_flow') === 'account_setup') {
         $session->set(self::SESSION_KEY, $uid);
       }
-      else {
+      elseif ($request->isMethod('GET')) {
         $session->remove(self::SESSION_KEY);
       }
       return;

--- a/web/modules/custom/myeventlane_auth/tests/src/Unit/AccountSetupPresentationContractTest.php
+++ b/web/modules/custom/myeventlane_auth/tests/src/Unit/AccountSetupPresentationContractTest.php
@@ -45,6 +45,8 @@ final class AccountSetupPresentationContractTest extends TestCase {
     self::assertStringContainsString("'register_no_approval_required'", $module);
     self::assertStringNotContainsString("remove('mel_account_setup_uid')", $module);
     self::assertStringContainsString('remove(AccountSetupFlowSubscriber::SESSION_KEY)', $module);
+    self::assertStringContainsString("['#submit'][] = 'myeventlane_auth_account_setup_complete_submit'", $module);
+    self::assertStringContainsString("setRedirect('myeventlane_account.dashboard')", $module);
 
     $subscriber = file_get_contents(dirname(__DIR__, 3) . '/src/EventSubscriber/AccountSetupFlowSubscriber.php');
     self::assertIsString($subscriber);
@@ -79,6 +81,24 @@ final class AccountSetupPresentationContractTest extends TestCase {
   }
 
   /**
+   * First-use settings open profile and security without exposing usernames.
+   */
+  public function testFirstUseSettingsPresentationContract(): void {
+    $account_module = file_get_contents(dirname(__DIR__, 7) . '/web/modules/custom/myeventlane_account/myeventlane_account.module');
+    self::assertIsString($account_module);
+    self::assertStringContainsString("data-mel-account-setup'] = 'true'", $account_module);
+    self::assertStringContainsString("['#access'] = FALSE", $account_module);
+    self::assertStringContainsString("t('Sign-in email')", $account_module);
+    self::assertStringContainsString("t('Finish account setup')", $account_module);
+    self::assertStringContainsString("['#required'] = TRUE", $account_module);
+
+    $hub_script = file_get_contents(dirname(__DIR__, 7) . '/web/themes/custom/myeventlane_theme/js/account-settings-hub.js');
+    self::assertIsString($hub_script);
+    self::assertStringContainsString("['profile', 'security'].forEach", $hub_script);
+    self::assertStringContainsString("form.dataset.melAccountSetup === 'true'", $hub_script);
+  }
+
+  /**
    * A normal recovery link clears abandoned account-setup presentation state.
    */
   public function testPasswordRecoveryClearsStaleAccountSetupIntent(): void {
@@ -99,6 +119,24 @@ final class AccountSetupPresentationContractTest extends TestCase {
     $recovery_request->attributes->set('uid', '123');
     $subscriber->onRequest(new RequestEvent($kernel, $recovery_request, HttpKernelInterface::MAIN_REQUEST));
     self::assertFalse($session->has(AccountSetupFlowSubscriber::SESSION_KEY));
+  }
+
+  /**
+   * Submitting Continue preserves first-use intent for the settings form.
+   */
+  public function testAccountSetupContinuePreservesIntent(): void {
+    $session = new Session(new MockArraySessionStorage());
+    $session->set(AccountSetupFlowSubscriber::SESSION_KEY, '123');
+    $kernel = $this->createMock(HttpKernelInterface::class);
+    $subscriber = new AccountSetupFlowSubscriber();
+
+    $continue_request = Request::create('/user/reset/123', 'POST');
+    $continue_request->setSession($session);
+    $continue_request->attributes->set('_route', 'user.reset');
+    $continue_request->attributes->set('uid', '123');
+    $subscriber->onRequest(new RequestEvent($kernel, $continue_request, HttpKernelInterface::MAIN_REQUEST));
+
+    self::assertSame('123', $session->get(AccountSetupFlowSubscriber::SESSION_KEY));
   }
 
 }

--- a/web/themes/custom/myeventlane_theme/js/account-settings-hub.js
+++ b/web/themes/custom/myeventlane_theme/js/account-settings-hub.js
@@ -61,6 +61,7 @@
         }
 
         const cards = Array.from(form.querySelectorAll('[data-mel-settings-card]'));
+        const isAccountSetup = form.dataset.melAccountSetup === 'true';
 
         const closeCard = (card) => {
           card.classList.remove('is-editing');
@@ -80,6 +81,25 @@
           const summary = card.querySelector('[data-mel-settings-summary]');
           if (summary && summaries[key]) {
             summary.textContent = summaries[key](form);
+          }
+        };
+
+        const openCard = (card, focusFirstControl = false) => {
+          const button = card.querySelector('[data-mel-settings-toggle]');
+          const editor = card.querySelector('[data-mel-settings-editor]');
+          card.classList.add('is-editing');
+          if (button) {
+            button.setAttribute('aria-expanded', 'true');
+            button.textContent = Drupal.t('Done');
+          }
+          if (editor) {
+            editor.hidden = false;
+            if (focusFirstControl) {
+              const firstControl = editor.querySelector('input:not([type="hidden"]), select, textarea, button, a');
+              if (firstControl) {
+                firstControl.focus({preventScroll: true});
+              }
+            }
           }
         };
 
@@ -117,16 +137,15 @@
 
           toggle.addEventListener('click', () => {
             const opening = !card.classList.contains('is-editing');
-            cards.forEach(closeCard);
+            if (!opening) {
+              closeCard(card);
+              return;
+            }
+            if (!isAccountSetup) {
+              cards.forEach(closeCard);
+            }
             if (opening) {
-              card.classList.add('is-editing');
-              toggle.setAttribute('aria-expanded', 'true');
-              toggle.textContent = Drupal.t('Done');
-              editor.hidden = false;
-              const firstControl = editor.querySelector('input:not([type="hidden"]), select, textarea, button, a');
-              if (firstControl) {
-                firstControl.focus({preventScroll: true});
-              }
+              openCard(card, true);
             }
           });
         });
@@ -145,7 +164,19 @@
           });
         }
 
-        if (form.dataset.melPasswordSetup === 'true') {
+        if (isAccountSetup) {
+          ['profile', 'security'].forEach((key) => {
+            const card = form.querySelector(`[data-mel-settings-card="${key}"]`);
+            if (card) {
+              openCard(card);
+            }
+          });
+          const actions = form.querySelector('.mel-account-settings__actions');
+          if (actions) {
+            actions.classList.add('is-visible');
+          }
+        }
+        else if (form.dataset.melPasswordSetup === 'true') {
           const securityToggle = form.querySelector('[data-mel-settings-card="security"] [data-mel-settings-toggle]');
           if (securityToggle) {
             securityToggle.click();

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_account-settings.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_account-settings.scss
@@ -154,6 +154,19 @@
   }
 }
 
+.mel-account-settings-form[data-mel-account-setup='true'] {
+  [data-mel-settings-card='profile'],
+  [data-mel-settings-card='security'] {
+    grid-column: 1 / -1;
+  }
+
+  .mel-account-settings__actions {
+    visibility: visible;
+    opacity: 1;
+    transform: none;
+  }
+}
+
 .mel-account-settings__heading {
   max-width: calc(100% - 5rem);
   margin: 0;


### PR DESCRIPTION
## What changed

- opens Profile and Account & security together during the one-time account setup journey
- hides the generated internal username and presents the verified sign-in email as read-only
- requires a display name and labels the final action Finish account setup
- clears first-use presentation state only after a successful save
- sends customers to My Account while preserving the organiser create-event onboarding route

## Why

The first-use marker was cleared during login, before the settings form rendered. The page therefore behaved like normal settings and exposed Drupal's generated username. The new customer redirect also needed to avoid replacing the existing organiser intent redirect.

## Validation

- customer browser journey: setup link, both cards open, save succeeds, redirect to `/my-account`
- organiser browser journey: setup link, save succeeds, redirect to `/vendor/onboard/profile?destination=/create-event`
- account setup unit tests: 6 tests, 39 assertions
- customer settings grouping unit tests: 3 tests, 19 assertions
- customer settings functional save-and-reload test: 1 test, 18 assertions
- PHP syntax checks and `git diff --check`
- theme lint and production builds

## Notes

The test suite reports existing Drupal and contributed-module deprecations. npm audit also reports existing dependency advisories; neither was introduced or changed by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches password-reset and session-gated onboarding plus post-save redirects; mistakes could strand users or override organiser create-event handoff, though existing redirect precedence and new tests mitigate that.
> 
> **Overview**
> Fixes **first-use account setup** so the settings page stays in onboarding mode until the user saves, instead of clearing setup state at login and showing normal settings (including the generated Drupal username).
> 
> **Auth flow:** Removes session cleanup from `hook_user_login()` and adds `myeventlane_auth_account_setup_complete_submit` on the password-reset user form save. That handler clears `mel_account_setup_uid` only after a successful save, redirects customers to **My Account** when no other redirect is set, and leaves **create-event** redirects from the existing submit handler intact. **AccountSetupFlowSubscriber** only clears setup intent on **GET** reset links (not POST **Continue**), so the marker survives the reset step.
> 
> **Settings UI:** When setup session + pass-reset align, the form gets `data-mel-account-setup`, hides username, makes sign-in email read-only, requires display name, and renames submit to **Finish account setup**. Theme JS opens **Profile** and **Security** together, keeps both editable during setup, and SCSS full-widths those cards and shows the sticky actions bar immediately.
> 
> Unit contract tests cover the new submit handler, POST continue behavior, and first-use presentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3a74b28984dd06cdb668900640cdb2f58664f0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->