### PR TITLE
fix: expose MapKit JWT in frontend location settings

### DIFF
--- a/web/modules/custom/myeventlane_location/js/address-autocomplete.js
+++ b/web/modules/custom/myeventlane_location/js/address-autocomplete.js
@@ -12,11 +12,15 @@
 (function (Drupal, drupalSettings, once) {
   'use strict';
 
-  const SETTINGS = (drupalSettings && drupalSettings.myeventlaneLocation) ? drupalSettings.myeventlaneLocation : {};
-  const DEBUG = !!SETTINGS.debug;
+  function getSettings() {
+    const live = (window.drupalSettings && window.drupalSettings.myeventlaneLocation)
+      ? window.drupalSettings.myeventlaneLocation
+      : ((drupalSettings && drupalSettings.myeventlaneLocation) ? drupalSettings.myeventlaneLocation : {});
+    return live || {};
+  }
 
   function log(...args) {
-    if (DEBUG && window.console) console.log('[MEL Location]', ...args);
+    if (getSettings().debug && window.console) console.log('[MEL Location]', ...args);
   }
   function warn(...args) {
     if (window.console) console.warn('[MEL Location]', ...args);
@@ -24,11 +28,14 @@
   function error(...args) {
     if (window.console) console.error('[MEL Location]', ...args);
   }
-  
-  // Always log critical initialization info
-  if (window.console && !SETTINGS.provider && !SETTINGS.debug) {
-    console.warn('[MEL Location] SETTINGS.provider is not set. Provider:', SETTINGS.provider, 'Full SETTINGS:', SETTINGS);
-  }
+
+  // Always log critical initialization info.
+  (function () {
+    const SETTINGS = getSettings();
+    if (window.console && !SETTINGS.provider && !SETTINGS.debug) {
+      console.warn('[MEL Location] SETTINGS.provider is not set. Provider:', SETTINGS.provider, 'Full SETTINGS:', SETTINGS);
+    }
+  })();
 
   /**
    * ------------------------------------------------------------------------
@@ -809,7 +816,7 @@
   }
 
   function setupGoogleAutocomplete(searchInput, form, widgetRoot) {
-    const apiKey = SETTINGS.google_maps_api_key;
+    const apiKey = getSettings().google_maps_api_key;
     if (!apiKey) {
       error('Google provider selected but SETTINGS.google_maps_api_key missing.');
       return;
@@ -977,9 +984,14 @@
   }
 
   function setupAppleAutocomplete(searchInput, form, widgetRoot) {
+    const SETTINGS = getSettings();
     const token = SETTINGS.apple_maps_token;
     if (!token) {
-      error('Apple provider selected but SETTINGS.apple_maps_token missing.');
+      error('Apple provider selected but SETTINGS.apple_maps_token missing.', SETTINGS);
+      return;
+    }
+
+    if (searchInput.dataset.melAutocompleteAttached === '1' || searchInput.dataset.melAppleAttached === '1') {
       return;
     }
 
@@ -989,8 +1001,9 @@
 
         if (searchInput.dataset.melAppleAttached === '1') return;
         searchInput.dataset.melAppleAttached = '1';
+        searchInput.dataset.melAutocompleteAttached = '1';
 
-        // Simple suggestion dropdown
+        // Simple suggestion dropdown.
         const wrapper = searchInput.parentElement;
         if (!wrapper) return;
 
@@ -998,6 +1011,7 @@
 
         const list = document.createElement('div');
         list.className = 'myeventlane-location-suggestions';
+        list.setAttribute('role', 'listbox');
         list.style.cssText = 'position:absolute;left:0;right:0;top:100%;background:#fff;border:1px solid #ccc;max-height:240px;overflow:auto;z-index:1000;display:none;';
         wrapper.appendChild(list);
 
@@ -1006,6 +1020,7 @@
             new mapkit.Coordinate(-25.2744, 133.7751),
             new mapkit.CoordinateSpan(40, 40)
           ),
+          getsUserLocation: false,
         });
 
         let t = null;
@@ -1020,7 +1035,13 @@
           clearTimeout(t);
           t = setTimeout(() => {
             searchService.search(q, (err, data) => {
-              if (err || !data || !data.places) {
+              if (err) {
+                error('Apple MapKit search failed', err);
+                list.style.display = 'none';
+                list.innerHTML = '';
+                return;
+              }
+              if (!data || !data.places) {
                 list.style.display = 'none';
                 list.innerHTML = '';
                 return;
@@ -1030,14 +1051,16 @@
               const places = data.places.slice(0, 6);
               for (const p of places) {
                 const item = document.createElement('div');
+                item.setAttribute('role', 'option');
                 item.style.cssText = 'padding:10px;border-bottom:1px solid #eee;cursor:pointer;';
                 item.textContent = p.name + (p.formattedAddressLines ? ' — ' + p.formattedAddressLines.join(', ') : '');
                 item.addEventListener('click', () => {
                   list.style.display = 'none';
                   list.innerHTML = '';
-                  searchInput.value = p.name;
-
                   const comps = extractAppleComponents(p);
+                  const formatted = p.formattedAddressLines ? p.formattedAddressLines.join(', ') : '';
+                  searchInput.value = formatted || p.name || '';
+
                   const lat = p.coordinate ? p.coordinate.latitude : null;
                   const lng = p.coordinate ? p.coordinate.longitude : null;
 
@@ -1053,7 +1076,7 @@
                     populateVenueAddress(form, comps);
                   }
 
-                  // Dispatch custom event for venue-selection.js to handle venue-specific logic
+                  // Event Studio + venue-selection listeners.
                   const placeSelectedEvent = new CustomEvent('place_selected', {
                     detail: {
                       place: p,
@@ -1130,7 +1153,7 @@
     if (!isVisible(input)) {
       return;
     }
-    const provider = SETTINGS.provider || 'google_maps';
+    const provider = getSettings().provider || 'google_maps';
     if (provider === 'google_maps') {
       setupGoogleAutocomplete(input, form, null);
     }
@@ -1188,7 +1211,7 @@
     // Set default country to AU if empty.
     ensureDefaultCountry(form, widgetRoot);
 
-    const provider = SETTINGS.provider || 'google_maps';
+    const provider = getSettings().provider || 'google_maps';
 
     log('Initializing provider:', provider, 'Form:', form);
 
@@ -1209,7 +1232,7 @@
   Drupal.behaviors.myeventlaneLocationAutocomplete = {
     attach(context) {
       log('Drupal.behaviors.myeventlaneLocationAutocomplete.attach called, context:', context);
-      log('SETTINGS:', SETTINGS);
+      log('SETTINGS:', getSettings());
       
       // Target forms that contain our address search field OR field_location wrapper.
       const candidates = [];

--- a/web/modules/custom/myeventlane_location/myeventlane_location.services.yml
+++ b/web/modules/custom/myeventlane_location/myeventlane_location.services.yml
@@ -5,6 +5,7 @@ services:
     arguments:
       - '@config.factory'
       - '@logger.factory'
+      - '@myeventlane_location.mapkit_token_generator'
 
   # MapKit token generator - generates JWT tokens for Apple Maps.
   myeventlane_location.mapkit_token_generator:

--- a/web/modules/custom/myeventlane_location/src/Service/LocationProviderManager.php
+++ b/web/modules/custom/myeventlane_location/src/Service/LocationProviderManager.php
@@ -15,17 +15,18 @@ final class LocationProviderManager {
 
   /**
    * The config factory.
-   *
-   * @var \Drupal\Core\Config\ConfigFactoryInterface
    */
   private ConfigFactoryInterface $configFactory;
 
   /**
    * The logger channel.
-   *
-   * @var \Drupal\Core\Logger\LoggerChannelInterface
    */
   private LoggerChannelInterface $logger;
+
+  /**
+   * MapKit JWT token generator.
+   */
+  private MapKitTokenGenerator $tokenGenerator;
 
   /**
    * Constructs a LocationProviderManager.
@@ -34,13 +35,17 @@ final class LocationProviderManager {
    *   The config factory.
    * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
    *   The logger factory.
+   * @param \Drupal\myeventlane_location\Service\MapKitTokenGenerator $token_generator
+   *   MapKit JWT token generator.
    */
   public function __construct(
     ConfigFactoryInterface $config_factory,
     LoggerChannelFactoryInterface $logger_factory,
+    MapKitTokenGenerator $token_generator,
   ) {
     $this->configFactory = $config_factory;
     $this->logger = $logger_factory->get('myeventlane_location');
+    $this->tokenGenerator = $token_generator;
   }
 
   /**
@@ -145,8 +150,11 @@ final class LocationProviderManager {
   /**
    * Gets public-safe settings for frontend JavaScript.
    *
+   * For Apple Maps this includes a short-lived MapKit JWT. The private key is
+   * never exposed to the browser.
+   *
    * @return array
-   *   An array with provider and public API keys (never private keys).
+   *   An array with provider and public API keys / tokens.
    */
   public function getFrontendSettings(): array {
     $provider = $this->getDefaultProvider();
@@ -158,10 +166,16 @@ final class LocationProviderManager {
       $settings['google_maps_api_key'] = $this->getGoogleMapsApiKey();
     }
     elseif ($provider === 'apple_maps') {
-      // For Apple Maps, we only expose Team ID and Key ID.
-      // The JWT token is generated server-side.
+      // Team/Key IDs are non-secret identifiers; JWT is required by MapKit JS.
       $settings['apple_maps_team_id'] = $this->getAppleMapsTeamId();
       $settings['apple_maps_key_id'] = $this->getAppleMapsKeyId();
+      $token = $this->tokenGenerator->generateToken();
+      if ($token !== '') {
+        $settings['apple_maps_token'] = $token;
+      }
+      else {
+        $this->logger->warning('Apple Maps is the default provider but MapKit JWT generation returned an empty token.');
+      }
     }
 
     return $settings;


### PR DESCRIPTION
## Summary

<!-- What changed and why (organiser outcome, not only technical delta). -->

## Zone map (Event Workspace — required before screenshots)

<!-- Required for any PR that changes Event Workspace / organiser Workspace UI.
     Remove only for PRs with zero Workspace UI impact (state N/A + rationale). -->

```text
Identity:   <!-- Where am I? -->
Guidance:   <!-- What should I do next? (one recommendation or omit) -->
Work:       <!-- How do I do it? -->
Outcome:    <!-- What happened? (or omit) -->
```

**Zone Gate:** If you cannot produce this map, the page has not been designed yet.  
Authority: `docs/design/vendor-studio-visual/07-workspace-zones.md`

## Vendor Studio Design System References

<!-- Required for any PR that changes Vendor Studio / organiser console experience or `docs/design/vendor-studio/`.
     Remove this section only for PRs with zero Vendor Studio impact. -->

This implementation follows:

- <!-- e.g. docs/design/vendor-studio-visual/07-workspace-zones.md -->
- <!-- e.g. docs/design/vendor-studio-visual/03-option-b5.md -->
- <!-- e.g. 02-information-architecture.md -->
- <!-- e.g. 05-component-library.md -->
- <!-- e.g. 11-design-tokens.md -->
- <!-- e.g. 16-design-review-checklist.md -->
- <!-- e.g. 21-definition-of-done.md -->
- <!-- e.g. ADR-0001 -->
- <!-- e.g. DDR-003 -->

**Build order:** PDS → Workspace Zones → Visual Language B.5 → Component Catalogue → Implementation  
**PDS home:** `docs/design/vendor-studio/` (Vendor Studio Product Design System v1.0 — FROZEN)

Please also apply the GitHub label: `design-system`

## Definition of Done / checklist

- [ ] Zone Gate map present (or N/A with rationale)
- [ ] Applicable gates in `docs/design/vendor-studio/21-definition-of-done.md`
- [ ] `docs/design/vendor-studio/16-design-review-checklist.md` completed (or N/A with rationale)
- [ ] No contradiction of higher-order PDS docs ([ADR-0001](../docs/design/vendor-studio/decisions/ADR-0001-design-authority.md))

## Test plan

- [ ] <!-- Manual / automated checks -->

## Risk

<!-- Access, Commerce, payments, cache, PII — or "None" -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 02d71f939e0e911f36811ca3a3caad6873a69e69. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->