### PR TITLE
Add venues to Platform Control Centre navigation

### DIFF
--- a/web/modules/custom/myeventlane_admin_dashboard/src/Plugin/Block/MelAdminSidebarNavBlock.php
+++ b/web/modules/custom/myeventlane_admin_dashboard/src/Plugin/Block/MelAdminSidebarNavBlock.php
@@ -29,6 +29,7 @@ final class MelAdminSidebarNavBlock extends BlockBase implements ContainerFactor
     'myeventlane_admin_dashboard.vendors' => 'Vendors',
     'myeventlane_admin_dashboard.orders' => 'Orders',
     'myeventlane_reporting.admin.events' => 'Events',
+    'entity.myeventlane_venue.collection' => 'Venues',
     'myeventlane_reporting.admin.finance' => 'Finance',
     'myeventlane_admin_dashboard.payouts' => 'Payouts',
     'myeventlane_reporting.admin.overview' => 'Reports',

--- a/web/modules/custom/myeventlane_admin_dashboard/tests/src/Unit/AdminVenueNavigationContractTest.php
+++ b/web/modules/custom/myeventlane_admin_dashboard/tests/src/Unit/AdminVenueNavigationContractTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_admin_dashboard\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards venue discovery from the Platform Control Centre.
+ *
+ * @group myeventlane_admin_dashboard
+ */
+final class AdminVenueNavigationContractTest extends TestCase {
+
+  /**
+   * Ensures staff can reach the canonical venue list from the sidebar.
+   */
+  public function testVenueCollectionIsInPlatformControlNavigation(): void {
+    $source = file_get_contents(
+      dirname(__DIR__, 3) . '/src/Plugin/Block/MelAdminSidebarNavBlock.php',
+    );
+
+    self::assertIsString($source);
+    self::assertStringContainsString(
+      "'entity.myeventlane_venue.collection' => 'Venues'",
+      $source,
+    );
+    self::assertStringContainsString(
+      'checkNamedRoute($route, [], $this->currentUser, TRUE)',
+      $source,
+    );
+
+    $eventsPosition = strpos($source, "'myeventlane_reporting.admin.events' => 'Events'");
+    $venuesPosition = strpos($source, "'entity.myeventlane_venue.collection' => 'Venues'");
+    $financePosition = strpos($source, "'myeventlane_reporting.admin.finance' => 'Finance'");
+
+    self::assertIsInt($eventsPosition);
+    self::assertIsInt($venuesPosition);
+    self::assertIsInt($financePosition);
+    self::assertGreaterThan($eventsPosition, $venuesPosition);
+    self::assertLessThan($financePosition, $venuesPosition);
+  }
+
+}


### PR DESCRIPTION
## What changed

- Add a **Venues** item to the Platform Control Centre sidebar.
- Link it to Drupal's canonical venue collection route.
- Add a focused contract test covering the route and menu placement.

## Why

Staff could manage venues at `/admin/structure/myeventlane/venues`, but the Platform Control Centre at `/admin/myeventlane` did not expose that destination. The route existed; the admin navigation map omitted it.

## Impact

Staff and administrators with access to the venue collection can now discover the venue list between **Events** and **Finance**. Existing route access checks remain in force.

## Validation

- PHP syntax checks passed for both changed files.
- Focused PHPUnit test passed: 1 test, 8 assertions.
- `git diff --check` passed.

## Deployment

Not deployed. This pull request is intentionally opened as a draft.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation-only change reusing an existing route and existing access checks; no new permissions or venue logic.
> 
> **Overview**
> Adds a **Venues** entry to the Platform Control Centre sidebar in `MelAdminSidebarNavBlock`, pointing at the existing `entity.myeventlane_venue.collection` route so staff can reach the venue list from `/admin/myeventlane` without hunting Structure admin.
> 
> The link is ordered between **Events** and **Finance** in `NAV_ITEMS`. Visibility still follows the same per-route `checkNamedRoute` access checks as other sidebar items.
> 
> A new unit contract test asserts the route label mapping, that access checks remain in the block source, and that Venues sits between Events and Finance in the nav list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6253dd442bf4674a199bee16cd39512cefd446a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->