### PR TITLE
Accept Apple form-post callback codes

### DIFF
--- a/web/modules/custom/myeventlane_auth/src/SocialAuth/MelAppleAuthManager.php
+++ b/web/modules/custom/myeventlane_auth/src/SocialAuth/MelAppleAuthManager.php
@@ -42,6 +42,9 @@ final class MelAppleAuthManager extends AppleAuthManager {
   public function authenticate(): void {
     $code = $this->request?->query->get('code');
     if (!is_string($code) || $code === '') {
+      $code = $this->request?->request->get('code');
+    }
+    if (!is_string($code) || $code === '') {
       return;
     }
 

--- a/web/modules/custom/myeventlane_auth/tests/src/Unit/MelAppleAuthManagerTest.php
+++ b/web/modules/custom/myeventlane_auth/tests/src/Unit/MelAppleAuthManagerTest.php
@@ -9,6 +9,8 @@ use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\myeventlane_auth\SocialAuth\MelAppleAuthManager;
 use League\OAuth2\Client\Provider\Apple;
+use League\OAuth2\Client\Token\AppleAccessToken;
+use Psr\Log\LoggerInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -59,6 +61,50 @@ final class MelAppleAuthManagerTest extends TestCase {
     $nonce = $session->get(MelAppleAuthManager::NONCE_SESSION_KEY);
     self::assertIsString($nonce);
     self::assertMatchesRegularExpression('/^[A-Za-z0-9_-]{43}$/', $nonce);
+  }
+
+  /**
+   * @covers ::authenticate
+   */
+  public function testAuthenticateReadsFormPostAuthorizationCode(): void {
+    $settings = $this->createMock(ImmutableConfig::class);
+    $settings->method('get')->willReturnMap([
+      ['client_id', 'com.myeventlane.myeventlane'],
+    ]);
+    $configFactory = $this->createMock(ConfigFactory::class);
+    $configFactory->method('get')->with('social_auth_apple.settings')->willReturn($settings);
+
+    $request = Request::create(
+      '/user/login/apple/callback',
+      'POST',
+      ['code' => 'apple-form-post-code'],
+    );
+    $session = new Session(new MockArraySessionStorage());
+    $session->set(MelAppleAuthManager::NONCE_SESSION_KEY, 'test-browser-session-nonce');
+    $request->setSession($session);
+    $requestStack = new RequestStack();
+    $requestStack->push($request);
+
+    $token = new AppleAccessToken([], [
+      'access_token' => 'test-access-token',
+      'id_token' => 'test-identity-token',
+    ]);
+    $client = $this->createMock(Apple::class);
+    $client->expects(self::once())
+      ->method('getAccessToken')
+      ->with('authorization_code', ['code' => 'apple-form-post-code'])
+      ->willReturn($token);
+
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects(self::once())->method('error');
+    $loggerFactory = $this->createMock(LoggerChannelFactoryInterface::class);
+    $loggerFactory->method('get')->with('social_auth_apple')->willReturn($logger);
+
+    $manager = new MelAppleAuthManager($configFactory, $loggerFactory, $requestStack);
+    $manager->setClient($client);
+    $manager->authenticate();
+
+    self::assertFalse($session->has(MelAppleAuthManager::NONCE_SESSION_KEY));
   }
 
 }


### PR DESCRIPTION
## What changed

- read Apple’s authorisation code from the query string first
- fall back to the POST body when the query value is absent or empty
- add a regression test proving token exchange starts for a `form_post` callback
- remove the single-use nonce from the session once the callback is consumed

## Why

PR #768 uses Apple’s required `response_mode=form_post` for name and email scopes. The contributed Drupal Apple controller currently normalises POST data through a same-route query redirect, so the deployed flow can work. Cursor correctly identified that the hardened manager itself was not robust if it receives the POST callback directly. This follow-up closes that boundary without weakening state, nonce or token validation.

## Related branding fault

The separate `VendorBrandingForm` cached-form restoration defect was fixed and tested in PR #769. It is intentionally not duplicated here.

## Validation

- 28 focused authentication and branding-serialisation tests passed with 144 assertions
- Drupal and DrupalPractice code-style checks passed, apart from one pre-existing line-length warning in `VendorBrandingForm.php`
- `git diff --check` passed
- DDEV’s branding form services survived serialise/unserialise with every injected property initialised
- the signed-in DDEV Message branding page rendered with no fatal error

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Apple authentication boundary and token exchange path; scope is small and existing nonce/session validation remains, but login failures would be user-visible if mis-handled.
> 
> **Overview**
> **Apple Sign In** callbacks that use `response_mode=form_post` can deliver the authorization `code` in the POST body instead of the query string. **`MelAppleAuthManager::authenticate()`** now keeps reading the query `code` first and **falls back to the request body** when that value is missing or empty, so direct POST callbacks still reach token exchange without changing nonce or identity-token checks.
> 
> A **unit test** posts `code` on the callback route and asserts **`getAccessToken`** runs with that value and the session nonce is cleared after consumption.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6cad0190ecd4c0221c9f8a91e308d6fcb504f6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->