### PR TITLE
Fix organiser Media Library modal styling

### DIFF
--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/_root-tokens.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/_root-tokens.scss
@@ -72,4 +72,62 @@
   --mel-es-panel-bg: #ffffff;
   --mel-es-panel-gap: 24px;
   --mel-es-panel-padding: 24px;
+
+  /*
+   * Gin compatibility values used by AJAX-loaded dialog and Media Library
+   * components. They stay inside the vendor theme and map to MEL's tokens;
+   * the full Gin admin theme is intentionally not loaded here.
+   */
+  --gin-bg-app: var(--mel-bg);
+  --gin-bg-input: var(--mel-surface);
+  --gin-bg-layer: var(--mel-surface);
+  --gin-bg-layer2: var(--mel-surface-2);
+  --gin-bg-layer3: var(--mel-surface);
+  --gin-border-color: #e9e3de;
+  --gin-border-color-form-element: #9aa3aa;
+  --gin-border-color-layer2: #e9e3de;
+  --gin-border-color-table-header: rgba(36, 48, 58, 0.24);
+  --gin-border-xs: 4px;
+  --gin-border-s: 6px;
+  --gin-border-m: var(--mel-radius-1);
+  --gin-border-l: 12px;
+  --gin-border-xl: var(--mel-radius-2);
+  --gin-color-button-text: #fff;
+  --gin-color-danger: #c44545;
+  --gin-color-disabled: #6f777e;
+  --gin-color-disabled-bg: #ece9e6;
+  --gin-color-disabled-border: #d4cfca;
+  --gin-color-focus: rgba(255, 107, 74, 0.28);
+  --gin-color-focus-border: var(--mel-focus);
+  --gin-color-primary: var(--mel-coral);
+  --gin-color-primary-active: #cf4f3d;
+  --gin-color-primary-hover: #e55c49;
+  --gin-color-primary-light: rgba(255, 107, 74, 0.14);
+  --gin-color-primary-light-active: rgba(255, 107, 74, 0.24);
+  --gin-color-text: var(--mel-text);
+  --gin-color-text-light: var(--mel-muted);
+  --gin-color-title: var(--mel-text);
+  --gin-font-size-xxs: 0.75rem;
+  --gin-font-size-xs: 0.8125rem;
+  --gin-font-size-s: 0.875rem;
+  --gin-font-size: 1rem;
+  --gin-font-size-l: 1.125rem;
+  --gin-font-weight-semibold: 600;
+  --gin-font-weight-bold: 700;
+  --gin-font-weight-heavy: 700;
+  --gin-link-decoration-style: solid;
+  --gin-max-line-length: 80ch;
+  --gin-pattern: rgba(36, 48, 58, 0.1);
+  --gin-pattern-fallback: var(--mel-surface-2);
+  --gin-pattern-square: 0.5rem;
+  --gin-shadow-l1: var(--mel-shadow-1);
+  --gin-spacing-xxs: var(--mel-space-1);
+  --gin-spacing-xs: var(--mel-space-2);
+  --gin-spacing-s: var(--mel-space-3);
+  --gin-spacing-m: var(--mel-space-4);
+  --gin-spacing-l: var(--mel-space-5);
+  --gin-spacing-xl: var(--mel-space-6);
+  --gin-spacing-density-s: var(--mel-space-3);
+  --gin-switch: #3f9b6c;
+  --gin-transition: 0.15s ease;
 }

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_media-library-modal.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/components/_media-library-modal.scss
@@ -1,0 +1,144 @@
+/**
+ * @file
+ * Media Library dialog presentation for organiser-facing pages.
+ *
+ * Media Library AJAX responses can attach Gin component CSS without Gin's
+ * global custom properties. Keep the compatibility values scoped to the
+ * vendor theme so those components remain usable without importing the full
+ * admin theme into Event Studio.
+ */
+
+// The overlay is next to the dialog rather than inside it.
+.ui-widget-overlay.ui-front {
+  background: rgba(36, 48, 58, 0.52);
+  backdrop-filter: blur(2px);
+  opacity: 1;
+}
+
+.media-library-widget-modal.ui-dialog:not(.ui-dialog-off-canvas) {
+  max-width: calc(100vw - (var(--mel-space-4) * 2));
+  color: var(--mel-text);
+  background: var(--mel-surface);
+  border: 0 !important;
+  border-radius: var(--mel-radius-3);
+  box-shadow: 0 24px 56px rgba(36, 48, 58, 0.2);
+  overflow: hidden;
+}
+
+.media-library-widget-modal .ui-dialog-titlebar.ui-widget-header {
+  display: flex;
+  align-items: center;
+  min-height: 64px;
+  padding: var(--mel-space-4) 64px var(--mel-space-4) var(--mel-space-5);
+  color: var(--mel-text);
+  background: var(--mel-surface);
+  border: 0;
+  border-block-end: 1px solid var(--mel-border-soft);
+  border-radius: var(--mel-radius-3) var(--mel-radius-3) 0 0;
+}
+
+.media-library-widget-modal .ui-dialog-title {
+  overflow: hidden;
+  font-size: 1.125rem;
+  font-weight: 700;
+  line-height: 1.4;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.media-library-widget-modal .ui-dialog-titlebar-close {
+  inset-block-start: 50%;
+  inset-inline-end: var(--mel-space-3);
+  width: 44px;
+  height: 44px;
+  margin: 0;
+  padding: 0;
+  color: var(--mel-text);
+  background-color: transparent;
+  border: 0;
+  border-radius: var(--mel-radius-pill);
+  transform: translateY(-50%);
+}
+
+.media-library-widget-modal .ui-dialog-titlebar-close:hover {
+  background-color: var(--mel-surface-2);
+}
+
+.media-library-widget-modal .ui-dialog-titlebar-close:focus-visible {
+  outline: 3px solid rgba(255, 107, 74, 0.32);
+  outline-offset: 2px;
+}
+
+.media-library-widget-modal .ui-dialog-content.ui-widget-content {
+  padding: var(--mel-space-5);
+  color: var(--mel-text);
+  background: var(--mel-surface);
+  border: 0;
+}
+
+.media-library-widget-modal .ui-dialog-buttonpane.ui-widget-content {
+  display: flex;
+  align-items: center;
+  gap: var(--mel-space-3);
+  margin: 0;
+  padding: var(--mel-space-4) var(--mel-space-5);
+  background: var(--mel-surface-2);
+  border: 0;
+  border-block-start: 1px solid var(--mel-border-soft);
+}
+
+.media-library-widget-modal .ui-dialog-buttonpane .form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--mel-space-2);
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.media-library-widget-modal .ui-dialog-buttonpane .button {
+  width: auto;
+  min-height: 44px;
+  margin: 0;
+  white-space: normal;
+}
+
+.media-library-widget-modal .media-library-selected-count {
+  color: var(--mel-muted);
+}
+
+@media (max-width: 48rem) {
+  .media-library-widget-modal.ui-dialog:not(.ui-dialog-off-canvas) {
+    inset-block-start: var(--mel-space-4) !important;
+    inset-inline-start: var(--mel-space-4) !important;
+    width: calc(100vw - (var(--mel-space-4) * 2)) !important;
+    max-height: calc(100dvh - (var(--mel-space-4) * 2));
+    border-radius: var(--mel-radius-2);
+  }
+
+  .media-library-widget-modal .ui-dialog-titlebar.ui-widget-header {
+    min-height: 56px;
+    padding: var(--mel-space-3) 60px var(--mel-space-3) var(--mel-space-4);
+    border-radius: var(--mel-radius-2) var(--mel-radius-2) 0 0;
+  }
+
+  .media-library-widget-modal .ui-dialog-content.ui-widget-content {
+    max-height: calc(100dvh - 176px) !important;
+    padding: var(--mel-space-4);
+  }
+
+  .media-library-widget-modal .ui-dialog-buttonpane.ui-widget-content {
+    align-items: stretch;
+    padding: var(--mel-space-3) var(--mel-space-4);
+  }
+
+  .media-library-widget-modal .ui-dialog-buttonpane .form-actions {
+    width: 100%;
+  }
+
+  .media-library-widget-modal .ui-dialog-buttonpane .button {
+    flex: 1 1 100%;
+    width: 100%;
+  }
+}

--- a/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
+++ b/web/themes/custom/myeventlane_vendor_theme/src/scss/main.scss
@@ -56,6 +56,7 @@
   @include meta.load-css('components/badges');
   @include meta.load-css('components/lists');
   @include meta.load-css('components/upload');
+  @include meta.load-css('components/media-library-modal');
   @include meta.load-css('components/inline-actions');
   @include meta.load-css('components/empty-states');
   @include meta.load-css('components/console');


### PR DESCRIPTION
## Summary

- restore a solid, contained Media Library dialog on organiser-facing pages
- add a dimmed overlay, MEL spacing, responsive actions and accessible focus treatment
- map the Gin variables used by AJAX-loaded Media Library components to MEL vendor-theme tokens
- keep the compatibility layer scoped to the vendor theme instead of loading the full Gin admin theme

## Root cause

The Media Library AJAX response loads Gin dialog and Media Library component CSS on the Stable 9-based vendor theme. Gin's global custom properties are not present on those organiser pages, so browser declarations such as dialog backgrounds, spacing, borders and shadows become invalid. The result is the transparent, collapsed modal shown in Event Studio.

## User impact

Organisers get a readable Media Library selector in Event Studio and venue image workflows. Mobile dialogs fit the viewport and action buttons remain touch-friendly.

Admin and staff Media permissions are unchanged. No Drupal configuration, access policy, database schema or Commerce behaviour is modified.

## Validation

- `npm run build` — passed
- `git diff --check` — passed
- confirmed the production bundle contains the MEL/Gin compatibility values, scoped dialog selectors and mobile rules
- `npm run lint:scss` — unable to run because this repository does not provide a Stylelint configuration; pointing it at Drupal core's configuration also fails because the theme package does not include `stylelint-prettier`

## Visual QA still required

The branch is not deployed. After a preview deployment, verify:

- Event Studio saved-image selector
- Event Studio gallery selector
- venue image selector
- upload, selection, alt text and dialog actions
- desktop and mobile layouts
- keyboard focus and close behaviour
- Gin/Claro admin Media Library remains unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only SCSS in the vendor theme; no PHP, config, or access changes. Overlay rules target `.ui-widget-overlay.ui-front` globally, which could affect other jQuery UI dialogs on organiser pages if they share that overlay class.
> 
> **Overview**
> Fixes broken **Media Library** dialogs on organiser-facing pages (Event Studio image/gallery flows) where AJAX-loaded Gin component CSS referenced missing `--gin-*` variables, leaving transparent, collapsed modals on the vendor theme.
> 
> Adds a **Gin compatibility layer** on `.mel-vendor` in `_root-tokens.scss`, mapping `--gin-*` custom properties to existing MEL tokens so those components work without loading the full Gin admin theme.
> 
> Introduces `_media-library-modal.scss` for `.media-library-widget-modal` and the jQuery UI overlay: dimmed backdrop, MEL surfaces, spacing, shadows, accessible close focus, and mobile viewport sizing with full-width action buttons. Wired into `main.scss` via `components/media-library-modal`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47f3a141df8a4407815cabe4edfdc21af40327a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->