### PR TITLE
Converge organiser display configuration

### DIFF
--- a/config/sync/core.entity_form_display.myeventlane_vendor.myeventlane_vendor.default.yml
+++ b/config/sync/core.entity_form_display.myeventlane_vendor.myeventlane_vendor.default.yml
@@ -83,14 +83,6 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  field_mel_vendor_banner_media:
-    type: media_library_widget
-    weight: 7
-    region: content
-    settings:
-      media_types:
-        - image
-    third_party_settings: {  }
   field_business_name:
     type: string_textfield
     weight: -9
@@ -114,6 +106,14 @@ content:
     settings:
       placeholder: ''
       size: 60
+    third_party_settings: {  }
+  field_mel_vendor_banner_media:
+    type: media_library_widget
+    weight: 7
+    region: content
+    settings:
+      media_types:
+        - image
     third_party_settings: {  }
   field_mel_vendor_email_media:
     type: media_library_widget
@@ -219,21 +219,27 @@ content:
       placeholder: ''
     third_party_settings: {  }
 hidden:
-  field_banner_image: true
   field_accent_colour: true
+  field_banner_image: true
+  field_logo_image: true
   field_msg_accent_color: true
   field_msg_footer: true
   field_msg_from_email: true
   field_msg_from_name: true
   field_msg_logo: true
-  field_logo_image: true
   field_msg_reply_to: true
   field_pref_email_digest: true
   field_pref_email_on_order: true
   field_pref_email_on_rsvp: true
+  field_public_profile_published: true
+  field_public_show_banner: true
+  field_public_show_description: true
   field_public_show_email: true
   field_public_show_location: true
   field_public_show_phone: true
+  field_public_show_social_links: true
+  field_public_show_summary: true
+  field_public_show_website: true
   field_tagline: true
   field_vendor_bio: true
   field_vendor_logo: true

--- a/config/sync/core.entity_view_display.myeventlane_vendor.myeventlane_vendor.default.yml
+++ b/config/sync/core.entity_view_display.myeventlane_vendor.myeventlane_vendor.default.yml
@@ -167,22 +167,28 @@ hidden:
   field_abn: true
   field_accent_colour: true
   field_business_name: true
+  field_mel_vendor_banner_media: true
+  field_mel_vendor_email_media: true
+  field_mel_vendor_logo_media: true
   field_msg_accent_color: true
   field_msg_footer: true
   field_msg_from_email: true
   field_msg_from_name: true
   field_msg_logo: true
-  field_mel_vendor_banner_media: true
-  field_mel_vendor_email_media: true
-  field_mel_vendor_logo_media: true
   field_msg_reply_to: true
   field_owner: true
   field_pref_email_digest: true
   field_pref_email_on_order: true
   field_pref_email_on_rsvp: true
+  field_public_profile_published: true
+  field_public_show_banner: true
+  field_public_show_description: true
   field_public_show_email: true
   field_public_show_location: true
   field_public_show_phone: true
+  field_public_show_social_links: true
+  field_public_show_summary: true
+  field_public_show_website: true
   field_tagline: true
   field_vendor_store: true
   field_vendor_terms_accepted_at: true

--- a/config/sync/core.entity_view_display.myeventlane_vendor.myeventlane_vendor.full.yml
+++ b/config/sync/core.entity_view_display.myeventlane_vendor.myeventlane_vendor.full.yml
@@ -85,6 +85,9 @@ hidden:
   field_description: true
   field_email: true
   field_logo_image: true
+  field_mel_vendor_banner_media: true
+  field_mel_vendor_email_media: true
+  field_mel_vendor_logo_media: true
   field_msg_accent_color: true
   field_msg_footer: true
   field_msg_from_email: true
@@ -96,9 +99,15 @@ hidden:
   field_pref_email_digest: true
   field_pref_email_on_order: true
   field_pref_email_on_rsvp: true
+  field_public_profile_published: true
+  field_public_show_banner: true
+  field_public_show_description: true
   field_public_show_email: true
   field_public_show_location: true
   field_public_show_phone: true
+  field_public_show_social_links: true
+  field_public_show_summary: true
+  field_public_show_website: true
   field_social_links: true
   field_summary: true
   field_tagline: true

--- a/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorBrandMediaBackfillContractTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorBrandMediaBackfillContractTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\myeventlane_vendor\Unit;
 
 use Drupal\Tests\UnitTestCase;
 use PHPUnit\Framework\Attributes\Group;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * Protects organiser brand Media capture, backfill, and fallback contracts.
@@ -38,6 +39,42 @@ final class VendorBrandMediaBackfillContractTest extends UnitTestCase {
     self::assertSame(3, substr_count($display, 'type: media_library_widget'));
     foreach (['field_vendor_logo', 'field_logo_image', 'field_banner_image', 'field_msg_logo'] as $legacyField) {
       self::assertStringContainsString($legacyField . ': true', $display);
+    }
+  }
+
+  /**
+   * Display config stays canonical after Drupal recalculates field visibility.
+   */
+  public function testVendorDisplaysIncludeAllHiddenPublicControlsInCanonicalOrder(): void {
+    $root = dirname(__DIR__, 7);
+    $displayNames = [
+      'core.entity_form_display.myeventlane_vendor.myeventlane_vendor.default',
+      'core.entity_view_display.myeventlane_vendor.myeventlane_vendor.default',
+      'core.entity_view_display.myeventlane_vendor.myeventlane_vendor.full',
+    ];
+    $publicControlFields = [
+      'field_public_profile_published',
+      'field_public_show_banner',
+      'field_public_show_description',
+      'field_public_show_social_links',
+      'field_public_show_summary',
+      'field_public_show_website',
+    ];
+
+    foreach ($displayNames as $displayName) {
+      $display = Yaml::parseFile($root . '/config/sync/' . $displayName . '.yml');
+      self::assertIsArray($display);
+      self::assertIsArray($display['hidden'] ?? NULL);
+      foreach ($publicControlFields as $fieldName) {
+        self::assertArrayHasKey($fieldName, $display['hidden'], $displayName);
+      }
+
+      foreach (['content', 'hidden'] as $section) {
+        $fieldNames = array_keys($display[$section] ?? []);
+        $sortedFieldNames = $fieldNames;
+        sort($sortedFieldNames, SORT_STRING);
+        self::assertSame($sortedFieldNames, $fieldNames, $displayName . ':' . $section);
+      }
     }
   }
 


### PR DESCRIPTION
## What changed

- canonicalises the organiser default form display and default/full view displays
- retains the six existing public-profile controls as hidden fields
- retains the three new organiser-brand Media fields in each applicable display
- adds regression coverage for hidden-field completeness and canonical field ordering

## Why

Staging update `myeventlane_vendor_update_10023` and configuration import completed, but deployment rolled back because these three display records remained different after import.

An isolated reproduction showed that the tracked YAML omitted existing public-profile controls and did not match Drupal's canonical saved field order. Drupal restored and reordered those values on every import, so the strict post-import convergence gate correctly rejected the release.

This repair updates source configuration to match Drupal's active canonical form. It does not expand `CIM_ALLOWED_DIFFERENCES`.

## Impact and safety boundary

- no legacy image fields are deleted
- no Media ownership or rendering behaviour changes
- no staging deployment is performed by this draft PR
- unrelated local checkout work is excluded

## Validation

- reproduced the three exact post-import differences in an isolated DDEV copy
- applied the repaired source configuration and confirmed a second import had no changes
- confirmed `config:status` reported no differences
- PHPUnit: 7 tests, 117 assertions
- Drupal and DrupalPractice PHPCS passed
- PHP syntax check passed
- `git diff --check` passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only display metadata reordering with no runtime field or Media behavior changes; intended to unblock deployment convergence checks.
> 
> **Overview**
> Aligns **three** `myeventlane_vendor` entity display configs (default form, default view, full view) with Drupal’s canonical saved shape so config import no longer rewrites them and trips the post-import convergence gate.
> 
> The **default form display** keeps the three organiser-brand Media library widgets and legacy image fields hidden, but **reorders** `content`/`hidden` keys to alphabetical order and **adds** six missing `field_public_*` controls to `hidden` (`field_public_profile_published`, show banner/description/social/summary/website). **Default and full view displays** get the same hidden public-control fields and **alphabetically sorted** `hidden` lists (including Media reference fields in canonical positions).
> 
> Adds **`VendorBrandMediaBackfillContractTest::testVendorDisplaysIncludeAllHiddenPublicControlsInCanonicalOrder`** to assert those six public controls stay hidden on all three displays and that `content` and `hidden` field keys remain alphabetically ordered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b914cb436cc9aa06cc56af07ff4ebf2ebfb5275b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->