### PR TITLE
Capture category images in Media Library

### DIFF
--- a/config/sync/core.entity_form_display.taxonomy_term.categories.default.yml
+++ b/config/sync/core.entity_form_display.taxonomy_term.categories.default.yml
@@ -4,12 +4,14 @@ status: true
 dependencies:
   config:
     - field.field.taxonomy_term.categories.field_category_image
+    - field.field.taxonomy_term.categories.field_category_media
     - field.field.taxonomy_term.categories.field_category_pill_color
     - field.field.taxonomy_term.categories.field_mel_slug
     - image.style.thumbnail
     - taxonomy.vocabulary.categories
   module:
     - image
+    - media_library
     - path
     - text
 id: taxonomy_term.categories.default
@@ -25,13 +27,13 @@ content:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
-  field_category_image:
-    type: image_image
+  field_category_media:
+    type: media_library_widget
     weight: 4
     region: content
     settings:
-      progress_indicator: throbber
-      preview_image_style: thumbnail
+      media_types:
+        - image
     third_party_settings: {  }
   field_category_pill_color:
     type: options_select
@@ -75,4 +77,5 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  field_category_image: true

--- a/config/sync/field.field.taxonomy_term.categories.field_category_media.yml
+++ b/config/sync/field.field.taxonomy_term.categories.field_category_media.yml
@@ -1,0 +1,31 @@
+uuid: 54bda190-5fdc-4dc2-8469-01b1489f52e7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_category_media
+    - media.type.image
+    - taxonomy.vocabulary.categories
+  module:
+    - media
+id: taxonomy_term.categories.field_category_media
+field_name: field_category_media
+entity_type: taxonomy_term
+bundle: categories
+label: 'Category image'
+description: 'Choose an image from Media Library or upload a reusable platform category image.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.taxonomy_term.field_category_media.yml
+++ b/config/sync/field.storage.taxonomy_term.field_category_media.yml
@@ -1,0 +1,20 @@
+uuid: d2530565-98a1-46e5-83f7-736b7524d7f2
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - taxonomy
+id: taxonomy_term.field_category_media
+field_name: field_category_media
+entity_type: taxonomy_term
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/myeventlane_page_visuals/myeventlane_page_visuals.info.yml
+++ b/web/modules/custom/myeventlane_page_visuals/myeventlane_page_visuals.info.yml
@@ -8,4 +8,5 @@ dependencies:
   - drupal:file
   - drupal:media
   - drupal:media_library
+  - drupal:taxonomy
   - myeventlane_core:myeventlane_core

--- a/web/modules/custom/myeventlane_page_visuals/myeventlane_page_visuals.install
+++ b/web/modules/custom/myeventlane_page_visuals/myeventlane_page_visuals.install
@@ -8,6 +8,12 @@ declare(strict_types=1);
  */
 
 use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\Utility\UpdateException;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\myeventlane_page_visuals\Service\CategoryImageMediaManager;
+use Drupal\Core\Entity\Entity\EntityFormDisplay;
+use Drupal\taxonomy\TermInterface;
 
 /**
  * Implements hook_install().
@@ -114,4 +120,154 @@ function myeventlane_page_visuals_update_9002(): string {
  */
 function myeventlane_page_visuals_update_9003(): string {
   return myeventlane_page_visuals_ensure_upload_directory();
+}
+
+/**
+ * Adds category Image Media and backfills legacy direct-file images.
+ */
+function myeventlane_page_visuals_update_9004(array &$sandbox): string {
+  myeventlane_page_visuals_ensure_category_media_field();
+
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $term_storage = $entity_type_manager->getStorage('taxonomy_term');
+  $logger = \Drupal::logger('myeventlane_page_visuals');
+  $manager = \Drupal::service('myeventlane.category_image_media_manager');
+  assert($manager instanceof CategoryImageMediaManager);
+
+  if (!isset($sandbox['ids'])) {
+    $sandbox['ids'] = array_values($term_storage->getQuery()
+      ->accessCheck(FALSE)
+      ->condition('vid', 'categories')
+      ->exists('field_category_image')
+      ->notExists('field_category_media')
+      ->sort('tid')
+      ->execute());
+    $sandbox['index'] = 0;
+    $sandbox['migrated'] = 0;
+    $sandbox['created'] = 0;
+    $sandbox['reused'] = 0;
+    $sandbox['skipped'] = 0;
+    $sandbox['errors'] = 0;
+  }
+
+  $total = count($sandbox['ids']);
+  $limit = min($sandbox['index'] + 20, $total);
+  while ($sandbox['index'] < $limit) {
+    $tid = (int) $sandbox['ids'][$sandbox['index']];
+    $sandbox['index']++;
+    $term = $term_storage->load($tid);
+
+    if (!$term instanceof TermInterface
+      || !$term->hasField('field_category_image')
+      || $term->get('field_category_image')->isEmpty()
+      || !$term->hasField('field_category_media')
+      || !$term->get('field_category_media')->isEmpty()) {
+      $sandbox['skipped']++;
+      continue;
+    }
+
+    try {
+      $capture = $manager->capture($term);
+      $term->set('field_category_media', [
+        ['target_id' => (int) $capture['media']->id()],
+      ]);
+      $term->save();
+      $sandbox[$capture['created'] ? 'created' : 'reused']++;
+      $sandbox['migrated']++;
+    }
+    catch (\Throwable $e) {
+      $sandbox['errors']++;
+      $logger->error('Category image Media backfill failed for term @tid: @message', [
+        '@tid' => (string) $tid,
+        '@message' => $e->getMessage(),
+      ]);
+    }
+  }
+
+  $sandbox['#finished'] = $total === 0 ? 1 : $sandbox['index'] / $total;
+  if ($sandbox['#finished'] < 1) {
+    return sprintf(
+      'Captured category images for %d of %d terms (%d Media created, %d reused, %d errors).',
+      $sandbox['index'],
+      $total,
+      $sandbox['created'],
+      $sandbox['reused'],
+      $sandbox['errors'],
+    );
+  }
+
+  if ($sandbox['errors'] > 0) {
+    throw new UpdateException(sprintf(
+      'Category image Media backfill stopped with %d errors. Review the myeventlane_page_visuals log and rerun updates.',
+      $sandbox['errors'],
+    ));
+  }
+
+  return sprintf(
+    'Category image Media backfill complete: %d migrated, %d Media created, %d reused, %d skipped, %d errors.',
+    $sandbox['migrated'],
+    $sandbox['created'],
+    $sandbox['reused'],
+    $sandbox['skipped'],
+    $sandbox['errors'],
+  );
+}
+
+/**
+ * Ensures the category Media field exists before the deployment config import.
+ */
+function myeventlane_page_visuals_ensure_category_media_field(): void {
+  $entity_type = 'taxonomy_term';
+  $bundle = 'categories';
+  $field_name = 'field_category_media';
+
+  $storage = FieldStorageConfig::loadByName($entity_type, $field_name);
+  if ($storage === NULL) {
+    FieldStorageConfig::create([
+      'uuid' => 'd2530565-98a1-46e5-83f7-736b7524d7f2',
+      'field_name' => $field_name,
+      'entity_type' => $entity_type,
+      'type' => 'entity_reference',
+      'settings' => ['target_type' => 'media'],
+      'cardinality' => 1,
+      'translatable' => FALSE,
+    ])->save();
+  }
+
+  $field = FieldConfig::loadByName($entity_type, $bundle, $field_name);
+  if ($field === NULL) {
+    FieldConfig::create([
+      'uuid' => '54bda190-5fdc-4dc2-8469-01b1489f52e7',
+      'field_name' => $field_name,
+      'entity_type' => $entity_type,
+      'bundle' => $bundle,
+      'label' => 'Category image',
+      'description' => 'Choose an image from Media Library or upload a reusable platform category image.',
+      'required' => FALSE,
+      'translatable' => FALSE,
+      'settings' => [
+        'handler' => 'default:media',
+        'handler_settings' => [
+          'target_bundles' => ['image' => 'image'],
+          'sort' => ['field' => '_none', 'direction' => 'ASC'],
+          'auto_create' => FALSE,
+          'auto_create_bundle' => '',
+        ],
+      ],
+    ])->save();
+  }
+
+  $display = EntityFormDisplay::load('taxonomy_term.categories.default');
+  if ($display !== NULL) {
+    $display->setComponent($field_name, [
+      'type' => 'media_library_widget',
+      'weight' => 4,
+      'region' => 'content',
+      'settings' => ['media_types' => ['image']],
+    ]);
+    $display->removeComponent('field_category_image');
+    $display->save();
+  }
+
+  \Drupal::entityTypeManager()->clearCachedDefinitions();
 }

--- a/web/modules/custom/myeventlane_page_visuals/myeventlane_page_visuals.services.yml
+++ b/web/modules/custom/myeventlane_page_visuals/myeventlane_page_visuals.services.yml
@@ -16,6 +16,12 @@ services:
       - '@current_user'
       - '@logger.channel.myeventlane_page_visuals'
 
+  myeventlane.category_image_media_manager:
+    class: Drupal\myeventlane_page_visuals\Service\CategoryImageMediaManager
+    arguments:
+      - '@entity_type.manager'
+      - '@file_system'
+
   logger.channel.myeventlane_page_visuals:
     parent: logger.channel_base
     arguments: ['myeventlane_page_visuals']

--- a/web/modules/custom/myeventlane_page_visuals/src/Service/CategoryImageMediaManager.php
+++ b/web/modules/custom/myeventlane_page_visuals/src/Service/CategoryImageMediaManager.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_page_visuals\Service;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\file\FileInterface;
+use Drupal\media\MediaInterface;
+use Drupal\media\MediaTypeInterface;
+use Drupal\taxonomy\TermInterface;
+
+/**
+ * Creates platform-owned Image Media for legacy category images.
+ */
+final class CategoryImageMediaManager {
+
+  /**
+   * System ownership keeps platform category assets out of organiser results.
+   */
+  private const PLATFORM_MEDIA_OWNER_ID = 0;
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly FileSystemInterface $fileSystem,
+  ) {}
+
+  /**
+   * Captures a category's legacy direct-file image as reusable Media.
+   *
+   * Category images are platform assets, so backfilled Media is deliberately
+   * system-owned rather than attributed to an organiser. This keeps category
+   * artwork out of organiser-owned Media Library results while staff retain
+   * their existing cross-owner access.
+   *
+   * @return array{media: \Drupal\media\MediaInterface, created: bool}
+   *   The captured Media item and whether it was newly created.
+   */
+  public function capture(TermInterface $term): array {
+    if ($term->bundle() !== 'categories'
+      || !$term->hasField('field_category_image')
+      || $term->get('field_category_image')->isEmpty()) {
+      throw new \InvalidArgumentException('A legacy category image is required.');
+    }
+
+    $image_item = $term->get('field_category_image')->first();
+    $image_value = $image_item?->getValue() ?? [];
+    $fid = (int) ($image_value['target_id'] ?? 0);
+    $file = $fid > 0
+      ? $this->entityTypeManager->getStorage('file')->load($fid)
+      : NULL;
+    if (!$file instanceof FileInterface) {
+      throw new \RuntimeException(sprintf('Category image file %d could not be loaded.', $fid));
+    }
+
+    $realpath = $this->fileSystem->realpath($file->getFileUri());
+    if ($realpath === FALSE || !is_file($realpath)) {
+      throw new \RuntimeException(sprintf('Category image file %d is missing from storage.', $fid));
+    }
+
+    $media_type = $this->entityTypeManager->getStorage('media_type')->load('image');
+    if (!$media_type instanceof MediaTypeInterface) {
+      throw new \RuntimeException('The Image media type is not available.');
+    }
+    $source_field = (string) ($media_type->getSource()->getConfiguration()['source_field'] ?? '');
+    if ($source_field === '') {
+      throw new \RuntimeException('The Image media source field is not configured.');
+    }
+
+    $owner_id = self::PLATFORM_MEDIA_OWNER_ID;
+    $media_storage = $this->entityTypeManager->getStorage('media');
+    $existing = $media_storage->loadByProperties([
+      'bundle' => 'image',
+      'uid' => $owner_id,
+      $source_field . '.target_id' => $fid,
+    ]);
+    $media = $existing ? reset($existing) : NULL;
+    if ($media instanceof MediaInterface) {
+      return ['media' => $media, 'created' => FALSE];
+    }
+
+    if ($file->isTemporary()) {
+      $file->setPermanent();
+      $file->save();
+    }
+
+    $alt = trim((string) ($image_value['alt'] ?? ''));
+    if ($alt === '') {
+      $alt = trim((string) $term->label());
+    }
+    if ($alt === '') {
+      $alt = $file->getFilename();
+    }
+
+    $media = $media_storage->create([
+      'bundle' => 'image',
+      'uid' => $owner_id,
+      'name' => sprintf('%s category image', $term->label()),
+      $source_field => [
+        'target_id' => $fid,
+        'alt' => $alt,
+        'title' => (string) ($image_value['title'] ?? ''),
+      ],
+    ]);
+    if (!$media instanceof MediaInterface) {
+      throw new \RuntimeException('The category Image Media item could not be created.');
+    }
+    $media->save();
+
+    return ['media' => $media, 'created' => TRUE];
+  }
+
+}

--- a/web/modules/custom/myeventlane_page_visuals/tests/src/Unit/CategoryImageMediaBackfillContractTest.php
+++ b/web/modules/custom/myeventlane_page_visuals/tests/src/Unit/CategoryImageMediaBackfillContractTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_page_visuals\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Protects category image Media capture, backfill, and fallback contracts.
+ */
+#[Group('myeventlane_page_visuals')]
+final class CategoryImageMediaBackfillContractTest extends UnitTestCase {
+
+  /**
+   * Category editing uses Image Media while retaining the legacy field.
+   */
+  public function testCategoryFieldAndFormDisplayContract(): void {
+    $root = dirname(__DIR__, 7);
+    $storage = file_get_contents($root . '/config/sync/field.storage.taxonomy_term.field_category_media.yml');
+    $field = file_get_contents($root . '/config/sync/field.field.taxonomy_term.categories.field_category_media.yml');
+    $display = file_get_contents($root . '/config/sync/core.entity_form_display.taxonomy_term.categories.default.yml');
+
+    self::assertIsString($storage);
+    self::assertIsString($field);
+    self::assertIsString($display);
+    self::assertStringContainsString('target_type: media', $storage);
+    self::assertStringContainsString('image: image', $field);
+    self::assertStringContainsString('field_category_media:', $display);
+    self::assertStringContainsString('type: media_library_widget', $display);
+    self::assertStringContainsString('field_category_image: true', $display);
+  }
+
+  /**
+   * The update is fail-closed and never removes the direct image field.
+   */
+  public function testBackfillPreservesLegacyCategoryImage(): void {
+    $module = dirname(__DIR__, 3);
+    $update = file_get_contents($module . '/myeventlane_page_visuals.install');
+
+    self::assertIsString($update);
+    self::assertStringContainsString('myeventlane_page_visuals_update_9004', $update);
+    self::assertStringContainsString("->notExists('field_category_media')", $update);
+    self::assertStringContainsString('$manager->capture($term)', $update);
+    self::assertStringContainsString("\$term->set('field_category_media'", $update);
+    self::assertStringContainsString('throw new UpdateException', $update);
+    self::assertStringNotContainsString("delete('field_category_image')", $update);
+    self::assertStringNotContainsString("set('field_category_image', [])", $update);
+  }
+
+  /**
+   * Rendering prefers Media and retains a physical-file legacy fallback.
+   */
+  public function testThemePrefersMediaAndKeepsLegacyFallback(): void {
+    $root = dirname(__DIR__, 7);
+    $theme = file_get_contents($root . '/web/themes/custom/myeventlane_theme/myeventlane_theme.theme');
+
+    self::assertIsString($theme);
+    $media_position = strpos($theme, "hasField('field_category_media')");
+    $legacy_position = strpos($theme, "hasField('field_category_image')", $media_position ?: 0);
+    self::assertNotFalse($media_position);
+    self::assertNotFalse($legacy_position);
+    self::assertLessThan($legacy_position, $media_position);
+    self::assertStringContainsString('file_exists($file->getFileUri())', $theme);
+  }
+
+}

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -20,6 +20,8 @@ use Drupal\Core\Routing\RouteNotFoundException;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
+use Drupal\file\FileInterface;
+use Drupal\media\MediaInterface;
 use Drupal\taxonomy\TermInterface;
 use Drupal\views\ViewExecutable;
 use Drupal\file\Entity\File;
@@ -3513,7 +3515,7 @@ function myeventlane_theme_preprocess_taxonomy_term(array &$variables): void {
 
     $variables['mel_category_slug'] = $category_slug;
 
-    // Banner URL: term field_category_image, then Page Visuals for this route.
+    // Banner URL: category Media/legacy fallback, then route Page Visuals.
     $banner_url = _myeventlane_theme_get_category_term_hero_url($term);
     if ($banner_url === NULL && \Drupal::hasService('myeventlane.page_visual_resolver')) {
       $page_visual = \Drupal::service('myeventlane.page_visual_resolver')
@@ -4181,8 +4183,8 @@ function _myeventlane_theme_build_discovery_hero(array $variables): array {
 /**
  * Applies hero image URLs from Page Visuals (single canonical source).
  *
- * Category routes may override with field_category_image on the active term
- * (content-owned image, not a parallel admin chain).
+ * Category routes may override with the active term's Media image, retaining
+ * the legacy direct image only as a migration fallback.
  */
 function _myeventlane_theme_apply_page_visual_hero(array &$variables, ?string $route = NULL): void {
   $route = $route ?? \Drupal::routeMatch()->getRouteName();
@@ -4210,22 +4212,49 @@ function _myeventlane_theme_apply_page_visual_hero(array &$variables, ?string $r
 }
 
 /**
- * Category term hero image from field_category_image when file exists on disk.
+ * Category term hero image from Media, with the legacy file as rollback.
  */
 function _myeventlane_theme_get_category_term_hero_url(?TermInterface $term = NULL): ?string {
   $term = $term ?? _myeventlane_theme_get_active_category_term();
   if (!$term instanceof TermInterface || $term->bundle() !== 'categories') {
     return NULL;
   }
-  if (!$term->hasField('field_category_image') || $term->get('field_category_image')->isEmpty()) {
-    return NULL;
-  }
-  $cat_files = $term->get('field_category_image')->referencedEntities();
-  $file = !empty($cat_files) ? reset($cat_files) : NULL;
-  if (!$file || !file_exists($file->getFileUri())) {
+
+  $file = _myeventlane_theme_get_category_term_hero_file($term);
+  if (!$file instanceof FileInterface) {
     return NULL;
   }
   return \Drupal::service('file_url_generator')->generateAbsoluteString($file->getFileUri());
+}
+
+/**
+ * Resolves the canonical category image file, preferring Media provenance.
+ */
+function _myeventlane_theme_get_category_term_hero_file(TermInterface $term): ?FileInterface {
+  if ($term->bundle() !== 'categories') {
+    return NULL;
+  }
+
+  if ($term->hasField('field_category_media') && !$term->get('field_category_media')->isEmpty()) {
+    $media = $term->get('field_category_media')->entity;
+    if ($media instanceof MediaInterface
+      && $media->hasField('field_media_image')
+      && !$media->get('field_media_image')->isEmpty()) {
+      $file = $media->get('field_media_image')->entity;
+      if ($file instanceof FileInterface && file_exists($file->getFileUri())) {
+        return $file;
+      }
+    }
+  }
+
+  if ($term->hasField('field_category_image') && !$term->get('field_category_image')->isEmpty()) {
+    $file = $term->get('field_category_image')->entity;
+    if ($file instanceof FileInterface && file_exists($file->getFileUri())) {
+      return $file;
+    }
+  }
+
+  return NULL;
 }
 
 /**
@@ -4247,13 +4276,7 @@ function _myeventlane_theme_get_listing_hero_url(?string $route): ?string {
   if ($route === 'entity.taxonomy_term.canonical') {
     $term = \Drupal::routeMatch()->getParameter('taxonomy_term');
     if ($term instanceof TermInterface && $term->bundle() === 'categories') {
-      if ($term->hasField('field_category_image') && !$term->get('field_category_image')->isEmpty()) {
-        $canon_files = $term->get('field_category_image')->referencedEntities();
-        $file = !empty($canon_files) ? reset($canon_files) : NULL;
-        if ($file && file_exists($file->getFileUri())) {
-          return \Drupal::service('file_url_generator')->generateAbsoluteString($file->getFileUri());
-        }
-      }
+      return _myeventlane_theme_get_category_term_hero_url($term);
     }
   }
   return NULL;
@@ -4849,15 +4872,10 @@ function myeventlane_theme_preprocess_node__event(array &$variables): void {
     $referenced_entities = $category_field->referencedEntities();
     if (!empty($referenced_entities)) {
       $term = reset($referenced_entities);
-      if ($term && $term->hasField('field_category_image') && !$term->get('field_category_image')->isEmpty()) {
-        $category_files = $term->get('field_category_image')->referencedEntities();
-        $file = !empty($category_files) ? reset($category_files) : NULL;
-        if ($file instanceof File) {
-          $uri = $file->getFileUri();
-          $real_cat_uri = $uri !== '' ? $file_system->realpath($uri) : FALSE;
-          if ($real_cat_uri !== FALSE && is_file($real_cat_uri)) {
-            $image_url = $file_url_generator->generateAbsoluteString($uri);
-          }
+      if ($term instanceof TermInterface) {
+        $file = _myeventlane_theme_get_category_term_hero_file($term);
+        if ($file instanceof FileInterface) {
+          $image_url = $file_url_generator->generateAbsoluteString($file->getFileUri());
         }
       }
     }


### PR DESCRIPTION
## Summary

- add a canonical Image Media reference for category taxonomy terms
- replace the category edit form's direct image widget with the Media Library widget
- backfill existing direct category images into reusable platform-owned Image Media
- prefer Media when rendering category heroes and event category fallbacks
- retain the existing direct image field and use it as a rollback fallback
- add focused migration, configuration, and rendering contract coverage

## Why

Category artwork was still stored only as direct file references. That kept it outside Drupal's reusable Media workflow and left category image management inconsistent with Event Studio, venues, Page Visuals, blog content, and Commerce imagery.

## User and developer impact

Staff can choose or upload category artwork through Media Library. Backfilled category Media is system-owned so it does not appear in organiser-owned Media Library results; staff and administrators retain their existing cross-owner access.

The legacy `field_category_image` field and every existing value remain intact. It is hidden from the edit form but remains the rendering fallback if the Media reference or source file cannot be resolved.

The update is idempotent and fails closed on migration errors. It also installs the field before backfill so MEL's update-before-config-import deployment order is supported.

## Validation

- PHPUnit: 3 tests, 21 assertions
- PHP syntax checks passed
- Drupal and DrupalPractice coding standards passed
- YAML parsing passed
- `git diff --check` passed
- isolated local Drupal database clone: 10 categories migrated, 10 Media created, 0 reused, 0 skipped, 0 errors
- all 10 legacy values preserved
- all 10 Media references matched their original source files
- all 10 category image URLs resolved
- legacy rendering fallback passed
- second backfill run produced zero changes
- original local database remained unchanged

## Boundaries

- no legacy field or image values are deleted
- no deployment is included
- organiser and staff Media access rules are unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit bc13aeb0af41eaf20f71a058fd1a7fdc078b8b3c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->