### PR TITLE
Make MEL Guide settings save atomic

### DIFF
--- a/web/modules/custom/mel_guide/mel_guide.services.yml
+++ b/web/modules/custom/mel_guide/mel_guide.services.yml
@@ -46,5 +46,6 @@ services:
       - '@mel_guide.asset_media_manager'
       - '@state'
       - '@cache_tags.invalidator'
+      - '@database'
     tags:
       - { name: form }

--- a/web/modules/custom/mel_guide/src/Form/MelGuideSettingsForm.php
+++ b/web/modules/custom/mel_guide/src/Form/MelGuideSettingsForm.php
@@ -7,6 +7,7 @@ namespace Drupal\mel_guide\Form;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\TypedConfigManagerInterface;
 use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -43,6 +44,7 @@ final class MelGuideSettingsForm extends ConfigFormBase {
     protected MelGuideAssetMediaManager $assetMediaManager,
     protected StateInterface $state,
     protected CacheTagsInvalidatorInterface $cacheTagsInvalidator,
+    protected Connection $database,
   ) {
     parent::__construct($config_factory, $typed_config_manager);
   }
@@ -59,6 +61,7 @@ final class MelGuideSettingsForm extends ConfigFormBase {
       $container->get('mel_guide.asset_media_manager'),
       $container->get('state'),
       $container->get('cache_tags.invalidator'),
+      $container->get('database'),
     );
   }
 
@@ -376,76 +379,104 @@ final class MelGuideSettingsForm extends ConfigFormBase {
     $asset_fids = [];
     $asset_media_uuids = [];
     $asset_paths = [];
+    $file_usage_changes = [];
+    $stored_media_uuids = $this->state->get(MelGuideAssetMediaManager::STATE_KEY, []);
+    if (!is_array($stored_media_uuids)) {
+      $stored_media_uuids = [];
+    }
+    $failed_key = '';
+    $transaction = $this->database->startTransaction();
 
-    if (is_array($states_input)) {
+    try {
       foreach (self::ASSET_KEYS as $key) {
+        $failed_key = $key;
         $upload = $states_input[$key]['upload'] ?? [];
         $new_fid = is_array($upload) && !empty($upload[0]) ? (int) $upload[0] : 0;
         $old_fid = (int) (($config->get('asset_fids') ?? [])[$key] ?? 0);
 
         if ($new_fid > 0) {
-          try {
+          $stored_uuid = is_string($stored_media_uuids[$key] ?? NULL)
+            ? $stored_media_uuids[$key]
+            : NULL;
+          $stored_media_fid = $this->assetMediaManager->getFileId($stored_uuid);
+          if ($new_fid === $old_fid) {
+            // Preserve a valid prior capture, but never recapture unchanged
+            // legacy assets merely because unrelated settings were submitted.
+            $asset_media_uuids[$key] = $stored_media_fid === $new_fid
+              ? $stored_uuid
+              : NULL;
+          }
+          else {
             $capture = $this->assetMediaManager->capture($new_fid, $this->assetAltText($key));
             $asset_media_uuids[$key] = $capture['media']->uuid();
-          }
-          catch (\InvalidArgumentException | \RuntimeException $exception) {
-            $this->messenger()->addError($this->t('The @state character image could not be saved as Image Media: @message', [
-              '@state' => $key,
-              '@message' => $exception->getMessage(),
-            ]));
-            return;
           }
         }
         else {
           $asset_media_uuids[$key] = NULL;
         }
 
+        $asset_fids[$key] = $new_fid;
+        $asset_paths[$key] = trim((string) ($states_input[$key]['path'] ?? ''));
+        $file_usage_changes[$key] = [
+          'old_fid' => $old_fid,
+          'new_fid' => $new_fid,
+        ];
+      }
+
+      $failed_key = 'settings';
+      foreach ($file_usage_changes as $key => $change) {
+        $old_fid = $change['old_fid'];
+        $new_fid = $change['new_fid'];
         if ($old_fid > 0 && $old_fid !== $new_fid) {
           $old_file = $storage->load($old_fid);
           if ($old_file instanceof FileInterface) {
             $this->fileUsage->delete($old_file, 'mel_guide', 'config', $key);
           }
         }
-
         if ($new_fid > 0 && $old_fid !== $new_fid) {
           $file = $storage->load($new_fid);
           if ($file instanceof FileInterface) {
-            $file->setPermanent();
-            $file->save();
             $this->fileUsage->add($file, 'mel_guide', 'config', $key);
           }
         }
-
-        $asset_fids[$key] = $new_fid;
-        $asset_paths[$key] = trim((string) ($states_input[$key]['path'] ?? ''));
       }
+
+      $this->config('mel_guide.settings')
+        ->set('enabled', (bool) $form_state->getValue('enabled'))
+        ->set('enabled_mobile', (bool) $form_state->getValue('enabled_mobile'))
+        ->set('enabled_desktop', (bool) $form_state->getValue('enabled_desktop'))
+        ->set('show_for_anonymous', (bool) $form_state->getValue('show_for_anonymous'))
+        ->set('show_for_authenticated', (bool) $form_state->getValue('show_for_authenticated'))
+        ->set('show_for_customers', (bool) $form_state->getValue('show_for_customers'))
+        ->set('show_for_organisers', (bool) $form_state->getValue('show_for_organisers'))
+        ->set('appearance_delay', (int) $form_state->getValue('appearance_delay'))
+        ->set('max_messages_per_session', (int) $form_state->getValue('max_messages_per_session'))
+        ->set('hide_days_after_dismiss', (int) $form_state->getValue('hide_days_after_dismiss'))
+        ->set('debug_force_display', (bool) $form_state->getValue('debug_force_display'))
+        ->set('debug_context', (string) $form_state->getValue('debug_context'))
+        ->set('position', (string) $form_state->getValue('position'))
+        ->set('asset_fids', $asset_fids)
+        ->set('messages', [
+          'welcome' => trim((string) ($states_input['wave']['message'] ?? '')),
+          'discover' => trim((string) ($states_input['think']['discover_message'] ?? '')),
+          'thinking' => trim((string) ($states_input['think']['thinking_message'] ?? '')),
+          'celebrate' => trim((string) ($states_input['celebrate']['message'] ?? '')),
+        ])
+        ->set('assets', $asset_paths)
+        ->save();
+
+      $this->state->set(MelGuideAssetMediaManager::STATE_KEY, $asset_media_uuids);
+    }
+    catch (\Throwable $exception) {
+      $transaction->rollBack();
+      $this->messenger()->addError($this->t('MEL Guide settings could not be saved while processing @state: @message', [
+        '@state' => $failed_key,
+        '@message' => $exception->getMessage(),
+      ]));
+      return;
     }
 
-    $this->config('mel_guide.settings')
-      ->set('enabled', (bool) $form_state->getValue('enabled'))
-      ->set('enabled_mobile', (bool) $form_state->getValue('enabled_mobile'))
-      ->set('enabled_desktop', (bool) $form_state->getValue('enabled_desktop'))
-      ->set('show_for_anonymous', (bool) $form_state->getValue('show_for_anonymous'))
-      ->set('show_for_authenticated', (bool) $form_state->getValue('show_for_authenticated'))
-      ->set('show_for_customers', (bool) $form_state->getValue('show_for_customers'))
-      ->set('show_for_organisers', (bool) $form_state->getValue('show_for_organisers'))
-      ->set('appearance_delay', (int) $form_state->getValue('appearance_delay'))
-      ->set('max_messages_per_session', (int) $form_state->getValue('max_messages_per_session'))
-      ->set('hide_days_after_dismiss', (int) $form_state->getValue('hide_days_after_dismiss'))
-      ->set('debug_force_display', (bool) $form_state->getValue('debug_force_display'))
-      ->set('debug_context', (string) $form_state->getValue('debug_context'))
-      ->set('position', (string) $form_state->getValue('position'))
-      ->set('asset_fids', $asset_fids)
-      ->set('messages', [
-        'welcome' => trim((string) ($states_input['wave']['message'] ?? '')),
-        'discover' => trim((string) ($states_input['think']['discover_message'] ?? '')),
-        'thinking' => trim((string) ($states_input['think']['thinking_message'] ?? '')),
-        'celebrate' => trim((string) ($states_input['celebrate']['message'] ?? '')),
-      ])
-      ->set('assets', $asset_paths)
-      ->save();
-
-    $this->state->set(MelGuideAssetMediaManager::STATE_KEY, $asset_media_uuids);
+    unset($transaction);
     $this->cacheTagsInvalidator->invalidateTags(['mel_guide:assets']);
 
     parent::submitForm($form, $form_state);

--- a/web/modules/custom/mel_guide/tests/src/Unit/MelGuideMediaContractTest.php
+++ b/web/modules/custom/mel_guide/tests/src/Unit/MelGuideMediaContractTest.php
@@ -90,4 +90,25 @@ final class MelGuideMediaContractTest extends UnitTestCase {
     self::assertStringNotContainsString("clear('assets')", $update);
   }
 
+  /**
+   * Form submission skips unchanged legacy capture and rolls back as one unit.
+   */
+  public function testSettingsSubmitIsAtomicAndLegacySafe(): void {
+    $module = dirname(__DIR__, 3);
+    $form = file_get_contents($module . '/src/Form/MelGuideSettingsForm.php');
+
+    self::assertIsString($form);
+    self::assertStringContainsString('if ($new_fid === $old_fid)', $form);
+    self::assertStringContainsString('never recapture unchanged', $form);
+    self::assertStringContainsString('$this->database->startTransaction()', $form);
+    self::assertStringContainsString('$transaction->rollBack()', $form);
+    self::assertStringContainsString('unset($transaction)', $form);
+
+    $capture_position = strpos($form, '$this->assetMediaManager->capture');
+    $usage_position = strpos($form, '$this->fileUsage->delete');
+    self::assertNotFalse($capture_position);
+    self::assertNotFalse($usage_position);
+    self::assertLessThan($usage_position, $capture_position);
+  }
+
 }


### PR DESCRIPTION
## Scope

Focused corrective follow-up to MG-1 and Cursor Bugbot's review of commit 7998b2c.

- Do not recapture unchanged legacy guide assets during unrelated settings saves.
- Keep legacy/path fallback active when an existing Media UUID does not resolve to the same file.
- Wrap Media capture, file-usage changes, configuration and state writes in one database transaction.
- Apply file-usage changes only after all captures succeed.
- Add a regression contract for unchanged legacy assets and atomic failure handling.

Only three MEL Guide files are changed. This does not alter organiser editors, deprecated hero settings, deployment configuration, or legacy files.

## Validation

- MEL Guide unit suite: 5 tests, 42 assertions.
- Drupal and DrupalPractice PHPCS: passed.
- Drupal static analysis for the manager and form: no errors.
- PHP syntax and `git diff --check`: passed.

The existing pre-MG-1 staging recovery snapshot remains available. After CI passes, this approved gate permits merge, staging deployment, Drupal update/config steps, and resumption of the admin/public desktop/mobile acceptance matrix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes admin config persistence, file usage, and Media capture ordering; failure handling is improved but the save path is more complex and touches shared Drupal storage.
> 
> **Overview**
> **MEL Guide settings saves are now atomic and safer for unchanged character images.**
> 
> `MelGuideSettingsForm` submit wraps Media capture, file-usage updates, config, and state writes in a **database transaction** with rollback and a single error message on failure. **File usage is applied only after all captures succeed**, and the form injects `@database` for that flow.
> 
> When a guide-state upload **file ID is unchanged**, the form **skips `capture()`** and keeps the stored Media UUID only if it still points at the same file—so unrelated settings saves do not re-run capture on legacy assets. New uploads still go through `capture()` (which still marks temporary files permanent).
> 
> A unit **contract test** asserts the unchanged-FID branch, transaction rollback, and that capture runs before file-usage deletes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4632b25067decc7f29a8ce19908672557a5af65d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->