### PR TITLE
Retain missing organiser brand references

### DIFF
--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.install
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.install
@@ -1142,6 +1142,7 @@ function myeventlane_vendor_update_10023(array &$sandbox): string {
     $sandbox['skipped'] = 0;
     $sandbox['conflicts'] = 0;
     $sandbox['unsupported'] = 0;
+    $sandbox['unavailable'] = 0;
     $sandbox['errors'] = 0;
   }
 
@@ -1177,8 +1178,9 @@ function myeventlane_vendor_update_10023(array &$sandbox): string {
         if ($result === NULL) {
           continue;
         }
-        if (($result['status'] ?? '') === 'unsupported') {
-          $sandbox['unsupported']++;
+        $status = $result['status'] ?? '';
+        if ($status === 'unsupported' || $status === 'unavailable') {
+          $sandbox[$status]++;
           continue;
         }
         $changed = TRUE;
@@ -1222,12 +1224,13 @@ function myeventlane_vendor_update_10023(array &$sandbox): string {
   $sandbox['#finished'] = $total === 0 ? 1 : $sandbox['index'] / $total;
   if ($sandbox['#finished'] < 1) {
     return sprintf(
-      'Checked %d of %d organisers (%d Media created, %d reused, %d unsupported legacy files retained, %d conflicts, %d errors).',
+      'Checked %d of %d organisers (%d Media created, %d reused, %d unsupported and %d unavailable legacy files retained, %d conflicts, %d errors).',
       $sandbox['index'],
       $total,
       $sandbox['created'],
       $sandbox['reused'],
       $sandbox['unsupported'],
+      $sandbox['unavailable'],
       $sandbox['conflicts'],
       $sandbox['errors'],
     );
@@ -1241,12 +1244,13 @@ function myeventlane_vendor_update_10023(array &$sandbox): string {
   }
 
   return sprintf(
-    'Organiser brand Media backfill complete: %d organiser records updated, %d Media created, %d reused, %d skipped, %d unsupported legacy files retained, %d legacy-logo conflicts reported, %d errors.',
+    'Organiser brand Media backfill complete: %d organiser records updated, %d Media created, %d reused, %d skipped, %d unsupported and %d unavailable legacy files retained, %d legacy-logo conflicts reported, %d errors.',
     $sandbox['migrated'],
     $sandbox['created'],
     $sandbox['reused'],
     $sandbox['skipped'],
     $sandbox['unsupported'],
+    $sandbox['unavailable'],
     $sandbox['conflicts'],
     $sandbox['errors'],
   );

--- a/web/modules/custom/myeventlane_vendor/src/Exception/UnavailableBrandMediaFileException.php
+++ b/web/modules/custom/myeventlane_vendor/src/Exception/UnavailableBrandMediaFileException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_vendor\Exception;
+
+/**
+ * Indicates that a retained brand image file is no longer available.
+ */
+final class UnavailableBrandMediaFileException extends \RuntimeException {
+
+}

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorBrandMediaManager.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorBrandMediaManager.php
@@ -12,6 +12,7 @@ use Drupal\file\FileInterface;
 use Drupal\media\MediaInterface;
 use Drupal\media\MediaTypeInterface;
 use Drupal\myeventlane_vendor\Entity\Vendor;
+use Drupal\myeventlane_vendor\Exception\UnavailableBrandMediaFileException;
 use Drupal\myeventlane_vendor\Exception\UnsupportedBrandMediaFileException;
 use Psr\Log\LoggerInterface;
 
@@ -72,12 +73,12 @@ final class VendorBrandMediaManager {
       ? $this->entityTypeManager->getStorage('file')->load($fid)
       : NULL;
     if (!$file instanceof FileInterface) {
-      throw new \RuntimeException(sprintf('%s file %d could not be loaded.', ucfirst($definition['label']), $fid));
+      throw new UnavailableBrandMediaFileException(sprintf('%s file %d could not be loaded.', ucfirst($definition['label']), $fid));
     }
 
     $realpath = $this->fileSystem->realpath($file->getFileUri());
     if ($realpath === FALSE || !is_file($realpath)) {
-      throw new \RuntimeException(sprintf('%s file %d is missing from storage.', ucfirst($definition['label']), $fid));
+      throw new UnavailableBrandMediaFileException(sprintf('%s file %d is missing from storage.', ucfirst($definition['label']), $fid));
     }
 
     [$mediaType, $sourceField] = $this->imageMediaSource();
@@ -149,9 +150,9 @@ final class VendorBrandMediaManager {
    * @param bool $clearWhenEmpty
    *   Clear the Media reference when the corresponding form cleared its file.
    *
-   * @return array<string, array{status: 'captured', media: \Drupal\media\MediaInterface, created: bool, source_field: string, conflict: bool}|array{status: 'unsupported', source_field: string, reason: string}|null>
-   *   Results keyed by asset type. Unsupported files retain their legacy
-   *   fallback; NULL means the reference was cleared/empty.
+   * @return array<string, array{status: 'captured', media: \Drupal\media\MediaInterface, created: bool, source_field: string, conflict: bool}|array{status: 'unsupported'|'unavailable', source_field: string, reason: string}|null>
+   *   Results keyed by asset type. Unsupported or unavailable files retain
+   *   their legacy reference; NULL means the reference was cleared/empty.
    */
   public function synchroniseFromLegacy(Vendor $vendor, array $assetTypes, bool $clearWhenEmpty = TRUE): array {
     $results = [];
@@ -174,18 +175,22 @@ final class VendorBrandMediaManager {
       try {
         $capture = $this->capture($vendor, $assetType);
       }
-      catch (UnsupportedBrandMediaFileException $e) {
+      catch (UnsupportedBrandMediaFileException | UnavailableBrandMediaFileException $e) {
+        $status = $e instanceof UnsupportedBrandMediaFileException
+          ? 'unsupported'
+          : 'unavailable';
         $this->logger->warning(
-          'Organiser @vendor_id legacy @asset in @field was retained without Media capture: @message',
+          'Organiser @vendor_id legacy @asset in @field was retained as @status without Media capture: @message',
           [
             '@vendor_id' => (string) $vendor->id(),
             '@asset' => $definition['label'],
             '@field' => $legacySource['field'],
+            '@status' => $status,
             '@message' => $e->getMessage(),
           ],
         );
         $results[$assetType] = [
-          'status' => 'unsupported',
+          'status' => $status,
           'source_field' => $legacySource['field'],
           'reason' => $e->getMessage(),
         ];

--- a/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorBrandMediaBackfillContractTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorBrandMediaBackfillContractTest.php
@@ -52,7 +52,8 @@ final class VendorBrandMediaBackfillContractTest extends UnitTestCase {
     self::assertStringContainsString('synchroniseFromLegacy($vendor, [$assetType], FALSE)', $update);
     self::assertStringContainsString('throw new UpdateException', $update);
     self::assertStringContainsString("\$sandbox['unsupported']", $update);
-    self::assertStringContainsString('unsupported legacy files retained', $update);
+    self::assertStringContainsString("\$sandbox['unavailable']", $update);
+    self::assertStringContainsString('unavailable legacy files retained', $update);
     self::assertStringContainsString('legacy-logo conflicts reported', $update);
     foreach (['field_vendor_logo', 'field_logo_image', 'field_banner_image', 'field_msg_logo'] as $legacyField) {
       self::assertStringNotContainsString("delete('{$legacyField}')", $update);

--- a/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorBrandMediaCompatibilityTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorBrandMediaCompatibilityTest.php
@@ -89,9 +89,10 @@ final class VendorBrandMediaCompatibilityTest extends UnitTestCase {
       $logger->expects(self::once())
         ->method('warning')
         ->with(
-          self::stringContains('retained without Media capture'),
+          self::stringContains('retained as @status without Media capture'),
           self::callback(static fn(array $context): bool => $context['@vendor_id'] === '7'
             && $context['@field'] === 'field_vendor_logo'
+            && $context['@status'] === 'unsupported'
             && str_contains($context['@message'], '.svg')),
         );
 
@@ -101,6 +102,117 @@ final class VendorBrandMediaCompatibilityTest extends UnitTestCase {
       self::assertSame('unsupported', $result[VendorBrandMediaManager::ASSET_PUBLIC_LOGO]['status']);
       self::assertSame('field_vendor_logo', $result[VendorBrandMediaManager::ASSET_PUBLIC_LOGO]['source_field']);
       self::assertStringContainsString('.svg', $result[VendorBrandMediaManager::ASSET_PUBLIC_LOGO]['reason']);
+    }
+    finally {
+      @unlink($temporaryPath);
+    }
+  }
+
+  /**
+   * A missing legacy file is retained without clearing Media or throwing.
+   */
+  public function testUnavailableLegacyFileIsReportedAndRetained(): void {
+    $item = $this->createMock(FieldItemInterface::class);
+    $item->method('getValue')->willReturn(['target_id' => 255, 'alt' => 'Missing logo']);
+
+    $legacyItems = $this->createMock(FieldItemListInterface::class);
+    $legacyItems->method('isEmpty')->willReturn(FALSE);
+    $legacyItems->method('first')->willReturn($item);
+    $legacyItems->method('__get')->with('target_id')->willReturn(255);
+
+    $vendor = $this->createMock(Vendor::class);
+    $vendor->method('id')->willReturn(1);
+    $vendor->method('hasField')->willReturnCallback(static fn(string $field): bool => in_array($field, [
+      VendorImageFieldPolicy::PUBLIC_LOGO_MEDIA_FIELD,
+      'field_vendor_logo',
+    ], TRUE));
+    $vendor->method('get')->with('field_vendor_logo')->willReturn($legacyItems);
+    $vendor->expects(self::never())->method('set');
+
+    $file = $this->createMock(FileInterface::class);
+    $file->method('id')->willReturn(255);
+    $file->method('getFileUri')->willReturn('public://vendor_logos/missing-logo.png');
+
+    $fileStorage = $this->createMock(EntityStorageInterface::class);
+    $fileStorage->method('load')->with(255)->willReturn($file);
+
+    $entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $entityTypeManager->method('getStorage')->with('file')->willReturn($fileStorage);
+
+    $fileSystem = $this->createMock(FileSystemInterface::class);
+    $fileSystem->method('realpath')->with('public://vendor_logos/missing-logo.png')->willReturn(FALSE);
+
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects(self::once())
+      ->method('warning')
+      ->with(
+        self::stringContains('retained as @status without Media capture'),
+        self::callback(static fn(array $context): bool => $context['@vendor_id'] === '1'
+          && $context['@field'] === 'field_vendor_logo'
+          && $context['@status'] === 'unavailable'
+          && str_contains($context['@message'], 'missing from storage')),
+      );
+
+    $manager = new VendorBrandMediaManager($entityTypeManager, $fileSystem, $logger);
+    $result = $manager->synchroniseFromLegacy($vendor, [VendorBrandMediaManager::ASSET_PUBLIC_LOGO]);
+
+    self::assertSame('unavailable', $result[VendorBrandMediaManager::ASSET_PUBLIC_LOGO]['status']);
+    self::assertSame('field_vendor_logo', $result[VendorBrandMediaManager::ASSET_PUBLIC_LOGO]['source_field']);
+    self::assertStringContainsString('missing from storage', $result[VendorBrandMediaManager::ASSET_PUBLIC_LOGO]['reason']);
+  }
+
+  /**
+   * A genuine Media configuration failure remains fail-closed.
+   */
+  public function testUnexpectedCaptureFailureStillEscapes(): void {
+    $temporaryPath = tempnam(sys_get_temp_dir(), 'mel-brand-media-');
+    self::assertIsString($temporaryPath);
+
+    try {
+      $item = $this->createMock(FieldItemInterface::class);
+      $item->method('getValue')->willReturn(['target_id' => 42, 'alt' => 'Valid logo']);
+
+      $legacyItems = $this->createMock(FieldItemListInterface::class);
+      $legacyItems->method('isEmpty')->willReturn(FALSE);
+      $legacyItems->method('first')->willReturn($item);
+      $legacyItems->method('__get')->with('target_id')->willReturn(42);
+
+      $vendor = $this->createMock(Vendor::class);
+      $vendor->method('hasField')->willReturnCallback(static fn(string $field): bool => in_array($field, [
+        VendorImageFieldPolicy::PUBLIC_LOGO_MEDIA_FIELD,
+        'field_vendor_logo',
+      ], TRUE));
+      $vendor->method('get')->with('field_vendor_logo')->willReturn($legacyItems);
+      $vendor->expects(self::never())->method('set');
+
+      $file = $this->createMock(FileInterface::class);
+      $file->method('id')->willReturn(42);
+      $file->method('getFileUri')->willReturn('public://vendor_logos/valid-logo.png');
+
+      $fileStorage = $this->createMock(EntityStorageInterface::class);
+      $fileStorage->method('load')->with(42)->willReturn($file);
+
+      $mediaTypeStorage = $this->createMock(EntityStorageInterface::class);
+      $mediaTypeStorage->method('load')->with('image')->willReturn(NULL);
+
+      $entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+      $entityTypeManager->method('getStorage')->willReturnCallback(static fn(string $entityTypeId): EntityStorageInterface => match ($entityTypeId) {
+        'file' => $fileStorage,
+        'media_type' => $mediaTypeStorage,
+        default => throw new \LogicException('Unexpected storage: ' . $entityTypeId),
+      });
+
+      $fileSystem = $this->createMock(FileSystemInterface::class);
+      $fileSystem->method('realpath')->with('public://vendor_logos/valid-logo.png')->willReturn($temporaryPath);
+
+      $logger = $this->createMock(LoggerInterface::class);
+      $logger->expects(self::never())->method('warning');
+
+      $manager = new VendorBrandMediaManager($entityTypeManager, $fileSystem, $logger);
+
+      $this->expectException(\RuntimeException::class);
+      $this->expectExceptionMessage('The Image media type is not available.');
+      $manager->synchroniseFromLegacy($vendor, [VendorBrandMediaManager::ASSET_PUBLIC_LOGO]);
     }
     finally {
       @unlink($temporaryPath);


### PR DESCRIPTION
## What changed

- distinguishes unavailable legacy organiser files from genuine Media migration failures
- retains missing file references without clearing or deleting legacy fields
- reports unavailable and unsupported assets separately in the organiser-brand backfill
- keeps Media configuration, database and entity-save failures fail-closed
- adds regression coverage for missing physical files and the fail-closed configuration boundary

## Root cause

Staging deployment run [#31062696532](https://github.com/anna-pye/myeventlane-platform/actions/runs/31062696532) reached `myeventlane_vendor_update_10023` and found six pre-existing legacy image references whose physical files were already missing from staging storage. The update correctly aborted and the release rolled back, but these stale references prevent every retry from completing.

## Impact

- unavailable legacy references remain intact for audit and possible recovery
- valid organiser images can continue into owner-scoped Image Media
- no file entity, legacy field or organiser reference is deleted
- unrelated runtime and migration failures still stop deployment

## Checks completed

- PHPUnit: 9 tests, 93 assertions passed
- PHP syntax checks passed
- Drupal and DrupalPractice coding standards passed
- targeted PHPStan passed
- staged diff whitespace and scope checks passed

## Deployment notes

The failed update remains pending and is idempotent. After this hotfix is reviewed and merged, the normal staging workflow should rerun database updates and configuration import. Staging currently remains on the previous healthy release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deployment-time organiser brand backfill behavior for stale file references; scope is bounded to legacy sync paths with explicit fail-closed boundaries for real configuration errors.
> 
> **Overview**
> Organiser brand Media migration now treats **missing or unloadable legacy image files** as an **`unavailable`** outcome (like unsupported formats), not a hard failure that aborts `myeventlane_vendor_update_10023`.
> 
> `VendorBrandMediaManager::capture()` raises **`UnavailableBrandMediaFileException`** when the file entity cannot be loaded or the path is missing on disk. **`synchroniseFromLegacy()`** catches that alongside unsupported files, logs a warning, returns status `unavailable` or `unsupported`, and **does not clear** legacy field references. Genuine problems (e.g. missing Image media type) still throw and remain **fail-closed** for the backfill.
> 
> The update hook adds **`$sandbox['unavailable']`** and reports unavailable vs unsupported counts in progress and completion messages. Unit tests cover unavailable retention, updated log wording, and that unexpected capture errors still escape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3152109dbc57cc32789db7cd99194a6029b2cda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->