### PR TITLE
Align social auth config ordering

### DIFF
--- a/config/sync/social_auth.settings.yml
+++ b/config/sync/social_auth.settings.yml
@@ -2,7 +2,7 @@ _core:
   default_config_hash: 0E8z47ONguVcapiw1PGWDRs6g0NRDCzrym4mP_jcELU
 auth: {  }
 post_login: /user
+user_allowed: login
 redirect_user_form: false
 disable_admin_login: true
 disabled_roles: {  }
-user_allowed: login


### PR DESCRIPTION
## What changed

- aligns the Social Auth configuration key order with Drupal's active configuration

## Why

PR #753 deployed its configuration successfully, but Drupal rewrote the key order during import. The strict staging parity gate then detected social_auth.settings as different and rolled the release back. Because configuration uses the shared database, this also left an Apple Social Auth schema entry while the previous code release was active.

## Validation

- YAML parses successfully
- configuration key order matches staging active configuration
- git diff --check

## Scope

One configuration file only. No OAuth credentials or environment URLs are included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single YAML reorder with no credential or setting value changes.
> 
> **Overview**
> Reorders keys in **`config/sync/social_auth.settings.yml`** so exported config matches Drupal’s active config shape—specifically moving **`user_allowed: login`** above **`redirect_user_form`** (values unchanged).
> 
> This avoids the staging parity gate treating the file as drift after import and triggering a failed release rollback, as seen when key order diverged post-deploy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aacef2bfe14ffb07a5b5e72ae469ac5192cfe469. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->