### PR TITLE
Add staff Media Embed format

### DIFF
--- a/config/sync/editor.editor.staff_media_html.yml
+++ b/config/sync/editor.editor.staff_media_html.yml
@@ -1,0 +1,61 @@
+uuid: 25898610-eb79-4b0a-8bb8-9cbb3fa16e25
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.staff_media_html
+  module:
+    - ckeditor5
+    - media
+    - media_library
+format: staff_media_html
+editor: ckeditor5
+settings:
+  toolbar:
+    items:
+      - bold
+      - italic
+      - '|'
+      - link
+      - '|'
+      - bulletedList
+      - numberedList
+      - '|'
+      - blockQuote
+      - drupalMedia
+      - '|'
+      - heading
+      - code
+      - '|'
+      - sourceEditing
+  plugins:
+    ckeditor5_heading:
+      enabled_headings:
+        - heading2
+        - heading3
+        - heading4
+        - heading5
+        - heading6
+    ckeditor5_list:
+      properties:
+        reversed: false
+        startIndex: true
+        styles: true
+      multiBlock: true
+    ckeditor5_sourceEditing:
+      allowed_tags:
+        - '<cite>'
+        - '<dl>'
+        - '<dt>'
+        - '<dd>'
+        - '<a hreflang>'
+        - '<blockquote cite>'
+        - '<h2 id>'
+        - '<h3 id>'
+        - '<h4 id>'
+        - '<h5 id>'
+        - '<h6 id>'
+    media_media:
+      allow_view_mode_override: false
+image_upload:
+  status: false

--- a/config/sync/field.field.node.article.body.yml
+++ b/config/sync/field.field.node.article.body.yml
@@ -22,5 +22,8 @@ default_value_callback: ''
 settings:
   display_summary: true
   required_summary: false
-  allowed_formats: {  }
+  allowed_formats:
+    - staff_media_html
+    - basic_html
+    - full_html
 field_type: text_with_summary

--- a/config/sync/field.field.node.page.body.yml
+++ b/config/sync/field.field.node.page.body.yml
@@ -22,5 +22,8 @@ default_value_callback: ''
 settings:
   display_summary: true
   required_summary: false
-  allowed_formats: {  }
+  allowed_formats:
+    - staff_media_html
+    - basic_html
+    - full_html
 field_type: text_with_summary

--- a/config/sync/filter.format.staff_media_html.yml
+++ b/config/sync/filter.format.staff_media_html.yml
@@ -1,0 +1,60 @@
+uuid: dc29202b-018c-47c0-ba6e-4e6de328c3be
+langcode: en
+status: true
+dependencies:
+  module:
+    - editor
+    - media
+name: 'Staff Media HTML'
+format: staff_media_html
+weight: -1
+filters:
+  editor_file_reference:
+    id: editor_file_reference
+    provider: editor
+    status: true
+    weight: 11
+    settings: {  }
+  filter_align:
+    id: filter_align
+    provider: filter
+    status: true
+    weight: 7
+    settings: {  }
+  filter_caption:
+    id: filter_caption
+    provider: filter
+    status: true
+    weight: 8
+    settings: {  }
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: true
+    weight: -10
+    settings:
+      allowed_html: '<br> <p> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <cite> <dl> <dt> <dd> <a hreflang href> <blockquote cite> <ul type> <ol start type> <strong> <em> <code> <li> <img src alt data-entity-uuid data-entity-type height width data-caption data-align> <drupal-media data-entity-type data-entity-uuid data-view-mode data-align data-caption alt title>'
+      filter_html_help: false
+      filter_html_nofollow: false
+  filter_html_image_secure:
+    id: filter_html_image_secure
+    provider: filter
+    status: true
+    weight: 9
+    settings: {  }
+  filter_image_lazy_load:
+    id: filter_image_lazy_load
+    provider: filter
+    status: true
+    weight: 15
+    settings: {  }
+  media_embed:
+    id: media_embed
+    provider: media
+    status: true
+    weight: 100
+    settings:
+      default_view_mode: default
+      allowed_view_modes: {  }
+      allowed_media_types:
+        image: image

--- a/config/sync/user.role.content_editor.yml
+++ b/config/sync/user.role.content_editor.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - filter.format.staff_media_html
     - node.type.article
     - node.type.page
     - taxonomy.vocabulary.tags
@@ -10,6 +11,7 @@ dependencies:
     - comment
     - contextual
     - file
+    - filter
     - media
     - myeventlane_vendor
     - node
@@ -46,6 +48,7 @@ permissions:
   - 'edit own page content'
   - 'edit terms in tags'
   - 'revert all revisions'
+  - 'use text format staff_media_html'
   - 'view all revisions'
   - 'view own unpublished content'
   - 'view the administration theme'

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.install
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.install
@@ -7,10 +7,13 @@
 
 use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\Core\Utility\UpdateException;
+use Drupal\editor\Entity\Editor;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\filter\Entity\FilterFormat;
 use Drupal\myeventlane_vendor\Entity\Vendor;
 use Drupal\myeventlane_vendor\Service\VendorBrandMediaManager;
+use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
 
 /**
@@ -1254,6 +1257,183 @@ function myeventlane_vendor_update_10023(array &$sandbox): string {
     $sandbox['conflicts'],
     $sandbox['errors'],
   );
+}
+
+/**
+ * Moves current Page and Article bodies to the staff-only Media HTML format.
+ *
+ * Historical revisions are deliberately retained with their original format.
+ * The state ledger records every changed current row for a bounded rollback.
+ */
+function myeventlane_vendor_update_10024(): string {
+  myeventlane_vendor_ensure_staff_media_html_config();
+
+  $format = \Drupal::entityTypeManager()
+    ->getStorage('filter_format')
+    ->load('staff_media_html');
+  if ($format === NULL) {
+    throw new UpdateException('Staff Media HTML must be imported before CK-1 body migration can run.');
+  }
+
+  $role = \Drupal::entityTypeManager()
+    ->getStorage('user_role')
+    ->load('content_editor');
+  if ($role === NULL || !$role->hasPermission('use text format staff_media_html')) {
+    throw new UpdateException('Content Editor must have Staff Media HTML access before CK-1 body migration can run.');
+  }
+
+  foreach (['page', 'article'] as $bundle) {
+    $field = FieldConfig::loadByName('node', $bundle, 'body');
+    $allowed = $field?->getSetting('allowed_formats') ?? [];
+    if (!in_array('staff_media_html', $allowed, TRUE)) {
+      throw new UpdateException(sprintf('The %s body field must allow Staff Media HTML before CK-1 migration can run.', $bundle));
+    }
+  }
+
+  $database = \Drupal::database();
+  $query = $database->select('node__body', 'b');
+  $query->join('node_field_data', 'n', 'n.nid = b.entity_id AND n.langcode = b.langcode');
+  $query->fields('b', [
+    'entity_id',
+    'revision_id',
+    'langcode',
+    'delta',
+    'body_value',
+    'body_format',
+  ]);
+  $query->addField('n', 'type', 'bundle');
+  $rows = $query
+    ->condition('n.type', ['page', 'article'], 'IN')
+    ->condition('b.body_format', 'basic_html')
+    ->orderBy('b.entity_id')
+    ->orderBy('b.langcode')
+    ->orderBy('b.delta')
+    ->execute()
+    ->fetchAll();
+
+  $ledger = [];
+  foreach ($rows as $row) {
+    $before = myeventlane_vendor_render_processed_text_for_update(
+      (string) $row->body_value,
+      'basic_html',
+      (string) $row->langcode,
+    );
+    $after = myeventlane_vendor_render_processed_text_for_update(
+      (string) $row->body_value,
+      'staff_media_html',
+      (string) $row->langcode,
+    );
+    if ($before !== $after) {
+      throw new UpdateException(sprintf('Rendered output differs for %s node %d; no CK-1 rows were changed.', $row->bundle, $row->entity_id));
+    }
+    $ledger[] = [
+      'entity_id' => (int) $row->entity_id,
+      'revision_id' => (int) $row->revision_id,
+      'langcode' => (string) $row->langcode,
+      'delta' => (int) $row->delta,
+      'bundle' => (string) $row->bundle,
+      'original_format' => 'basic_html',
+      'value_hash' => hash('sha256', (string) $row->body_value),
+    ];
+  }
+
+  if ($ledger === []) {
+    return 'No current Page or Article Basic HTML bodies required CK-1 migration.';
+  }
+
+  $transaction = $database->startTransaction();
+  try {
+    foreach ($ledger as $item) {
+      $database->update('node__body')
+        ->fields(['body_format' => 'staff_media_html'])
+        ->condition('entity_id', $item['entity_id'])
+        ->condition('langcode', $item['langcode'])
+        ->condition('delta', $item['delta'])
+        ->condition('body_format', 'basic_html')
+        ->execute();
+
+      $database->update('node_revision__body')
+        ->fields(['body_format' => 'staff_media_html'])
+        ->condition('entity_id', $item['entity_id'])
+        ->condition('langcode', $item['langcode'])
+        ->condition('delta', $item['delta'])
+        ->condition('body_format', 'basic_html')
+        ->condition('revision_id', $item['revision_id'])
+        ->execute();
+    }
+    \Drupal::state()->set('myeventlane_vendor.ck1_staff_media_html_ledger', $ledger);
+  }
+  catch (\Throwable $exception) {
+    $transaction->rollBack();
+    throw $exception;
+  }
+
+  return sprintf('Migrated %d current Page/Article bodies to Staff Media HTML; historical revisions were retained.', count($ledger));
+}
+
+/**
+ * Renders formatted text for CK-1's byte-preserving equivalence gate.
+ */
+function myeventlane_vendor_render_processed_text_for_update(
+  string $value,
+  string $format,
+  string $langcode,
+): string {
+  $build = [
+    '#type' => 'processed_text',
+    '#text' => $value,
+    '#format' => $format,
+    '#langcode' => $langcode,
+  ];
+  return (string) \Drupal::service('renderer')->renderInIsolation($build);
+}
+
+/**
+ * Activates only the CK-1 prerequisites before update 10024 migrates data.
+ *
+ * Staging deliberately mirrors the release config into sync storage before it
+ * runs database updates, while the full config import runs afterwards.
+ */
+function myeventlane_vendor_ensure_staff_media_html_config(): void {
+  $sync = \Drupal::service('config.storage.sync');
+
+  if (FilterFormat::load('staff_media_html') === NULL) {
+    $data = $sync->read('filter.format.staff_media_html');
+    if (!is_array($data)) {
+      throw new UpdateException('Missing Staff Media HTML format in configuration sync.');
+    }
+    FilterFormat::create($data)->save();
+  }
+
+  if (Editor::load('staff_media_html') === NULL) {
+    $data = $sync->read('editor.editor.staff_media_html');
+    if (!is_array($data)) {
+      throw new UpdateException('Missing Staff Media HTML editor in configuration sync.');
+    }
+    Editor::create($data)->save();
+  }
+
+  $role = Role::load('content_editor');
+  if ($role === NULL) {
+    throw new UpdateException('Content Editor role is required for CK-1.');
+  }
+  if (!$role->hasPermission('use text format staff_media_html')) {
+    $role->grantPermission('use text format staff_media_html');
+    $role->save();
+  }
+
+  foreach (['page', 'article'] as $bundle) {
+    $field = FieldConfig::loadByName('node', $bundle, 'body');
+    if ($field === NULL) {
+      throw new UpdateException(sprintf('The %s body field is required for CK-1.', $bundle));
+    }
+    $allowed = $field->getSetting('allowed_formats') ?? [];
+    $required = ['staff_media_html', 'basic_html', 'full_html'];
+    if ($allowed !== $required) {
+      $field->setSetting('allowed_formats', $required);
+      $field->save();
+    }
+  }
 }
 
 /**

--- a/web/modules/custom/myeventlane_vendor/tests/src/Kernel/StaffMediaFormatMigrationTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Kernel/StaffMediaFormatMigrationTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_vendor\Kernel;
+
+use Drupal\editor\Entity\Editor;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\filter\Entity\FilterFormat;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\user\Entity\Role;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Verifies the bounded CK-1 current-body migration.
+ */
+#[Group('myeventlane_vendor')]
+#[RunTestsInSeparateProcesses]
+final class StaffMediaFormatMigrationTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'filter',
+    'editor',
+    'ckeditor5',
+    'node',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig(['filter', 'node']);
+
+    foreach (['page', 'article', 'event'] as $bundle) {
+      NodeType::create(['type' => $bundle, 'name' => ucfirst($bundle)])->save();
+    }
+    FieldStorageConfig::create([
+      'entity_type' => 'node',
+      'field_name' => 'body',
+      'type' => 'text_with_summary',
+    ])->save();
+    foreach (['page', 'article', 'event'] as $bundle) {
+      FieldConfig::create([
+        'entity_type' => 'node',
+        'bundle' => $bundle,
+        'field_name' => 'body',
+        'label' => 'Body',
+        'settings' => [
+          'allowed_formats' => $bundle === 'event'
+            ? ['basic_html']
+            : ['staff_media_html', 'basic_html', 'full_html'],
+        ],
+      ])->save();
+    }
+
+    foreach (['basic_html', 'staff_media_html'] as $id) {
+      FilterFormat::create([
+        'format' => $id,
+        'name' => $id,
+        'filters' => [
+          'filter_html' => [
+            'status' => TRUE,
+            'settings' => ['allowed_html' => '<p> <strong> <em>'],
+          ],
+        ],
+      ])->save();
+    }
+    Editor::create([
+      'format' => 'staff_media_html',
+      'editor' => 'ckeditor5',
+      'settings' => ['toolbar' => ['items' => []]],
+      'image_upload' => ['status' => FALSE],
+    ])->save();
+    $role = Role::create(['id' => 'content_editor', 'label' => 'Content editor']);
+    $role->grantPermission('use text format staff_media_html');
+    $role->save();
+
+    require_once dirname(__DIR__, 3) . '/myeventlane_vendor.install';
+  }
+
+  /**
+   * Preserves values and old revisions while changing current format IDs.
+   */
+  public function testMigrationIsEquivalentBoundedAndIdempotent(): void {
+    $page = Node::create([
+      'type' => 'page',
+      'title' => 'Page',
+      'body' => ['value' => '<p><strong>Existing</strong> page</p>', 'format' => 'basic_html'],
+    ]);
+    $page->save();
+    $oldRevision = (int) $page->getRevisionId();
+    $page->setNewRevision(TRUE);
+    $page->set('title', 'Page updated');
+    $page->save();
+
+    $article = Node::create([
+      'type' => 'article',
+      'title' => 'Article',
+      'body' => ['value' => '<p>Article</p>', 'format' => 'basic_html'],
+    ]);
+    $article->save();
+    $event = Node::create([
+      'type' => 'event',
+      'title' => 'Event',
+      'body' => ['value' => '<p>Event</p>', 'format' => 'basic_html'],
+    ]);
+    $event->save();
+
+    $pageValue = $page->body->value;
+    self::assertStringContainsString('Migrated 2 current', myeventlane_vendor_update_10024());
+
+    $storage = $this->container->get('entity_type.manager')->getStorage('node');
+    $storage->resetCache();
+    $currentPage = $storage->load($page->id());
+    self::assertSame($pageValue, $currentPage->body->value);
+    self::assertSame('staff_media_html', $currentPage->body->format);
+    self::assertSame('staff_media_html', $storage->load($article->id())->body->format);
+    self::assertSame('basic_html', $storage->load($event->id())->body->format);
+    self::assertSame('basic_html', $storage->loadRevision($oldRevision)->body->format);
+
+    $ledger = $this->container->get('state')
+      ->get('myeventlane_vendor.ck1_staff_media_html_ledger');
+    self::assertCount(2, $ledger);
+    self::assertSame(hash('sha256', (string) $pageValue), $ledger[0]['value_hash']);
+    self::assertStringContainsString('No current', myeventlane_vendor_update_10024());
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor/tests/src/Unit/StaffMediaEditorConfigTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Unit/StaffMediaEditorConfigTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_vendor\Unit;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Guards the CK-1 staff editor and organiser boundary configuration.
+ */
+#[Group('myeventlane_vendor')]
+final class StaffMediaEditorConfigTest extends TestCase {
+
+  /**
+   * Verifies that staff use Media Embed without direct file uploads.
+   */
+  public function testStaffEditorUsesMediaEmbedOnly(): void {
+    $editor = $this->config('editor.editor.staff_media_html.yml');
+    $toolbar = $editor['settings']['toolbar']['items'] ?? [];
+
+    self::assertContains('drupalMedia', $toolbar);
+    self::assertNotContains('drupalInsertImage', $toolbar);
+    self::assertFalse($editor['image_upload']['status'] ?? TRUE);
+
+    $format = $this->config('filter.format.staff_media_html.yml');
+    self::assertTrue($format['filters']['media_embed']['status'] ?? FALSE);
+    self::assertSame(
+      ['image' => 'image'],
+      $format['filters']['media_embed']['settings']['allowed_media_types'] ?? [],
+    );
+  }
+
+  /**
+   * Verifies that CK-1 does not grant the staff format to organisers.
+   */
+  public function testFormatPermissionRemainsStaffOnly(): void {
+    $staff = $this->config('user.role.content_editor.yml');
+    $vendor = $this->config('user.role.vendor.yml');
+
+    self::assertContains('use text format staff_media_html', $staff['permissions'] ?? []);
+    self::assertNotContains('use text format staff_media_html', $vendor['permissions'] ?? []);
+    self::assertContains('use text format basic_html', $vendor['permissions'] ?? []);
+
+    $basicEditor = $this->config('editor.editor.basic_html.yml');
+    self::assertTrue($basicEditor['image_upload']['status'] ?? FALSE);
+    self::assertContains(
+      'drupalInsertImage',
+      $basicEditor['settings']['toolbar']['items'] ?? [],
+    );
+    self::assertNotContains(
+      'drupalMedia',
+      $basicEditor['settings']['toolbar']['items'] ?? [],
+    );
+  }
+
+  /**
+   * Verifies that only the approved Page and Article fields opt in.
+   */
+  public function testPageAndArticleAllowStaffFormatAndLegacyFormats(): void {
+    foreach (['page', 'article'] as $bundle) {
+      $field = $this->config('field.field.node.' . $bundle . '.body.yml');
+      self::assertSame(
+        ['staff_media_html', 'basic_html', 'full_html'],
+        $field['settings']['allowed_formats'] ?? [],
+      );
+    }
+
+    $event = $this->config('field.field.node.event.body.yml');
+    self::assertSame(['plain_text'], $event['settings']['allowed_formats'] ?? []);
+  }
+
+  /**
+   * Loads a synchronised configuration file.
+   *
+   * @return array<string, mixed>
+   *   Parsed configuration.
+   */
+  private function config(string $file): array {
+    $path = dirname(__DIR__, 7) . '/config/sync/' . $file;
+    self::assertFileExists($path);
+    $data = Yaml::parseFile($path);
+    self::assertIsArray($data);
+    return $data;
+  }
+
+}


### PR DESCRIPTION
## What changed

- adds a staff-only `staff_media_html` CKEditor 5 format for Page and Article content
- replaces direct CKEditor file uploads with Image Media Embed for that format
- grants the format to Content Editor while leaving the organiser Basic HTML editor unchanged
- migrates only current Page and Article Basic HTML format identifiers after rendered-output equivalence checks
- retains HTML values, older revisions, legacy inline files and organiser Media ownership boundaries
- records a hashed rollback ledger and keeps the migration idempotent

## Why

Staff-authored Page and Article content currently uses CKEditor direct uploads into `public://inline-images`, outside the shared Media provenance and reuse model. Applying Media Embed to the organiser Basic HTML format would broaden the change across an ownership-sensitive workflow, so CK-1 introduces a separate staff format.

## Deployment notes

Staging mirrors release configuration before running `updatedb`, then runs full `config:import`. Update `myeventlane_vendor_update_10024()` activates only its synced CK-1 prerequisites before the format migration, then the normal import reconciles active configuration.

The update fails closed if required configuration, role or fields are absent, or if Basic HTML and Staff Media HTML render differently for any candidate row.

Do not merge until staging migration counts and the signed-in acceptance plan are reviewed.

## Validation

- migration kernel test: 1 test passed, 16 assertions
- configuration boundary tests: 3 tests passed, 30 assertions
- PHP syntax checks passed
- new test files pass Drupal coding standards
- YAML parsing and `git diff --check` passed
- no database update or configuration import was run against the active MEL site

## Acceptance still required

- Content Editor: new and migrated Page/Article editing, Image Media Embed and reload
- Administrator: full Media access
- Organiser A/B: unchanged Basic HTML workflow and cross-organiser Media isolation
- Public/customer: accessible desktop and mobile rendering
- revision view/revert on disposable staging content

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The update hook changes live body format metadata for Page/Article content and fails closed on render mismatches, but organiser workflows and historical revisions are intentionally untouched.
> 
> **Overview**
> Introduces a staff-only **`staff_media_html`** text format and CKEditor 5 profile that uses **drupalMedia** (image embed) instead of direct inline uploads, and limits Page/Article body fields to `staff_media_html`, `basic_html`, and `full_html`. **Content Editor** gains permission to use the new format; organiser **basic_html** stays unchanged.
> 
> **`myeventlane_vendor_update_10024()`** migrates only *current* Page/Article rows whose format is `basic_html` to `staff_media_html` after a rendered-output equivalence check; it updates the matching current revision row, leaves older revisions on `basic_html`, skips other bundles, and stores a hashed state ledger for rollback. **`myeventlane_vendor_ensure_staff_media_html_config()`** can activate synced format/editor/role/field prerequisites before that migration when staging runs updates ahead of full config import.
> 
> Unit and kernel tests lock in media-only toolbar boundaries, staff-vs-vendor permissions, field allowlists, and bounded migration behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ad0aa3885e2e50fe03bb2595c881c8f58cafb10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->