### PR TITLE
Secure organiser media and migrate venue images

### DIFF
--- a/config/sync/user.role.vendor.yml
+++ b/config/sync/user.role.vendor.yml
@@ -59,7 +59,6 @@ permissions:
   - 'access checkout'
   - 'access commerce_order overview'
   - 'access contextual links'
-  - 'access files overview'
   - 'access vendor console'
   - 'access vendor dashboard'
   - 'access vendor venues'

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.install
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.install
@@ -1092,6 +1092,30 @@ function myeventlane_vendor_update_10021(): string {
 }
 
 /**
+ * Removes the global Files overview from organiser accounts.
+ *
+ * The core Files view is permission-gated and is not filtered by media owner.
+ * Organisers continue to upload and select their own assets through Media
+ * Library; staff retain the Files overview through role configuration.
+ */
+function myeventlane_vendor_update_10022(): string {
+  $role = \Drupal::entityTypeManager()->getStorage('user_role')->load('vendor');
+  if ($role === NULL) {
+    return 'Vendor role not found; Files overview permission removal skipped.';
+  }
+
+  $permission = 'access files overview';
+  if (!$role->hasPermission($permission)) {
+    return 'Vendor role already omits the global Files overview permission.';
+  }
+
+  $role->revokePermission($permission);
+  $role->save();
+
+  return 'Removed the global Files overview permission from the Vendor role.';
+}
+
+/**
  * Implements hook_uninstall().
  */
 function myeventlane_vendor_uninstall(): void {

--- a/web/modules/custom/myeventlane_vendor/tests/src/Unit/MediaRoleBoundaryConfigTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Unit/MediaRoleBoundaryConfigTest.php
@@ -20,6 +20,7 @@ final class MediaRoleBoundaryConfigTest extends TestCase {
   public function testContentEditorHasFullMediaManagementAccess(): void {
     $permissions = $this->rolePermissions('content_editor');
 
+    self::assertContains('access files overview', $permissions);
     self::assertContains('access media overview', $permissions);
     self::assertContains('access all myeventlane media assets', $permissions);
     self::assertContains('administer media', $permissions);
@@ -33,8 +34,29 @@ final class MediaRoleBoundaryConfigTest extends TestCase {
 
     self::assertNotContains('access all myeventlane media assets', $permissions);
     self::assertNotContains('administer media', $permissions);
+    self::assertNotContains('access files overview', $permissions);
     self::assertNotContains('access content overview', $permissions);
     self::assertNotContains('access toolbar', $permissions);
+  }
+
+  /**
+   * Verifies the core Files overview is permission-gated, not owner-filtered.
+   */
+  public function testFilesOverviewPermissionRemainsStaffOnly(): void {
+    $root = dirname(__DIR__, 7);
+    $path = $root . '/web/core/modules/file/config/optional/views.view.files.yml';
+    self::assertFileExists($path);
+
+    $data = Yaml::parseFile($path);
+    self::assertIsArray($data);
+    self::assertSame('admin/content/files', $data['display']['page_1']['display_options']['path'] ?? NULL);
+    self::assertSame(
+      'access files overview',
+      $data['display']['default']['display_options']['access']['options']['perm'] ?? NULL,
+    );
+
+    self::assertNotContains('access files overview', $this->rolePermissions('vendor'));
+    self::assertContains('access files overview', $this->rolePermissions('content_editor'));
   }
 
   /**

--- a/web/modules/custom/myeventlane_venue/myeventlane_venue.info.yml
+++ b/web/modules/custom/myeventlane_venue/myeventlane_venue.info.yml
@@ -6,6 +6,8 @@ version: 1.0.1
 core_version_requirement: ^10 || ^11
 
 dependencies:
+  - drupal:media
+  - drupal:media_library
   - drupal:user
   - myeventlane_vendor:myeventlane_vendor
   - myeventlane_location:myeventlane_location

--- a/web/modules/custom/myeventlane_venue/myeventlane_venue.install
+++ b/web/modules/custom/myeventlane_venue/myeventlane_venue.install
@@ -102,3 +102,121 @@ function myeventlane_venue_update_10001(): void {
     '@entity' => $entity_type_id,
   ]);
 }
+
+/**
+ * Adds Media Library venue images and migrates legacy direct-file images.
+ */
+function myeventlane_venue_update_10002(array &$sandbox): string {
+  $entity_type_id = 'myeventlane_venue';
+  $field_name = 'image_media';
+  $update_manager = \Drupal::entityDefinitionUpdateManager();
+
+  if (!isset($sandbox['ids'])) {
+    $entity_type = \Drupal::entityTypeManager()->getDefinition($entity_type_id);
+    $definition = \Drupal\myeventlane_venue\Entity\Venue::baseFieldDefinitions($entity_type)[$field_name] ?? NULL;
+    if ($definition === NULL) {
+      throw new \RuntimeException('Venue image_media base field definition is missing.');
+    }
+
+    if (!$update_manager->getFieldStorageDefinition($field_name, $entity_type_id)) {
+      $update_manager->installFieldStorageDefinition(
+        $field_name,
+        $entity_type_id,
+        'myeventlane_venue',
+        $definition,
+      );
+      \Drupal::entityTypeManager()->clearCachedDefinitions();
+    }
+
+    $venue_storage = \Drupal::entityTypeManager()->getStorage($entity_type_id);
+    $sandbox['ids'] = array_values($venue_storage->getQuery()
+      ->accessCheck(FALSE)
+      ->sort('id')
+      ->execute());
+    $sandbox['index'] = 0;
+    $sandbox['migrated'] = 0;
+    $sandbox['reused'] = 0;
+    $sandbox['created'] = 0;
+    $sandbox['skipped'] = 0;
+  }
+
+  $ids = $sandbox['ids'];
+  $total = count($ids);
+  $limit = min($sandbox['index'] + 25, $total);
+  $venue_storage = \Drupal::entityTypeManager()->getStorage($entity_type_id);
+  $media_storage = \Drupal::entityTypeManager()->getStorage('media');
+
+  while ($sandbox['index'] < $limit) {
+    $venue_id = (int) $ids[$sandbox['index']];
+    $venue = $venue_storage->load($venue_id);
+    if ($venue === NULL
+      || !$venue->hasField($field_name)
+      || !$venue->get($field_name)->isEmpty()
+      || !$venue->hasField('image')
+      || $venue->get('image')->isEmpty()) {
+      $sandbox['skipped']++;
+      $sandbox['index']++;
+      continue;
+    }
+
+    $legacy_item = $venue->get('image')->first();
+    $file = $legacy_item?->entity;
+    if (!$file instanceof \Drupal\file\FileInterface) {
+      \Drupal::logger('myeventlane_venue')->warning(
+        'Venue @venue legacy image could not be migrated because its file is missing.',
+        ['@venue' => (string) $venue_id],
+      );
+      $sandbox['skipped']++;
+      $sandbox['index']++;
+      continue;
+    }
+
+    $owner_id = max(0, (int) $venue->getOwnerId());
+    $existing = $media_storage->loadByProperties([
+      'bundle' => 'image',
+      'uid' => $owner_id,
+      'field_media_image.target_id' => (int) $file->id(),
+    ]);
+    $media = $existing ? reset($existing) : NULL;
+
+    if (!$media instanceof \Drupal\media\MediaInterface) {
+      $alt = trim((string) ($legacy_item?->alt ?? ''));
+      if ($alt === '') {
+        $alt = (string) $venue->label();
+      }
+      $media = $media_storage->create([
+        'bundle' => 'image',
+        'uid' => $owner_id,
+        'name' => $file->getFilename(),
+        'field_media_image' => [
+          'target_id' => (int) $file->id(),
+          'alt' => $alt,
+          'title' => (string) ($legacy_item?->title ?? ''),
+        ],
+      ]);
+      $media->save();
+      $sandbox['created']++;
+    }
+    else {
+      $sandbox['reused']++;
+    }
+
+    $venue->set($field_name, ['target_id' => (int) $media->id()]);
+    $venue->save();
+    $sandbox['migrated']++;
+    $sandbox['index']++;
+  }
+
+  $sandbox['#finished'] = $total === 0 ? 1 : $sandbox['index'] / $total;
+  if ($sandbox['#finished'] < 1) {
+    return sprintf('Migrated %d of %d venue records to Media Library images.', $sandbox['index'], $total);
+  }
+
+  return sprintf(
+    'Venue image Media migration complete: %d migrated, %d Media created, %d reused, %d skipped.',
+    $sandbox['migrated'],
+    $sandbox['created'],
+    $sandbox['reused'],
+    $sandbox['skipped'],
+  );
+}

--- a/web/modules/custom/myeventlane_venue/myeventlane_venue.module
+++ b/web/modules/custom/myeventlane_venue/myeventlane_venue.module
@@ -31,6 +31,8 @@ function myeventlane_venue_theme(array $existing, $type, $theme, $path): array {
     'myeventlane_venue_page' => [
       'variables' => [
         'venue' => NULL,
+        'image_url' => NULL,
+        'image_alt' => '',
         'can_edit' => FALSE,
         'edit_url' => NULL,
         'locations' => [],

--- a/web/modules/custom/myeventlane_venue/src/Controller/VendorVenuesController.php
+++ b/web/modules/custom/myeventlane_venue/src/Controller/VendorVenuesController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_venue\Controller;
 
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Url;
 use Drupal\myeventlane_venue\Entity\Venue;
@@ -67,8 +68,18 @@ class VendorVenuesController extends ControllerBase {
     $venues = $this->accessResolver->getAccessibleVenues($this->currentUser());
 
     $rows = [];
+    $cacheTags = ['myeventlane_venue_list'];
     foreach ($venues as $venue) {
       $rows[] = $this->buildVenueRow($venue);
+      $cacheTags = Cache::mergeTags($cacheTags, $venue->getCacheTags());
+      $imageMedia = $venue->getImageMedia();
+      $imageFile = $venue->getImageFile();
+      if ($imageMedia !== NULL) {
+        $cacheTags = Cache::mergeTags($cacheTags, $imageMedia->getCacheTags());
+      }
+      elseif ($imageFile !== NULL) {
+        $cacheTags = Cache::mergeTags($cacheTags, $imageFile->getCacheTags());
+      }
     }
 
     $build = [
@@ -80,7 +91,7 @@ class VendorVenuesController extends ControllerBase {
       ],
       '#cache' => [
         'contexts' => ['user'],
-        'tags' => ['myeventlane_venue_list'],
+        'tags' => $cacheTags,
       ],
     ];
 

--- a/web/modules/custom/myeventlane_venue/src/Controller/VenueViewController.php
+++ b/web/modules/custom/myeventlane_venue/src/Controller/VenueViewController.php
@@ -6,6 +6,7 @@ namespace Drupal\myeventlane_venue\Controller;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
@@ -55,15 +56,27 @@ class VenueViewController extends ControllerBase {
    *   Render array.
    */
   public function view(Venue $myeventlane_venue): array {
+    $image_file = $myeventlane_venue->getImageFile();
+    $image_media = $myeventlane_venue->getImageMedia();
+    $cache_tags = $myeventlane_venue->getCacheTags();
+    if ($image_media !== NULL) {
+      $cache_tags = Cache::mergeTags($cache_tags, $image_media->getCacheTags());
+    }
+    elseif ($image_file !== NULL) {
+      $cache_tags = Cache::mergeTags($cache_tags, $image_file->getCacheTags());
+    }
+
     $build = [
       '#theme' => 'myeventlane_venue_page',
       '#venue' => $myeventlane_venue,
+      '#image_url' => $myeventlane_venue->getImageUrl('large') ?? $myeventlane_venue->getImageUrl(),
+      '#image_alt' => $myeventlane_venue->getImageAlt(),
       '#can_edit' => $this->canEdit($myeventlane_venue),
       '#edit_url' => $this->getEditUrl($myeventlane_venue),
       '#locations' => $this->getLocations($myeventlane_venue),
       '#events' => $this->getEvents($myeventlane_venue),
       '#cache' => [
-        'tags' => $myeventlane_venue->getCacheTags(),
+        'tags' => $cache_tags,
         'contexts' => ['user', 'url'],
       ],
       '#attached' => [

--- a/web/modules/custom/myeventlane_venue/src/Entity/Venue.php
+++ b/web/modules/custom/myeventlane_venue/src/Entity/Venue.php
@@ -11,6 +11,8 @@ use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\file\FileInterface;
+use Drupal\media\MediaInterface;
 use Drupal\user\EntityOwnerInterface;
 use Drupal\user\EntityOwnerTrait;
 
@@ -210,10 +212,11 @@ class Venue extends ContentEntityBase implements EntityChangedInterface, EntityO
       ->setDisplayConfigurable('form', TRUE)
       ->setDisplayConfigurable('view', TRUE);
 
-    // Venue image.
+    // Legacy venue image. Retained as a hidden migration fallback while venue
+    // imagery moves to owner-attributed Image Media entities.
     $fields['image'] = BaseFieldDefinition::create('image')
-      ->setLabel(new TranslatableMarkup('Venue image'))
-      ->setDescription(new TranslatableMarkup('An image representing this venue.'))
+      ->setLabel(new TranslatableMarkup('Legacy venue image'))
+      ->setDescription(new TranslatableMarkup('Legacy direct-file venue image retained for migration fallback.'))
       ->setSettings([
         'file_directory' => 'venues',
         'alt_field' => TRUE,
@@ -221,16 +224,44 @@ class Venue extends ContentEntityBase implements EntityChangedInterface, EntityO
         'max_filesize' => '5 MB',
         'file_extensions' => 'png jpg jpeg gif webp',
       ])
-      ->setDisplayOptions('form', [
-        'type' => 'image_image',
-        'weight' => 6,
-      ])
       ->setDisplayOptions('view', [
         'label' => 'hidden',
         'type' => 'image',
         'weight' => -5,
         'settings' => [
           'image_style' => 'large',
+        ],
+      ])
+      ->setDisplayConfigurable('form', FALSE)
+      ->setDisplayConfigurable('view', FALSE);
+
+    // Canonical venue image in Media Library.
+    $fields['image_media'] = BaseFieldDefinition::create('entity_reference')
+      ->setLabel(new TranslatableMarkup('Venue image'))
+      ->setDescription(new TranslatableMarkup('Choose an image from your Media Library or upload a reusable venue image.'))
+      ->setSetting('target_type', 'media')
+      ->setSetting('handler', 'default:media')
+      ->setSetting('handler_settings', [
+        'target_bundles' => [
+          'image' => 'image',
+        ],
+        'sort' => [
+          'field' => '_none',
+          'direction' => 'ASC',
+        ],
+        'auto_create' => FALSE,
+        'auto_create_bundle' => '',
+      ])
+      ->setDisplayOptions('form', [
+        'type' => 'media_library_widget',
+        'weight' => 6,
+      ])
+      ->setDisplayOptions('view', [
+        'label' => 'hidden',
+        'type' => 'entity_reference_entity_view',
+        'weight' => -5,
+        'settings' => [
+          'view_mode' => 'default',
         ],
       ])
       ->setDisplayConfigurable('form', TRUE)
@@ -508,7 +539,19 @@ class Venue extends ContentEntityBase implements EntityChangedInterface, EntityO
    *   TRUE if an image is set.
    */
   public function hasImage(): bool {
-    return !$this->get('image')->isEmpty();
+    return $this->getImageFile() instanceof FileInterface;
+  }
+
+  /**
+   * Gets the canonical venue image Media entity.
+   */
+  public function getImageMedia(): ?MediaInterface {
+    if (!$this->hasField('image_media') || $this->get('image_media')->isEmpty()) {
+      return NULL;
+    }
+
+    $media = $this->get('image_media')->entity;
+    return $media instanceof MediaInterface ? $media : NULL;
   }
 
   /**
@@ -517,11 +560,49 @@ class Venue extends ContentEntityBase implements EntityChangedInterface, EntityO
    * @return \Drupal\file\FileInterface|null
    *   The file entity or NULL.
    */
-  public function getImageFile(): ?\Drupal\file\FileInterface {
-    if ($this->hasImage()) {
-      return $this->get('image')->entity;
+  public function getImageFile(): ?FileInterface {
+    $media = $this->getImageMedia();
+    if ($media instanceof MediaInterface) {
+      $source_field = (string) ($media->getSource()->getConfiguration()['source_field'] ?? '');
+      $file = $source_field !== '' && $media->hasField($source_field)
+        ? $media->get($source_field)->entity
+        : NULL;
+      if ($file instanceof FileInterface) {
+        return $file;
+      }
     }
+
+    if ($this->hasField('image') && !$this->get('image')->isEmpty()) {
+      $file = $this->get('image')->entity;
+      return $file instanceof FileInterface ? $file : NULL;
+    }
+
     return NULL;
+  }
+
+  /**
+   * Gets accessible alt text for the canonical or legacy venue image.
+   */
+  public function getImageAlt(): string {
+    $media = $this->getImageMedia();
+    if ($media instanceof MediaInterface) {
+      $source_field = (string) ($media->getSource()->getConfiguration()['source_field'] ?? '');
+      $alt = $source_field !== '' && $media->hasField($source_field)
+        ? trim((string) ($media->get($source_field)->alt ?? ''))
+        : '';
+      if ($alt !== '') {
+        return $alt;
+      }
+    }
+
+    if ($this->hasField('image') && !$this->get('image')->isEmpty()) {
+      $alt = trim((string) ($this->get('image')->alt ?? ''));
+      if ($alt !== '') {
+        return $alt;
+      }
+    }
+
+    return $this->getName();
   }
 
   /**

--- a/web/modules/custom/myeventlane_venue/src/Form/VenueForm.php
+++ b/web/modules/custom/myeventlane_venue/src/Form/VenueForm.php
@@ -4,14 +4,41 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_venue\Form;
 
+use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
+use Drupal\media\MediaInterface;
+use Drupal\myeventlane_vendor\Service\OrganiserMediaAccess;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Form handler for the Venue entity add/edit forms.
  */
 class VenueForm extends ContentEntityForm {
+
+  public function __construct(
+    EntityRepositoryInterface $entity_repository,
+    EntityTypeBundleInfoInterface $entity_type_bundle_info,
+    TimeInterface $time,
+    protected OrganiserMediaAccess $organiserMediaAccess,
+  ) {
+    parent::__construct($entity_repository, $entity_type_bundle_info, $time);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('entity.repository'),
+      $container->get('entity_type.bundle.info'),
+      $container->get('datetime.time'),
+      $container->get('myeventlane_vendor.organiser_media_access'),
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -23,6 +50,40 @@ class VenueForm extends ContentEntityForm {
     $form['#attributes']['class'][] = 'mel-venue-form';
 
     return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    $original_media_id = $this->entity->hasField('image_media') && !$this->entity->get('image_media')->isEmpty()
+      ? (int) $this->entity->get('image_media')->target_id
+      : 0;
+    $entity = parent::validateForm($form, $form_state);
+    if (!$entity->hasField('image_media') || $entity->get('image_media')->isEmpty()) {
+      return $entity;
+    }
+
+    $media = $entity->get('image_media')->entity;
+    $selected_media_id = $media instanceof MediaInterface ? (int) $media->id() : 0;
+    $is_unchanged_selection = $selected_media_id > 0 && $selected_media_id === $original_media_id;
+    if (!$is_unchanged_selection
+      && (!$media instanceof MediaInterface || !$this->organiserMediaAccess->canSelect($media))) {
+      if (isset($form['image_media'])) {
+        $form_state->setError(
+          $form['image_media'],
+          $this->t('Choose a venue image uploaded by your organiser account.'),
+        );
+      }
+      else {
+        $form_state->setErrorByName(
+          'image_media',
+          $this->t('Choose a venue image uploaded by your organiser account.'),
+        );
+      }
+    }
+
+    return $entity;
   }
 
   /**

--- a/web/modules/custom/myeventlane_venue/templates/myeventlane-venue-page.html.twig
+++ b/web/modules/custom/myeventlane_venue/templates/myeventlane-venue-page.html.twig
@@ -5,6 +5,8 @@
  *
  * Available variables:
  * - venue: The venue entity.
+ * - image_url: URL for the canonical Media-backed venue image.
+ * - image_alt: Alt text from Media, legacy image data, or the venue name.
  * - can_edit: Boolean indicating if the user can edit.
  * - edit_url: URL object for editing the venue.
  * - locations: Array of venue locations.
@@ -17,9 +19,8 @@
     {# Hero section with image and title #}
     <section class="mel-venue-hero" aria-labelledby="mel-venue-title">
       <div class="mel-venue-hero__media">
-        {% if venue.image.entity %}
-          {% set image_url = file_url(venue.image.entity.fileuri) %}
-          <img src="{{ image_url }}" alt="{{ venue.name.value }}" class="mel-venue-hero__image" loading="eager">
+        {% if image_url %}
+          <img src="{{ image_url }}" alt="{{ image_alt }}" class="mel-venue-hero__image" loading="eager">
         {% else %}
           <div class="mel-venue-hero__placeholder" aria-hidden="true">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="64" height="64">

--- a/web/modules/custom/myeventlane_venue/tests/src/Kernel/VenueMediaFieldDefinitionKernelTest.php
+++ b/web/modules/custom/myeventlane_venue/tests/src/Kernel/VenueMediaFieldDefinitionKernelTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_venue\Kernel;
+
+use Drupal\Core\Entity\ContentEntityType;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\myeventlane_venue\Entity\Venue;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Verifies the real venue base-field definitions for Media Library images.
+ *
+ * @group myeventlane_venue
+ */
+#[RunTestsInSeparateProcesses]
+final class VenueMediaFieldDefinitionKernelTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'file',
+    'image',
+    'media',
+    'media_library',
+    'options',
+    'text',
+    'views',
+  ];
+
+  /**
+   * Ensures the canonical field accepts only Image Media Library entities.
+   */
+  public function testVenueImageMediaFieldDefinition(): void {
+    // The isolated worktree reuses the primary checkout's Composer vendor
+    // directory, so load the worktree entity class before Composer resolves
+    // the same namespace from the primary checkout.
+    require_once dirname(__DIR__, 3) . '/src/Entity/Venue.php';
+
+    $entity_type = new ContentEntityType([
+      'id' => 'myeventlane_venue',
+      'label' => 'Venue',
+      'class' => Venue::class,
+      'entity_keys' => [
+        'id' => 'id',
+        'uuid' => 'uuid',
+        'label' => 'name',
+        'owner' => 'uid',
+      ],
+    ]);
+
+    $fields = Venue::baseFieldDefinitions($entity_type);
+    self::assertArrayHasKey('image_media', $fields);
+    self::assertSame('entity_reference', $fields['image_media']->getType());
+    self::assertSame('media', $fields['image_media']->getSetting('target_type'));
+    self::assertSame(
+      ['image' => 'image'],
+      $fields['image_media']->getSetting('handler_settings')['target_bundles'] ?? NULL,
+    );
+    self::assertSame('media_library_widget', $fields['image_media']->getDisplayOptions('form')['type'] ?? NULL);
+
+    self::assertArrayHasKey('image', $fields);
+    self::assertSame(['region' => 'hidden'], $fields['image']->getDisplayOptions('form'));
+  }
+
+}

--- a/web/modules/custom/myeventlane_venue/tests/src/Unit/VenueMediaArchitectureContractTest.php
+++ b/web/modules/custom/myeventlane_venue/tests/src/Unit/VenueMediaArchitectureContractTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_venue\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards the Media-backed venue image architecture and migration contract.
+ *
+ * @group myeventlane_venue
+ */
+final class VenueMediaArchitectureContractTest extends TestCase {
+
+  /**
+   * Verifies venue editing uses Image Media and keeps the legacy fallback.
+   */
+  public function testVenueImageUsesMediaLibraryWithLegacyFallback(): void {
+    $root = dirname(__DIR__, 7);
+    $entity = file_get_contents($root . '/web/modules/custom/myeventlane_venue/src/Entity/Venue.php');
+    $form = file_get_contents($root . '/web/modules/custom/myeventlane_venue/src/Form/VenueForm.php');
+    $template = file_get_contents($root . '/web/modules/custom/myeventlane_venue/templates/myeventlane-venue-page.html.twig');
+
+    self::assertIsString($entity);
+    self::assertStringContainsString("\$fields['image_media'] = BaseFieldDefinition::create('entity_reference')", $entity);
+    self::assertStringContainsString("->setSetting('target_type', 'media')", $entity);
+    self::assertStringContainsString("'image' => 'image'", $entity);
+    self::assertStringContainsString("'type' => 'media_library_widget'", $entity);
+    self::assertStringContainsString("\$fields['image'] = BaseFieldDefinition::create('image')", $entity);
+    self::assertStringContainsString('return $this->getName();', $entity);
+
+    self::assertIsString($form);
+    self::assertStringContainsString('organiserMediaAccess->canSelect($media)', $form);
+    self::assertStringContainsString('$is_unchanged_selection', $form);
+    self::assertStringContainsString('Choose a venue image uploaded by your organiser account.', $form);
+
+    self::assertIsString($template);
+    self::assertStringContainsString('{% if image_url %}', $template);
+    self::assertStringNotContainsString('venue.image.entity', $template);
+  }
+
+  /**
+   * Verifies the update preserves ownership, alt text, and legacy data.
+   */
+  public function testVenueImageMigrationPreservesOwnerAndAccessibilityData(): void {
+    $root = dirname(__DIR__, 7);
+    $install = file_get_contents($root . '/web/modules/custom/myeventlane_venue/myeventlane_venue.install');
+
+    self::assertIsString($install);
+    self::assertStringContainsString('function myeventlane_venue_update_10002(array &$sandbox): string', $install);
+    self::assertStringContainsString("'uid' => \$owner_id", $install);
+    self::assertStringContainsString("'field_media_image.target_id' => (int) \$file->id()", $install);
+    self::assertStringContainsString("'alt' => \$alt", $install);
+    self::assertStringContainsString("\$venue->set(\$field_name, ['target_id' => (int) \$media->id()])", $install);
+    self::assertStringNotContainsString("\$venue->set('image', NULL)", $install);
+  }
+
+}


### PR DESCRIPTION
## Summary

- move venue images onto Drupal Media Library while retaining the legacy image field as a rollback fallback
- migrate existing venue image files to owner-attributed Image media items
- restrict organisers to selecting their own media while allowing unchanged staff-selected media
- remove the global Files overview permission from the Vendor role
- retain full media access for admin and staff roles
- render venue images through the canonical Media reference with correct cache tags
- add unit and kernel coverage for the role boundary and venue Media field

## Why

Venue images were stored directly as image fields, so they were not consistently represented in Drupal Media. Vendors also had access to the global Files overview, which was broader than the intended organiser media boundary.

## Impact

Venue images become reusable Media Library items. Organisers can manage their own media without gaining access to other organisers' files. Admin and staff retain full access to all media.

The update hook preserves the original venue image field and data as a fallback. Existing venue images are reused when a matching owner/file Media item exists; otherwise an owner-attributed Image media item is created.

## Validation

- focused PHPUnit suite: 9 tests, 69 assertions passed
- PHP syntax checks passed
- Composer validation passed
- `git diff --check` passed
- Drupal/DrupalPractice PHPCS: no new errors; two pre-existing warnings remain outside the changed lines
- six PHPUnit deprecation notices remain

## Deployment and verification

Deployment must run both:

- `RUN_UPDB=1`
- `RUN_CIM=1`

After deployment, verify with an admin/staff account and two separate organiser accounts:

- admin/staff can access all Media and Files administration
- each organiser sees and selects only their own media
- existing venue images appear through Media Library
- venue pages and venue lists render the migrated images and alt text correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches permissions, batched entity migration, and media ownership validation on save; deploy needs RUN_UPDB and RUN_CIM with post-deploy checks on images and organiser isolation.
> 
> **Overview**
> Venue imagery moves from a direct **image** field to **`image_media`** (Image Media + Media Library widget), with the legacy field kept hidden for rollback and display fallback. **`myeventlane_venue_update_10002`** installs the field and batch-migrates existing venue files into owner-attributed Image media (reusing matches by owner + file), preserving alt text and leaving legacy data in place.
> 
> **Organiser boundary:** the **Vendor** role loses **`access files overview`** (sync + **`myeventlane_vendor_update_10022`**). **`VenueForm`** blocks selecting media the current organiser cannot use via **`OrganiserMediaAccess`**, while unchanged staff-picked media on edit still saves. Venue list and public pages resolve URLs/alt through the entity helpers and merge media/file **cache tags**.
> 
> PHPUnit/kernel tests lock the vendor vs content_editor permission split, Files overview gating, and the media field/migration contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 540d0d45a02b961ceb66ef1896bda6cf54d1743f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->