### PR TITLE
Harden Apple identity token verification

### DIFF
--- a/web/modules/custom/myeventlane_auth/myeventlane_auth.module
+++ b/web/modules/custom/myeventlane_auth/myeventlane_auth.module
@@ -17,8 +17,21 @@ use Drupal\Core\Site\Settings;
 use Drupal\myeventlane_auth\EventSubscriber\AccountSetupFlowSubscriber;
 use Drupal\myeventlane_auth\EventSubscriber\MelPostLoginSessionRedirectSubscriber;
 use Drupal\myeventlane_auth\Service\IdentityIntentResolver;
+use Drupal\myeventlane_auth\SocialAuth\MelAppleAuthManager;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Implements hook_social_api_network_info_alter().
+ *
+ * Keeps the contributed Apple integration while adding MEL's nonce and
+ * identity-token verification requirements at the authentication boundary.
+ */
+function myeventlane_auth_social_api_network_info_alter(array &$definitions): void {
+  if (isset($definitions['social_auth_apple'])) {
+    $definitions['social_auth_apple']['auth_manager'] = MelAppleAuthManager::class;
+  }
+}
 
 /**
  * Implements hook_cron().

--- a/web/modules/custom/myeventlane_auth/src/Service/SocialLoginProviderAvailability.php
+++ b/web/modules/custom/myeventlane_auth/src/Service/SocialLoginProviderAvailability.php
@@ -48,7 +48,12 @@ final class SocialLoginProviderAvailability {
       }
     }
 
-    return is_readable((string) $config->get('key_file_path'))
+    $teamId = trim((string) $config->get('team_id'));
+    $keyId = trim((string) $config->get('key_file_id'));
+
+    return preg_match('/^[A-Z0-9]{10}$/', $teamId) === 1
+      && preg_match('/^[A-Z0-9]{10}$/', $keyId) === 1
+      && is_readable((string) $config->get('key_file_path'))
       && $this->hasOAuth2Defaults($config->get('scopes'), $config->get('endpoints'));
   }
 

--- a/web/modules/custom/myeventlane_auth/src/SocialAuth/AppleIdentityTokenValidator.php
+++ b/web/modules/custom/myeventlane_auth/src/SocialAuth/AppleIdentityTokenValidator.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_auth\SocialAuth;
+
+use Firebase\JWT\JWK;
+use Firebase\JWT\JWT;
+use GuzzleHttp\ClientInterface;
+
+/**
+ * Verifies Apple identity-token signatures and required OpenID claims.
+ */
+final class AppleIdentityTokenValidator {
+
+  private const APPLE_ISSUER = 'https://appleid.apple.com';
+  private const APPLE_KEYS_URL = 'https://appleid.apple.com/auth/keys';
+
+  public function __construct(
+    private readonly ClientInterface $httpClient,
+  ) {}
+
+  /**
+   * Verifies an Apple identity token for the initiating browser session.
+   *
+   * @return array<string, mixed>
+   *   The verified claims.
+   *
+   * @throws \UnexpectedValueException
+   *   When the signature or any required claim is invalid.
+   */
+  public function validate(string $identityToken, string $clientId, string $nonce): array {
+    if ($identityToken === '' || $clientId === '' || $nonce === '') {
+      throw new \UnexpectedValueException('Apple identity-token validation context is incomplete.');
+    }
+
+    $response = $this->httpClient->request('GET', self::APPLE_KEYS_URL);
+    if ($response->getStatusCode() !== 200) {
+      throw new \UnexpectedValueException('Apple identity keys could not be loaded.');
+    }
+
+    $keySet = json_decode((string) $response->getBody(), TRUE, 512, JSON_THROW_ON_ERROR);
+    if (!is_array($keySet) || !isset($keySet['keys'])) {
+      throw new \UnexpectedValueException('Apple identity keys are invalid.');
+    }
+
+    $decoded = JWT::decode($identityToken, JWK::parseKeySet($keySet));
+    $claims = get_object_vars($decoded);
+    $this->validateClaims($claims, $clientId, $nonce);
+
+    return $claims;
+  }
+
+  /**
+   * Enforces Apple's issuer, audience, expiry, subject and nonce contract.
+   *
+   * @param array<string, mixed> $claims
+   *   Verified JWT claims.
+   * @param string $clientId
+   *   The Apple Services ID expected in the audience claim.
+   * @param string $nonce
+   *   The nonce stored when the browser authentication started.
+   */
+  public function validateClaims(array $claims, string $clientId, string $nonce): void {
+    if (!isset($claims['iss']) || !is_string($claims['iss']) || !hash_equals(self::APPLE_ISSUER, $claims['iss'])) {
+      throw new \UnexpectedValueException('Apple identity-token issuer is invalid.');
+    }
+
+    $audiences = is_array($claims['aud'] ?? NULL)
+      ? $claims['aud']
+      : [$claims['aud'] ?? NULL];
+    if (!in_array($clientId, $audiences, TRUE)) {
+      throw new \UnexpectedValueException('Apple identity-token audience is invalid.');
+    }
+
+    if (!isset($claims['exp']) || !is_int($claims['exp']) || $claims['exp'] <= time()) {
+      throw new \UnexpectedValueException('Apple identity token has expired.');
+    }
+
+    if (!isset($claims['sub']) || !is_string($claims['sub']) || trim($claims['sub']) === '') {
+      throw new \UnexpectedValueException('Apple identity-token subject is invalid.');
+    }
+
+    if (!isset($claims['nonce']) || !is_string($claims['nonce']) || !hash_equals($nonce, $claims['nonce'])) {
+      throw new \UnexpectedValueException('Apple identity-token nonce is invalid.');
+    }
+  }
+
+}

--- a/web/modules/custom/myeventlane_auth/src/SocialAuth/MelAppleAuthManager.php
+++ b/web/modules/custom/myeventlane_auth/src/SocialAuth/MelAppleAuthManager.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_auth\SocialAuth;
+
+use Drupal\Core\Utility\Error;
+use Drupal\social_auth_apple\AppleAuthManager;
+use League\OAuth2\Client\Token\AppleAccessToken;
+
+/**
+ * Adds Apple nonce correlation and explicit identity-token claim validation.
+ */
+final class MelAppleAuthManager extends AppleAuthManager {
+
+  public const NONCE_SESSION_KEY = 'myeventlane_auth.apple_nonce';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAuthorizationUrl(): string {
+    $nonce = self::generateNonce();
+    if ($this->request === NULL || !$this->request->hasSession()) {
+      throw new \UnexpectedValueException('Apple authentication requires a browser session.');
+    }
+    $this->request->getSession()->set(self::NONCE_SESSION_KEY, $nonce);
+
+    $scopes = ['name', 'email'];
+    if ($extraScopes = $this->getScopes()) {
+      $scopes = array_merge($scopes, explode(',', $extraScopes));
+    }
+
+    return $this->client->getAuthorizationUrl([
+      'scope' => $scopes,
+      'nonce' => $nonce,
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function authenticate(): void {
+    $code = $this->request?->query->get('code');
+    if (!is_string($code) || $code === '') {
+      return;
+    }
+
+    try {
+      if (!$this->request->hasSession()) {
+        throw new \UnexpectedValueException('Apple authentication session is missing.');
+      }
+      $session = $this->request->getSession();
+      $nonce = $session->get(self::NONCE_SESSION_KEY);
+      $session->remove(self::NONCE_SESSION_KEY);
+      if (!is_string($nonce) || $nonce === '') {
+        throw new \UnexpectedValueException('Apple authentication nonce is missing.');
+      }
+
+      $token = $this->client->getAccessToken('authorization_code', ['code' => $code]);
+      if (!$token instanceof AppleAccessToken || !is_string($token->getIdToken())) {
+        throw new \UnexpectedValueException('Apple identity token is missing.');
+      }
+
+      $validator = new AppleIdentityTokenValidator($this->client->getHttpClient());
+      $validator->validate(
+        $token->getIdToken(),
+        (string) $this->settings->get('client_id'),
+        $nonce,
+      );
+      $this->setAccessToken($token);
+    }
+    catch (\Throwable $exception) {
+      $this->loggerFactory->get('social_auth_apple')->error(
+        'Apple identity verification failed. ' . Error::DEFAULT_ERROR_MESSAGE . ' @backtrace_string',
+        Error::decodeException($exception),
+      );
+    }
+  }
+
+  /**
+   * Generates an unguessable, URL-safe OpenID nonce.
+   */
+  private static function generateNonce(): string {
+    return rtrim(strtr(base64_encode(random_bytes(32)), '+/', '-_'), '=');
+  }
+
+}

--- a/web/modules/custom/myeventlane_auth/tests/src/Unit/AccountSetupPresentationContractTest.php
+++ b/web/modules/custom/myeventlane_auth/tests/src/Unit/AccountSetupPresentationContractTest.php
@@ -182,6 +182,13 @@ final class AccountSetupPresentationContractTest extends TestCase {
     self::assertStringContainsString("t('Sign in with Apple')", $module);
     self::assertStringContainsString("'alt' => (string) \$label", $module);
     self::assertStringContainsString("'aria-label' => (string) \$label", $module);
+    self::assertStringContainsString('myeventlane_auth_social_api_network_info_alter', $module);
+    self::assertStringContainsString('MelAppleAuthManager::class', $module);
+
+    $manager = file_get_contents(dirname(__DIR__, 3) . '/src/SocialAuth/MelAppleAuthManager.php');
+    self::assertIsString($manager);
+    self::assertStringContainsString("'nonce' => \$nonce", $manager);
+    self::assertStringContainsString('AppleIdentityTokenValidator', $manager);
 
     $button = dirname(__DIR__, 3) . '/images/sign-in-with-apple@2x.png';
     self::assertFileExists($button);

--- a/web/modules/custom/myeventlane_auth/tests/src/Unit/AppleIdentityTokenValidatorTest.php
+++ b/web/modules/custom/myeventlane_auth/tests/src/Unit/AppleIdentityTokenValidatorTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_auth\Unit;
+
+use Drupal\myeventlane_auth\SocialAuth\AppleIdentityTokenValidator;
+use Firebase\JWT\JWT;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_auth\SocialAuth\AppleIdentityTokenValidator
+ * @group myeventlane_auth
+ */
+final class AppleIdentityTokenValidatorTest extends TestCase {
+
+  private const CLIENT_ID = 'com.myeventlane.myeventlane';
+  private const NONCE = 'test-browser-session-nonce';
+
+  /**
+   * @covers ::validate
+   */
+  public function testValidSignedAppleIdentityTokenIsAccepted(): void {
+    [$privateKey, $jwk] = $this->createRsaKeyPair();
+    $token = JWT::encode($this->validClaims(), $privateKey, 'RS256', 'test-key');
+    $validator = $this->validatorForJwk($jwk);
+
+    $claims = $validator->validate($token, self::CLIENT_ID, self::NONCE);
+
+    self::assertSame('apple-user-123', $claims['sub']);
+  }
+
+  /**
+   * @covers ::validateClaims
+   */
+  #[DataProvider('invalidClaimsProvider')]
+  public function testRequiredAppleClaimsFailClosed(array $changes): void {
+    $validator = $this->validatorForJwk([]);
+    $claims = array_replace($this->validClaims(), $changes);
+
+    $this->expectException(\UnexpectedValueException::class);
+    $validator->validateClaims($claims, self::CLIENT_ID, self::NONCE);
+  }
+
+  /**
+   * Invalid issuer, audience, expiry, subject and nonce examples.
+   */
+  public static function invalidClaimsProvider(): array {
+    return [
+      'issuer' => [['iss' => 'https://example.com']],
+      'audience' => [['aud' => 'different-client']],
+      'expiry' => [['exp' => 1]],
+      'subject' => [['sub' => '']],
+      'nonce' => [['nonce' => 'different-nonce']],
+    ];
+  }
+
+  /**
+   * Provides a complete valid Apple identity-token claim set.
+   *
+   * @return array<string, mixed>
+   *   Valid claims.
+   */
+  private function validClaims(): array {
+    return [
+      'iss' => 'https://appleid.apple.com',
+      'aud' => self::CLIENT_ID,
+      'exp' => time() + 300,
+      'iat' => time(),
+      'sub' => 'apple-user-123',
+      'nonce' => self::NONCE,
+    ];
+  }
+
+  /**
+   * Creates a disposable RSA key pair and its public JWK.
+   *
+   * @return array{0: string, 1: array<string, string>}
+   *   The PEM private key and public JWK.
+   */
+  private function createRsaKeyPair(): array {
+    $resource = openssl_pkey_new([
+      'private_key_bits' => 2048,
+      'private_key_type' => OPENSSL_KEYTYPE_RSA,
+    ]);
+    self::assertNotFalse($resource);
+    self::assertTrue(openssl_pkey_export($resource, $privateKey));
+    $details = openssl_pkey_get_details($resource);
+    self::assertIsArray($details);
+
+    return [
+      $privateKey,
+      [
+        'kty' => 'RSA',
+        'kid' => 'test-key',
+        'use' => 'sig',
+        'alg' => 'RS256',
+        'n' => $this->base64UrlEncode($details['rsa']['n']),
+        'e' => $this->base64UrlEncode($details['rsa']['e']),
+      ],
+    ];
+  }
+
+  /**
+   * Creates a validator backed by a deterministic Apple key response.
+   */
+  private function validatorForJwk(array $jwk): AppleIdentityTokenValidator {
+    $handler = new MockHandler([
+      new Response(200, [], json_encode(['keys' => [$jwk]], JSON_THROW_ON_ERROR)),
+    ]);
+    return new AppleIdentityTokenValidator(new Client([
+      'handler' => HandlerStack::create($handler),
+    ]));
+  }
+
+  /**
+   * Encodes binary RSA parameters for a JSON Web Key.
+   */
+  private function base64UrlEncode(string $value): string {
+    return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
+  }
+
+}

--- a/web/modules/custom/myeventlane_auth/tests/src/Unit/MelAppleAuthManagerTest.php
+++ b/web/modules/custom/myeventlane_auth/tests/src/Unit/MelAppleAuthManagerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_auth\Unit;
+
+use Drupal\Core\Config\ConfigFactory;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\myeventlane_auth\SocialAuth\MelAppleAuthManager;
+use League\OAuth2\Client\Provider\Apple;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_auth\SocialAuth\MelAppleAuthManager
+ * @group myeventlane_auth
+ */
+final class MelAppleAuthManagerTest extends TestCase {
+
+  /**
+   * @covers ::getAuthorizationUrl
+   */
+  public function testAuthorizationRequestStoresAndSendsSingleUseNonce(): void {
+    $settings = $this->createMock(ImmutableConfig::class);
+    $settings->method('get')->willReturnMap([
+      ['scopes', ''],
+    ]);
+    $configFactory = $this->createMock(ConfigFactory::class);
+    $configFactory->method('get')->with('social_auth_apple.settings')->willReturn($settings);
+
+    $request = Request::create('/user/login/apple');
+    $session = new Session(new MockArraySessionStorage());
+    $request->setSession($session);
+    $requestStack = new RequestStack();
+    $requestStack->push($request);
+
+    $client = $this->createMock(Apple::class);
+    $client->expects(self::once())
+      ->method('getAuthorizationUrl')
+      ->with(self::callback(static function (array $options): bool {
+        return $options['scope'] === ['name', 'email']
+          && is_string($options['nonce'])
+          && preg_match('/^[A-Za-z0-9_-]{43}$/', $options['nonce']) === 1;
+      }))
+      ->willReturn('https://appleid.apple.com/auth/authorize');
+
+    $manager = new MelAppleAuthManager(
+      $configFactory,
+      $this->createMock(LoggerChannelFactoryInterface::class),
+      $requestStack,
+    );
+    $manager->setClient($client);
+
+    self::assertSame('https://appleid.apple.com/auth/authorize', $manager->getAuthorizationUrl());
+    $nonce = $session->get(MelAppleAuthManager::NONCE_SESSION_KEY);
+    self::assertIsString($nonce);
+    self::assertMatchesRegularExpression('/^[A-Za-z0-9_-]{43}$/', $nonce);
+  }
+
+}

--- a/web/modules/custom/myeventlane_auth/tests/src/Unit/SocialLoginProviderAvailabilityTest.php
+++ b/web/modules/custom/myeventlane_auth/tests/src/Unit/SocialLoginProviderAvailabilityTest.php
@@ -29,8 +29,8 @@ final class SocialLoginProviderAvailabilityTest extends UnitTestCase {
     ]);
     $apple = $this->config([
       'client_id' => 'apple-id',
-      'team_id' => 'team-id',
-      'key_file_id' => 'key-id',
+      'team_id' => 'WT8K739P63',
+      'key_file_id' => 'G82FTJW6MN',
       'key_file_path' => '',
       'scopes' => '',
       'endpoints' => '',
@@ -57,8 +57,8 @@ final class SocialLoginProviderAvailabilityTest extends UnitTestCase {
     ]);
     $apple = $this->config([
       'client_id' => 'apple-id',
-      'team_id' => 'team-id',
-      'key_file_id' => 'key-id',
+      'team_id' => 'WT8K739P63',
+      'key_file_id' => 'G82FTJW6MN',
       'key_file_path' => __FILE__,
       'scopes' => '',
       'endpoints' => '',
@@ -83,8 +83,8 @@ final class SocialLoginProviderAvailabilityTest extends UnitTestCase {
     ]);
     $apple = $this->config([
       'client_id' => 'apple-id',
-      'team_id' => 'team-id',
-      'key_file_id' => 'key-id',
+      'team_id' => 'WT8K739P63',
+      'key_file_id' => 'G82FTJW6MN',
       'key_file_path' => __FILE__,
     ]);
     $factory = $this->configFactory($google, $apple);
@@ -112,6 +112,26 @@ final class SocialLoginProviderAvailabilityTest extends UnitTestCase {
 
     $availability = new SocialLoginProviderAvailability($factory, $modules);
     self::assertFalse($availability->googleIsAvailable());
+  }
+
+  /**
+   * @covers ::appleIsAvailable
+   */
+  public function testAppleFailsClosedWithMalformedKeyId(): void {
+    $apple = $this->config([
+      'client_id' => 'com.myeventlane.myeventlane',
+      'team_id' => 'WT8K739P63',
+      'key_file_id' => 'SHORTKEY1',
+      'key_file_path' => __FILE__,
+      'scopes' => '',
+      'endpoints' => '',
+    ]);
+    $factory = $this->configFactory($this->config([]), $apple);
+    $modules = $this->createMock(ModuleHandlerInterface::class);
+    $modules->method('moduleExists')->willReturn(TRUE);
+
+    $availability = new SocialLoginProviderAvailability($factory, $modules);
+    self::assertFalse($availability->appleIsAvailable());
   }
 
   /**


### PR DESCRIPTION
## What changed

- send a cryptographically random, single-use nonce with each Apple authorisation request
- bind that nonce to the initiating Drupal session and validate it on callback
- independently verify Apple identity-token signatures against Apple’s public keys
- explicitly enforce Apple issuer, audience, expiry and subject claims
- fail the Apple login control closed when the Team ID or Key ID format is invalid
- add focused unit and presentation-contract coverage

## Why

The existing contributed integration verified Apple’s token signature, but MyEventLane did not explicitly enforce Apple’s issuer, audience or nonce requirements. Staging also accepted a malformed Key ID until the protected environment setting was corrected.

## Impact

Valid Apple sign-ins retain the existing login-only account policy. Invalid, replayed or incorrectly targeted identity tokens are rejected before Drupal authenticates the account. No customer profile, registration or Apple Wallet behaviour is changed.

## Validation

- all 26 `myeventlane_auth` unit tests passed: 122 assertions
- focused Drupal and DrupalPractice code-style checks passed
- `composer validate --no-check-publish` passed
- `git diff --check` passed
- staging Key ID was rechecked without exposing it: 10 characters, expected value matched, format valid

## Deployment note

Deploy only after review and required checks pass. Rebuild Drupal caches after deployment so the altered Social API plugin definition becomes active. Then test logged-out Apple sign-in in Chrome and Safari.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication for Apple Sign In (nonce binding, JWT claim enforcement, and fail-closed callback handling); misconfiguration or edge cases could block legitimate logins until caches are rebuilt and config is valid.
> 
> **Overview**
> **Apple Sign In** is tightened at the auth boundary by swapping in `MelAppleAuthManager` via `hook_social_api_network_info_alter`, while keeping the contributed Social Auth Apple flow.
> 
> Each authorization request now generates a **single-use nonce**, stores it on the Drupal session, sends it to Apple, and on callback verifies the identity token’s signature against Apple’s JWKS plus **issuer, audience, expiry, subject, and nonce** before Drupal accepts the token. Failed verification is logged and does not set an access token (login stays closed).
> 
> **Provider gating** for showing the Apple button now requires Apple **Team ID and Key ID** to match a 10-character alphanumeric pattern, so malformed staging credentials no longer expose the control.
> 
> Unit and presentation-contract tests cover nonce issuance, claim validation, and the altered plugin wiring. **Cache rebuild** is needed after deploy so the Social API plugin definition picks up the custom manager.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f81887925430fdfc160df506485a585eaf0233c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->