### PR TITLE
Preserve unavailable MEL Guide legacy files

### DIFF
--- a/web/modules/custom/mel_guide/src/Form/MelGuideSettingsForm.php
+++ b/web/modules/custom/mel_guide/src/Form/MelGuideSettingsForm.php
@@ -394,6 +394,16 @@ final class MelGuideSettingsForm extends ConfigFormBase {
         $new_fid = is_array($upload) && !empty($upload[0]) ? (int) $upload[0] : 0;
         $old_fid = (int) (($config->get('asset_fids') ?? [])[$key] ?? 0);
 
+        if ($new_fid === 0 && $old_fid > 0) {
+          $old_file = $storage->load($old_fid);
+          if (!$old_file instanceof FileInterface) {
+            // An unavailable legacy file cannot appear in managed_file, so an
+            // empty submission is not evidence that the editor removed it.
+            // Retain the rollback ID while the editable path fallback renders.
+            $new_fid = $old_fid;
+          }
+        }
+
         if ($new_fid > 0) {
           $stored_uuid = is_string($stored_media_uuids[$key] ?? NULL)
             ? $stored_media_uuids[$key]

--- a/web/modules/custom/mel_guide/tests/src/Unit/MelGuideMediaContractTest.php
+++ b/web/modules/custom/mel_guide/tests/src/Unit/MelGuideMediaContractTest.php
@@ -100,6 +100,9 @@ final class MelGuideMediaContractTest extends UnitTestCase {
     self::assertIsString($form);
     self::assertStringContainsString('if ($new_fid === $old_fid)', $form);
     self::assertStringContainsString('never recapture unchanged', $form);
+    self::assertStringContainsString('if ($new_fid === 0 && $old_fid > 0)', $form);
+    self::assertStringContainsString('empty submission is not evidence that the editor removed it', $form);
+    self::assertStringContainsString('$new_fid = $old_fid;', $form);
     self::assertStringContainsString('$this->database->startTransaction()', $form);
     self::assertStringContainsString('$transaction->rollBack()', $form);
     self::assertStringContainsString('unset($transaction)', $form);


### PR DESCRIPTION
## Scope

Focused MG-1A correction following staging acceptance of PR #774.

- Preserve a positive legacy guide file ID when the managed-file submission is empty because the referenced file entity is unavailable.
- Keep the existing deliberate-removal behaviour when the old file entity is valid.
- Retain the editable path fallback and avoid creating Media or file-usage changes for unavailable legacy files.
- Add regression contract coverage for the missing-file distinction.

Only the MEL Guide settings form and its unit contract test are changed. Deprecated hero settings, organiser workflows, file deletion and production deployment remain out of scope.

## Root cause

Drupal's managed-file widget cannot return an unavailable legacy file as its submitted value. The empty value was therefore interpreted as an editor removal and overwrote the retained rollback ID with zero during an otherwise unchanged settings save.

## Validation

- MEL Guide unit suite: 5 tests, 45 assertions.
- Drupal and DrupalPractice coding standards: passed.
- Drupal static analysis: no errors.
- PHP syntax and `git diff --check`: passed.

After CI passes, the approved MG-1A gate permits merge, staging deployment and repetition of the unchanged admin-save acceptance test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to MEL Guide admin settings submit and a unit contract test; no auth or front-end behaviour changes beyond preventing accidental config clears on unchanged saves.
> 
> **Overview**
> Fixes **MEL Guide settings saves** wiping stored `asset_fids` when the character image widget submits empty because Drupal cannot surface an **unavailable legacy file** in `managed_file`.
> 
> On submit, if the upload is empty but config still has a positive legacy file ID, the form now **reloads that file entity**. When the entity is missing, it **keeps the stored ID** instead of treating the empty value as a deliberate removal, so rollback IDs stay intact while the **editable path fallback** still drives display. If the file entity exists and the widget is empty, removal behaviour is unchanged.
> 
> `MelGuideMediaContractTest` adds string-contract checks for this branch and the retain-`$old_fid` logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e524ef15535c6f3439df1ab6c5e5f09393453a36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->