### PR TITLE
Capture organiser brand images in Media

### DIFF
--- a/config/sync/core.entity_form_display.myeventlane_vendor.myeventlane_vendor.default.yml
+++ b/config/sync/core.entity_form_display.myeventlane_vendor.myeventlane_vendor.default.yml
@@ -11,6 +11,9 @@ dependencies:
     - field.field.myeventlane_vendor.myeventlane_vendor.field_description
     - field.field.myeventlane_vendor.myeventlane_vendor.field_email
     - field.field.myeventlane_vendor.myeventlane_vendor.field_logo_image
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_mel_vendor_banner_media
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_mel_vendor_email_media
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_mel_vendor_logo_media
     - field.field.myeventlane_vendor.myeventlane_vendor.field_msg_accent_color
     - field.field.myeventlane_vendor.myeventlane_vendor.field_msg_footer
     - field.field.myeventlane_vendor.myeventlane_vendor.field_msg_from_email
@@ -41,6 +44,7 @@ dependencies:
   module:
     - image
     - link
+    - media_library
     - myeventlane_vendor
     - path
     - telephone
@@ -79,13 +83,13 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  field_banner_image:
-    type: image_image
+  field_mel_vendor_banner_media:
+    type: media_library_widget
     weight: 7
     region: content
     settings:
-      progress_indicator: throbber
-      preview_image_style: thumbnail
+      media_types:
+        - image
     third_party_settings: {  }
   field_business_name:
     type: string_textfield
@@ -111,13 +115,21 @@ content:
       placeholder: ''
       size: 60
     third_party_settings: {  }
-  field_logo_image:
-    type: image_image
+  field_mel_vendor_email_media:
+    type: media_library_widget
     weight: 8
     region: content
     settings:
-      progress_indicator: throbber
-      preview_image_style: thumbnail
+      media_types:
+        - image
+    third_party_settings: {  }
+  field_mel_vendor_logo_media:
+    type: media_library_widget
+    weight: 6
+    region: content
+    settings:
+      media_types:
+        - image
     third_party_settings: {  }
   field_owner:
     type: entity_reference_autocomplete
@@ -207,12 +219,14 @@ content:
       placeholder: ''
     third_party_settings: {  }
 hidden:
+  field_banner_image: true
   field_accent_colour: true
   field_msg_accent_color: true
   field_msg_footer: true
   field_msg_from_email: true
   field_msg_from_name: true
   field_msg_logo: true
+  field_logo_image: true
   field_msg_reply_to: true
   field_pref_email_digest: true
   field_pref_email_on_order: true

--- a/config/sync/core.entity_view_display.myeventlane_vendor.myeventlane_vendor.default.yml
+++ b/config/sync/core.entity_view_display.myeventlane_vendor.myeventlane_vendor.default.yml
@@ -11,6 +11,9 @@ dependencies:
     - field.field.myeventlane_vendor.myeventlane_vendor.field_description
     - field.field.myeventlane_vendor.myeventlane_vendor.field_email
     - field.field.myeventlane_vendor.myeventlane_vendor.field_logo_image
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_mel_vendor_banner_media
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_mel_vendor_email_media
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_mel_vendor_logo_media
     - field.field.myeventlane_vendor.myeventlane_vendor.field_msg_accent_color
     - field.field.myeventlane_vendor.myeventlane_vendor.field_msg_footer
     - field.field.myeventlane_vendor.myeventlane_vendor.field_msg_from_email
@@ -169,6 +172,9 @@ hidden:
   field_msg_from_email: true
   field_msg_from_name: true
   field_msg_logo: true
+  field_mel_vendor_banner_media: true
+  field_mel_vendor_email_media: true
+  field_mel_vendor_logo_media: true
   field_msg_reply_to: true
   field_owner: true
   field_pref_email_digest: true

--- a/config/sync/field.field.myeventlane_vendor.myeventlane_vendor.field_mel_vendor_banner_media.yml
+++ b/config/sync/field.field.myeventlane_vendor.myeventlane_vendor.field_mel_vendor_banner_media.yml
@@ -1,0 +1,30 @@
+uuid: 7e309331-3fb0-4b2a-b1f1-c679b4dff342
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.myeventlane_vendor.field_mel_vendor_banner_media
+    - media.type.image
+  module:
+    - media
+id: myeventlane_vendor.myeventlane_vendor.field_mel_vendor_banner_media
+field_name: field_mel_vendor_banner_media
+entity_type: myeventlane_vendor
+bundle: myeventlane_vendor
+label: 'Organiser banner'
+description: 'Reusable organiser banner captured in Media Library. The retained direct-file field remains available for rollback.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.myeventlane_vendor.myeventlane_vendor.field_mel_vendor_email_media.yml
+++ b/config/sync/field.field.myeventlane_vendor.myeventlane_vendor.field_mel_vendor_email_media.yml
@@ -1,0 +1,30 @@
+uuid: 44bf3562-7b10-43e7-961e-a50836d25f97
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.myeventlane_vendor.field_mel_vendor_email_media
+    - media.type.image
+  module:
+    - media
+id: myeventlane_vendor.myeventlane_vendor.field_mel_vendor_email_media
+field_name: field_mel_vendor_email_media
+entity_type: myeventlane_vendor
+bundle: myeventlane_vendor
+label: 'Email logo override'
+description: 'Optional reusable email logo. When empty, messages use the organiser logo.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.myeventlane_vendor.myeventlane_vendor.field_mel_vendor_logo_media.yml
+++ b/config/sync/field.field.myeventlane_vendor.myeventlane_vendor.field_mel_vendor_logo_media.yml
@@ -1,0 +1,30 @@
+uuid: 1c9118f2-cfe4-437a-80eb-c27eb14cd1ec
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.myeventlane_vendor.field_mel_vendor_logo_media
+    - media.type.image
+  module:
+    - media
+id: myeventlane_vendor.myeventlane_vendor.field_mel_vendor_logo_media
+field_name: field_mel_vendor_logo_media
+entity_type: myeventlane_vendor
+bundle: myeventlane_vendor
+label: 'Organiser logo'
+description: 'Reusable organiser logo captured in Media Library. The retained direct-file fields remain available for rollback.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.myeventlane_vendor.field_mel_vendor_banner_media.yml
+++ b/config/sync/field.storage.myeventlane_vendor.field_mel_vendor_banner_media.yml
@@ -1,0 +1,20 @@
+uuid: 65e70200-c0a5-462e-bd40-291d003a2b31
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - myeventlane_vendor
+id: myeventlane_vendor.field_mel_vendor_banner_media
+field_name: field_mel_vendor_banner_media
+entity_type: myeventlane_vendor
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.myeventlane_vendor.field_mel_vendor_email_media.yml
+++ b/config/sync/field.storage.myeventlane_vendor.field_mel_vendor_email_media.yml
@@ -1,0 +1,20 @@
+uuid: 2c0b583a-b960-4260-bc7b-bf9025d223e7
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - myeventlane_vendor
+id: myeventlane_vendor.field_mel_vendor_email_media
+field_name: field_mel_vendor_email_media
+entity_type: myeventlane_vendor
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.myeventlane_vendor.field_mel_vendor_logo_media.yml
+++ b/config/sync/field.storage.myeventlane_vendor.field_mel_vendor_logo_media.yml
@@ -1,0 +1,20 @@
+uuid: 9c1e8678-10a2-4073-b384-113d1cbedd64
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - myeventlane_vendor
+id: myeventlane_vendor.field_mel_vendor_logo_media
+field_name: field_mel_vendor_logo_media
+entity_type: myeventlane_vendor
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/myeventlane_messaging/myeventlane_messaging.services.yml
+++ b/web/modules/custom/myeventlane_messaging/myeventlane_messaging.services.yml
@@ -52,6 +52,7 @@ services:
       - '@config.factory'
       - '@myeventlane_vendor.current_vendor_resolver'
       - '@file_url_generator'
+      - '@myeventlane_vendor.brand_media_manager'
 
   myeventlane_messaging.utm_linker:
     class: Drupal\myeventlane_messaging\Service\UtmLinker

--- a/web/modules/custom/myeventlane_messaging/src/Form/VendorBrandingForm.php
+++ b/web/modules/custom/myeventlane_messaging/src/Form/VendorBrandingForm.php
@@ -14,6 +14,7 @@ use Drupal\file\FileInterface;
 use Drupal\myeventlane_vendor\Entity\Vendor;
 use Drupal\myeventlane_vendor\Service\CurrentVendorResolverInterface;
 use Drupal\myeventlane_vendor\Service\UserVendorMembershipQuery;
+use Drupal\myeventlane_vendor\Service\VendorBrandMediaManager;
 use Drupal\myeventlane_vendor\Service\VendorImageFieldPolicy;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -38,6 +39,7 @@ final class VendorBrandingForm extends FormBase {
     private readonly LoggerInterface $logger,
     private readonly CurrentVendorResolverInterface $vendorResolver,
     private readonly UserVendorMembershipQuery $userVendorMembershipQuery,
+    private readonly VendorBrandMediaManager $brandMediaManager,
   ) {}
 
   /**
@@ -51,6 +53,7 @@ final class VendorBrandingForm extends FormBase {
       $container->get('logger.channel.myeventlane_messaging'),
       $container->get('myeventlane_vendor.current_vendor_resolver'),
       $container->get('myeventlane_vendor.user_vendor_membership_query'),
+      $container->get('myeventlane_vendor.brand_media_manager'),
     );
   }
 
@@ -126,7 +129,11 @@ final class VendorBrandingForm extends FormBase {
     ];
 
     if ($form['logo_field_name']['#value'] !== '') {
-      $logo_default = $this->getManagedFileDefaultValue($vendor, $form['logo_field_name']['#value']);
+      $logo_default = $this->getManagedFileDefaultValue(
+        $vendor,
+        $form['logo_field_name']['#value'],
+        VendorBrandMediaManager::ASSET_EMAIL_LOGO,
+      );
       $form['branding']['logo_preview'] = $this->buildAssetPreview(
         $logo_default,
         (string) $this->t('@name logo preview', ['@name' => $vendor->label()]),
@@ -147,7 +154,11 @@ final class VendorBrandingForm extends FormBase {
     }
 
     if ($vendor->hasField('field_banner_image')) {
-      $banner_default = $this->getManagedFileDefaultValue($vendor, 'field_banner_image');
+      $banner_default = $this->getManagedFileDefaultValue(
+        $vendor,
+        'field_banner_image',
+        VendorBrandMediaManager::ASSET_BANNER,
+      );
       $form['branding']['banner_preview'] = $this->buildAssetPreview(
         $banner_default,
         (string) $this->t('@name banner preview', ['@name' => $vendor->label()]),
@@ -255,6 +266,11 @@ final class VendorBrandingForm extends FormBase {
       $this->saveManagedFileField($vendor, 'field_banner_image', $values['banner'] ?? [], 'banner');
       $this->savePrimaryColor($vendor, $values['primary_color'] ?? self::DEFAULT_PRIMARY_COLOR);
 
+      $this->brandMediaManager->synchroniseFromLegacy($vendor, [
+        VendorBrandMediaManager::ASSET_EMAIL_LOGO,
+        VendorBrandMediaManager::ASSET_BANNER,
+      ]);
+
       $vendor->save();
 
       $this->cacheTagsInvalidator->invalidateTags([
@@ -361,12 +377,24 @@ final class VendorBrandingForm extends FormBase {
   }
 
   /**
-   * Gets the managed_file default value for an entity reference field.
+   * Gets the Media-first managed_file default for a retained direct field.
+   *
+   * @param \Drupal\myeventlane_vendor\Entity\Vendor $vendor
+   *   The organiser whose asset is displayed.
+   * @param string $field_name
+   *   Retained direct-file field used when no Media reference exists.
+   * @param string $asset_type
+   *   Canonical Media asset type.
    *
    * @return array<int>
    *   File IDs for the managed file element.
    */
-  private function getManagedFileDefaultValue(Vendor $vendor, string $field_name): array {
+  private function getManagedFileDefaultValue(Vendor $vendor, string $field_name, string $asset_type): array {
+    $mediaFile = $this->brandMediaManager->fileForAsset($vendor, $asset_type);
+    if ($mediaFile !== NULL) {
+      return [(int) $mediaFile->id()];
+    }
+
     if ($field_name === '' || !$vendor->hasField($field_name) || $vendor->get($field_name)->isEmpty()) {
       return [];
     }
@@ -438,8 +466,14 @@ final class VendorBrandingForm extends FormBase {
   /**
    * Saves a managed_file field value and marks the file permanent.
    *
+   * @param \Drupal\myeventlane_vendor\Entity\Vendor $vendor
+   *   The organiser being updated.
+   * @param string $field_name
+   *   The retained direct-file field name.
    * @param array<mixed>|mixed $file_ids
    *   Managed file element value.
+   * @param string $asset_type
+   *   Asset label used for logging.
    */
   private function saveManagedFileField(Vendor $vendor, string $field_name, mixed $file_ids, string $asset_type): void {
     if ($field_name === '' || !$vendor->hasField($field_name)) {

--- a/web/modules/custom/myeventlane_messaging/src/Service/VendorBrandResolver.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/VendorBrandResolver.php
@@ -10,8 +10,8 @@ use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\file\FileInterface;
 use Drupal\myeventlane_messaging\ValueObject\Brand;
 use Drupal\myeventlane_vendor\Entity\Vendor;
+use Drupal\myeventlane_vendor\Service\VendorBrandMediaManager;
 use Drupal\myeventlane_vendor\Service\CurrentVendorResolverInterface;
-use Drupal\myeventlane_vendor\Service\VendorImageFieldPolicy;
 
 /**
  * Resolves vendor branding for messages from Vendor entity fields.
@@ -34,11 +34,14 @@ final class VendorBrandResolver implements BrandResolverInterface {
    *   The current vendor resolver.
    * @param \Drupal\Core\File\FileUrlGeneratorInterface $fileUrlGenerator
    *   The file URL generator.
+   * @param \Drupal\myeventlane_vendor\Service\VendorBrandMediaManager $brandMediaManager
+   *   Resolves canonical organiser Media with legacy fallback.
    */
   public function __construct(
     private readonly ConfigFactoryInterface $configFactory,
     private readonly CurrentVendorResolverInterface $vendorResolver,
     private readonly FileUrlGeneratorInterface $fileUrlGenerator,
+    private readonly VendorBrandMediaManager $brandMediaManager,
   ) {}
 
   /**
@@ -99,13 +102,7 @@ final class VendorBrandResolver implements BrandResolverInterface {
       $accentColor = Brand::DEFAULT_ACCENT_COLOR;
     }
 
-    $logoUrl = '';
-    foreach (VendorImageFieldPolicy::EMAIL_LOGO_FIELDS as $fieldName) {
-      $logoUrl = $this->getLogoUrl($vendor, $fieldName);
-      if ($logoUrl !== '') {
-        break;
-      }
-    }
+    $logoUrl = $this->getLogoUrl($vendor);
 
     return new Brand(
       fromName: $fromName,
@@ -161,22 +158,17 @@ final class VendorBrandResolver implements BrandResolverInterface {
   }
 
   /**
-   * Gets the logo URL from an image field.
+   * Gets the Media-first logo URL with retained direct-file fallback.
    *
    * @param \Drupal\myeventlane_vendor\Entity\Vendor $vendor
    *   The vendor entity.
-   * @param string $fieldName
-   *   The image field name.
    *
    * @return string
    *   Absolute URL to the logo, or empty string.
    */
-  private function getLogoUrl(Vendor $vendor, string $fieldName): string {
-    if (!$vendor->hasField($fieldName) || $vendor->get($fieldName)->isEmpty()) {
-      return '';
-    }
-
-    $file = $vendor->get($fieldName)->entity;
+  private function getLogoUrl(Vendor $vendor): string {
+    $file = $this->brandMediaManager->fileForAsset($vendor, VendorBrandMediaManager::ASSET_EMAIL_LOGO)
+      ?? $this->brandMediaManager->fileForAsset($vendor, VendorBrandMediaManager::ASSET_PUBLIC_LOGO);
     if (!$file instanceof FileInterface) {
       return '';
     }

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.info.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.info.yml
@@ -19,6 +19,7 @@ dependencies:
   - drupal:image
   - drupal:link
   - drupal:media
+  - drupal:media_library
   - drupal:user
   - drupal:views
   - drupal:field_ui

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.install
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.install
@@ -6,7 +6,11 @@
  */
 
 use Drupal\Core\Entity\Entity\EntityFormDisplay;
+use Drupal\Core\Utility\UpdateException;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\myeventlane_vendor\Entity\Vendor;
+use Drupal\myeventlane_vendor\Service\VendorBrandMediaManager;
 use Drupal\user\Entity\User;
 
 /**
@@ -1113,6 +1117,215 @@ function myeventlane_vendor_update_10022(): string {
   $role->save();
 
   return 'Removed the global Files overview permission from the Vendor role.';
+}
+
+/**
+ * Adds organiser brand Media fields and backfills retained direct images.
+ */
+function myeventlane_vendor_update_10023(array &$sandbox): string {
+  myeventlane_vendor_ensure_brand_media_fields();
+
+  $storage = \Drupal::entityTypeManager()->getStorage('myeventlane_vendor');
+  $manager = \Drupal::service('myeventlane_vendor.brand_media_manager');
+  assert($manager instanceof VendorBrandMediaManager);
+  $logger = \Drupal::logger('myeventlane_vendor');
+
+  if (!isset($sandbox['ids'])) {
+    $sandbox['ids'] = array_values($storage->getQuery()
+      ->accessCheck(FALSE)
+      ->sort('id')
+      ->execute());
+    $sandbox['index'] = 0;
+    $sandbox['migrated'] = 0;
+    $sandbox['created'] = 0;
+    $sandbox['reused'] = 0;
+    $sandbox['skipped'] = 0;
+    $sandbox['conflicts'] = 0;
+    $sandbox['errors'] = 0;
+  }
+
+  $assetTypes = [
+    VendorBrandMediaManager::ASSET_PUBLIC_LOGO,
+    VendorBrandMediaManager::ASSET_BANNER,
+    VendorBrandMediaManager::ASSET_EMAIL_LOGO,
+  ];
+  $total = count($sandbox['ids']);
+  $limit = min($sandbox['index'] + 20, $total);
+  while ($sandbox['index'] < $limit) {
+    $vendorId = (int) $sandbox['ids'][$sandbox['index']];
+    $sandbox['index']++;
+    $vendor = $storage->load($vendorId);
+    if (!$vendor instanceof Vendor) {
+      $sandbox['skipped']++;
+      continue;
+    }
+
+    $changed = FALSE;
+    foreach ($assetTypes as $assetType) {
+      $mediaField = match ($assetType) {
+        VendorBrandMediaManager::ASSET_PUBLIC_LOGO => 'field_mel_vendor_logo_media',
+        VendorBrandMediaManager::ASSET_BANNER => 'field_mel_vendor_banner_media',
+        VendorBrandMediaManager::ASSET_EMAIL_LOGO => 'field_mel_vendor_email_media',
+      };
+      if (!$vendor->hasField($mediaField) || !$vendor->get($mediaField)->isEmpty()) {
+        continue;
+      }
+
+      try {
+        $result = $manager->synchroniseFromLegacy($vendor, [$assetType], FALSE)[$assetType] ?? NULL;
+        if ($result === NULL) {
+          continue;
+        }
+        $changed = TRUE;
+        $sandbox[$result['created'] ? 'created' : 'reused']++;
+        if ($result['conflict']) {
+          $sandbox['conflicts']++;
+          $logger->warning(
+            'Organiser @vendor_id has different files in field_vendor_logo and field_logo_image. Backfill preserved both direct fields and selected field_vendor_logo for canonical Media.',
+            ['@vendor_id' => (string) $vendorId],
+          );
+        }
+      }
+      catch (\Throwable $e) {
+        $sandbox['errors']++;
+        $logger->error('Organiser brand Media backfill failed for organiser @vendor_id asset @asset: @message', [
+          '@vendor_id' => (string) $vendorId,
+          '@asset' => $assetType,
+          '@message' => $e->getMessage(),
+        ]);
+      }
+    }
+
+    if ($changed) {
+      try {
+        $vendor->save();
+        $sandbox['migrated']++;
+      }
+      catch (\Throwable $e) {
+        $sandbox['errors']++;
+        $logger->error('Organiser brand Media references could not be saved for organiser @vendor_id: @message', [
+          '@vendor_id' => (string) $vendorId,
+          '@message' => $e->getMessage(),
+        ]);
+      }
+    }
+    else {
+      $sandbox['skipped']++;
+    }
+  }
+
+  $sandbox['#finished'] = $total === 0 ? 1 : $sandbox['index'] / $total;
+  if ($sandbox['#finished'] < 1) {
+    return sprintf(
+      'Checked %d of %d organisers (%d Media created, %d reused, %d conflicts, %d errors).',
+      $sandbox['index'],
+      $total,
+      $sandbox['created'],
+      $sandbox['reused'],
+      $sandbox['conflicts'],
+      $sandbox['errors'],
+    );
+  }
+
+  if ($sandbox['errors'] > 0) {
+    throw new UpdateException(sprintf(
+      'Organiser brand Media backfill stopped with %d errors. No legacy fields were deleted; review the myeventlane_vendor log and rerun updates.',
+      $sandbox['errors'],
+    ));
+  }
+
+  return sprintf(
+    'Organiser brand Media backfill complete: %d organiser records updated, %d Media created, %d reused, %d skipped, %d legacy-logo conflicts reported, %d errors.',
+    $sandbox['migrated'],
+    $sandbox['created'],
+    $sandbox['reused'],
+    $sandbox['skipped'],
+    $sandbox['conflicts'],
+    $sandbox['errors'],
+  );
+}
+
+/**
+ * Ensures brand Media fields exist before deployment config import runs.
+ */
+function myeventlane_vendor_ensure_brand_media_fields(): void {
+  $fields = [
+    'field_mel_vendor_logo_media' => [
+      'storage_uuid' => '9c1e8678-10a2-4073-b384-113d1cbedd64',
+      'field_uuid' => '1c9118f2-cfe4-437a-80eb-c27eb14cd1ec',
+      'label' => 'Organiser logo',
+      'description' => 'Reusable organiser logo captured in Media Library. The retained direct-file fields remain available for rollback.',
+      'weight' => 6,
+    ],
+    'field_mel_vendor_banner_media' => [
+      'storage_uuid' => '65e70200-c0a5-462e-bd40-291d003a2b31',
+      'field_uuid' => '7e309331-3fb0-4b2a-b1f1-c679b4dff342',
+      'label' => 'Organiser banner',
+      'description' => 'Reusable organiser banner captured in Media Library. The retained direct-file field remains available for rollback.',
+      'weight' => 7,
+    ],
+    'field_mel_vendor_email_media' => [
+      'storage_uuid' => '2c0b583a-b960-4260-bc7b-bf9025d223e7',
+      'field_uuid' => '44bf3562-7b10-43e7-961e-a50836d25f97',
+      'label' => 'Email logo override',
+      'description' => 'Optional reusable email logo. When empty, messages use the organiser logo.',
+      'weight' => 8,
+    ],
+  ];
+
+  foreach ($fields as $fieldName => $definition) {
+    if (FieldStorageConfig::loadByName('myeventlane_vendor', $fieldName) === NULL) {
+      FieldStorageConfig::create([
+        'uuid' => $definition['storage_uuid'],
+        'field_name' => $fieldName,
+        'entity_type' => 'myeventlane_vendor',
+        'type' => 'entity_reference',
+        'settings' => ['target_type' => 'media'],
+        'cardinality' => 1,
+        'translatable' => FALSE,
+      ])->save();
+    }
+
+    if (FieldConfig::loadByName('myeventlane_vendor', 'myeventlane_vendor', $fieldName) === NULL) {
+      FieldConfig::create([
+        'uuid' => $definition['field_uuid'],
+        'field_name' => $fieldName,
+        'entity_type' => 'myeventlane_vendor',
+        'bundle' => 'myeventlane_vendor',
+        'label' => $definition['label'],
+        'description' => $definition['description'],
+        'required' => FALSE,
+        'translatable' => FALSE,
+        'settings' => [
+          'handler' => 'default:media',
+          'handler_settings' => [
+            'target_bundles' => ['image' => 'image'],
+            'sort' => ['field' => '_none', 'direction' => 'ASC'],
+            'auto_create' => FALSE,
+            'auto_create_bundle' => '',
+          ],
+        ],
+      ])->save();
+    }
+  }
+
+  $display = EntityFormDisplay::load('myeventlane_vendor.myeventlane_vendor.default');
+  if ($display !== NULL) {
+    foreach ($fields as $fieldName => $definition) {
+      $display->setComponent($fieldName, [
+        'type' => 'media_library_widget',
+        'weight' => $definition['weight'],
+        'region' => 'content',
+        'settings' => ['media_types' => ['image']],
+      ]);
+    }
+    foreach (['field_vendor_logo', 'field_logo_image', 'field_banner_image', 'field_msg_logo'] as $legacyField) {
+      $display->removeComponent($legacyField);
+    }
+    $display->save();
+  }
+
+  \Drupal::entityTypeManager()->clearCachedDefinitions();
 }
 
 /**

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.install
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.install
@@ -1141,6 +1141,7 @@ function myeventlane_vendor_update_10023(array &$sandbox): string {
     $sandbox['reused'] = 0;
     $sandbox['skipped'] = 0;
     $sandbox['conflicts'] = 0;
+    $sandbox['unsupported'] = 0;
     $sandbox['errors'] = 0;
   }
 
@@ -1174,6 +1175,10 @@ function myeventlane_vendor_update_10023(array &$sandbox): string {
       try {
         $result = $manager->synchroniseFromLegacy($vendor, [$assetType], FALSE)[$assetType] ?? NULL;
         if ($result === NULL) {
+          continue;
+        }
+        if (($result['status'] ?? '') === 'unsupported') {
+          $sandbox['unsupported']++;
           continue;
         }
         $changed = TRUE;
@@ -1217,11 +1222,12 @@ function myeventlane_vendor_update_10023(array &$sandbox): string {
   $sandbox['#finished'] = $total === 0 ? 1 : $sandbox['index'] / $total;
   if ($sandbox['#finished'] < 1) {
     return sprintf(
-      'Checked %d of %d organisers (%d Media created, %d reused, %d conflicts, %d errors).',
+      'Checked %d of %d organisers (%d Media created, %d reused, %d unsupported legacy files retained, %d conflicts, %d errors).',
       $sandbox['index'],
       $total,
       $sandbox['created'],
       $sandbox['reused'],
+      $sandbox['unsupported'],
       $sandbox['conflicts'],
       $sandbox['errors'],
     );
@@ -1235,11 +1241,12 @@ function myeventlane_vendor_update_10023(array &$sandbox): string {
   }
 
   return sprintf(
-    'Organiser brand Media backfill complete: %d organiser records updated, %d Media created, %d reused, %d skipped, %d legacy-logo conflicts reported, %d errors.',
+    'Organiser brand Media backfill complete: %d organiser records updated, %d Media created, %d reused, %d skipped, %d unsupported legacy files retained, %d legacy-logo conflicts reported, %d errors.',
     $sandbox['migrated'],
     $sandbox['created'],
     $sandbox['reused'],
     $sandbox['skipped'],
+    $sandbox['unsupported'],
     $sandbox['conflicts'],
     $sandbox['errors'],
   );

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -47,6 +47,7 @@ services:
       - '@datetime.time'
       - '@current_user'
       - '@myeventlane_core.vendor_follow'
+      - '@myeventlane_vendor.brand_media_manager'
 
   myeventlane_vendor.user_vendor_membership_query:
     class: Drupal\myeventlane_vendor\Service\UserVendorMembershipQuery
@@ -58,6 +59,12 @@ services:
     class: Drupal\myeventlane_vendor\Service\OrganiserMediaAccess
     arguments:
       - '@current_user'
+
+  myeventlane_vendor.brand_media_manager:
+    class: Drupal\myeventlane_vendor\Service\VendorBrandMediaManager
+    arguments:
+      - '@entity_type.manager'
+      - '@file_system'
 
   myeventlane_vendor.event_studio_create:
     class: Drupal\myeventlane_vendor\Service\VendorEventStudioCreateService

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -65,6 +65,7 @@ services:
     arguments:
       - '@entity_type.manager'
       - '@file_system'
+      - '@logger.channel.myeventlane_vendor'
 
   myeventlane_vendor.event_studio_create:
     class: Drupal\myeventlane_vendor\Service\VendorEventStudioCreateService

--- a/web/modules/custom/myeventlane_vendor/src/Controller/VendorDetailController.php
+++ b/web/modules/custom/myeventlane_vendor/src/Controller/VendorDetailController.php
@@ -83,7 +83,9 @@ final class VendorDetailController extends ControllerBase {
       '#content' => $content,
       '#label' => $myeventlane_vendor->label(),
       '#vendor_id' => (int) $myeventlane_vendor->id(),
-      '#banner' => $content['field_banner_image'] ?? NULL,
+      '#banner' => $this->canShowVisibilitySetting($myeventlane_vendor, 'field_public_show_banner')
+        ? $this->vendorCardBuilder->buildBanner($myeventlane_vendor)
+        : NULL,
       '#logo' => $this->vendorCardBuilder->buildLogo($myeventlane_vendor),
       '#tagline' => $this->vendorCardBuilder->fieldText($myeventlane_vendor, ['field_tagline', 'field_summary']),
       '#description' => $content['field_vendor_bio'] ?? $content['field_description'] ?? NULL,
@@ -180,6 +182,15 @@ final class VendorDetailController extends ControllerBase {
     }
 
     return !$vendor->get($visibility_field)->isEmpty() && (bool) $vendor->get($visibility_field)->value;
+  }
+
+  /**
+   * Checks a public visibility toggle for a Media-first logical asset.
+   */
+  private function canShowVisibilitySetting(Vendor $vendor, string $visibilityField): bool {
+    return $vendor->hasField($visibilityField)
+      && !$vendor->get($visibilityField)->isEmpty()
+      && (bool) $vendor->get($visibilityField)->value;
   }
 
   /**

--- a/web/modules/custom/myeventlane_vendor/src/Exception/UnsupportedBrandMediaFileException.php
+++ b/web/modules/custom/myeventlane_vendor/src/Exception/UnsupportedBrandMediaFileException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_vendor\Exception;
+
+/**
+ * Indicates that a retained brand image cannot be captured as Image Media.
+ */
+final class UnsupportedBrandMediaFileException extends \RuntimeException {
+
+}

--- a/web/modules/custom/myeventlane_vendor/src/Form/VendorBrandingForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/VendorBrandingForm.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\myeventlane_vendor\Entity\Vendor;
+use Drupal\myeventlane_vendor\Service\VendorBrandMediaManager;
 use Drupal\myeventlane_vendor\Service\VendorImageFieldPolicy;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -22,11 +23,17 @@ final class VendorBrandingForm extends FormBase {
   protected EntityTypeManagerInterface $entityTypeManager;
 
   /**
+   * Captures retained direct files as reusable organiser Media.
+   */
+  protected VendorBrandMediaManager $brandMediaManager;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container): static {
     $instance = new static();
     $instance->entityTypeManager = $container->get('entity_type.manager');
+    $instance->brandMediaManager = $container->get('myeventlane_vendor.brand_media_manager');
     return $instance;
   }
 
@@ -58,10 +65,8 @@ final class VendorBrandingForm extends FormBase {
     // Logo field.
     $logo_field = VendorImageFieldPolicy::canonicalPublicLogoField($vendor);
     if ($logo_field !== '') {
-      $existing_logo_fid = NULL;
-      if ($vendor->hasField($logo_field) && !$vendor->get($logo_field)->isEmpty()) {
-        $existing_logo_fid = $vendor->get($logo_field)->target_id;
-      }
+      $existing_logo_fid = $this->brandMediaManager
+        ->fileForAsset($vendor, VendorBrandMediaManager::ASSET_PUBLIC_LOGO)?->id();
 
       $form['logo'] = [
         '#type' => 'managed_file',
@@ -69,7 +74,7 @@ final class VendorBrandingForm extends FormBase {
         '#default_value' => $existing_logo_fid ? [$existing_logo_fid] : [],
         '#upload_location' => 'public://vendor-assets/',
         '#upload_validators' => [
-          'FileExtension' => ['extensions' => 'png jpg jpeg gif svg webp'],
+          'FileExtension' => ['extensions' => 'png jpg jpeg gif webp'],
           'FileImageDimensions' => ['maxDimensions' => '2000x2000', 'minDimensions' => '100x100'],
         ],
         '#description' => $this->t('Your organisation logo. Recommended size: 400x400px. Square format works best.'),
@@ -82,10 +87,8 @@ final class VendorBrandingForm extends FormBase {
 
     // Banner image field.
     if ($vendor->hasField('field_banner_image')) {
-      $existing_banner_fid = NULL;
-      if (!$vendor->get('field_banner_image')->isEmpty()) {
-        $existing_banner_fid = $vendor->get('field_banner_image')->target_id;
-      }
+      $existing_banner_fid = $this->brandMediaManager
+        ->fileForAsset($vendor, VendorBrandMediaManager::ASSET_BANNER)?->id();
 
       $form['banner'] = [
         '#type' => 'managed_file',
@@ -180,7 +183,12 @@ final class VendorBrandingForm extends FormBase {
       }
     }
 
-    // Save the vendor.
+    $this->brandMediaManager->synchroniseFromLegacy($vendor, [
+      VendorBrandMediaManager::ASSET_PUBLIC_LOGO,
+      VendorBrandMediaManager::ASSET_BANNER,
+    ]);
+
+    // Save the direct-file rollback fields and canonical Media references.
     $vendor->save();
 
     // Redirect to next step.

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorBrandMediaManager.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorBrandMediaManager.php
@@ -1,0 +1,289 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_vendor\Service;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\file\FileInterface;
+use Drupal\media\MediaInterface;
+use Drupal\media\MediaTypeInterface;
+use Drupal\myeventlane_vendor\Entity\Vendor;
+
+/**
+ * Captures and resolves organiser brand images as reusable Image Media.
+ */
+final class VendorBrandMediaManager {
+
+  public const ASSET_PUBLIC_LOGO = 'public_logo';
+
+  public const ASSET_BANNER = 'banner';
+
+  public const ASSET_EMAIL_LOGO = 'email_logo';
+
+  /**
+   * Canonical Media fields and their legacy direct-file sources.
+   */
+  private const ASSET_FIELDS = [
+    self::ASSET_PUBLIC_LOGO => [
+      'media' => VendorImageFieldPolicy::PUBLIC_LOGO_MEDIA_FIELD,
+      'legacy' => VendorImageFieldPolicy::PUBLIC_LOGO_FIELDS,
+      'label' => 'organiser logo',
+    ],
+    self::ASSET_BANNER => [
+      'media' => VendorImageFieldPolicy::BANNER_MEDIA_FIELD,
+      'legacy' => ['field_banner_image'],
+      'label' => 'organiser banner',
+    ],
+    self::ASSET_EMAIL_LOGO => [
+      'media' => VendorImageFieldPolicy::EMAIL_LOGO_MEDIA_FIELD,
+      'legacy' => ['field_msg_logo'],
+      'label' => 'email logo',
+    ],
+  ];
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly FileSystemInterface $fileSystem,
+  ) {}
+
+  /**
+   * Captures one legacy organiser asset as owner-scoped Image Media.
+   *
+   * @return array{media: \Drupal\media\MediaInterface, created: bool, source_field: string, conflict: bool}
+   *   Capture result and provenance details.
+   */
+  public function capture(Vendor $vendor, string $assetType): array {
+    $definition = $this->assetDefinition($assetType);
+    $source = $this->legacySource($vendor, $assetType);
+    if ($source === NULL) {
+      throw new \InvalidArgumentException(sprintf('A legacy %s image is required.', $definition['label']));
+    }
+
+    $imageValue = $source['items']->first()?->getValue() ?? [];
+    $fid = (int) ($imageValue['target_id'] ?? 0);
+    $file = $fid > 0
+      ? $this->entityTypeManager->getStorage('file')->load($fid)
+      : NULL;
+    if (!$file instanceof FileInterface) {
+      throw new \RuntimeException(sprintf('%s file %d could not be loaded.', ucfirst($definition['label']), $fid));
+    }
+
+    $realpath = $this->fileSystem->realpath($file->getFileUri());
+    if ($realpath === FALSE || !is_file($realpath)) {
+      throw new \RuntimeException(sprintf('%s file %d is missing from storage.', ucfirst($definition['label']), $fid));
+    }
+
+    [$mediaType, $sourceField] = $this->imageMediaSource();
+    $this->assertAllowedExtension($file, $sourceField);
+
+    $ownerId = max(0, (int) $vendor->getOwnerId());
+    $mediaStorage = $this->entityTypeManager->getStorage('media');
+    $existing = $mediaStorage->loadByProperties([
+      'bundle' => $mediaType->id(),
+      'uid' => $ownerId,
+      $sourceField . '.target_id' => $fid,
+    ]);
+    $media = $existing ? reset($existing) : NULL;
+    if ($media instanceof MediaInterface) {
+      return [
+        'media' => $media,
+        'created' => FALSE,
+        'source_field' => $source['field'],
+        'conflict' => $source['conflict'],
+      ];
+    }
+
+    if ($file->isTemporary()) {
+      $file->setPermanent();
+      $file->save();
+    }
+
+    $vendorLabel = trim((string) $vendor->label());
+    $alt = trim((string) ($imageValue['alt'] ?? ''));
+    if ($alt === '') {
+      $alt = trim($vendorLabel . ' ' . $definition['label']);
+    }
+    if ($alt === '') {
+      $alt = $file->getFilename();
+    }
+
+    $media = $mediaStorage->create([
+      'bundle' => $mediaType->id(),
+      'uid' => $ownerId,
+      'name' => trim($vendorLabel . ' ' . $definition['label']),
+      $sourceField => [
+        'target_id' => $fid,
+        'alt' => $alt,
+        'title' => (string) ($imageValue['title'] ?? ''),
+      ],
+    ]);
+    if (!$media instanceof MediaInterface) {
+      throw new \RuntimeException(sprintf('The %s Image Media item could not be created.', $definition['label']));
+    }
+    $media->save();
+
+    return [
+      'media' => $media,
+      'created' => TRUE,
+      'source_field' => $source['field'],
+      'conflict' => $source['conflict'],
+    ];
+  }
+
+  /**
+   * Synchronises selected Media fields from the retained legacy forms.
+   *
+   * @param \Drupal\myeventlane_vendor\Entity\Vendor $vendor
+   *   The organiser whose direct fields were edited.
+   * @param string[] $assetTypes
+   *   Asset constants to synchronise.
+   * @param bool $clearWhenEmpty
+   *   Clear the Media reference when the corresponding form cleared its file.
+   *
+   * @return array<string, array{media: \Drupal\media\MediaInterface, created: bool, source_field: string, conflict: bool}|null>
+   *   Results keyed by asset type; NULL means the reference was cleared/empty.
+   */
+  public function synchroniseFromLegacy(Vendor $vendor, array $assetTypes, bool $clearWhenEmpty = TRUE): array {
+    $results = [];
+    foreach ($assetTypes as $assetType) {
+      $definition = $this->assetDefinition($assetType);
+      $mediaField = $definition['media'];
+      if (!$vendor->hasField($mediaField)) {
+        continue;
+      }
+
+      if ($this->legacySource($vendor, $assetType) === NULL) {
+        if ($clearWhenEmpty) {
+          $vendor->set($mediaField, []);
+        }
+        $results[$assetType] = NULL;
+        continue;
+      }
+
+      $capture = $this->capture($vendor, $assetType);
+      $vendor->set($mediaField, [['target_id' => (int) $capture['media']->id()]]);
+      $results[$assetType] = $capture;
+    }
+
+    return $results;
+  }
+
+  /**
+   * Resolves the Media-first image field items for rendering.
+   */
+  public function imageItemsForAsset(ContentEntityInterface $vendor, string $assetType): ?FieldItemListInterface {
+    $definition = $this->assetDefinition($assetType);
+    $mediaField = $definition['media'];
+    if ($vendor->hasField($mediaField) && !$vendor->get($mediaField)->isEmpty()) {
+      $media = $vendor->get($mediaField)->entity;
+      if ($media instanceof MediaInterface) {
+        [, $sourceField] = $this->imageMediaSource();
+        if ($media->hasField($sourceField) && !$media->get($sourceField)->isEmpty()) {
+          return $media->get($sourceField);
+        }
+      }
+    }
+
+    $source = $this->legacySource($vendor, $assetType);
+    return $source['items'] ?? NULL;
+  }
+
+  /**
+   * Resolves the Media-first file entity for URLs and non-render consumers.
+   */
+  public function fileForAsset(ContentEntityInterface $vendor, string $assetType): ?FileInterface {
+    $items = $this->imageItemsForAsset($vendor, $assetType);
+    $file = $items?->entity;
+    return $file instanceof FileInterface ? $file : NULL;
+  }
+
+  /**
+   * Returns a validated asset definition.
+   *
+   * @return array{media: string, legacy: string[], label: string}
+   *   Canonical field names and a human-readable asset label.
+   */
+  private function assetDefinition(string $assetType): array {
+    if (!isset(self::ASSET_FIELDS[$assetType])) {
+      throw new \InvalidArgumentException(sprintf('Unknown organiser brand asset type "%s".', $assetType));
+    }
+    return self::ASSET_FIELDS[$assetType];
+  }
+
+  /**
+   * Finds the preferred direct-file source and detects duplicate-logo drift.
+   *
+   * @return array{field: string, items: \Drupal\Core\Field\FieldItemListInterface, conflict: bool}|null
+   *   The preferred source and conflict state, or NULL when no source exists.
+   */
+  private function legacySource(ContentEntityInterface $vendor, string $assetType): ?array {
+    $definition = $this->assetDefinition($assetType);
+    $populated = [];
+    foreach ($definition['legacy'] as $fieldName) {
+      if ($vendor->hasField($fieldName) && !$vendor->get($fieldName)->isEmpty()) {
+        $populated[$fieldName] = $vendor->get($fieldName);
+      }
+    }
+    if ($populated === []) {
+      return NULL;
+    }
+
+    $firstField = array_key_first($populated);
+    $firstItems = $populated[$firstField];
+    $fileIds = [];
+    foreach ($populated as $items) {
+      $fileIds[] = (int) ($items->target_id ?? 0);
+    }
+
+    return [
+      'field' => $firstField,
+      'items' => $firstItems,
+      'conflict' => count(array_unique(array_filter($fileIds))) > 1,
+    ];
+  }
+
+  /**
+   * Loads the Image media type and its source field.
+   *
+   * @return array{\Drupal\media\MediaTypeInterface, string}
+   *   The Image media type and its configured source field name.
+   */
+  private function imageMediaSource(): array {
+    $mediaType = $this->entityTypeManager->getStorage('media_type')->load('image');
+    if (!$mediaType instanceof MediaTypeInterface) {
+      throw new \RuntimeException('The Image media type is not available.');
+    }
+    $sourceField = (string) ($mediaType->getSource()->getConfiguration()['source_field'] ?? '');
+    if ($sourceField === '') {
+      throw new \RuntimeException('The Image media source field is not configured.');
+    }
+    return [$mediaType, $sourceField];
+  }
+
+  /**
+   * Prevents Media creation with formats rejected by the Image media bundle.
+   */
+  private function assertAllowedExtension(FileInterface $file, string $sourceField): void {
+    $field = $this->entityTypeManager->getStorage('field_config')->load('media.image.' . $sourceField);
+    $extensions = $field?->getSetting('file_extensions');
+    if (!is_string($extensions) || trim($extensions) === '') {
+      return;
+    }
+
+    $extension = strtolower((string) pathinfo($file->getFilename(), PATHINFO_EXTENSION));
+    $allowed = preg_split('/\s+/', strtolower(trim($extensions))) ?: [];
+    if ($extension === '' || !in_array($extension, $allowed, TRUE)) {
+      throw new \RuntimeException(sprintf(
+        'File %d uses .%s, which the Image media type does not allow (%s).',
+        (int) $file->id(),
+        $extension !== '' ? $extension : 'unknown',
+        implode(', ', $allowed),
+      ));
+    }
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorBrandMediaManager.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorBrandMediaManager.php
@@ -12,6 +12,8 @@ use Drupal\file\FileInterface;
 use Drupal\media\MediaInterface;
 use Drupal\media\MediaTypeInterface;
 use Drupal\myeventlane_vendor\Entity\Vendor;
+use Drupal\myeventlane_vendor\Exception\UnsupportedBrandMediaFileException;
+use Psr\Log\LoggerInterface;
 
 /**
  * Captures and resolves organiser brand images as reusable Image Media.
@@ -48,12 +50,13 @@ final class VendorBrandMediaManager {
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly FileSystemInterface $fileSystem,
+    private readonly LoggerInterface $logger,
   ) {}
 
   /**
    * Captures one legacy organiser asset as owner-scoped Image Media.
    *
-   * @return array{media: \Drupal\media\MediaInterface, created: bool, source_field: string, conflict: bool}
+   * @return array{status: 'captured', media: \Drupal\media\MediaInterface, created: bool, source_field: string, conflict: bool}
    *   Capture result and provenance details.
    */
   public function capture(Vendor $vendor, string $assetType): array {
@@ -90,6 +93,7 @@ final class VendorBrandMediaManager {
     $media = $existing ? reset($existing) : NULL;
     if ($media instanceof MediaInterface) {
       return [
+        'status' => 'captured',
         'media' => $media,
         'created' => FALSE,
         'source_field' => $source['field'],
@@ -127,6 +131,7 @@ final class VendorBrandMediaManager {
     $media->save();
 
     return [
+      'status' => 'captured',
       'media' => $media,
       'created' => TRUE,
       'source_field' => $source['field'],
@@ -144,8 +149,9 @@ final class VendorBrandMediaManager {
    * @param bool $clearWhenEmpty
    *   Clear the Media reference when the corresponding form cleared its file.
    *
-   * @return array<string, array{media: \Drupal\media\MediaInterface, created: bool, source_field: string, conflict: bool}|null>
-   *   Results keyed by asset type; NULL means the reference was cleared/empty.
+   * @return array<string, array{status: 'captured', media: \Drupal\media\MediaInterface, created: bool, source_field: string, conflict: bool}|array{status: 'unsupported', source_field: string, reason: string}|null>
+   *   Results keyed by asset type. Unsupported files retain their legacy
+   *   fallback; NULL means the reference was cleared/empty.
    */
   public function synchroniseFromLegacy(Vendor $vendor, array $assetTypes, bool $clearWhenEmpty = TRUE): array {
     $results = [];
@@ -156,7 +162,8 @@ final class VendorBrandMediaManager {
         continue;
       }
 
-      if ($this->legacySource($vendor, $assetType) === NULL) {
+      $legacySource = $this->legacySource($vendor, $assetType);
+      if ($legacySource === NULL) {
         if ($clearWhenEmpty) {
           $vendor->set($mediaField, []);
         }
@@ -164,7 +171,26 @@ final class VendorBrandMediaManager {
         continue;
       }
 
-      $capture = $this->capture($vendor, $assetType);
+      try {
+        $capture = $this->capture($vendor, $assetType);
+      }
+      catch (UnsupportedBrandMediaFileException $e) {
+        $this->logger->warning(
+          'Organiser @vendor_id legacy @asset in @field was retained without Media capture: @message',
+          [
+            '@vendor_id' => (string) $vendor->id(),
+            '@asset' => $definition['label'],
+            '@field' => $legacySource['field'],
+            '@message' => $e->getMessage(),
+          ],
+        );
+        $results[$assetType] = [
+          'status' => 'unsupported',
+          'source_field' => $legacySource['field'],
+          'reason' => $e->getMessage(),
+        ];
+        continue;
+      }
       $vendor->set($mediaField, [['target_id' => (int) $capture['media']->id()]]);
       $results[$assetType] = $capture;
     }
@@ -277,7 +303,7 @@ final class VendorBrandMediaManager {
     $extension = strtolower((string) pathinfo($file->getFilename(), PATHINFO_EXTENSION));
     $allowed = preg_split('/\s+/', strtolower(trim($extensions))) ?: [];
     if ($extension === '' || !in_array($extension, $allowed, TRUE)) {
-      throw new \RuntimeException(sprintf(
+      throw new UnsupportedBrandMediaFileException(sprintf(
         'File %d uses .%s, which the Image media type does not allow (%s).',
         (int) $file->id(),
         $extension !== '' ? $extension : 'unknown',

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorCardBuilder.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorCardBuilder.php
@@ -44,6 +44,7 @@ final class VendorCardBuilder {
     private readonly TimeInterface $time,
     private readonly AccountProxyInterface $currentUser,
     private readonly VendorFollowService $vendorFollowService,
+    private readonly VendorBrandMediaManager $brandMediaManager,
   ) {}
 
   /**
@@ -79,7 +80,10 @@ final class VendorCardBuilder {
   }
 
   /**
+   * Builds follow-control data for an organiser card.
+   *
    * @return array<string, mixed>
+   *   Template variables for the follow control.
    */
   private function buildVendorFollowVariables(Vendor $vendor): array {
     $vid = (int) $vendor->id();
@@ -220,17 +224,40 @@ final class VendorCardBuilder {
   }
 
   /**
-   * Builds the organiser logo render array using the canonical logo image style.
+   * Builds the organiser logo with Media-first direct-file fallback.
    *
    * @return array|null
    *   A render array, or NULL when no logo exists.
    */
   public function buildLogo(EntityInterface $entity): ?array {
-    return $this->buildStyledImage(
-      $entity,
-      VendorImageFieldPolicy::PUBLIC_LOGO_FIELDS,
-      self::LOGO_IMAGE_STYLE,
-    );
+    if (!$entity instanceof Vendor) {
+      return $this->buildStyledImage($entity, VendorImageFieldPolicy::PUBLIC_LOGO_FIELDS, self::LOGO_IMAGE_STYLE);
+    }
+
+    $items = $this->brandMediaManager->imageItemsForAsset($entity, VendorBrandMediaManager::ASSET_PUBLIC_LOGO);
+    return $items?->view([
+      'type' => 'image',
+      'label' => 'hidden',
+      'settings' => [
+        'image_style' => self::LOGO_IMAGE_STYLE,
+        'image_link' => '',
+      ],
+    ]);
+  }
+
+  /**
+   * Builds the organiser banner with Media-first legacy fallback.
+   */
+  public function buildBanner(Vendor $vendor): ?array {
+    $items = $this->brandMediaManager->imageItemsForAsset($vendor, VendorBrandMediaManager::ASSET_BANNER);
+    return $items?->view([
+      'type' => 'image',
+      'label' => 'hidden',
+      'settings' => [
+        'image_style' => 'large',
+        'image_link' => '',
+      ],
+    ]);
   }
 
   /**
@@ -245,12 +272,14 @@ final class VendorCardBuilder {
       return NULL;
     }
 
+    if ($entity instanceof Vendor) {
+      $file = $this->brandMediaManager->fileForAsset($entity, VendorBrandMediaManager::ASSET_PUBLIC_LOGO);
+      return $file !== NULL ? $style->buildUrl($file->getFileUri()) : NULL;
+    }
+
     foreach (VendorImageFieldPolicy::PUBLIC_LOGO_FIELDS as $field_name) {
-      if ($entity->hasField($field_name) && !$entity->get($field_name)->isEmpty()) {
-        $file = $entity->get($field_name)->entity;
-        if ($file !== NULL) {
-          return $style->buildUrl($file->getFileUri());
-        }
+      if ($entity->hasField($field_name) && !$entity->get($field_name)->isEmpty() && $entity->get($field_name)->entity !== NULL) {
+        return $style->buildUrl($entity->get($field_name)->entity->getFileUri());
       }
     }
 

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorImageFieldPolicy.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorImageFieldPolicy.php
@@ -11,6 +11,12 @@ use Drupal\Core\Entity\ContentEntityInterface;
  */
 final class VendorImageFieldPolicy {
 
+  public const PUBLIC_LOGO_MEDIA_FIELD = 'field_mel_vendor_logo_media';
+
+  public const BANNER_MEDIA_FIELD = 'field_mel_vendor_banner_media';
+
+  public const EMAIL_LOGO_MEDIA_FIELD = 'field_mel_vendor_email_media';
+
   public const PUBLIC_LOGO_FIELDS = [
     'field_vendor_logo',
     'field_logo_image',
@@ -26,6 +32,12 @@ final class VendorImageFieldPolicy {
    * Returns the canonical public logo field, with legacy schema fallback.
    */
   public static function canonicalPublicLogoField(ContentEntityInterface $vendor): string {
+    foreach (self::PUBLIC_LOGO_FIELDS as $fieldName) {
+      if ($vendor->hasField($fieldName) && !$vendor->get($fieldName)->isEmpty()) {
+        return $fieldName;
+      }
+    }
+
     foreach (self::PUBLIC_LOGO_FIELDS as $fieldName) {
       if ($vendor->hasField($fieldName)) {
         return $fieldName;

--- a/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorBrandMediaBackfillContractTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorBrandMediaBackfillContractTest.php
@@ -51,6 +51,8 @@ final class VendorBrandMediaBackfillContractTest extends UnitTestCase {
     self::assertStringContainsString('myeventlane_vendor_update_10023', $update);
     self::assertStringContainsString('synchroniseFromLegacy($vendor, [$assetType], FALSE)', $update);
     self::assertStringContainsString('throw new UpdateException', $update);
+    self::assertStringContainsString("\$sandbox['unsupported']", $update);
+    self::assertStringContainsString('unsupported legacy files retained', $update);
     self::assertStringContainsString('legacy-logo conflicts reported', $update);
     foreach (['field_vendor_logo', 'field_logo_image', 'field_banner_image', 'field_msg_logo'] as $legacyField) {
       self::assertStringNotContainsString("delete('{$legacyField}')", $update);

--- a/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorBrandMediaBackfillContractTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorBrandMediaBackfillContractTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_vendor\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Protects organiser brand Media capture, backfill, and fallback contracts.
+ */
+#[Group('myeventlane_vendor')]
+final class VendorBrandMediaBackfillContractTest extends UnitTestCase {
+
+  /**
+   * The canonical model has three Image Media references and admin widgets.
+   */
+  public function testThreeCanonicalMediaFieldsAndAdminWidgets(): void {
+    $root = dirname(__DIR__, 7);
+    $fieldNames = [
+      'field_mel_vendor_logo_media',
+      'field_mel_vendor_banner_media',
+      'field_mel_vendor_email_media',
+    ];
+
+    foreach ($fieldNames as $fieldName) {
+      $storage = file_get_contents($root . '/config/sync/field.storage.myeventlane_vendor.' . $fieldName . '.yml');
+      $field = file_get_contents($root . '/config/sync/field.field.myeventlane_vendor.myeventlane_vendor.' . $fieldName . '.yml');
+      self::assertIsString($storage);
+      self::assertIsString($field);
+      self::assertStringContainsString('target_type: media', $storage);
+      self::assertStringContainsString('image: image', $field);
+    }
+
+    $display = file_get_contents($root . '/config/sync/core.entity_form_display.myeventlane_vendor.myeventlane_vendor.default.yml');
+    self::assertIsString($display);
+    self::assertSame(3, substr_count($display, 'type: media_library_widget'));
+    foreach (['field_vendor_logo', 'field_logo_image', 'field_banner_image', 'field_msg_logo'] as $legacyField) {
+      self::assertStringContainsString($legacyField . ': true', $display);
+    }
+  }
+
+  /**
+   * Backfill reports errors and retains every direct-file rollback source.
+   */
+  public function testBackfillIsFailClosedAndPreservesEveryLegacyField(): void {
+    $module = dirname(__DIR__, 3);
+    $update = file_get_contents($module . '/myeventlane_vendor.install');
+    self::assertIsString($update);
+    self::assertStringContainsString('myeventlane_vendor_update_10023', $update);
+    self::assertStringContainsString('synchroniseFromLegacy($vendor, [$assetType], FALSE)', $update);
+    self::assertStringContainsString('throw new UpdateException', $update);
+    self::assertStringContainsString('legacy-logo conflicts reported', $update);
+    foreach (['field_vendor_logo', 'field_logo_image', 'field_banner_image', 'field_msg_logo'] as $legacyField) {
+      self::assertStringNotContainsString("delete('{$legacyField}')", $update);
+      self::assertStringNotContainsString("set('{$legacyField}', [])", $update);
+    }
+  }
+
+  /**
+   * All write and read paths delegate to one Media provenance service.
+   */
+  public function testSaveAndRenderPathsUseTheCentralMediaManager(): void {
+    $paths = [
+      $module = dirname(__DIR__, 3) . '/src/Form/VendorBrandingForm.php',
+      dirname(__DIR__, 7) . '/web/modules/custom/myeventlane_vendor_settings/src/Form/VendorSettingsForm.php',
+      dirname(__DIR__, 7) . '/web/modules/custom/myeventlane_messaging/src/Form/VendorBrandingForm.php',
+      dirname(__DIR__, 3) . '/src/Service/VendorCardBuilder.php',
+      dirname(__DIR__, 7) . '/web/modules/custom/myeventlane_messaging/src/Service/VendorBrandResolver.php',
+    ];
+    foreach ($paths as $path) {
+      $contents = file_get_contents($path);
+      self::assertIsString($contents);
+      self::assertStringContainsString('VendorBrandMediaManager', $contents, $path);
+    }
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorBrandMediaCompatibilityTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorBrandMediaCompatibilityTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_vendor\Unit;
+
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Field\FieldItemInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\field\FieldConfigInterface;
+use Drupal\file\FileInterface;
+use Drupal\media\MediaSourceInterface;
+use Drupal\media\MediaTypeInterface;
+use Drupal\myeventlane_vendor\Entity\Vendor;
+use Drupal\myeventlane_vendor\Service\VendorBrandMediaManager;
+use Drupal\myeventlane_vendor\Service\VendorImageFieldPolicy;
+use Drupal\Tests\UnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests compatibility handling for retained organiser brand images.
+ */
+#[Group('myeventlane_vendor')]
+final class VendorBrandMediaCompatibilityTest extends UnitTestCase {
+
+  /**
+   * An unsupported legacy SVG is retained without clearing Media or throwing.
+   */
+  public function testUnsupportedLegacySvgIsReportedAndRetained(): void {
+    $temporaryPath = tempnam(sys_get_temp_dir(), 'mel-brand-media-');
+    self::assertIsString($temporaryPath);
+
+    try {
+      $item = $this->createMock(FieldItemInterface::class);
+      $item->method('getValue')->willReturn(['target_id' => 41, 'alt' => 'Legacy logo']);
+
+      $legacyItems = $this->createMock(FieldItemListInterface::class);
+      $legacyItems->method('isEmpty')->willReturn(FALSE);
+      $legacyItems->method('first')->willReturn($item);
+      $legacyItems->method('__get')->with('target_id')->willReturn(41);
+
+      $vendor = $this->createMock(Vendor::class);
+      $vendor->method('id')->willReturn(7);
+      $vendor->method('hasField')->willReturnCallback(static fn(string $field): bool => in_array($field, [
+        VendorImageFieldPolicy::PUBLIC_LOGO_MEDIA_FIELD,
+        'field_vendor_logo',
+      ], TRUE));
+      $vendor->method('get')->with('field_vendor_logo')->willReturn($legacyItems);
+      $vendor->expects(self::never())->method('set');
+
+      $file = $this->createMock(FileInterface::class);
+      $file->method('id')->willReturn(41);
+      $file->method('getFilename')->willReturn('legacy-logo.svg');
+      $file->method('getFileUri')->willReturn('public://vendor_logos/legacy-logo.svg');
+
+      $fileStorage = $this->createMock(EntityStorageInterface::class);
+      $fileStorage->method('load')->with(41)->willReturn($file);
+
+      $mediaSource = $this->createMock(MediaSourceInterface::class);
+      $mediaSource->method('getConfiguration')->willReturn(['source_field' => 'field_media_image']);
+
+      $mediaType = $this->createMock(MediaTypeInterface::class);
+      $mediaType->method('getSource')->willReturn($mediaSource);
+
+      $mediaTypeStorage = $this->createMock(EntityStorageInterface::class);
+      $mediaTypeStorage->method('load')->with('image')->willReturn($mediaType);
+
+      $fieldConfig = $this->createMock(FieldConfigInterface::class);
+      $fieldConfig->method('getSetting')->with('file_extensions')->willReturn('png gif jpg jpeg webp');
+
+      $fieldConfigStorage = $this->createMock(EntityStorageInterface::class);
+      $fieldConfigStorage->method('load')->with('media.image.field_media_image')->willReturn($fieldConfig);
+
+      $entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+      $entityTypeManager->method('getStorage')->willReturnCallback(static fn(string $entityTypeId): EntityStorageInterface => match ($entityTypeId) {
+        'file' => $fileStorage,
+        'media_type' => $mediaTypeStorage,
+        'field_config' => $fieldConfigStorage,
+        default => throw new \LogicException('Unexpected storage: ' . $entityTypeId),
+      });
+
+      $fileSystem = $this->createMock(FileSystemInterface::class);
+      $fileSystem->method('realpath')->with('public://vendor_logos/legacy-logo.svg')->willReturn($temporaryPath);
+
+      $logger = $this->createMock(LoggerInterface::class);
+      $logger->expects(self::once())
+        ->method('warning')
+        ->with(
+          self::stringContains('retained without Media capture'),
+          self::callback(static fn(array $context): bool => $context['@vendor_id'] === '7'
+            && $context['@field'] === 'field_vendor_logo'
+            && str_contains($context['@message'], '.svg')),
+        );
+
+      $manager = new VendorBrandMediaManager($entityTypeManager, $fileSystem, $logger);
+      $result = $manager->synchroniseFromLegacy($vendor, [VendorBrandMediaManager::ASSET_PUBLIC_LOGO]);
+
+      self::assertSame('unsupported', $result[VendorBrandMediaManager::ASSET_PUBLIC_LOGO]['status']);
+      self::assertSame('field_vendor_logo', $result[VendorBrandMediaManager::ASSET_PUBLIC_LOGO]['source_field']);
+      self::assertStringContainsString('.svg', $result[VendorBrandMediaManager::ASSET_PUBLIC_LOGO]['reason']);
+    }
+    finally {
+      @unlink($temporaryPath);
+    }
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorImageFieldPolicyTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorImageFieldPolicyTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\myeventlane_vendor\Unit;
 
+require_once dirname(__DIR__, 3) . '/src/Service/VendorImageFieldPolicy.php';
+
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\myeventlane_vendor\Service\VendorImageFieldPolicy;
 use Drupal\Tests\UnitTestCase;
 
@@ -27,6 +30,9 @@ final class VendorImageFieldPolicyTest extends UnitTestCase {
         'field_msg_logo',
       ], TRUE),
     );
+    $empty = $this->createMock(FieldItemListInterface::class);
+    $empty->method('isEmpty')->willReturn(TRUE);
+    $vendor->method('get')->willReturn($empty);
 
     self::assertSame('field_vendor_logo', VendorImageFieldPolicy::canonicalPublicLogoField($vendor));
     self::assertSame('field_msg_logo', VendorImageFieldPolicy::emailOverrideField($vendor));
@@ -48,6 +54,27 @@ final class VendorImageFieldPolicyTest extends UnitTestCase {
     $vendor->method('hasField')->willReturnCallback(
       static fn(string $field): bool => $field === 'field_logo_image',
     );
+    $empty = $this->createMock(FieldItemListInterface::class);
+    $empty->method('isEmpty')->willReturn(TRUE);
+    $vendor->method('get')->willReturn($empty);
+
+    self::assertSame('field_logo_image', VendorImageFieldPolicy::canonicalPublicLogoField($vendor));
+  }
+
+  /**
+   * @covers ::canonicalPublicLogoField
+   */
+  public function testPopulatedLegacyLogoBeatsEmptyPreferredField(): void {
+    $vendor = $this->createMock(ContentEntityInterface::class);
+    $vendor->method('hasField')->willReturn(TRUE);
+    $empty = $this->createMock(FieldItemListInterface::class);
+    $empty->method('isEmpty')->willReturn(TRUE);
+    $populated = $this->createMock(FieldItemListInterface::class);
+    $populated->method('isEmpty')->willReturn(FALSE);
+    $vendor->method('get')->willReturnMap([
+      ['field_vendor_logo', $empty],
+      ['field_logo_image', $populated],
+    ]);
 
     self::assertSame('field_logo_image', VendorImageFieldPolicy::canonicalPublicLogoField($vendor));
   }

--- a/web/modules/custom/myeventlane_vendor_settings/src/Form/VendorSettingsForm.php
+++ b/web/modules/custom/myeventlane_vendor_settings/src/Form/VendorSettingsForm.php
@@ -21,6 +21,7 @@ use Drupal\myeventlane_vendor\EventSubscriber\VendorStoreSubscriber;
 use Drupal\myeventlane_vendor\Form\FormActionUrlFixer;
 use Drupal\myeventlane_vendor\Service\CurrentVendorResolverInterface;
 use Drupal\myeventlane_vendor\Service\UserVendorMembershipQuery;
+use Drupal\myeventlane_vendor\Service\VendorBrandMediaManager;
 use Drupal\myeventlane_vendor\Service\VendorImageFieldPolicy;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -71,6 +72,11 @@ class VendorSettingsForm extends FormBase {
   protected RouteProviderInterface $routeProvider;
 
   /**
+   * Captures retained direct files as reusable organiser Media.
+   */
+  protected VendorBrandMediaManager $brandMediaManager;
+
+  /**
    * Dedupes onboarding panel when MELWorkflowSystem already renders primary region.
    */
   protected ?MelWorkflowManager $melWorkflowManager = NULL;
@@ -93,6 +99,7 @@ class VendorSettingsForm extends FormBase {
     $instance->userVendorMembershipQuery = $container->get('myeventlane_vendor.user_vendor_membership_query');
     $instance->accessManager = $container->get('access_manager');
     $instance->routeProvider = $container->get('router.route_provider');
+    $instance->brandMediaManager = $container->get('myeventlane_vendor.brand_media_manager');
     $instance->melWorkflowManager = $container->has('myeventlane_surface.workflow_manager')
       ? $container->get('myeventlane_surface.workflow_manager')
       : NULL;
@@ -696,17 +703,16 @@ class VendorSettingsForm extends FormBase {
     $logo_field = VendorImageFieldPolicy::canonicalPublicLogoField($vendor);
 
     if ($logo_field !== '') {
-      $logo_default = [];
-      if (!$vendor->get($logo_field)->isEmpty()) {
-        $logo_default = [$vendor->get($logo_field)->target_id];
-      }
+      $logo_file = $this->brandMediaManager
+        ->fileForAsset($vendor, VendorBrandMediaManager::ASSET_PUBLIC_LOGO);
+      $logo_default = $logo_file !== NULL ? [(int) $logo_file->id()] : [];
       $form['visual_assets']['logo'] = [
         '#type' => 'managed_file',
         '#title' => $this->t('Logo'),
         '#default_value' => $logo_default,
         '#upload_location' => 'public://vendor-assets/',
         '#upload_validators' => [
-          'FileExtension' => ['extensions' => 'png jpg jpeg gif svg webp'],
+          'FileExtension' => ['extensions' => 'png jpg jpeg gif webp'],
           'FileSizeLimit' => ['fileLimit' => 5 * 1024 * 1024],
         ],
         '#description' => $this->t('Your organisation logo. Recommended size: 400×400px. Square format works best.'),
@@ -718,10 +724,9 @@ class VendorSettingsForm extends FormBase {
     }
 
     if ($vendor->hasField('field_banner_image')) {
-      $banner_default = [];
-      if (!$vendor->get('field_banner_image')->isEmpty()) {
-        $banner_default = [$vendor->get('field_banner_image')->target_id];
-      }
+      $banner_file = $this->brandMediaManager
+        ->fileForAsset($vendor, VendorBrandMediaManager::ASSET_BANNER);
+      $banner_default = $banner_file !== NULL ? [(int) $banner_file->id()] : [];
       $form['visual_assets']['banner'] = [
         '#type' => 'managed_file',
         '#title' => $this->t('Banner image'),
@@ -1890,6 +1895,10 @@ class VendorSettingsForm extends FormBase {
     }
 
     try {
+      $this->brandMediaManager->synchroniseFromLegacy($vendor, [
+        VendorBrandMediaManager::ASSET_PUBLIC_LOGO,
+        VendorBrandMediaManager::ASSET_BANNER,
+      ]);
       $vendor->save();
 
       $this->logger->notice('VendorSettingsForm SUBMIT SUCCESS vendor_id=@vid', [


### PR DESCRIPTION
## What changed

- adds organiser logo, banner and email-logo references to the Image Media bundle
- captures organiser uploads as organiser-owned reusable Media while retaining the existing direct image fields
- renders Media first with a legacy-field fallback
- adds an idempotent, fail-closed backfill update for existing organiser brand images
- keeps the organiser-facing forms unchanged while exposing the captured items through the Media Library

## Why

Organiser brand images need Media Library provenance and reuse without breaking current organiser workflows, public rendering or rollback. The legacy fields remain the source fallback until the Media migration is accepted in staging.

## Impact

- organisers continue managing branding through the existing profile and branding forms
- staff and administrators can access the captured Media items through their existing full-library access
- cross-organiser Media access rules remain unchanged
- no legacy field is deleted

## Deployment notes

This tranche requires the normal Drupal configuration import and database update. `myeventlane_vendor_update_10023` creates missing fields and backfills existing data in batches. It fails closed and reports errors rather than deleting or overwriting the retained legacy fields.

## Checks completed

- PHP syntax checks passed for all changed PHP files
- changed YAML files parsed successfully
- PHPUnit: 6 tests, 47 assertions passed
- staged diff whitespace check passed
- isolated-DDEV backfill completed with no errors
- second backfill run created no duplicate Media items
- Media ownership and source-file provenance matched organiser ownership and legacy files
- all three administrative fields use the Media Library widget
- organiser profile branding workflow passed visual acceptance
- targeted PHPStan still reports 19 pre-existing findings in older touched classes; none were reported in the new Media manager
- existing theme npm audit advisories remain; no package or lock files changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches branding across profile, messaging, and public pages plus a large batched update; legacy fields remain for rollback but wrong backfill or sync could mis-associate Media or leave inconsistent logo sources until rerun.
> 
> **Overview**
> Introduces **three Image Media references** on organisers (logo, banner, email logo) and a central **`VendorBrandMediaManager`** that creates owner-scoped Media from retained direct-file fields, resolves **Media-first with legacy fallback**, and handles unsupported formats (e.g. SVG) without wiping rollback data.
> 
> **Admin entity forms** switch logo/banner widgets to **Media Library** and hide the old direct image fields; **organiser profile, onboarding, and messaging branding forms** still use `managed_file` on legacy fields but default previews and saves go through the manager, with **`synchroniseFromLegacy`** after upload.
> 
> **Read paths** (public organiser page banner/logo, card builder, email **`VendorBrandResolver`**) now pull files via the manager instead of scanning legacy field lists.
> 
> **`myeventlane_vendor_update_10023`** ensures field config, batch-backfills empty Media refs from legacy files, logs conflicts/unsupported assets, and **fails closed** on errors without deleting legacy fields. Unit tests lock the backfill and compatibility contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e4ea37d76d0b2195d8d54847aa0877a79eb61aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->