### PR TITLE
Fix vendor branding form restoration

### DIFF
--- a/web/modules/custom/myeventlane_messaging/src/Form/VendorBrandingForm.php
+++ b/web/modules/custom/myeventlane_messaging/src/Form/VendorBrandingForm.php
@@ -33,13 +33,13 @@ final class VendorBrandingForm extends FormBase {
    * Constructs the vendor branding form.
    */
   public function __construct(
-    private readonly EntityTypeManagerInterface $entityTypeManager,
-    private readonly AccountProxyInterface $currentUser,
-    private readonly CacheTagsInvalidatorInterface $cacheTagsInvalidator,
-    private readonly LoggerInterface $logger,
-    private readonly CurrentVendorResolverInterface $vendorResolver,
-    private readonly UserVendorMembershipQuery $userVendorMembershipQuery,
-    private readonly VendorBrandMediaManager $brandMediaManager,
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected AccountProxyInterface $currentUser,
+    protected CacheTagsInvalidatorInterface $cacheTagsInvalidator,
+    protected LoggerInterface $logger,
+    protected CurrentVendorResolverInterface $vendorResolver,
+    protected UserVendorMembershipQuery $userVendorMembershipQuery,
+    protected VendorBrandMediaManager $brandMediaManager,
   ) {}
 
   /**

--- a/web/modules/custom/myeventlane_messaging/tests/src/Unit/VendorBrandingFormSerializationTest.php
+++ b/web/modules/custom/myeventlane_messaging/tests/src/Unit/VendorBrandingFormSerializationTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_messaging\Unit;
+
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\Test\TestKernel;
+use Drupal\myeventlane_messaging\Form\VendorBrandingForm;
+use Drupal\myeventlane_vendor\Service\CurrentVendorResolverInterface;
+use Drupal\myeventlane_vendor\Service\UserVendorMembershipQuery;
+use Drupal\myeventlane_vendor\Service\VendorBrandMediaManager;
+use Drupal\Tests\UnitTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests the vendor branding form's cached form-state compatibility.
+ */
+#[CoversClass(VendorBrandingForm::class)]
+#[Group('myeventlane_messaging')]
+final class VendorBrandingFormSerializationTest extends UnitTestCase {
+
+  /**
+   * Ensures injected services survive Drupal's form cache lifecycle.
+   */
+  public function testInjectedServicesSurviveSerialization(): void {
+    $entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $currentUser = $this->createMock(AccountProxyInterface::class);
+    $cacheTagsInvalidator = $this->createMock(CacheTagsInvalidatorInterface::class);
+    $logger = $this->createMock(LoggerInterface::class);
+    $vendorResolver = $this->createMock(CurrentVendorResolverInterface::class);
+    $userVendorMembershipQuery = new UserVendorMembershipQuery(
+      $entityTypeManager,
+      $this->createMock(EntityFieldManagerInterface::class),
+    );
+    $brandMediaManager = new VendorBrandMediaManager(
+      $entityTypeManager,
+      $this->createMock(FileSystemInterface::class),
+      $logger,
+    );
+
+    $services = [
+      'entityTypeManager' => ['entity_type.manager', $entityTypeManager],
+      'currentUser' => ['current_user', $currentUser],
+      'cacheTagsInvalidator' => ['cache_tags.invalidator', $cacheTagsInvalidator],
+      'logger' => ['logger.channel.myeventlane_messaging', $logger],
+      'vendorResolver' => ['myeventlane_vendor.current_vendor_resolver', $vendorResolver],
+      'userVendorMembershipQuery' => ['myeventlane_vendor.user_vendor_membership_query', $userVendorMembershipQuery],
+      'brandMediaManager' => ['myeventlane_vendor.brand_media_manager', $brandMediaManager],
+    ];
+
+    $container = TestKernel::setContainerWithKernel();
+    foreach ($services as [$serviceId, $service]) {
+      $container->set($serviceId, $service);
+    }
+
+    $form = new VendorBrandingForm(
+      $entityTypeManager,
+      $currentUser,
+      $cacheTagsInvalidator,
+      $logger,
+      $vendorResolver,
+      $userVendorMembershipQuery,
+      $brandMediaManager,
+    );
+
+    $restoredForm = unserialize(serialize($form), [
+      'allowed_classes' => [VendorBrandingForm::class],
+    ]);
+    self::assertInstanceOf(VendorBrandingForm::class, $restoredForm);
+
+    foreach ($services as $propertyName => [, $service]) {
+      $property = new \ReflectionProperty($restoredForm, $propertyName);
+      self::assertTrue(
+        $property->isInitialized($restoredForm),
+        sprintf('The %s service was not restored.', $propertyName),
+      );
+      self::assertSame($service, $property->getValue($restoredForm));
+    }
+  }
+
+}


### PR DESCRIPTION
## Summary

- make the `VendorBrandingForm` injected services compatible with Drupal's cached form-state restoration
- add a focused regression test that serialises and restores the real form and verifies all seven injected services remain initialised
- leave organiser branding behaviour, Media capture, permissions and legacy fields unchanged

## Root cause

`VendorBrandingForm` declared its injected services as child-private readonly promoted properties. Drupal's inherited `DependencySerializationTrait` cannot discover those private child properties when the form is cached. The restored form therefore reached validation with an uninitialised `entityTypeManager`, causing the staging fatal error.

## Impact

Organisers can submit the Message Branding form without the cached form object losing its dependencies. This specifically protects the logo and banner upload/save lifecycle that exposed the staging failure.

## Validation

- focused serialization regression test: 1 test, 15 assertions
- full `myeventlane_messaging` unit suite: 28 tests, 143 assertions
- PHP syntax checks: passed
- Drupal and DrupalPractice code standards: no errors
- static analysis of the new regression test: passed
- `git diff --check`: passed

## Pending

- GitHub checks and review
- staging deployment
- signed-in organiser acceptance for saving logo and banner branding

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow constructor visibility change plus a unit regression test; branding behaviour and permissions are unchanged.
> 
> **Overview**
> Fixes a staging fatal when organisers submit **Message Branding** after the form object was cached: injected services were not reattached on restore.
> 
> **`VendorBrandingForm`** changes constructor-promoted dependencies from `private readonly` to **`protected`** (no `readonly`). That matches other MyEventLane forms and lets `FormBase`’s `DependencySerializationTrait` discover and rehydrate the seven services when Drupal serializes the form for cached form state—avoiding an uninitialized `entityTypeManager` during validation/submit (e.g. logo/banner saves).
> 
> Adds **`VendorBrandingFormSerializationTest`**, which serializes and unserializes the real form with a test container and asserts every injected service stays initialized and identical.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bbec114928ca88ded9eb1d855dd0667b33c3396. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->