### PR TITLE
Load social auth credentials from environment

### DIFF
--- a/web/modules/custom/myeventlane_auth/tests/src/Unit/AccountSetupPresentationContractTest.php
+++ b/web/modules/custom/myeventlane_auth/tests/src/Unit/AccountSetupPresentationContractTest.php
@@ -163,6 +163,18 @@ final class AccountSetupPresentationContractTest extends TestCase {
     $settings = file_get_contents($root . '/web/sites/default/settings.mel_shared_session.php');
     self::assertIsString($settings);
     self::assertStringContainsString("\$config['social_auth.settings']['user_allowed'] = 'login';", $settings);
+    foreach ([
+      'MEL_SOCIAL_APPLE_CLIENT_ID',
+      'MEL_SOCIAL_APPLE_TEAM_ID',
+      'MEL_SOCIAL_APPLE_KEY_FILE_ID',
+      'MEL_SOCIAL_APPLE_KEY_FILE_PATH',
+      'MEL_SOCIAL_GOOGLE_CLIENT_ID',
+      'MEL_SOCIAL_GOOGLE_CLIENT_SECRET',
+    ] as $environmentName) {
+      self::assertStringContainsString($environmentName, $settings);
+    }
+    self::assertStringContainsString("\$config['social_auth_apple.settings']['scopes'] = '';", $settings);
+    self::assertStringContainsString("\$config['social_auth_google.settings']['scopes'] = '';", $settings);
 
     $module = file_get_contents(dirname(__DIR__, 3) . '/myeventlane_auth.module');
     self::assertIsString($module);

--- a/web/sites/default/settings.mel_shared_session.php
+++ b/web/sites/default/settings.mel_shared_session.php
@@ -171,6 +171,45 @@ $melGetEnv = static function (string $name): string {
 // change the global Social Auth behaviour to provider-led registration.
 $config['social_auth.settings']['user_allowed'] = 'login';
 
+// Social provider credentials are environment-owned. Config imports must not
+// remove working sign-in credentials or place secrets in config/sync.
+//
+// Apple:
+//   MEL_SOCIAL_APPLE_CLIENT_ID
+//   MEL_SOCIAL_APPLE_TEAM_ID
+//   MEL_SOCIAL_APPLE_KEY_FILE_ID
+//   MEL_SOCIAL_APPLE_KEY_FILE_PATH
+// Google:
+//   MEL_SOCIAL_GOOGLE_CLIENT_ID
+//   MEL_SOCIAL_GOOGLE_CLIENT_SECRET
+//
+// Provider availability fails closed until every required value is present.
+$mel_social_apple = [
+  'client_id' => $melGetEnv('MEL_SOCIAL_APPLE_CLIENT_ID'),
+  'team_id' => $melGetEnv('MEL_SOCIAL_APPLE_TEAM_ID'),
+  'key_file_id' => $melGetEnv('MEL_SOCIAL_APPLE_KEY_FILE_ID'),
+  'key_file_path' => $melGetEnv('MEL_SOCIAL_APPLE_KEY_FILE_PATH'),
+];
+foreach ($mel_social_apple as $key => $value) {
+  if ($value !== '') {
+    $config['social_auth_apple.settings'][$key] = $value;
+  }
+}
+$config['social_auth_apple.settings']['scopes'] = '';
+$config['social_auth_apple.settings']['endpoints'] = '';
+
+$mel_social_google = [
+  'client_id' => $melGetEnv('MEL_SOCIAL_GOOGLE_CLIENT_ID'),
+  'client_secret' => $melGetEnv('MEL_SOCIAL_GOOGLE_CLIENT_SECRET'),
+];
+foreach ($mel_social_google as $key => $value) {
+  if ($value !== '') {
+    $config['social_auth_google.settings'][$key] = $value;
+  }
+}
+$config['social_auth_google.settings']['scopes'] = '';
+$config['social_auth_google.settings']['endpoints'] = '';
+
 $mel_stripe_secret = $melGetEnv('MEL_STRIPE_SECRET_KEY');
 if ($mel_stripe_secret !== '') {
   $config['commerce_payment.commerce_payment_gateway.stripe']['configuration']['secret_key'] = $mel_stripe_secret;


### PR DESCRIPTION
## What changed

- load Apple and Google social-auth credentials from protected environment variables
- initialise scopes and endpoints as strings to satisfy the contrib OAuth manager
- keep provider availability fail-closed when credentials are absent
- keep social sign-in restricted to existing MEL accounts

## Root cause

Staging provider settings existed only in Drupal active configuration. The staging config import removed those database-only objects during deployment, hiding the buttons and causing direct provider routes to fail.

## Validation

- 12 focused tests passed (76 assertions)
- PHP syntax passed
- DDEV environment-only Apple and Google provider checks passed
- staging credentials migrated to the protected environment without printing or committing values

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication provider configuration and login availability across environments; misconfigured or missing env vars will disable social sign-in until fixed.
> 
> **Overview**
> **Apple and Google sign-in credentials** are now applied at bootstrap from environment variables in `settings.mel_shared_session.php`, following the same pattern as Stripe/Postmark, so **config imports no longer wipe** staging-only provider settings or push secrets into `config/sync`.
> 
> For each provider, non-empty env values override `social_auth_apple.settings` / `social_auth_google.settings`; **`scopes` and `endpoints` are forced to empty strings** for the contrib OAuth manager. Partial or missing env vars leave credentials unset so providers stay **fail-closed** until fully configured.
> 
> The existing **`social_auth.settings` `user_allowed = login`** invariant is unchanged. Unit contract tests now assert the documented `MEL_SOCIAL_*` env names and scope initialization in shared settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93e35a4cad28f064280293ea842b77bc3bd6ac3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->