### PR TITLE
fix: implement MapKit JS JWT signing for Apple Maps

### DIFF
--- a/web/modules/custom/myeventlane_location/myeventlane_location.services.yml
+++ b/web/modules/custom/myeventlane_location/myeventlane_location.services.yml
@@ -12,3 +12,4 @@ services:
     arguments:
       - '@config.factory'
       - '@logger.factory'
+      - '@request_stack'

--- a/web/modules/custom/myeventlane_location/src/Form/LocationSettingsForm.php
+++ b/web/modules/custom/myeventlane_location/src/Form/LocationSettingsForm.php
@@ -4,13 +4,42 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_location\Form;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\myeventlane_location\Service\LocationProviderManager;
+use Drupal\myeventlane_location\Service\MapKitTokenGenerator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Configuration form for MyEventLane location settings.
  */
 final class LocationSettingsForm extends ConfigFormBase {
+
+  /**
+   * Constructs a LocationSettingsForm.
+   */
+  public function __construct(
+    ConfigFactoryInterface $config_factory,
+    TypedConfigManagerInterface $typed_config_manager,
+    private readonly MapKitTokenGenerator $tokenGenerator,
+    private readonly LocationProviderManager $providerManager,
+  ) {
+    parent::__construct($config_factory, $typed_config_manager);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): static {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('config.typed'),
+      $container->get('myeventlane_location.mapkit_token_generator'),
+      $container->get('myeventlane_location.provider_manager'),
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -31,6 +60,18 @@ final class LocationSettingsForm extends ConfigFormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state): array {
     $config = $this->config('myeventlane_location.settings');
+
+    $form['status'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Integration status'),
+      '#open' => TRUE,
+      '#weight' => -10,
+    ];
+
+    $form['status']['summary'] = [
+      '#theme' => 'item_list',
+      '#items' => $this->buildStatusItems(),
+    ];
 
     $form['provider'] = [
       '#type' => 'details',
@@ -89,14 +130,14 @@ final class LocationSettingsForm extends ConfigFormBase {
     $form['apple_maps']['apple_maps_private_key'] = [
       '#type' => 'textarea',
       '#title' => $this->t('Private key (PEM format)'),
-      '#description' => $this->t('The private key file content in PEM format. For security, consider storing this in settings.php or environment variables instead. See README for details.'),
+      '#description' => $this->t('The private key file content in PEM format (-----BEGIN PRIVATE KEY----- …). For security, prefer settings.php constants: MYEVENTLANE_APPLE_MAPS_TEAM_ID, MYEVENTLANE_APPLE_MAPS_KEY_ID, MYEVENTLANE_APPLE_MAPS_PRIVATE_KEY, and optionally MYEVENTLANE_APPLE_MAPS_ORIGIN.'),
       '#default_value' => $config->get('apple_maps_private_key') ?? '',
       '#rows' => 10,
     ];
 
     $form['security_note'] = [
       '#type' => 'markup',
-      '#markup' => '<div class="messages messages--warning"><p><strong>' . $this->t('Security note:') . '</strong> ' . $this->t('API keys and private keys should ideally be stored in settings.php or environment variables, not in the database. See the module README for configuration examples.') . '</p></div>',
+      '#markup' => '<div class="messages messages--warning"><p><strong>' . $this->t('Security note:') . '</strong> ' . $this->t('API keys and private keys should ideally be stored in settings.php or environment variables, not in the database.') . '</p></div>',
     ];
 
     return parent::buildForm($form, $form_state);
@@ -115,6 +156,46 @@ final class LocationSettingsForm extends ConfigFormBase {
       ->save();
 
     parent::submitForm($form, $form_state);
+  }
+
+  /**
+   * Builds human-readable status lines for the settings form.
+   *
+   * @return array<int, string|\Drupal\Component\Render\MarkupInterface>
+   *   Status list items.
+   */
+  private function buildStatusItems(): array {
+    $items = [];
+    $provider = $this->providerManager->getDefaultProvider();
+    $items[] = $this->t('Default provider: @provider', [
+      '@provider' => $provider === 'apple_maps' ? 'Apple Maps (MapKit JS)' : 'Google Maps',
+    ]);
+
+    if ($provider === 'google_maps') {
+      $items[] = $this->providerManager->isProviderConfigured('google_maps')
+        ? $this->t('Google Maps API key: configured')
+        : $this->t('Google Maps API key: missing');
+      return $items;
+    }
+
+    if (!$this->tokenGenerator->isConfigured()) {
+      $items[] = $this->t('Apple Maps credentials: incomplete (need Team ID, Key ID, and private key)');
+      return $items;
+    }
+
+    $token = $this->tokenGenerator->generateToken();
+    if ($token === '') {
+      $items[] = $this->t('Apple Maps credentials: present, but JWT signing failed. Check watchdog (myeventlane_location) and PEM key format.');
+      return $items;
+    }
+
+    $parts = explode('.', $token);
+    $items[] = $this->t('Apple Maps MapKit JWT: generated successfully (@segments segments, @length chars)', [
+      '@segments' => (string) count($parts),
+      '@length' => (string) strlen($token),
+    ]);
+
+    return $items;
   }
 
 }

--- a/web/modules/custom/myeventlane_location/src/Service/MapKitTokenGenerator.php
+++ b/web/modules/custom/myeventlane_location/src/Service/MapKitTokenGenerator.php
@@ -7,30 +7,41 @@ namespace Drupal\myeventlane_location\Service;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Generates MapKit JS JWT tokens for Apple Maps integration.
  *
- * This service generates JWT tokens required for MapKit JS authentication.
- * The token is signed using the Apple-provided private key.
+ * Tokens are signed with ES256 using the Apple-provided .p8 private key.
  *
- * @see https://developer.apple.com/documentation/mapkitjs/creating_an_api_key
+ * @see https://developer.apple.com/documentation/mapkitjs/creating_and_using_tokens_with_mapkit_js
  */
 final class MapKitTokenGenerator {
 
   /**
+   * Token lifetime in seconds (1 hour).
+   */
+  private const TOKEN_TTL = 3600;
+
+  /**
+   * P-256 ECDSA component length in bytes (R and S).
+   */
+  private const ES256_PART_LENGTH = 32;
+
+  /**
    * The config factory.
-   *
-   * @var \Drupal\Core\Config\ConfigFactoryInterface
    */
   private ConfigFactoryInterface $configFactory;
 
   /**
    * The logger channel.
-   *
-   * @var \Drupal\Core\Logger\LoggerChannelInterface
    */
   private LoggerChannelInterface $logger;
+
+  /**
+   * The request stack.
+   */
+  private RequestStack $requestStack;
 
   /**
    * Constructs a MapKitTokenGenerator.
@@ -39,13 +50,17 @@ final class MapKitTokenGenerator {
    *   The config factory.
    * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
    *   The logger factory.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request stack (used for the optional MapKit origin claim).
    */
   public function __construct(
     ConfigFactoryInterface $config_factory,
     LoggerChannelFactoryInterface $logger_factory,
+    RequestStack $request_stack,
   ) {
     $this->configFactory = $config_factory;
     $this->logger = $logger_factory->get('myeventlane_location');
+    $this->requestStack = $request_stack;
   }
 
   /**
@@ -53,67 +68,42 @@ final class MapKitTokenGenerator {
    *
    * @return string
    *   The JWT token, or empty string if generation fails.
-   *
-   * @todo Implement JWT signing using firebase/php-jwt or similar library.
-   *   The token should include:
-   *   - Header: {"alg": "ES256", "kid": "<KEY_ID>", "typ": "JWT"}
-   *   - Payload: {"iss": "<TEAM_ID>", "iat": <timestamp>, "exp": <timestamp+3600>}
-   *   - Signature: ES256 signature using the private key
-   *
-   *   Example implementation:
-   *   ```php
-   *   use Firebase\JWT\JWT;
-   *   use Firebase\JWT\Key;
-   *
-   *   $config = $this->configFactory->get('myeventlane_location.settings');
-   *   $team_id = $config->get('apple_maps_team_id');
-   *   $key_id = $config->get('apple_maps_key_id');
-   *   $private_key = $config->get('apple_maps_private_key');
-   *
-   *   if (empty($team_id) || empty($key_id) || empty($private_key)) {
-   *     return '';
-   *   }
-   *
-   *   $header = ['alg' => 'ES256', 'kid' => $key_id, 'typ' => 'JWT'];
-   *   $payload = [
-   *     'iss' => $team_id,
-   *     'iat' => time(),
-   *     'exp' => time() + 3600,
-   *   ];
-   *
-   *   return JWT::encode($payload, $private_key, 'ES256', $key_id, $header);
-   *   ```
    */
   public function generateToken(): string {
-    $config = $this->configFactory->get('myeventlane_location.settings');
-    $team_id = $config->get('apple_maps_team_id');
-    $key_id = $config->get('apple_maps_key_id');
-    $private_key = $config->get('apple_maps_private_key');
-
-    // Allow override from settings.php or environment.
-    if (empty($team_id) && defined('MYEVENTLANE_APPLE_MAPS_TEAM_ID')) {
-      $team_id = MYEVENTLANE_APPLE_MAPS_TEAM_ID;
-    }
-    if (empty($key_id) && defined('MYEVENTLANE_APPLE_MAPS_KEY_ID')) {
-      $key_id = MYEVENTLANE_APPLE_MAPS_KEY_ID;
-    }
-    if (empty($private_key) && defined('MYEVENTLANE_APPLE_MAPS_PRIVATE_KEY')) {
-      $private_key = MYEVENTLANE_APPLE_MAPS_PRIVATE_KEY;
-    }
-
-    if (empty($team_id) || empty($key_id) || empty($private_key)) {
+    $credentials = $this->resolveCredentials();
+    if ($credentials === NULL) {
       $this->logger->warning('MapKit token generation failed: missing credentials. Configure Team ID, Key ID, and private key in location settings or settings.php.');
       return '';
     }
 
-    // @todo Implement JWT signing.
-    // For now, return empty string to indicate token generation is not yet implemented.
-    // To implement:
-    // 1. Add firebase/php-jwt to composer.json: composer require firebase/php-jwt
-    // 2. Uncomment and adapt the example code in the docblock above.
-    // 3. Ensure the private key is in PEM format and properly formatted.
-    $this->logger->warning('MapKit token generation not yet implemented. Install firebase/php-jwt and implement JWT signing.');
-    return '';
+    [$team_id, $key_id, $private_key] = $credentials;
+
+    $now = time();
+    $header = [
+      'alg' => 'ES256',
+      'kid' => $key_id,
+      'typ' => 'JWT',
+    ];
+    $payload = [
+      'iss' => $team_id,
+      'iat' => $now,
+      'exp' => $now + self::TOKEN_TTL,
+    ];
+
+    $origin = $this->resolveOrigin();
+    if ($origin !== '') {
+      $payload['origin'] = $origin;
+    }
+
+    try {
+      return $this->encodeEs256Jwt($header, $payload, $private_key);
+    }
+    catch (\Throwable $e) {
+      $this->logger->error('MapKit token generation failed: @message', [
+        '@message' => $e->getMessage(),
+      ]);
+      return '';
+    }
   }
 
   /**
@@ -123,23 +113,203 @@ final class MapKitTokenGenerator {
    *   TRUE if all required credentials are available.
    */
   public function isConfigured(): bool {
+    return $this->resolveCredentials() !== NULL;
+  }
+
+  /**
+   * Resolves Team ID, Key ID, and private key from config or settings.php.
+   *
+   * @return array{0: string, 1: string, 2: string}|null
+   *   [team_id, key_id, private_key] or NULL when incomplete.
+   */
+  private function resolveCredentials(): ?array {
     $config = $this->configFactory->get('myeventlane_location.settings');
-    $team_id = $config->get('apple_maps_team_id');
-    $key_id = $config->get('apple_maps_key_id');
-    $private_key = $config->get('apple_maps_private_key');
+    $team_id = (string) ($config->get('apple_maps_team_id') ?? '');
+    $key_id = (string) ($config->get('apple_maps_key_id') ?? '');
+    $private_key = (string) ($config->get('apple_maps_private_key') ?? '');
 
-    // Check for settings.php overrides.
-    if (empty($team_id) && defined('MYEVENTLANE_APPLE_MAPS_TEAM_ID')) {
-      $team_id = MYEVENTLANE_APPLE_MAPS_TEAM_ID;
+    if ($team_id === '' && defined('MYEVENTLANE_APPLE_MAPS_TEAM_ID')) {
+      $team_id = (string) MYEVENTLANE_APPLE_MAPS_TEAM_ID;
     }
-    if (empty($key_id) && defined('MYEVENTLANE_APPLE_MAPS_KEY_ID')) {
-      $key_id = MYEVENTLANE_APPLE_MAPS_KEY_ID;
+    if ($key_id === '' && defined('MYEVENTLANE_APPLE_MAPS_KEY_ID')) {
+      $key_id = (string) MYEVENTLANE_APPLE_MAPS_KEY_ID;
     }
-    if (empty($private_key) && defined('MYEVENTLANE_APPLE_MAPS_PRIVATE_KEY')) {
-      $private_key = MYEVENTLANE_APPLE_MAPS_PRIVATE_KEY;
+    if ($private_key === '' && defined('MYEVENTLANE_APPLE_MAPS_PRIVATE_KEY')) {
+      $private_key = (string) MYEVENTLANE_APPLE_MAPS_PRIVATE_KEY;
     }
 
-    return !empty($team_id) && !empty($key_id) && !empty($private_key);
+    $private_key = $this->normalizePrivateKey($private_key);
+
+    if ($team_id === '' || $key_id === '' || $private_key === '') {
+      return NULL;
+    }
+
+    return [$team_id, $key_id, $private_key];
+  }
+
+  /**
+   * Builds the MapKit origin claim from the current request host.
+   *
+   * MapKit expects a scheme + host matching the browser Origin header,
+   * e.g. https://staging.myeventlane.com.au
+   */
+  private function resolveOrigin(): string {
+    if (defined('MYEVENTLANE_APPLE_MAPS_ORIGIN') && MYEVENTLANE_APPLE_MAPS_ORIGIN !== '') {
+      return (string) MYEVENTLANE_APPLE_MAPS_ORIGIN;
+    }
+
+    $request = $this->requestStack->getCurrentRequest();
+    if ($request === NULL) {
+      return '';
+    }
+
+    return $request->getSchemeAndHttpHost();
+  }
+
+  /**
+   * Normalizes PEM private key text pasted into config.
+   */
+  private function normalizePrivateKey(string $private_key): string {
+    $private_key = trim($private_key);
+    if ($private_key === '') {
+      return '';
+    }
+
+    // Config/textarea pastes often store literal \n sequences.
+    if (str_contains($private_key, '\\n')) {
+      $private_key = str_replace('\\n', "\n", $private_key);
+    }
+
+    $private_key = str_replace(["\r\n", "\r"], "\n", $private_key);
+
+    return trim($private_key);
+  }
+
+  /**
+   * Encodes and ES256-signs a JWT.
+   *
+   * @param array<string, mixed> $header
+   *   JWT header claims.
+   * @param array<string, mixed> $payload
+   *   JWT payload claims.
+   * @param string $private_key
+   *   PEM-encoded EC private key.
+   *
+   * @return string
+   *   Compact JWT serialization.
+   *
+   * @throws \RuntimeException
+   *   When OpenSSL cannot load the key or sign the payload.
+   */
+  private function encodeEs256Jwt(array $header, array $payload, string $private_key): string {
+    $segments = $this->base64UrlEncode((string) json_encode($header, JSON_THROW_ON_ERROR))
+      . '.'
+      . $this->base64UrlEncode((string) json_encode($payload, JSON_THROW_ON_ERROR));
+
+    $key = openssl_pkey_get_private($private_key);
+    if ($key === FALSE) {
+      throw new \RuntimeException('Unable to load Apple Maps private key. Ensure it is a valid PEM EC key (.p8).');
+    }
+
+    $der_signature = '';
+    $signed = openssl_sign($segments, $der_signature, $key, OPENSSL_ALGO_SHA256);
+    if (!$signed || $der_signature === '') {
+      throw new \RuntimeException('OpenSSL failed to sign the MapKit JWT (ES256).');
+    }
+
+    $jose_signature = $this->derToJose($der_signature, self::ES256_PART_LENGTH);
+    return $segments . '.' . $this->base64UrlEncode($jose_signature);
+  }
+
+  /**
+   * Converts an ASN.1 DER ECDSA signature to IEEE P1363 (R||S) for JWS.
+   *
+   * @param string $der
+   *   DER-encoded ECDSA signature from openssl_sign().
+   * @param int $part_length
+   *   Expected byte length of R and S (32 for P-256 / ES256).
+   *
+   * @return string
+   *   Raw R||S signature bytes.
+   *
+   * @throws \RuntimeException
+   *   When the DER structure is invalid.
+   */
+  private function derToJose(string $der, int $part_length): string {
+    $offset = 0;
+    $length = strlen($der);
+
+    if ($length < 8 || ord($der[$offset++]) !== 0x30) {
+      throw new \RuntimeException('Invalid DER ECDSA signature (expected SEQUENCE).');
+    }
+
+    $seq_length = $this->readDerLength($der, $offset);
+    if ($seq_length < 1 || $offset + $seq_length > $length) {
+      throw new \RuntimeException('Invalid DER ECDSA signature length.');
+    }
+
+    $r = $this->readDerInteger($der, $offset, $part_length);
+    $s = $this->readDerInteger($der, $offset, $part_length);
+
+    return $r . $s;
+  }
+
+  /**
+   * Reads a DER length value and advances $offset past the length bytes.
+   */
+  private function readDerLength(string $der, int &$offset): int {
+    if (!isset($der[$offset])) {
+      throw new \RuntimeException('Unexpected end of DER signature while reading length.');
+    }
+
+    $byte = ord($der[$offset++]);
+    if (($byte & 0x80) === 0) {
+      return $byte;
+    }
+
+    $num_bytes = $byte & 0x7F;
+    if ($num_bytes === 0 || $num_bytes > 3 || !isset($der[$offset + $num_bytes - 1])) {
+      throw new \RuntimeException('Invalid DER length encoding.');
+    }
+
+    $length = 0;
+    for ($i = 0; $i < $num_bytes; $i++) {
+      $length = ($length << 8) | ord($der[$offset++]);
+    }
+
+    return $length;
+  }
+
+  /**
+   * Reads a DER INTEGER and returns it as a fixed-width unsigned big-endian value.
+   */
+  private function readDerInteger(string $der, int &$offset, int $part_length): string {
+    if (!isset($der[$offset]) || ord($der[$offset++]) !== 0x02) {
+      throw new \RuntimeException('Invalid DER ECDSA signature (expected INTEGER).');
+    }
+
+    $int_length = $this->readDerLength($der, $offset);
+    if ($int_length < 1 || !isset($der[$offset + $int_length - 1])) {
+      throw new \RuntimeException('Invalid DER INTEGER length.');
+    }
+
+    $value = substr($der, $offset, $int_length);
+    $offset += $int_length;
+
+    // Strip leading zero padding used for sign bit, then left-pad to part length.
+    $value = ltrim($value, "\x00");
+    if (strlen($value) > $part_length) {
+      throw new \RuntimeException('ECDSA signature component exceeds ES256 size.');
+    }
+
+    return str_pad($value, $part_length, "\x00", STR_PAD_LEFT);
+  }
+
+  /**
+   * Base64url-encodes binary data without padding.
+   */
+  private function base64UrlEncode(string $data): string {
+    return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
   }
 
 }


### PR DESCRIPTION
## Summary

<!-- What changed and why (organiser outcome, not only technical delta). -->

## Zone map (Event Workspace — required before screenshots)

<!-- Required for any PR that changes Event Workspace / organiser Workspace UI.
     Remove only for PRs with zero Workspace UI impact (state N/A + rationale). -->

```text
Identity:   <!-- Where am I? -->
Guidance:   <!-- What should I do next? (one recommendation or omit) -->
Work:       <!-- How do I do it? -->
Outcome:    <!-- What happened? (or omit) -->
```

**Zone Gate:** If you cannot produce this map, the page has not been designed yet.  
Authority: `docs/design/vendor-studio-visual/07-workspace-zones.md`

## Vendor Studio Design System References

<!-- Required for any PR that changes Vendor Studio / organiser console experience or `docs/design/vendor-studio/`.
     Remove this section only for PRs with zero Vendor Studio impact. -->

This implementation follows:

- <!-- e.g. docs/design/vendor-studio-visual/07-workspace-zones.md -->
- <!-- e.g. docs/design/vendor-studio-visual/03-option-b5.md -->
- <!-- e.g. 02-information-architecture.md -->
- <!-- e.g. 05-component-library.md -->
- <!-- e.g. 11-design-tokens.md -->
- <!-- e.g. 16-design-review-checklist.md -->
- <!-- e.g. 21-definition-of-done.md -->
- <!-- e.g. ADR-0001 -->
- <!-- e.g. DDR-003 -->

**Build order:** PDS → Workspace Zones → Visual Language B.5 → Component Catalogue → Implementation  
**PDS home:** `docs/design/vendor-studio/` (Vendor Studio Product Design System v1.0 — FROZEN)

Please also apply the GitHub label: `design-system`

## Definition of Done / checklist

- [ ] Zone Gate map present (or N/A with rationale)
- [ ] Applicable gates in `docs/design/vendor-studio/21-definition-of-done.md`
- [ ] `docs/design/vendor-studio/16-design-review-checklist.md` completed (or N/A with rationale)
- [ ] No contradiction of higher-order PDS docs ([ADR-0001](../docs/design/vendor-studio/decisions/ADR-0001-design-authority.md))

## Test plan

- [ ] <!-- Manual / automated checks -->

## Risk

<!-- Access, Commerce, payments, cache, PII — or "None" -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential handling and cryptographic signing for third-party map auth; misconfiguration or origin mismatch could break Apple Maps in production, but scope is limited to the location module admin/config path.
> 
> **Overview**
> **Replaces the MapKit JWT stub** with real **ES256** signing via OpenSSL (no new JWT library), so Apple Maps can receive a valid `apple_maps_token` in frontend `drupalSettings` when the default provider is Apple Maps.
> 
> **`MapKitTokenGenerator`** now resolves credentials from config or `settings.php` constants, normalizes pasted PEM keys, optionally adds a MapKit **`origin`** claim from `MYEVENTLANE_APPLE_MAPS_ORIGIN` or the current request host, and converts OpenSSL DER ECDSA signatures to JWS form. **`request_stack`** is injected for origin resolution.
> 
> **Location settings** gains an **Integration status** section that reports default provider, Google key presence, Apple credential completeness, and a live JWT generation check (with segment/length on success). Help text now documents the `settings.php` constants including optional origin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 294557beb1ca11e7a7680d45037b0b71c74b348a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->