### PR TITLE
Update Guzzle to 7.15.2

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6257,16 +6257,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.15.1",
+            "version": "7.15.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/744101956d78b7c1384d0cbf379db13e859167bf",
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf",
                 "shasum": ""
             },
             "require": {
@@ -6365,7 +6365,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.2"
             },
             "funding": [
                 {
@@ -6381,7 +6381,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-18T11:23:11+00:00"
+            "time": "2026-07-26T23:23:20+00:00"
         },
         {
             "name": "guzzlehttp/promises",


### PR DESCRIPTION
## Summary
- update `guzzlehttp/guzzle` from `7.15.1` to `7.15.2`
- remediate CVE-2026-69246 and CVE-2026-69245 reported by the Composer CI audit
- keep the change limited to `composer.lock`

## Validation
- `composer validate --strict`
- `composer install --dry-run --no-dev`
- `composer audit --locked --no-dev` reports no advisories
- `git diff --check`

This is the prerequisite security fix for PR #757.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only lockfile patch with no direct code changes; risk is limited to Guzzle HTTP client behavior in patch release 7.15.2.
> 
> **Overview**
> Bumps the locked **`guzzlehttp/guzzle`** dependency from **7.15.1** to **7.15.2** in `composer.lock` only—no `composer.json` or application code changes.
> 
> This addresses **CVE-2026-69246** and **CVE-2026-69245** flagged by Composer audit and is described as a prerequisite for PR #757.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d99d8836f1baf4d7e98f33a0935b55ff961ed9ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->