### PR TITLE
Capture event covers in Media Library

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.info.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.info.yml
@@ -5,6 +5,8 @@ core_version_requirement: ^11
 package: MyEventLane
 
 dependencies:
+  - drupal:media
+  - drupal:media_library
   - drupal:node
   - myeventlane_legal:myeventlane_legal
   - myeventlane_vendor:myeventlane_vendor

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.post_update.php
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.post_update.php
@@ -1,12 +1,21 @@
 <?php
 
+/**
+ * @file
+ * Post-update hooks for MyEventLane Event Studio.
+ */
+
 declare(strict_types=1);
 
 use Drupal\Core\Image\ImageFactory;
+use Drupal\Core\Utility\UpdateException;
 use Drupal\crop\Entity\Crop;
 use Drupal\crop\CropInterface;
 use Drupal\file\FileInterface;
 use Drupal\focal_point\FocalPointManagerInterface;
+use Drupal\myeventlane_event\Utility\EventNodeRevisionSave;
+use Drupal\myeventlane_event_studio\Service\EventCoverMediaManager;
+use Drupal\node\NodeInterface;
 
 /**
  * Backfill event_hero crops for legacy focal-only hero images.
@@ -157,6 +166,102 @@ function myeventlane_event_studio_post_update_backfill_event_hero_from_focal(arr
     '@total' => $sandbox['total'],
     '@created' => $sandbox['created'],
   ]);
+}
+
+/**
+ * Captures legacy event cover files as organiser-owned Image Media.
+ *
+ * The field_event_image field remains the public rendering source
+ * and rollback path. This update only fills field_mel_event_cover_media when it
+ * is empty, and reuses Media only when both organiser and source file match.
+ */
+function myeventlane_event_studio_post_update_backfill_event_cover_media(array &$sandbox): string {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $node_storage = $entity_type_manager->getStorage('node');
+  $logger = \Drupal::logger('myeventlane_event_studio');
+  $manager = \Drupal::service('myeventlane_event_studio.event_cover_media_manager');
+  assert($manager instanceof EventCoverMediaManager);
+
+  if (!isset($sandbox['ids'])) {
+    $sandbox['ids'] = array_values($node_storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('type', 'event')
+      ->exists('field_event_image')
+      ->notExists('field_mel_event_cover_media')
+      ->sort('nid')
+      ->execute());
+    $sandbox['index'] = 0;
+    $sandbox['migrated'] = 0;
+    $sandbox['created'] = 0;
+    $sandbox['reused'] = 0;
+    $sandbox['skipped'] = 0;
+    $sandbox['errors'] = 0;
+  }
+
+  $total = count($sandbox['ids']);
+  $limit = min($sandbox['index'] + 20, $total);
+  while ($sandbox['index'] < $limit) {
+    $nid = (int) $sandbox['ids'][$sandbox['index']];
+    $sandbox['index']++;
+    $event = $node_storage->load($nid);
+
+    if (!$event instanceof NodeInterface
+      || !$event->hasField('field_event_image')
+      || $event->get('field_event_image')->isEmpty()
+      || !$event->hasField('field_mel_event_cover_media')
+      || !$event->get('field_mel_event_cover_media')->isEmpty()) {
+      $sandbox['skipped']++;
+      continue;
+    }
+
+    try {
+      $capture = $manager->capture($event);
+      $event->set('field_mel_event_cover_media', [
+        [
+          'target_id' => (int) $capture['media']->id(),
+        ],
+      ]);
+      EventNodeRevisionSave::prepare($event, 'Backfilled event cover Media Library provenance.');
+      $event->save();
+      $sandbox[$capture['created'] ? 'created' : 'reused']++;
+      $sandbox['migrated']++;
+    }
+    catch (\Throwable $e) {
+      $sandbox['errors']++;
+      $logger->error('Event cover Media backfill failed for event @nid: @message', [
+        '@nid' => (string) $nid,
+        '@message' => $e->getMessage(),
+      ]);
+    }
+  }
+
+  $sandbox['#finished'] = $total === 0 ? 1 : $sandbox['index'] / $total;
+  if ($sandbox['#finished'] < 1) {
+    return sprintf(
+      'Captured event covers for %d of %d events (%d Media created, %d reused, %d errors).',
+      $sandbox['index'],
+      $total,
+      $sandbox['created'],
+      $sandbox['reused'],
+      $sandbox['errors'],
+    );
+  }
+
+  if ($sandbox['errors'] > 0) {
+    throw new UpdateException(sprintf(
+      'Event cover Media backfill stopped with %d errors. Review the myeventlane_event_studio log and rerun updates.',
+      $sandbox['errors'],
+    ));
+  }
+
+  return sprintf(
+    'Event cover Media backfill complete: %d migrated, %d Media created, %d reused, %d skipped, %d errors.',
+    $sandbox['migrated'],
+    $sandbox['created'],
+    $sandbox['reused'],
+    $sandbox['skipped'],
+    $sandbox['errors'],
+  );
 }
 
 /**

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -445,6 +445,12 @@ services:
       - '@request_stack'
       - '@file.repository'
       - '@myeventlane_vendor.organiser_media_access'
+      - '@myeventlane_event_studio.event_cover_media_manager'
+
+  myeventlane_event_studio.event_cover_media_manager:
+    class: Drupal\myeventlane_event_studio\Service\EventCoverMediaManager
+    arguments:
+      - '@entity_type.manager'
 
   myeventlane_event_studio.readiness:
     class: Drupal\myeventlane_event_studio\Service\EventReadinessService

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventCoverMediaManager.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventCoverMediaManager.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Service;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\file\FileInterface;
+use Drupal\media\MediaInterface;
+use Drupal\media\MediaTypeInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Creates or reuses organiser-owned Image Media for legacy event covers.
+ */
+final class EventCoverMediaManager {
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+  ) {}
+
+  /**
+   * Captures the event's raw cover file in the organiser's Media Library.
+   *
+   * The legacy field_event_image value remains unchanged and continues to be
+   * the public rendering source. Reuse is deliberately scoped by organiser and
+   * file so a shared legacy file never grants cross-organiser Media access.
+   *
+   * @return array{media: \Drupal\media\MediaInterface, created: bool}
+   *   The captured Media item and whether it was newly created.
+   */
+  public function capture(NodeInterface $event): array {
+    if ($event->bundle() !== 'event'
+      || !$event->hasField('field_event_image')
+      || $event->get('field_event_image')->isEmpty()) {
+      throw new \InvalidArgumentException('An event cover image is required.');
+    }
+
+    $cover_item = $event->get('field_event_image')->first();
+    $cover_value = $cover_item?->getValue() ?? [];
+    $fid = (int) ($cover_value['target_id'] ?? 0);
+    $file = $fid > 0
+      ? $this->entityTypeManager->getStorage('file')->load($fid)
+      : NULL;
+    if (!$file instanceof FileInterface) {
+      throw new \RuntimeException(sprintf('Event cover file %d could not be loaded.', $fid));
+    }
+
+    $media_type = $this->entityTypeManager->getStorage('media_type')->load('image');
+    if (!$media_type instanceof MediaTypeInterface) {
+      throw new \RuntimeException('The Image media type is not available.');
+    }
+    $source_field = (string) ($media_type->getSource()->getConfiguration()['source_field'] ?? '');
+    if ($source_field === '') {
+      throw new \RuntimeException('The Image media source field is not configured.');
+    }
+
+    $owner_id = max(0, (int) $event->getOwnerId());
+    $media_storage = $this->entityTypeManager->getStorage('media');
+    $existing = $media_storage->loadByProperties([
+      'bundle' => 'image',
+      'uid' => $owner_id,
+      $source_field . '.target_id' => $fid,
+    ]);
+    $media = $existing ? reset($existing) : NULL;
+    if ($media instanceof MediaInterface) {
+      return ['media' => $media, 'created' => FALSE];
+    }
+
+    if ($file->isTemporary()) {
+      $file->setPermanent();
+      $file->save();
+    }
+
+    $alt = trim((string) ($cover_value['alt'] ?? ''));
+    if ($alt === '') {
+      $alt = trim((string) $event->label());
+    }
+    if ($alt === '') {
+      $alt = $file->getFilename();
+    }
+
+    $media = $media_storage->create([
+      'bundle' => 'image',
+      'uid' => $owner_id,
+      'name' => $file->getFilename(),
+      $source_field => [
+        'target_id' => $fid,
+        'alt' => $alt,
+        'title' => (string) ($cover_value['title'] ?? ''),
+      ],
+    ]);
+    if (!$media instanceof MediaInterface) {
+      throw new \RuntimeException('The Image media item could not be created.');
+    }
+    $media->save();
+
+    return ['media' => $media, 'created' => TRUE];
+  }
+
+  /**
+   * Returns the source file ID for an Image Media item.
+   */
+  public function sourceFileId(MediaInterface $media): int {
+    $source_field = (string) ($media->getSource()->getConfiguration()['source_field'] ?? '');
+    if ($source_field === '' || !$media->hasField($source_field) || $media->get($source_field)->isEmpty()) {
+      return 0;
+    }
+    return (int) ($media->get($source_field)->target_id ?? 0);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -75,6 +75,7 @@ final class EventStudioSaveService {
     private readonly ?RequestStack $requestStack = NULL,
     private readonly ?FileRepositoryInterface $fileRepository = NULL,
     private readonly ?OrganiserMediaAccess $organiserMediaAccess = NULL,
+    private readonly ?EventCoverMediaManager $eventCoverMediaManager = NULL,
   ) {}
 
   /**
@@ -374,11 +375,17 @@ final class EventStudioSaveService {
 
     $this->applyOptionalCoordinates($node, $payload);
 
+    $cover_media_sync = NULL;
     if ($this->shouldApplyHeroImagePayload($payload)) {
+      $previous_hero_fid = $this->brandingHeroFidFromNode($node);
+      $previous_cover_media_id = $node->hasField('field_mel_event_cover_media')
+        ? (int) ($node->get('field_mel_event_cover_media')->target_id ?? 0)
+        : 0;
       $image_errors = $this->applyHeroImagePayload($node, $payload, $draft);
       if ($image_errors !== []) {
         return $this->abortSectionScopedSave($image_errors, $payload);
       }
+      $cover_media_sync = [$previous_hero_fid, $previous_cover_media_id];
     }
 
     if (array_key_exists('event_highlights_items_state', $payload)) {
@@ -415,6 +422,17 @@ final class EventStudioSaveService {
       $eligibility = $this->publishEligibilityEvaluator->evaluate($node, $account);
       if (!$eligibility['allowed']) {
         return $this->abortSectionScopedSave($eligibility['messages'], $payload);
+      }
+    }
+
+    if ($cover_media_sync !== NULL) {
+      $cover_media_errors = $this->captureDirectCoverMedia(
+        $node,
+        $cover_media_sync[0],
+        $cover_media_sync[1],
+      );
+      if ($cover_media_errors !== []) {
+        return $this->abortSectionScopedSave($cover_media_errors, $payload);
       }
     }
 
@@ -1364,17 +1382,6 @@ final class EventStudioSaveService {
       }
     }
 
-    $cover_media_errors = $this->saveBrandingCoverMediaField(
-      $node,
-      $mel_structure,
-      $form_state,
-      $fid,
-      $previous_hero_fid,
-    );
-    if ($cover_media_errors !== []) {
-      return ['node' => NULL, 'errors' => $cover_media_errors, 'warnings' => []];
-    }
-
     $gallery_errors = $this->saveBrandingGalleryField($node, $mel_structure, $form_state);
     if ($gallery_errors !== []) {
       return ['node' => NULL, 'errors' => $gallery_errors, 'warnings' => []];
@@ -1386,6 +1393,17 @@ final class EventStudioSaveService {
     );
     if ($style_errors !== []) {
       return ['node' => NULL, 'errors' => $style_errors, 'warnings' => []];
+    }
+
+    $cover_media_errors = $this->saveBrandingCoverMediaField(
+      $node,
+      $mel_structure,
+      $form_state,
+      $this->brandingHeroFidFromNode($node),
+      $previous_hero_fid,
+    );
+    if ($cover_media_errors !== []) {
+      return ['node' => NULL, 'errors' => $cover_media_errors, 'warnings' => []];
     }
 
     $final_target_id = $node->hasField('field_event_image') && !$node->get('field_event_image')->isEmpty()
@@ -1421,15 +1439,21 @@ final class EventStudioSaveService {
   }
 
   /**
-   * Persists Media Library provenance when it matches the saved cover file.
+   * Persists Media Library provenance for selected and directly uploaded covers.
    *
-   * Direct uploads remain supported. If a direct upload replaces a saved-media
-   * cover, the stale media reference is cleared while field_event_image remains
-   * the public rendering source of truth.
-   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The event being saved.
    * @param array<string, mixed> $mel_structure
+   *   The Event Studio form structure.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The submitted form state.
+   * @param int $saved_hero_fid
+   *   The cover file ID currently assigned to the event.
+   * @param int $previous_hero_fid
+   *   The cover file ID assigned before this save.
    *
    * @return list<string>
+   *   User-facing validation errors.
    */
   private function saveBrandingCoverMediaField(
     NodeInterface $node,
@@ -1442,37 +1466,50 @@ final class EventStudioSaveService {
       return [];
     }
 
-    $display = $this->entityTypeManager->getStorage('entity_form_display')->load('node.event.studio_branding');
-    $widget = $display instanceof EntityFormDisplay
-      ? $display->getRenderer('field_mel_event_cover_media')
-      : NULL;
-    if (!$widget instanceof WidgetInterface || !isset($mel_structure['field_mel_event_cover_media'])) {
-      return [];
-    }
+    $previous_cover_media_id = (int) ($node->get('field_mel_event_cover_media')->target_id ?? 0);
 
     try {
-      $mel_form = $this->normalizeBrandingMelFormStructure($mel_structure);
-      $items = $node->get('field_mel_event_cover_media');
-      $widget->extractFormValues($items, $mel_form, $form_state);
-
       $matching_value = [];
-      foreach ($items->referencedEntities() as $media) {
-        $source_field = method_exists($media, 'getSource')
-          ? (string) ($media->getSource()->getConfiguration()['source_field'] ?? '')
-          : '';
-        if ($source_field === '' || !$media->hasField($source_field)) {
-          continue;
-        }
-        $media_fid = (int) ($media->get($source_field)->target_id ?? 0);
-        $already_applied_media = (int) ($node->get('field_mel_event_cover_media')->target_id ?? 0) === (int) $media->id()
-          && $saved_hero_fid > 0
-          && $saved_hero_fid === $previous_hero_fid;
-        if (($saved_hero_fid > 0 && $media_fid === $saved_hero_fid) || $already_applied_media) {
-          $matching_value = [['target_id' => (int) $media->id()]];
-          break;
+      $display = $this->entityTypeManager->getStorage('entity_form_display')->load('node.event.studio_branding');
+      $widget = $display instanceof EntityFormDisplay
+        ? $display->getRenderer('field_mel_event_cover_media')
+        : NULL;
+      if ($widget instanceof WidgetInterface && isset($mel_structure['field_mel_event_cover_media'])) {
+        $mel_form = $this->normalizeBrandingMelFormStructure($mel_structure);
+        $items = $node->get('field_mel_event_cover_media');
+        $widget->extractFormValues($items, $mel_form, $form_state);
+
+        foreach ($items->referencedEntities() as $media) {
+          if (!$media instanceof MediaInterface) {
+            continue;
+          }
+          $media_fid = $this->eventCoverMediaManager instanceof EventCoverMediaManager
+            ? $this->eventCoverMediaManager->sourceFileId($media)
+            : 0;
+          $already_applied_media = $previous_cover_media_id === (int) $media->id()
+            && $saved_hero_fid > 0
+            && $saved_hero_fid === $previous_hero_fid;
+          if (($saved_hero_fid > 0 && $media_fid === $saved_hero_fid) || $already_applied_media) {
+            $matching_value = [['target_id' => (int) $media->id()]];
+            break;
+          }
         }
       }
-      $node->set('field_mel_event_cover_media', $matching_value);
+
+      if ($saved_hero_fid < 1) {
+        $node->set('field_mel_event_cover_media', []);
+        return [];
+      }
+      if ($matching_value !== []) {
+        $node->set('field_mel_event_cover_media', $matching_value);
+        return [];
+      }
+      if ($saved_hero_fid === $previous_hero_fid && $previous_cover_media_id > 0) {
+        $node->set('field_mel_event_cover_media', [['target_id' => $previous_cover_media_id]]);
+        return [];
+      }
+
+      return $this->captureDirectCoverMedia($node, $previous_hero_fid, $previous_cover_media_id);
     }
     catch (\Throwable $e) {
       $this->logger->error('Branding saved-cover media persistence failed for node @nid: @message', [
@@ -1480,6 +1517,61 @@ final class EventStudioSaveService {
         '@message' => $e->getMessage(),
       ]);
       return ['Could not save the selected Media Library image.'];
+    }
+
+    return [];
+  }
+
+  /**
+   * Captures a changed direct upload while preserving selected-media provenance.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The event being saved.
+   * @param int $previous_hero_fid
+   *   The cover file ID assigned before this save.
+   * @param int $previous_cover_media_id
+   *   The Media ID assigned before this save.
+   *
+   * @return list<string>
+   *   User-facing validation errors.
+   */
+  private function captureDirectCoverMedia(
+    NodeInterface $node,
+    int $previous_hero_fid,
+    int $previous_cover_media_id,
+  ): array {
+    if (!$node->hasField('field_mel_event_cover_media')) {
+      return [];
+    }
+    if (!$node->hasField('field_event_image') || $node->get('field_event_image')->isEmpty()) {
+      $node->set('field_mel_event_cover_media', []);
+      return [];
+    }
+
+    $saved_hero_fid = $this->brandingHeroFidFromNode($node);
+    if ($saved_hero_fid === $previous_hero_fid && $previous_cover_media_id > 0) {
+      $node->set('field_mel_event_cover_media', [['target_id' => $previous_cover_media_id]]);
+      return [];
+    }
+    if (!$this->eventCoverMediaManager instanceof EventCoverMediaManager) {
+      $this->logger->error('Event cover Media capture service is unavailable for node @nid.', [
+        '@nid' => (string) $node->id(),
+      ]);
+      return ['The cover image could not be added to Media Library. Try again.'];
+    }
+
+    try {
+      $capture = $this->eventCoverMediaManager->capture($node);
+      $node->set('field_mel_event_cover_media', [[
+        'target_id' => (int) $capture['media']->id(),
+      ]]);
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('Event cover Media capture failed for node @nid: @message', [
+        '@nid' => (string) $node->id(),
+        '@message' => $e->getMessage(),
+      ]);
+      return ['The cover image could not be added to Media Library. Try again.'];
     }
 
     return [];

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventCoverMediaBackfillContractTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventCoverMediaBackfillContractTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Protects the event cover backfill architecture contract.
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventCoverMediaBackfillContractTest extends UnitTestCase {
+
+  /**
+   * The backfill fills Media provenance without removing the legacy field.
+   */
+  public function testBackfillPreservesLegacyFieldAndUsesMediaManager(): void {
+    $module = dirname(__DIR__, 3);
+    $update = file_get_contents($module . '/myeventlane_event_studio.post_update.php');
+    self::assertIsString($update);
+
+    self::assertStringContainsString('post_update_backfill_event_cover_media', $update);
+    self::assertStringContainsString("->notExists('field_mel_event_cover_media')", $update);
+    self::assertStringContainsString('$manager->capture($event)', $update);
+    self::assertStringContainsString("\$event->set('field_mel_event_cover_media'", $update);
+    self::assertStringContainsString('throw new UpdateException', $update);
+    self::assertStringNotContainsString("delete('field_event_image')", $update);
+    self::assertStringNotContainsString("set('field_event_image', [])", $update);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventCoverMediaManagerTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventCoverMediaManagerTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Field\FieldItemInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\file\FileInterface;
+use Drupal\media\MediaInterface;
+use Drupal\media\MediaSourceInterface;
+use Drupal\media\MediaTypeInterface;
+use Drupal\myeventlane_event_studio\Service\EventCoverMediaManager;
+use Drupal\node\NodeInterface;
+use Drupal\Tests\UnitTestCase;
+
+require_once dirname(__DIR__, 3) . '/src/Service/EventCoverMediaManager.php';
+
+/**
+ * Tests organiser-scoped event cover Media capture.
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventCoverMediaManagerTest extends UnitTestCase {
+
+  /**
+   * Direct uploads create Media owned by the event organiser.
+   */
+  public function testCaptureCreatesMediaOwnedByEventOrganiser(): void {
+    $file = $this->createMock(FileInterface::class);
+    $file->method('getFilename')->willReturn('community-day.jpg');
+    $file->method('isTemporary')->willReturn(FALSE);
+
+    $media = $this->createMock(MediaInterface::class);
+    $media->method('id')->willReturn('81');
+    $media->expects($this->once())->method('save');
+
+    $media_storage = $this->createMock(EntityStorageInterface::class);
+    $media_storage->expects($this->once())
+      ->method('loadByProperties')
+      ->with([
+        'bundle' => 'image',
+        'uid' => 23,
+        'field_media_image.target_id' => 55,
+      ])
+      ->willReturn([]);
+    $media_storage->expects($this->once())
+      ->method('create')
+      ->with([
+        'bundle' => 'image',
+        'uid' => 23,
+        'name' => 'community-day.jpg',
+        'field_media_image' => [
+          'target_id' => 55,
+          'alt' => 'People gathering at Community Day',
+          'title' => '',
+        ],
+      ])
+      ->willReturn($media);
+
+    $manager = new EventCoverMediaManager($this->entityTypeManager($file, $media_storage));
+    $result = $manager->capture($this->event(23, 55, 'People gathering at Community Day'));
+
+    self::assertTrue($result['created']);
+    self::assertSame($media, $result['media']);
+  }
+
+  /**
+   * Existing Media is reused only for the matching organiser and source file.
+   */
+  public function testCaptureReusesOnlySameOrganiserAndFile(): void {
+    $file = $this->createMock(FileInterface::class);
+    $existing = $this->createMock(MediaInterface::class);
+
+    $media_storage = $this->createMock(EntityStorageInterface::class);
+    $media_storage->expects($this->once())
+      ->method('loadByProperties')
+      ->with([
+        'bundle' => 'image',
+        'uid' => 48,
+        'field_media_image.target_id' => 55,
+      ])
+      ->willReturn([$existing]);
+    $media_storage->expects($this->never())->method('create');
+
+    $manager = new EventCoverMediaManager($this->entityTypeManager($file, $media_storage));
+    $result = $manager->capture($this->event(48, 55, 'Cover alt'));
+
+    self::assertFalse($result['created']);
+    self::assertSame($existing, $result['media']);
+  }
+
+  /**
+   * Builds storage mocks for event cover capture.
+   */
+  private function entityTypeManager(FileInterface $file, EntityStorageInterface $media_storage): EntityTypeManagerInterface {
+    $file_storage = $this->createMock(EntityStorageInterface::class);
+    $file_storage->method('load')->with(55)->willReturn($file);
+
+    $source = $this->createMock(MediaSourceInterface::class);
+    $source->method('getConfiguration')->willReturn(['source_field' => 'field_media_image']);
+    $media_type = $this->createMock(MediaTypeInterface::class);
+    $media_type->method('getSource')->willReturn($source);
+    $media_type_storage = $this->createMock(EntityStorageInterface::class);
+    $media_type_storage->method('load')->with('image')->willReturn($media_type);
+
+    $entity_type_manager = $this->createMock(EntityTypeManagerInterface::class);
+    $entity_type_manager->method('getStorage')->willReturnMap([
+      ['file', $file_storage],
+      ['media', $media_storage],
+      ['media_type', $media_type_storage],
+    ]);
+    return $entity_type_manager;
+  }
+
+  /**
+   * Builds an event mock with a legacy cover field value.
+   */
+  private function event(int $owner_id, int $fid, string $alt): NodeInterface {
+    $item = $this->createMock(FieldItemInterface::class);
+    $item->method('getValue')->willReturn([
+      'target_id' => $fid,
+      'alt' => $alt,
+      'title' => '',
+    ]);
+    $cover = $this->createMock(FieldItemListInterface::class);
+    $cover->method('isEmpty')->willReturn(FALSE);
+    $cover->method('first')->willReturn($item);
+
+    $event = $this->createMock(NodeInterface::class);
+    $event->method('bundle')->willReturn('event');
+    $event->method('hasField')->with('field_event_image')->willReturn(TRUE);
+    $event->method('get')->with('field_event_image')->willReturn($cover);
+    $event->method('getOwnerId')->willReturn($owner_id);
+    $event->method('label')->willReturn('Community Day');
+    return $event;
+  }
+
+}


### PR DESCRIPTION
## What changed

- capture direct Event Studio cover uploads as organiser-owned Image Media
- reuse Image Media only when organiser and source file both match
- preserve selected Media provenance for copied and framed event covers
- add an idempotent post-update backfill for legacy event covers
- retain `field_event_image` as the public rendering and rollback source
- keep existing admin/staff full-media access unchanged

## Why

Most event covers were stored only in the legacy image field, so organisers could not reliably find and reuse them through Media Library. The backfill attaches Media provenance without changing current public rendering.

## Validation

- focused Event Studio suite: 13 tests, 53 assertions passed
- runtime capture smoke test passed against local Drupal; transaction rollback confirmed no persisted test data
- local backfill forecast: 68 event references, 41 organiser/file Media pairs, 27 in-batch reuses
- `git diff --check` passed
- full Event Studio suite has the same pre-existing 5 errors and 5 failures as `main`

## Deployment requirements

Run Drupal database updates so `myeventlane_event_studio_post_update_backfill_event_cover_media()` executes. The update fails closed if any event cannot be migrated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Data migration and save-path changes touch event nodes and Media entities; the post-update fails closed on errors and organiser scoping limits cross-account reuse risk.
> 
> **Overview**
> Adds **Media Library provenance** for event covers while **`field_event_image` stays the public display and rollback source**.
> 
> A new **`EventCoverMediaManager`** creates or reuses organiser-owned Image Media for the legacy cover file, scoped by **organiser uid + source file** so shared legacy files do not grant cross-organiser access. **`EventStudioSaveService`** now captures direct uploads into Media (via `captureDirectCoverMedia`) on full saves and branding saves, keeps selected-library provenance when the copied/framed cover still matches, and runs the same capture after hero payload changes in section saves.
> 
> A batched **`post_update_backfill_event_cover_media`** fills empty `field_mel_event_cover_media` for events with legacy covers and **fails closed** with `UpdateException` if any row errors. Module dependencies add **`drupal:media`** and **`drupal:media_library`**; unit tests cover the manager and backfill contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7127731a477547bb3f32056e3072afaaf5a4a524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->