### PR TITLE
Add Media-first MEL Guide assets

### DIFF
--- a/web/modules/custom/mel_guide/mel_guide.info.yml
+++ b/web/modules/custom/mel_guide/mel_guide.info.yml
@@ -10,5 +10,6 @@ dependencies:
   - myeventlane_surface:myeventlane_surface
   - drupal:block
   - drupal:file
+  - drupal:media
   - drupal:node
   - drupal:user

--- a/web/modules/custom/mel_guide/mel_guide.install
+++ b/web/modules/custom/mel_guide/mel_guide.install
@@ -7,6 +7,10 @@
 
 declare(strict_types=1);
 
+use Drupal\Core\Utility\UpdateException;
+use Drupal\file\FileInterface;
+use Drupal\mel_guide\Service\MelGuideAssetMediaManager;
+
 /**
  * Add v1.1 configuration keys for help panel, version, debug context, position.
  */
@@ -72,4 +76,83 @@ function mel_guide_update_9003(): void {
 
   $messages['celebrate'] = "You're going! 🎉";
   $config->set('messages', $messages)->save();
+}
+
+/**
+ * Adds Media-first character assets while retaining all legacy fallbacks.
+ */
+function mel_guide_update_9004(): string {
+  $config = \Drupal::configFactory()->get('mel_guide.settings');
+  $state = \Drupal::state();
+  $media_uuids = $state->get(MelGuideAssetMediaManager::STATE_KEY, []);
+  if (!is_array($media_uuids)) {
+    $media_uuids = [];
+  }
+
+  $fids = $config->get('asset_fids');
+  if (!is_array($fids)) {
+    $fids = [];
+  }
+  $manager = \Drupal::service('mel_guide.asset_media_manager');
+  assert($manager instanceof MelGuideAssetMediaManager);
+  $file_storage = \Drupal::entityTypeManager()->getStorage('file');
+  $file_system = \Drupal::service('file_system');
+  $created = 0;
+  $reused = 0;
+  $unavailable = 0;
+
+  foreach (['wave', 'think', 'celebrate'] as $key) {
+    $existing_uuid = trim((string) ($media_uuids[$key] ?? ''));
+    if ($existing_uuid !== '' && $manager->getFileId($existing_uuid) > 0) {
+      continue;
+    }
+    $media_uuids[$key] = NULL;
+
+    $fid = (int) ($fids[$key] ?? 0);
+    $file = $fid > 0 ? $file_storage->load($fid) : NULL;
+    $realpath = $file instanceof FileInterface
+      ? $file_system->realpath($file->getFileUri())
+      : FALSE;
+    if (!$file instanceof FileInterface || $realpath === FALSE || !is_file($realpath)) {
+      $media_uuids[$key] = NULL;
+      $unavailable++;
+      continue;
+    }
+
+    try {
+      $capture = $manager->capture($fid, sprintf('MEL %s', $key));
+      $media_uuids[$key] = $capture['media']->uuid();
+      if ($capture['created']) {
+        $created++;
+      }
+      else {
+        $reused++;
+      }
+    }
+    catch (\InvalidArgumentException $exception) {
+      // Unsupported legacy formats retain their file-ID and path fallbacks.
+      $media_uuids[$key] = NULL;
+      $unavailable++;
+      \Drupal::logger('mel_guide')->warning('MEL Guide @state asset was not captured as Image Media: @message', [
+        '@state' => $key,
+        '@message' => $exception->getMessage(),
+      ]);
+    }
+    catch (\Throwable $exception) {
+      throw new UpdateException(sprintf('MEL Guide %s Media capture failed: %s', $key, $exception->getMessage()), 0, $exception);
+    }
+  }
+
+  foreach (['wave', 'think', 'celebrate'] as $key) {
+    $media_uuids[$key] = $media_uuids[$key] ?? NULL;
+  }
+  $state->set(MelGuideAssetMediaManager::STATE_KEY, $media_uuids);
+  \Drupal::service('cache_tags.invalidator')->invalidateTags(['mel_guide:assets']);
+
+  return sprintf(
+    'MEL Guide Media capture complete: %d created, %d reused, %d unavailable legacy assets retained with fallback.',
+    $created,
+    $reused,
+    $unavailable,
+  );
 }

--- a/web/modules/custom/mel_guide/mel_guide.services.yml
+++ b/web/modules/custom/mel_guide/mel_guide.services.yml
@@ -17,7 +17,17 @@ services:
       - '@request_stack'
       - '@mel_guide.visibility'
       - '@entity_type.manager'
+      - '@state'
+      - '@entity.repository'
+      - '@file_system'
       - '@file_url_generator'
+
+  mel_guide.asset_media_manager:
+    class: Drupal\mel_guide\Service\MelGuideAssetMediaManager
+    arguments:
+      - '@entity_type.manager'
+      - '@entity.repository'
+      - '@file_system'
 
   cache_context.mel_guide_device_class:
     class: Drupal\mel_guide\Cache\Context\MelGuideDeviceCacheContext
@@ -33,5 +43,8 @@ services:
       - '@config.typed'
       - '@file.usage'
       - '@entity_type.manager'
+      - '@mel_guide.asset_media_manager'
+      - '@state'
+      - '@cache_tags.invalidator'
     tags:
       - { name: form }

--- a/web/modules/custom/mel_guide/src/Form/MelGuideSettingsForm.php
+++ b/web/modules/custom/mel_guide/src/Form/MelGuideSettingsForm.php
@@ -6,11 +6,14 @@ namespace Drupal\mel_guide\Form;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\TypedConfigManagerInterface;
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\State\StateInterface;
 use Drupal\file\FileInterface;
 use Drupal\file\FileUsage\FileUsageInterface;
+use Drupal\mel_guide\Service\MelGuideAssetMediaManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -37,6 +40,9 @@ final class MelGuideSettingsForm extends ConfigFormBase {
     TypedConfigManagerInterface $typed_config_manager,
     protected FileUsageInterface $fileUsage,
     protected EntityTypeManagerInterface $entityTypeManager,
+    protected MelGuideAssetMediaManager $assetMediaManager,
+    protected StateInterface $state,
+    protected CacheTagsInvalidatorInterface $cacheTagsInvalidator,
   ) {
     parent::__construct($config_factory, $typed_config_manager);
   }
@@ -50,6 +56,9 @@ final class MelGuideSettingsForm extends ConfigFormBase {
       $container->get('config.typed'),
       $container->get('file.usage'),
       $container->get('entity_type.manager'),
+      $container->get('mel_guide.asset_media_manager'),
+      $container->get('state'),
+      $container->get('cache_tags.invalidator'),
     );
   }
 
@@ -207,11 +216,15 @@ final class MelGuideSettingsForm extends ConfigFormBase {
     $messages = $config->get('messages') ?? [];
     $assets = $config->get('assets') ?? [];
     $asset_fids = $config->get('asset_fids') ?? [];
+    $asset_media_uuids = $this->state->get(MelGuideAssetMediaManager::STATE_KEY, []);
+    if (!is_array($asset_media_uuids)) {
+      $asset_media_uuids = [];
+    }
 
     $form['guide_states'] = [
       '#type' => 'details',
       '#title' => $this->t('Guide states'),
-      '#description' => $this->t('Message copy and character image for each guide moment. Uploaded images take precedence over fallback paths.'),
+      '#description' => $this->t('Message copy and character image for each guide moment. Uploads are captured as platform-owned Image Media and take precedence over retained file and path fallbacks.'),
       '#open' => TRUE,
       '#tree' => TRUE,
     ];
@@ -232,10 +245,10 @@ final class MelGuideSettingsForm extends ConfigFormBase {
       '#title' => $this->t('Character image'),
       '#upload_location' => 'public://mel-guide/',
       '#upload_validators' => [
-        'FileExtension' => ['extensions' => 'png jpg jpeg gif webp svg'],
+        'FileExtension' => ['extensions' => 'png jpg jpeg gif webp'],
         'FileSizeLimit' => ['fileLimit' => 2 * 1024 * 1024],
       ],
-      '#default_value' => $this->fidToDefaultValue($asset_fids['wave'] ?? 0),
+      '#default_value' => $this->assetDefaultValue($asset_media_uuids['wave'] ?? NULL, $asset_fids['wave'] ?? 0),
       '#description' => $this->t('Square PNG or WebP recommended. Desktop display is 80–96px; mobile is 64–72px.'),
     ];
     $form['guide_states']['wave']['path'] = [
@@ -269,10 +282,10 @@ final class MelGuideSettingsForm extends ConfigFormBase {
       '#title' => $this->t('Character image'),
       '#upload_location' => 'public://mel-guide/',
       '#upload_validators' => [
-        'FileExtension' => ['extensions' => 'png jpg jpeg gif webp svg'],
+        'FileExtension' => ['extensions' => 'png jpg jpeg gif webp'],
         'FileSizeLimit' => ['fileLimit' => 2 * 1024 * 1024],
       ],
-      '#default_value' => $this->fidToDefaultValue($asset_fids['think'] ?? 0),
+      '#default_value' => $this->assetDefaultValue($asset_media_uuids['think'] ?? NULL, $asset_fids['think'] ?? 0),
       '#description' => $this->t('Square PNG or WebP recommended. Desktop display is 80–96px; mobile is 64–72px.'),
     ];
     $form['guide_states']['think']['path'] = [
@@ -299,10 +312,10 @@ final class MelGuideSettingsForm extends ConfigFormBase {
       '#title' => $this->t('Character image'),
       '#upload_location' => 'public://mel-guide/',
       '#upload_validators' => [
-        'FileExtension' => ['extensions' => 'png jpg jpeg gif webp svg'],
+        'FileExtension' => ['extensions' => 'png jpg jpeg gif webp'],
         'FileSizeLimit' => ['fileLimit' => 2 * 1024 * 1024],
       ],
-      '#default_value' => $this->fidToDefaultValue($asset_fids['celebrate'] ?? 0),
+      '#default_value' => $this->assetDefaultValue($asset_media_uuids['celebrate'] ?? NULL, $asset_fids['celebrate'] ?? 0),
       '#description' => $this->t('Square PNG or WebP recommended. Desktop display is 80–96px; mobile is 64–72px.'),
     ];
     $form['guide_states']['celebrate']['path'] = [
@@ -361,6 +374,7 @@ final class MelGuideSettingsForm extends ConfigFormBase {
       $states_input = [];
     }
     $asset_fids = [];
+    $asset_media_uuids = [];
     $asset_paths = [];
 
     if (is_array($states_input)) {
@@ -369,6 +383,23 @@ final class MelGuideSettingsForm extends ConfigFormBase {
         $new_fid = is_array($upload) && !empty($upload[0]) ? (int) $upload[0] : 0;
         $old_fid = (int) (($config->get('asset_fids') ?? [])[$key] ?? 0);
 
+        if ($new_fid > 0) {
+          try {
+            $capture = $this->assetMediaManager->capture($new_fid, $this->assetAltText($key));
+            $asset_media_uuids[$key] = $capture['media']->uuid();
+          }
+          catch (\InvalidArgumentException | \RuntimeException $exception) {
+            $this->messenger()->addError($this->t('The @state character image could not be saved as Image Media: @message', [
+              '@state' => $key,
+              '@message' => $exception->getMessage(),
+            ]));
+            return;
+          }
+        }
+        else {
+          $asset_media_uuids[$key] = NULL;
+        }
+
         if ($old_fid > 0 && $old_fid !== $new_fid) {
           $old_file = $storage->load($old_fid);
           if ($old_file instanceof FileInterface) {
@@ -376,7 +407,7 @@ final class MelGuideSettingsForm extends ConfigFormBase {
           }
         }
 
-        if ($new_fid > 0) {
+        if ($new_fid > 0 && $old_fid !== $new_fid) {
           $file = $storage->load($new_fid);
           if ($file instanceof FileInterface) {
             $file->setPermanent();
@@ -414,20 +445,40 @@ final class MelGuideSettingsForm extends ConfigFormBase {
       ->set('assets', $asset_paths)
       ->save();
 
+    $this->state->set(MelGuideAssetMediaManager::STATE_KEY, $asset_media_uuids);
+    $this->cacheTagsInvalidator->invalidateTags(['mel_guide:assets']);
+
     parent::submitForm($form, $form_state);
   }
 
   /**
-   * Converts a config file ID to a managed_file default value.
-   *
-   * @param mixed $fid
-   *   Stored file ID.
+   * Resolves a Media-first or legacy managed_file default value.
    *
    * @return list<int>
+   *   A one-item file ID list, or an empty list when no valid asset exists.
    */
-  private function fidToDefaultValue(mixed $fid): array {
-    $fid = (int) ($fid ?? 0);
+  private function assetDefaultValue(mixed $media_uuid, mixed $legacy_fid): array {
+    $fid = $this->assetMediaManager->getFileId(is_string($media_uuid) ? $media_uuid : NULL);
+    if ($fid <= 0) {
+      $fid = (int) ($legacy_fid ?? 0);
+      $file = $fid > 0 ? $this->entityTypeManager->getStorage('file')->load($fid) : NULL;
+      if (!$file instanceof FileInterface) {
+        $fid = 0;
+      }
+    }
     return $fid > 0 ? [$fid] : [];
+  }
+
+  /**
+   * Builds accessible alt text for platform-owned character Media.
+   */
+  private function assetAltText(string $key): string {
+    return match ($key) {
+      'wave' => (string) $this->t('MEL waving'),
+      'think' => (string) $this->t('MEL thinking'),
+      'celebrate' => (string) $this->t('MEL celebrating'),
+      default => (string) $this->t('MEL Guide character'),
+    };
   }
 
 }

--- a/web/modules/custom/mel_guide/src/Plugin/Block/MelGuideBlock.php
+++ b/web/modules/custom/mel_guide/src/Plugin/Block/MelGuideBlock.php
@@ -62,6 +62,7 @@ final class MelGuideBlock extends BlockBase implements ContainerFactoryPluginInt
   public function getCacheTags(): array {
     return Cache::mergeTags(parent::getCacheTags(), [
       'config:mel_guide.settings',
+      'mel_guide:assets',
     ]);
   }
 
@@ -109,7 +110,7 @@ final class MelGuideBlock extends BlockBase implements ContainerFactoryPluginInt
       ],
       '#cache' => [
         'contexts' => $this->getCacheContexts(),
-        'tags' => $this->getCacheTags(),
+        'tags' => Cache::mergeTags($this->getCacheTags(), $variables['cache_tags'] ?? []),
       ],
     ];
   }

--- a/web/modules/custom/mel_guide/src/Service/MelGuideAssetMediaManager.php
+++ b/web/modules/custom/mel_guide/src/Service/MelGuideAssetMediaManager.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\mel_guide\Service;
+
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\file\FileInterface;
+use Drupal\media\MediaInterface;
+use Drupal\media\MediaTypeInterface;
+
+/**
+ * Captures MEL Guide character files as platform-owned Image Media.
+ */
+final class MelGuideAssetMediaManager {
+
+  /**
+   * Environment-local Media selection, deliberately outside config import.
+   */
+  public const STATE_KEY = 'mel_guide.asset_media_uuids';
+
+  /**
+   * System ownership keeps platform artwork out of organiser Media results.
+   */
+  private const PLATFORM_MEDIA_OWNER_ID = 0;
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly EntityRepositoryInterface $entityRepository,
+    private readonly FileSystemInterface $fileSystem,
+  ) {}
+
+  /**
+   * Creates or reuses platform-owned Image Media for a character asset.
+   *
+   * @return array{media: \Drupal\media\MediaInterface, created: bool}
+   *   The captured Media item and whether it was newly created.
+   *
+   * @throws \InvalidArgumentException
+   *   When the source file is unavailable or unsupported by Image Media.
+   * @throws \RuntimeException
+   *   When Image Media is unavailable or cannot be saved.
+   */
+  public function capture(int $fid, string $alt): array {
+    $file = $this->entityTypeManager->getStorage('file')->load($fid);
+    if (!$file instanceof FileInterface) {
+      throw new \InvalidArgumentException(sprintf('MEL Guide file %d could not be loaded.', $fid));
+    }
+
+    $realpath = $this->fileSystem->realpath($file->getFileUri());
+    if ($realpath === FALSE || !is_file($realpath)) {
+      throw new \InvalidArgumentException(sprintf('MEL Guide file %d is missing from storage.', $fid));
+    }
+
+    $media_type = $this->entityTypeManager->getStorage('media_type')->load('image');
+    if (!$media_type instanceof MediaTypeInterface) {
+      throw new \RuntimeException('The Image media type is not available.');
+    }
+    $source_field = (string) ($media_type->getSource()->getConfiguration()['source_field'] ?? '');
+    if ($source_field === '') {
+      throw new \RuntimeException('The Image media source field is not configured.');
+    }
+
+    $media_storage = $this->entityTypeManager->getStorage('media');
+    $existing = $media_storage->loadByProperties([
+      'bundle' => 'image',
+      'uid' => self::PLATFORM_MEDIA_OWNER_ID,
+      $source_field . '.target_id' => $fid,
+    ]);
+    $media = $existing ? reset($existing) : NULL;
+    if ($media instanceof MediaInterface) {
+      return ['media' => $media, 'created' => FALSE];
+    }
+
+    if ($file->isTemporary()) {
+      $file->setPermanent();
+      $file->save();
+    }
+
+    $alt = trim($alt);
+    if ($alt === '') {
+      $alt = $file->getFilename();
+    }
+    $media = $media_storage->create([
+      'bundle' => 'image',
+      'uid' => self::PLATFORM_MEDIA_OWNER_ID,
+      'status' => 1,
+      'name' => sprintf('MEL Guide: %s', $alt),
+      $source_field => [
+        'target_id' => $fid,
+        'alt' => $alt,
+      ],
+    ]);
+    if (!$media instanceof MediaInterface) {
+      throw new \RuntimeException('The MEL Guide Image Media item could not be created.');
+    }
+
+    $violations = $media->validate();
+    if ($violations->count() > 0) {
+      throw new \InvalidArgumentException(sprintf('MEL Guide file %d is not supported by Image Media: %s', $fid, (string) $violations));
+    }
+
+    try {
+      $media->save();
+    }
+    catch (\Throwable $exception) {
+      throw new \RuntimeException(sprintf('The MEL Guide Image Media item could not be saved: %s', $exception->getMessage()), 0, $exception);
+    }
+    return ['media' => $media, 'created' => TRUE];
+  }
+
+  /**
+   * Resolves a Media UUID to its source file ID.
+   */
+  public function getFileId(?string $media_uuid): int {
+    if ($media_uuid === NULL || $media_uuid === '') {
+      return 0;
+    }
+    $media = $this->entityRepository->loadEntityByUuid('media', $media_uuid);
+    if (!$media instanceof MediaInterface || $media->bundle() !== 'image') {
+      return 0;
+    }
+    $source = $media->getSource();
+    $source_field = (string) ($source->getConfiguration()['source_field'] ?? '');
+    if ($source_field === '' || !$media->hasField($source_field) || $media->get($source_field)->isEmpty()) {
+      return 0;
+    }
+    $file = $media->get($source_field)->entity;
+    if (!$file instanceof FileInterface) {
+      return 0;
+    }
+    $realpath = $this->fileSystem->realpath($file->getFileUri());
+    return $realpath !== FALSE && is_file($realpath) ? (int) $file->id() : 0;
+  }
+
+}

--- a/web/modules/custom/mel_guide/src/Service/MelGuideContext.php
+++ b/web/modules/custom/mel_guide/src/Service/MelGuideContext.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace Drupal\mel_guide\Service;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\State\StateInterface;
 use Drupal\file\FileInterface;
+use Drupal\media\MediaInterface;
 use Drupal\node\NodeInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -34,6 +38,9 @@ final class MelGuideContext {
     private readonly RequestStack $requestStack,
     private readonly MelGuideVisibility $visibility,
     private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly StateInterface $state,
+    private readonly EntityRepositoryInterface $entityRepository,
+    private readonly FileSystemInterface $fileSystem,
     private readonly FileUrlGeneratorInterface $fileUrlGenerator,
   ) {}
 
@@ -54,15 +61,16 @@ final class MelGuideContext {
       return NULL;
     }
 
-    $image_url = $this->resolveImageUrl($state);
-    if ($image_url === NULL) {
+    $image = $this->resolveImage($state);
+    if ($image === NULL) {
       return NULL;
     }
 
     return [
       'state' => $state,
       'message' => $message,
-      'image_url' => $image_url,
+      'image_url' => $image['url'],
+      'cache_tags' => $image['cache_tags'],
       'image_alt' => $this->resolveImageAlt($state),
       'appearance_delay' => (int) $config->get('appearance_delay'),
       'max_messages_per_session' => (int) $config->get('max_messages_per_session'),
@@ -73,25 +81,55 @@ final class MelGuideContext {
   }
 
   /**
-   * Resolves the public image URL for a character state.
+   * Resolves the public image URL and cache tags for a character state.
+   *
+   * @return array{url: string, cache_tags: string[]}|null
+   *   The resolved image data, or NULL when no source is available.
    */
-  private function resolveImageUrl(string $state): ?string {
+  private function resolveImage(string $state): ?array {
     if (!in_array($state, self::ASSET_KEYS, TRUE)) {
       return NULL;
     }
 
     $config = $this->configFactory->get('mel_guide.settings');
+    $media_uuids = $this->state->get(MelGuideAssetMediaManager::STATE_KEY, []);
+    $media_uuid = is_array($media_uuids) ? trim((string) ($media_uuids[$state] ?? '')) : '';
+    if ($media_uuid !== '') {
+      $media = $this->entityRepository->loadEntityByUuid('media', $media_uuid);
+      if ($media instanceof MediaInterface && $media->bundle() === 'image') {
+        $source_field = (string) ($media->getSource()->getConfiguration()['source_field'] ?? '');
+        $file = $source_field !== '' && $media->hasField($source_field)
+          ? $media->get($source_field)->entity
+          : NULL;
+        if ($file instanceof FileInterface && $this->fileExists($file)) {
+          return [
+            'url' => $this->fileUrlGenerator->generateString($file->getFileUri()),
+            'cache_tags' => array_merge($media->getCacheTags(), $file->getCacheTags()),
+          ];
+        }
+      }
+    }
+
     $fids = $config->get('asset_fids') ?? [];
+    if (!is_array($fids)) {
+      $fids = [];
+    }
     $fid = (int) ($fids[$state] ?? 0);
 
     if ($fid > 0) {
       $file = $this->entityTypeManager->getStorage('file')->load($fid);
-      if ($file instanceof FileInterface) {
-        return $this->fileUrlGenerator->generateString($file->getFileUri());
+      if ($file instanceof FileInterface && $this->fileExists($file)) {
+        return [
+          'url' => $this->fileUrlGenerator->generateString($file->getFileUri()),
+          'cache_tags' => $file->getCacheTags(),
+        ];
       }
     }
 
     $assets = $config->get('assets') ?? [];
+    if (!is_array($assets)) {
+      $assets = [];
+    }
     $asset_path = $assets[$state] ?? '';
     if ($asset_path === '') {
       return NULL;
@@ -99,7 +137,18 @@ final class MelGuideContext {
 
     $request = $this->requestStack->getCurrentRequest();
     $base_path = $request?->getBasePath() ?? '';
-    return $base_path . '/' . ltrim($asset_path, '/');
+    return [
+      'url' => $base_path . '/' . ltrim($asset_path, '/'),
+      'cache_tags' => [],
+    ];
+  }
+
+  /**
+   * Confirms a managed file still exists in storage.
+   */
+  private function fileExists(FileInterface $file): bool {
+    $realpath = $this->fileSystem->realpath($file->getFileUri());
+    return $realpath !== FALSE && is_file($realpath);
   }
 
   /**

--- a/web/modules/custom/mel_guide/tests/src/Unit/MelGuideMediaContractTest.php
+++ b/web/modules/custom/mel_guide/tests/src/Unit/MelGuideMediaContractTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mel_guide\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Protects MEL Guide Media capture and fallback contracts.
+ */
+#[Group('mel_guide')]
+final class MelGuideMediaContractTest extends UnitTestCase {
+
+  /**
+   * Media UUIDs extend rather than replace the rollback configuration.
+   */
+  public function testEnvironmentStateRetainsConfigFallbacks(): void {
+    $module = dirname(__DIR__, 3);
+    $root = dirname(__DIR__, 7);
+    $install = file_get_contents($module . '/config/install/mel_guide.settings.yml');
+    $sync = file_get_contents($root . '/config/sync/mel_guide.settings.yml');
+    $manager = file_get_contents($module . '/src/Service/MelGuideAssetMediaManager.php');
+
+    self::assertIsString($install);
+    self::assertIsString($sync);
+    self::assertIsString($manager);
+    self::assertStringContainsString("STATE_KEY = 'mel_guide.asset_media_uuids'", $manager);
+    self::assertStringNotContainsString('asset_media_uuids:', $install);
+    self::assertStringNotContainsString('asset_media_uuids:', $sync);
+    self::assertStringContainsString('asset_fids:', $install);
+    self::assertStringContainsString('assets:', $install);
+  }
+
+  /**
+   * Runtime resolution is Media, legacy file, then editable path fallback.
+   */
+  public function testResolutionOrderAndCacheContract(): void {
+    $module = dirname(__DIR__, 3);
+    $context = file_get_contents($module . '/src/Service/MelGuideContext.php');
+    $block = file_get_contents($module . '/src/Plugin/Block/MelGuideBlock.php');
+
+    self::assertIsString($context);
+    self::assertIsString($block);
+    $media_position = strpos($context, 'MelGuideAssetMediaManager::STATE_KEY');
+    $fid_position = strpos($context, "get('asset_fids')");
+    $path_position = strpos($context, "get('assets')");
+    self::assertNotFalse($media_position);
+    self::assertNotFalse($fid_position);
+    self::assertNotFalse($path_position);
+    self::assertLessThan($fid_position, $media_position);
+    self::assertLessThan($path_position, $fid_position);
+    self::assertStringContainsString('fileExists($file)', $context);
+    self::assertStringContainsString("'cache_tags' => array_merge(\$media->getCacheTags(), \$file->getCacheTags())", $context);
+    self::assertStringContainsString("Cache::mergeTags(\$this->getCacheTags(), \$variables['cache_tags'] ?? [])", $block);
+  }
+
+  /**
+   * Capture is system-owned and accepts only Image Media-compatible uploads.
+   */
+  public function testPlatformOwnershipAndUploadContract(): void {
+    $module = dirname(__DIR__, 3);
+    $manager = file_get_contents($module . '/src/Service/MelGuideAssetMediaManager.php');
+    $form = file_get_contents($module . '/src/Form/MelGuideSettingsForm.php');
+
+    self::assertIsString($manager);
+    self::assertIsString($form);
+    self::assertStringContainsString('PLATFORM_MEDIA_OWNER_ID = 0', $manager);
+    self::assertStringContainsString("load('image')", $manager);
+    self::assertStringContainsString('$media->validate()', $manager);
+    self::assertStringContainsString("'extensions' => 'png jpg jpeg gif webp'", $form);
+    self::assertStringNotContainsString('webp svg', $form);
+    self::assertStringContainsString("->set('asset_fids', \$asset_fids)", $form);
+    self::assertStringContainsString('MelGuideAssetMediaManager::STATE_KEY, $asset_media_uuids', $form);
+  }
+
+  /**
+   * Update skips missing/unsupported files but fails closed on save errors.
+   */
+  public function testBackfillRetainsUnavailableLegacyAssets(): void {
+    $module = dirname(__DIR__, 3);
+    $update = file_get_contents($module . '/mel_guide.install');
+
+    self::assertIsString($update);
+    self::assertStringContainsString('mel_guide_update_9004', $update);
+    self::assertStringContainsString('catch (\\InvalidArgumentException', $update);
+    self::assertStringContainsString('throw new UpdateException', $update);
+    self::assertStringNotContainsString("clear('asset_fids')", $update);
+    self::assertStringNotContainsString("clear('assets')", $update);
+  }
+
+}


### PR DESCRIPTION
## What changed

- Captures MEL Guide character uploads as published, system-owned Image Media.
- Resolves Guide artwork in the order Media, valid legacy file, then retained path fallback.
- Stores environment-selected Media UUIDs outside configuration sync so a full configuration import cannot overwrite them.
- Preserves legacy file IDs, fallback paths, existing files and current rendering.
- Restricts new Guide uploads to formats supported by the existing Image Media bundle.
- Adds Media and file cache invalidation.
- Adds a bounded update hook that backfills only available supported legacy files and fails closed on Media save errors.

## Why

Staging currently has missing MEL Guide file IDs 585-587 and renders through the retained theme path. Storing environment-created Media UUIDs in imported configuration would repeat the unresolved-reference defect already observed in some Page Visual records. Environment-local state keeps the Media selection editable and durable across normal configuration imports.

## Validation

- PHPUnit: 4 tests, 33 assertions.
- Drupal static analysis: passed.
- Drupal and DrupalPractice coding standards: passed.
- PHP syntax, YAML parsing and diff checks: passed.

## Boundaries

This draft does not authorise or include staging updates, configuration import, deployment, deprecated hero repair, organiser editor changes, legacy-field deletion or file deletion. Runtime and visual persona validation remain a separate staging gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches asset resolution, state vs config, and a data-migration update hook; behavior stays backward-compatible but deploy must run updates and depends on the Image media type.
> 
> **Overview**
> MEL Guide character images move to **platform-owned Image Media** while keeping existing file IDs and theme path fallbacks.
> 
> New uploads and update hook `9004` create or reuse Image Media via `MelGuideAssetMediaManager`; **Media UUIDs live in state** (`mel_guide.asset_media_uuids`) so config import cannot overwrite environment-specific references. Runtime resolution is **Media → valid legacy file → fallback path**, with existence checks and **media/file cache tags** merged on the block (`mel_guide:assets`).
> 
> The settings form captures uploads as Media on save, drops **SVG** from allowed extensions, and fails the save if Media capture errors. Legacy `asset_fids` and `assets` config remain for rollback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7998b2cdc08feab83ccfab96465f54d6faa4e9e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->