### PR TITLE
Improve media ownership and staff access

### DIFF
--- a/config/sync/user.role.content_editor.yml
+++ b/config/sync/user.role.content_editor.yml
@@ -10,6 +10,8 @@ dependencies:
     - comment
     - contextual
     - file
+    - media
+    - myeventlane_vendor
     - node
     - path
     - system
@@ -23,10 +25,13 @@ weight: -8
 is_admin: false
 permissions:
   - 'access administration pages'
+  - 'access all myeventlane media assets'
   - 'access content overview'
   - 'access contextual links'
   - 'access files overview'
+  - 'access media overview'
   - 'access toolbar'
+  - 'administer media'
   - 'administer url aliases'
   - 'create article content'
   - 'create page content'

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -444,6 +444,7 @@ services:
       - '@myeventlane_event_studio.question_template_manager'
       - '@request_stack'
       - '@file.repository'
+      - '@myeventlane_vendor.organiser_media_access'
 
   myeventlane_event_studio.readiness:
     class: Drupal\myeventlane_event_studio\Service\EventReadinessService

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -27,6 +27,7 @@ use Drupal\myeventlane_event\Service\EventPasscodeAccess;
 use Drupal\myeventlane_event\Service\PublicEventVisibility;
 use Drupal\myeventlane_event\Utility\EventNodeRevisionSave;
 use Drupal\myeventlane_event_studio\Service\EventStudioQuestionTemplateManager;
+use Drupal\myeventlane_vendor\Service\OrganiserMediaAccess;
 use Drupal\myeventlane_venue\Entity\Venue;
 use Drupal\myeventlane_venue\Service\VenueManager;
 use Drupal\media\MediaInterface;
@@ -73,6 +74,7 @@ final class EventStudioSaveService {
     private readonly ?EventStudioQuestionTemplateManager $questionTemplateManager = NULL,
     private readonly ?RequestStack $requestStack = NULL,
     private readonly ?FileRepositoryInterface $fileRepository = NULL,
+    private readonly ?OrganiserMediaAccess $organiserMediaAccess = NULL,
   ) {}
 
   /**
@@ -90,6 +92,10 @@ final class EventStudioSaveService {
       || !$this->fileRepository instanceof FileRepositoryInterface
     ) {
       return ['node' => NULL, 'errors' => ['Saved image selection is not available.']];
+    }
+    if ($this->organiserMediaAccess instanceof OrganiserMediaAccess
+      && !$this->organiserMediaAccess->canSelect($media)) {
+      return ['node' => NULL, 'errors' => ['Choose an image uploaded by your organiser account.']];
     }
 
     $source_field = (string) ($media->getSource()->getConfiguration()['source_field'] ?? '');
@@ -1528,6 +1534,16 @@ final class EventStudioSaveService {
 
       $final_value = $items->getValue();
       $final_ids = $this->brandingGalleryMediaIdsFromField($final_value);
+      $new_ids = array_values(array_diff($final_ids, $before_ids));
+      if ($new_ids !== [] && $this->organiserMediaAccess instanceof OrganiserMediaAccess) {
+        $selected_media = $this->entityTypeManager->getStorage('media')->loadMultiple($new_ids);
+        foreach ($new_ids as $media_id) {
+          $media = $selected_media[$media_id] ?? NULL;
+          if (!$media instanceof MediaInterface || !$this->organiserMediaAccess->canSelect($media)) {
+            return ['One or more gallery images are not available to your organiser account.'];
+          }
+        }
+      }
       $node->set('field_mel_event_gallery', $final_value);
 
       $this->logger->info('Branding gallery save for node @nid: before=@before submitted=@submitted final=@final', [

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioMediaOwnershipTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioMediaOwnershipTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\Image\ImageFactory;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\file\FileRepositoryInterface;
+use Drupal\focal_point\FocalPointManagerInterface;
+use Drupal\media\MediaInterface;
+use Drupal\myeventlane_event_studio\Service\EventHighlightHelper;
+use Drupal\myeventlane_event_studio\Service\EventStudioSaveService;
+use Drupal\myeventlane_event_studio\Service\PublishEligibilityEvaluator;
+use Drupal\myeventlane_event_studio\Service\QuestionFieldTypeRegistry;
+use Drupal\myeventlane_vendor\Service\OrganiserMediaAccess;
+use Drupal\myeventlane_venue\Service\VenueManager;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\UnitTestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests Event Studio Media Library ownership enforcement.
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventStudioMediaOwnershipTest extends UnitTestCase {
+
+  /**
+   * Verifies that organisers cannot save a foreign Media Library cover.
+   */
+  public function testForeignCoverSelectionIsRejected(): void {
+    $account = $this->createMock(AccountProxyInterface::class);
+    $account->method('id')->willReturn(23);
+    $account->method('hasPermission')
+      ->with(OrganiserMediaAccess::ACCESS_ALL_PERMISSION)
+      ->willReturn(FALSE);
+
+    $media = $this->createMock(MediaInterface::class);
+    $media->method('getOwnerId')->willReturn(99);
+
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('hasField')->willReturnMap([
+      ['field_event_image', TRUE],
+      ['field_mel_event_cover_media', TRUE],
+    ]);
+
+    $service = new EventStudioSaveService(
+      $this->createMock(EntityTypeManagerInterface::class),
+      $this->createMock(VenueManager::class),
+      $this->createMock(LoggerInterface::class),
+      (new \ReflectionClass(EventHighlightHelper::class))->newInstanceWithoutConstructor(),
+      (new \ReflectionClass(PublishEligibilityEvaluator::class))->newInstanceWithoutConstructor(),
+      new QuestionFieldTypeRegistry(),
+      $this->createMock(ImageFactory::class),
+      $this->createMock(TranslationInterface::class),
+      $this->createMock(FileSystemInterface::class),
+      $this->createMock(FocalPointManagerInterface::class),
+      fileRepository: $this->createMock(FileRepositoryInterface::class),
+      organiserMediaAccess: new OrganiserMediaAccess($account),
+    );
+
+    $result = $service->applyBrandingCoverMedia($node, $media);
+
+    self::assertNull($result['node']);
+    self::assertSame(
+      ['Choose an image uploaded by your organiser account.'],
+      $result['errors'],
+    );
+  }
+
+}

--- a/web/modules/custom/myeventlane_messaging/src/Form/VendorBrandingForm.php
+++ b/web/modules/custom/myeventlane_messaging/src/Form/VendorBrandingForm.php
@@ -14,6 +14,7 @@ use Drupal\file\FileInterface;
 use Drupal\myeventlane_vendor\Entity\Vendor;
 use Drupal\myeventlane_vendor\Service\CurrentVendorResolverInterface;
 use Drupal\myeventlane_vendor\Service\UserVendorMembershipQuery;
+use Drupal\myeventlane_vendor\Service\VendorImageFieldPolicy;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -133,14 +134,14 @@ final class VendorBrandingForm extends FormBase {
       );
       $form['branding']['logo'] = [
         '#type' => 'managed_file',
-        '#title' => $this->t('Logo'),
+        '#title' => $this->t('Email logo override'),
         '#upload_location' => 'public://vendor_logos/',
         '#upload_validators' => [
           'FileExtension' => ['extensions' => 'png jpg jpeg gif webp'],
           'FileSizeLimit' => ['fileLimit' => 5 * 1024 * 1024],
         ],
         '#default_value' => $logo_default,
-        '#description' => $this->t('Square PNG, JPG or WebP works best. Maximum 5 MB. This appears in message headers and your organiser profile.'),
+        '#description' => $this->t('Optional. Used in message headers instead of your organiser logo. Square PNG, JPG or WebP works best; maximum 5 MB.'),
         '#wrapper_attributes' => ['class' => ['mel-vendor-brand-v2__asset-field']],
       ];
     }
@@ -356,13 +357,7 @@ final class VendorBrandingForm extends FormBase {
    * Finds the vendor logo field this form can save.
    */
   private function getLogoFieldName(Vendor $vendor): string {
-    foreach (['field_msg_logo', 'field_vendor_logo', 'field_logo_image'] as $field_name) {
-      if ($vendor->hasField($field_name)) {
-        return $field_name;
-      }
-    }
-
-    return '';
+    return VendorImageFieldPolicy::emailOverrideField($vendor);
   }
 
   /**

--- a/web/modules/custom/myeventlane_messaging/src/Service/VendorBrandResolver.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/VendorBrandResolver.php
@@ -11,6 +11,7 @@ use Drupal\file\FileInterface;
 use Drupal\myeventlane_messaging\ValueObject\Brand;
 use Drupal\myeventlane_vendor\Entity\Vendor;
 use Drupal\myeventlane_vendor\Service\CurrentVendorResolverInterface;
+use Drupal\myeventlane_vendor\Service\VendorImageFieldPolicy;
 
 /**
  * Resolves vendor branding for messages from Vendor entity fields.
@@ -98,13 +99,12 @@ final class VendorBrandResolver implements BrandResolverInterface {
       $accentColor = Brand::DEFAULT_ACCENT_COLOR;
     }
 
-    // Logo URL from field_msg_logo, fallback to field_vendor_logo.
-    $logoUrl = $this->getLogoUrl($vendor, 'field_msg_logo');
-    if ($logoUrl === '') {
-      $logoUrl = $this->getLogoUrl($vendor, 'field_vendor_logo');
-    }
-    if ($logoUrl === '') {
-      $logoUrl = $this->getLogoUrl($vendor, 'field_logo_image');
+    $logoUrl = '';
+    foreach (VendorImageFieldPolicy::EMAIL_LOGO_FIELDS as $fieldName) {
+      $logoUrl = $this->getLogoUrl($vendor, $fieldName);
+      if ($logoUrl !== '') {
+        break;
+      }
     }
 
     return new Brand(

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.info.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.info.yml
@@ -18,6 +18,7 @@ dependencies:
   - drupal:text
   - drupal:image
   - drupal:link
+  - drupal:media
   - drupal:user
   - drupal:views
   - drupal:field_ui

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.module
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.module
@@ -22,7 +22,33 @@ use Drupal\Core\Url;
 use Drupal\myeventlane_vendor\Entity\Vendor;
 use Drupal\node\NodeInterface;
 use Drupal\user\UserInterface;
+use Drupal\views\Plugin\views\query\QueryPluginBase;
+use Drupal\views\Plugin\views\query\Sql;
+use Drupal\views\ViewExecutable;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
+
+/**
+ * Implements hook_views_query_alter().
+ *
+ * Organiser-facing Media Library widgets must not become a catalogue of other
+ * organisers' uploads. Staff with the explicit unrestricted permission and
+ * administrators keep the complete library.
+ */
+function myeventlane_vendor_views_query_alter(ViewExecutable $view, QueryPluginBase $query): void {
+  if ($view->id() !== 'media_library' || !$query instanceof Sql) {
+    return;
+  }
+
+  /** @var \Drupal\myeventlane_vendor\Service\OrganiserMediaAccess $media_access */
+  $media_access = \Drupal::service('myeventlane_vendor.organiser_media_access');
+  if ($media_access->hasUnrestrictedAccess()) {
+    return;
+  }
+
+  $owner_ids = $media_access->allowedOwnerIds();
+  $table = $query->ensureTable('media_field_data');
+  $query->addWhere(0, $table . '.uid', $owner_ids !== [] ? $owner_ids : [-1], 'IN');
+}
 
 /**
  * Implements hook_user_login().

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.permissions.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.permissions.yml
@@ -14,3 +14,8 @@ access vendor dashboard:
 use pro financial analytics:
   title: 'Use Pro financial analytics'
   description: 'Access Pro-only financial analytics routes and insights.'
+
+access all myeventlane media assets:
+  title: 'Access all MyEventLane media assets'
+  description: 'Browse and select platform and organiser media across ownership boundaries.'
+  restrict access: true

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -54,6 +54,11 @@ services:
       - '@entity_type.manager'
       - '@entity_field.manager'
 
+  myeventlane_vendor.organiser_media_access:
+    class: Drupal\myeventlane_vendor\Service\OrganiserMediaAccess
+    arguments:
+      - '@current_user'
+
   myeventlane_vendor.event_studio_create:
     class: Drupal\myeventlane_vendor\Service\VendorEventStudioCreateService
     arguments:

--- a/web/modules/custom/myeventlane_vendor/src/Form/VendorBrandingForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/VendorBrandingForm.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\myeventlane_vendor\Entity\Vendor;
+use Drupal\myeventlane_vendor\Service\VendorImageFieldPolicy;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -55,8 +56,8 @@ final class VendorBrandingForm extends FormBase {
     ];
 
     // Logo field.
-    if ($vendor->hasField('field_vendor_logo') || $vendor->hasField('field_logo_image')) {
-      $logo_field = $vendor->hasField('field_vendor_logo') ? 'field_vendor_logo' : 'field_logo_image';
+    $logo_field = VendorImageFieldPolicy::canonicalPublicLogoField($vendor);
+    if ($logo_field !== '') {
       $existing_logo_fid = NULL;
       if ($vendor->hasField($logo_field) && !$vendor->get($logo_field)->isEmpty()) {
         $existing_logo_fid = $vendor->get($logo_field)->target_id;

--- a/web/modules/custom/myeventlane_vendor/src/Service/OrganiserMediaAccess.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/OrganiserMediaAccess.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_vendor\Service;
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\media\MediaInterface;
+
+/**
+ * Defines which Media Library assets an organiser may select.
+ *
+ * Media entities currently carry a user owner, not a vendor-organisation
+ * reference. Non-staff accounts are therefore restricted to their own media.
+ * This is intentionally narrower than inferring access from vendor membership.
+ */
+final class OrganiserMediaAccess {
+
+  public const ACCESS_ALL_PERMISSION = 'access all myeventlane media assets';
+
+  public function __construct(
+    private readonly AccountProxyInterface $currentUser,
+  ) {}
+
+  /**
+   * Whether the account may browse and select every Media Library asset.
+   */
+  public function hasUnrestrictedAccess(?AccountInterface $account = NULL): bool {
+    $account ??= $this->currentUser;
+    return $account->hasPermission(self::ACCESS_ALL_PERMISSION);
+  }
+
+  /**
+   * Owner IDs allowed in organiser-facing Media Library listings.
+   *
+   * @return list<int>
+   *   One account ID, or an empty list for anonymous accounts.
+   */
+  public function allowedOwnerIds(?AccountInterface $account = NULL): array {
+    $account ??= $this->currentUser;
+    $uid = (int) $account->id();
+    return $uid > 0 ? [$uid] : [];
+  }
+
+  /**
+   * Whether an account may newly select the supplied media entity.
+   */
+  public function canSelect(MediaInterface $media, ?AccountInterface $account = NULL): bool {
+    $account ??= $this->currentUser;
+    if ($this->hasUnrestrictedAccess($account)) {
+      return TRUE;
+    }
+
+    return in_array((int) $media->getOwnerId(), $this->allowedOwnerIds($account), TRUE);
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorCardBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorCardBuilder.php
@@ -29,11 +29,6 @@ final class VendorCardBuilder {
    */
   private const LOGO_IMAGE_STYLE = 'mel_vendor_logo';
 
-  /**
-   * Candidate logo fields in preference order.
-   */
-  private const LOGO_FIELD_NAMES = ['field_logo_image', 'field_vendor_logo'];
-
   private const DESCRIPTION_LIMIT = 120;
 
   private const NEW_ORGANISER_DAYS = 30;
@@ -231,7 +226,11 @@ final class VendorCardBuilder {
    *   A render array, or NULL when no logo exists.
    */
   public function buildLogo(EntityInterface $entity): ?array {
-    return $this->buildStyledImage($entity, self::LOGO_FIELD_NAMES, self::LOGO_IMAGE_STYLE);
+    return $this->buildStyledImage(
+      $entity,
+      VendorImageFieldPolicy::PUBLIC_LOGO_FIELDS,
+      self::LOGO_IMAGE_STYLE,
+    );
   }
 
   /**
@@ -246,7 +245,7 @@ final class VendorCardBuilder {
       return NULL;
     }
 
-    foreach (self::LOGO_FIELD_NAMES as $field_name) {
+    foreach (VendorImageFieldPolicy::PUBLIC_LOGO_FIELDS as $field_name) {
       if ($entity->hasField($field_name) && !$entity->get($field_name)->isEmpty()) {
         $file = $entity->get($field_name)->entity;
         if ($file !== NULL) {

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorImageFieldPolicy.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorImageFieldPolicy.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_vendor\Service;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+
+/**
+ * Canonical organiser image fields and legacy fallbacks.
+ */
+final class VendorImageFieldPolicy {
+
+  public const PUBLIC_LOGO_FIELDS = [
+    'field_vendor_logo',
+    'field_logo_image',
+  ];
+
+  public const EMAIL_LOGO_FIELDS = [
+    'field_msg_logo',
+    'field_vendor_logo',
+    'field_logo_image',
+  ];
+
+  /**
+   * Returns the canonical public logo field, with legacy schema fallback.
+   */
+  public static function canonicalPublicLogoField(ContentEntityInterface $vendor): string {
+    foreach (self::PUBLIC_LOGO_FIELDS as $fieldName) {
+      if ($vendor->hasField($fieldName)) {
+        return $fieldName;
+      }
+    }
+
+    return '';
+  }
+
+  /**
+   * Returns the optional email override field, then public schema fallback.
+   */
+  public static function emailOverrideField(ContentEntityInterface $vendor): string {
+    foreach (self::EMAIL_LOGO_FIELDS as $fieldName) {
+      if ($vendor->hasField($fieldName)) {
+        return $fieldName;
+      }
+    }
+
+    return '';
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorWorkspaceHealthService.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorWorkspaceHealthService.php
@@ -181,7 +181,7 @@ final class VendorWorkspaceHealthService {
     $configured = FALSE;
     if ($vendor instanceof Vendor) {
       $hasLogo = FALSE;
-      foreach (['field_vendor_logo', 'field_msg_logo', 'field_logo_image'] as $logoField) {
+      foreach (VendorImageFieldPolicy::EMAIL_LOGO_FIELDS as $logoField) {
         if ($vendor->hasField($logoField) && !$vendor->get($logoField)->isEmpty()) {
           $hasLogo = TRUE;
           break;

--- a/web/modules/custom/myeventlane_vendor/tests/src/Unit/MediaRoleBoundaryConfigTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Unit/MediaRoleBoundaryConfigTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_vendor\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Guards staff and organiser media-management boundaries.
+ *
+ * @group myeventlane_vendor
+ */
+final class MediaRoleBoundaryConfigTest extends TestCase {
+
+  /**
+   * Verifies that staff can manage every media asset.
+   */
+  public function testContentEditorHasFullMediaManagementAccess(): void {
+    $permissions = $this->rolePermissions('content_editor');
+
+    self::assertContains('access media overview', $permissions);
+    self::assertContains('access all myeventlane media assets', $permissions);
+    self::assertContains('administer media', $permissions);
+  }
+
+  /**
+   * Verifies that organisers retain the non-admin ownership boundary.
+   */
+  public function testVendorRoleOmitsAdministrationPermissions(): void {
+    $permissions = $this->rolePermissions('vendor');
+
+    self::assertNotContains('access all myeventlane media assets', $permissions);
+    self::assertNotContains('administer media', $permissions);
+    self::assertNotContains('access content overview', $permissions);
+    self::assertNotContains('access toolbar', $permissions);
+  }
+
+  /**
+   * Loads permissions from a synchronised role configuration file.
+   *
+   * @return list<string>
+   *   Permission machine names assigned to the role.
+   */
+  private function rolePermissions(string $role): array {
+    $path = dirname(__DIR__, 7) . '/config/sync/user.role.' . $role . '.yml';
+    self::assertFileExists($path);
+
+    $data = Yaml::parseFile($path);
+    self::assertIsArray($data);
+    $permissions = $data['permissions'] ?? [];
+    self::assertIsArray($permissions);
+
+    return array_values(array_filter($permissions, 'is_string'));
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor/tests/src/Unit/OrganiserMediaAccessTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Unit/OrganiserMediaAccessTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_vendor\Unit;
+
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\media\MediaInterface;
+use Drupal\myeventlane_vendor\Service\OrganiserMediaAccess;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_vendor\Service\OrganiserMediaAccess
+ * @group myeventlane_vendor
+ */
+final class OrganiserMediaAccessTest extends UnitTestCase {
+
+  /**
+   * @covers ::canSelect
+   * @covers ::allowedOwnerIds
+   */
+  public function testOrganiserCanSelectOnlyOwnMedia(): void {
+    $account = $this->account(23, FALSE);
+    $service = new OrganiserMediaAccess($this->proxy($account));
+
+    $own_media = $this->createMock(MediaInterface::class);
+    $own_media->method('getOwnerId')->willReturn(23);
+    $other_media = $this->createMock(MediaInterface::class);
+    $other_media->method('getOwnerId')->willReturn(99);
+
+    self::assertSame([23], $service->allowedOwnerIds());
+    self::assertTrue($service->canSelect($own_media));
+    self::assertFalse($service->canSelect($other_media));
+  }
+
+  /**
+   * @covers ::canSelect
+   * @covers ::hasUnrestrictedAccess
+   */
+  public function testStaffPermissionCanSelectAnyMedia(): void {
+    $account = $this->account(7, TRUE);
+    $service = new OrganiserMediaAccess($this->proxy($account));
+    $media = $this->createMock(MediaInterface::class);
+    $media->method('getOwnerId')->willReturn(99);
+
+    self::assertTrue($service->hasUnrestrictedAccess());
+    self::assertTrue($service->canSelect($media));
+  }
+
+  /**
+   * Creates a test account.
+   */
+  private function account(int $uid, bool $unrestricted): AccountInterface {
+    $account = $this->createMock(AccountInterface::class);
+    $account->method('id')->willReturn($uid);
+    $account->method('hasPermission')
+      ->with(OrganiserMediaAccess::ACCESS_ALL_PERMISSION)
+      ->willReturn($unrestricted);
+    return $account;
+  }
+
+  /**
+   * Creates the current-user proxy used by the service.
+   */
+  private function proxy(AccountInterface $account): AccountProxyInterface {
+    $proxy = $this->createMock(AccountProxyInterface::class);
+    $proxy->method('id')->willReturn($account->id());
+    $proxy->method('hasPermission')
+      ->with(OrganiserMediaAccess::ACCESS_ALL_PERMISSION)
+      ->willReturn($account->hasPermission(OrganiserMediaAccess::ACCESS_ALL_PERMISSION));
+    return $proxy;
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorImageFieldPolicyTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorImageFieldPolicyTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_vendor\Unit;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\myeventlane_vendor\Service\VendorImageFieldPolicy;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_vendor\Service\VendorImageFieldPolicy
+ * @group myeventlane_vendor
+ */
+final class VendorImageFieldPolicyTest extends UnitTestCase {
+
+  /**
+   * @covers ::canonicalPublicLogoField
+   * @covers ::emailOverrideField
+   */
+  public function testCanonicalAndEmailLogoContracts(): void {
+    $vendor = $this->createMock(ContentEntityInterface::class);
+    $vendor->method('hasField')->willReturnCallback(
+      static fn(string $field): bool => in_array($field, [
+        'field_vendor_logo',
+        'field_logo_image',
+        'field_msg_logo',
+      ], TRUE),
+    );
+
+    self::assertSame('field_vendor_logo', VendorImageFieldPolicy::canonicalPublicLogoField($vendor));
+    self::assertSame('field_msg_logo', VendorImageFieldPolicy::emailOverrideField($vendor));
+    self::assertSame(
+      ['field_vendor_logo', 'field_logo_image'],
+      VendorImageFieldPolicy::PUBLIC_LOGO_FIELDS,
+    );
+    self::assertSame(
+      ['field_msg_logo', 'field_vendor_logo', 'field_logo_image'],
+      VendorImageFieldPolicy::EMAIL_LOGO_FIELDS,
+    );
+  }
+
+  /**
+   * @covers ::canonicalPublicLogoField
+   */
+  public function testLegacyPublicLogoFallback(): void {
+    $vendor = $this->createMock(ContentEntityInterface::class);
+    $vendor->method('hasField')->willReturnCallback(
+      static fn(string $field): bool => $field === 'field_logo_image',
+    );
+
+    self::assertSame('field_logo_image', VendorImageFieldPolicy::canonicalPublicLogoField($vendor));
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor_settings/src/Form/VendorSettingsForm.php
+++ b/web/modules/custom/myeventlane_vendor_settings/src/Form/VendorSettingsForm.php
@@ -21,6 +21,7 @@ use Drupal\myeventlane_vendor\EventSubscriber\VendorStoreSubscriber;
 use Drupal\myeventlane_vendor\Form\FormActionUrlFixer;
 use Drupal\myeventlane_vendor\Service\CurrentVendorResolverInterface;
 use Drupal\myeventlane_vendor\Service\UserVendorMembershipQuery;
+use Drupal\myeventlane_vendor\Service\VendorImageFieldPolicy;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -692,13 +693,7 @@ class VendorSettingsForm extends FormBase {
       '#weight' => -10,
     ];
 
-    $logo_field = '';
-    foreach (['field_msg_logo', 'field_vendor_logo', 'field_logo_image'] as $candidate) {
-      if ($vendor->hasField($candidate)) {
-        $logo_field = $candidate;
-        break;
-      }
-    }
+    $logo_field = VendorImageFieldPolicy::canonicalPublicLogoField($vendor);
 
     if ($logo_field !== '') {
       $logo_default = [];


### PR DESCRIPTION
## Summary
- restrict organiser Media Library selection to media owned by the current organiser account
- give administrators and content editors full access to manage all media
- standardise the public organiser logo field while retaining a separate email-logo override
- enforce the same ownership boundary when Event Studio saves cover and gallery media

## Validation
- 22 focused PHPUnit tests passed with 138 assertions
- changed PHP files passed syntax checks
- modified YAML parsed successfully
- `git diff --check` passed
- new files passed Drupal and DrupalPractice coding standards

## Deployment
Staging deployment on merge runs database updates and configuration import (`RUN_UPDB=1`, `RUN_CIM=1`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authorization for media selection and listing (browse + server-side save validation); misconfigured roles could block organisers or over-expose assets, but enforcement is layered (Views + save checks) with tests for role boundaries.
> 
> **Overview**
> Introduces **organiser-scoped Media Library access**: organisers only see and can select media they own, while accounts with `access all myeventlane media assets` (granted to **content editors** via config sync, with `administer media` / media overview) keep the full library. The `media_library` view query is altered in `myeventlane_vendor` to enforce the owner filter at browse time.
> 
> **Event Studio** now rejects cover and newly added gallery media that fail `OrganiserMediaAccess::canSelect()`, closing a bypass if someone posts foreign media IDs.
> 
> **Vendor logo fields** are centralized in `VendorImageFieldPolicy`: public/profile surfaces use `field_vendor_logo` (with legacy fallbacks); email/messaging prefers `field_msg_logo` then public fields. Messaging branding UI copy clarifies the email logo as an optional override.
> 
> Unit tests cover `OrganiserMediaAccess`, role permission boundaries, image field policy, and foreign cover rejection in Event Studio.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc04b1e861722eeadaa15fbdd9da077bc653539a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->