### PR TITLE
Add useful MEL Guide actions

### DIFF
--- a/config/sync/mel_guide.settings.yml
+++ b/config/sync/mel_guide.settings.yml
@@ -20,7 +20,7 @@ asset_fids:
   think: 586
   celebrate: 587
 messages:
-  welcome: "Hi, I'm MEL. Looking for something fun?"
+  welcome: "Hi, I'm MEL. I can help you find your next event."
   discover: 'Need help finding an event?'
   thinking: 'Still exploring?'
   celebrate: "You're going! 🎉"

--- a/web/modules/custom/mel_guide/config/install/mel_guide.settings.yml
+++ b/web/modules/custom/mel_guide/config/install/mel_guide.settings.yml
@@ -18,7 +18,7 @@ asset_fids:
   think: 0
   celebrate: 0
 messages:
-  welcome: "Hi, I'm MEL. Looking for something fun?"
+  welcome: "Hi, I'm MEL. I can help you find your next event."
   discover: 'Need help finding an event?'
   thinking: 'Still exploring?'
   celebrate: "You're going! 🎉"

--- a/web/modules/custom/mel_guide/css/mel-guide.css
+++ b/web/modules/custom/mel_guide/css/mel-guide.css
@@ -47,26 +47,66 @@
 
 .mel-guide__actions {
   margin-top: var(--mel-space-2, 8px);
+  display: grid;
+  gap: var(--mel-space-2, 8px);
 }
 
 .mel-guide__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   appearance: none;
+  border: 1px solid transparent;
+  border-radius: var(--mel-radius-sm, 10px);
+  font-size: 0.875rem;
+  font-weight: 650;
+  line-height: 1.2;
+  text-align: center;
+  text-decoration: none;
+  cursor: pointer;
+  padding: var(--mel-space-2, 8px) var(--mel-space-3, 12px);
+  min-height: 44px;
+}
+
+.mel-guide__action--primary {
+  background: var(--mel-color-primary, #f26d5b);
+  color: #fff;
+}
+
+.mel-guide__action--secondary {
+  border-color: var(--mel-color-border, #e9e3de);
+  background: var(--mel-color-surface, #fff);
+  color: var(--mel-color-text, #24303a);
+}
+
+.mel-guide__action--hide {
+  justify-self: start;
   border: 0;
   background: transparent;
   color: var(--mel-color-text-secondary, #5b6670);
   font-size: 0.8125rem;
+  font-weight: 400;
   text-decoration: underline;
-  cursor: pointer;
-  padding: var(--mel-space-1, 4px);
-  min-height: 44px;
-  min-width: 44px;
+  padding-inline: var(--mel-space-1, 4px);
 }
 
 .mel-guide__action:hover,
 .mel-guide__action:focus-visible {
-  color: var(--mel-color-primary, #f26d5b);
   outline: 2px solid var(--mel-focus, var(--mel-color-primary, #f26d5b));
   outline-offset: 2px;
+}
+
+.mel-guide__action--primary:hover,
+.mel-guide__action--primary:focus-visible {
+  color: #fff;
+  filter: brightness(0.94);
+}
+
+.mel-guide__action--secondary:hover,
+.mel-guide__action--secondary:focus-visible,
+.mel-guide__action--hide:hover,
+.mel-guide__action--hide:focus-visible {
+  color: var(--mel-color-primary, #f26d5b);
 }
 
 .mel-guide__close {

--- a/web/modules/custom/mel_guide/mel_guide.module
+++ b/web/modules/custom/mel_guide/mel_guide.module
@@ -20,6 +20,7 @@ function mel_guide_theme(array $existing, string $type, string $theme, string $p
         'message' => '',
         'image_url' => '',
         'image_alt' => '',
+        'actions' => [],
         'position' => 'bottom_right',
       ],
       'template' => 'mel-guide',

--- a/web/modules/custom/mel_guide/mel_guide.services.yml
+++ b/web/modules/custom/mel_guide/mel_guide.services.yml
@@ -21,6 +21,8 @@ services:
       - '@entity.repository'
       - '@file_system'
       - '@file_url_generator'
+      - '@module_handler'
+      - '@current_user'
 
   mel_guide.asset_media_manager:
     class: Drupal\mel_guide\Service\MelGuideAssetMediaManager

--- a/web/modules/custom/mel_guide/src/Plugin/Block/MelGuideBlock.php
+++ b/web/modules/custom/mel_guide/src/Plugin/Block/MelGuideBlock.php
@@ -62,6 +62,7 @@ final class MelGuideBlock extends BlockBase implements ContainerFactoryPluginInt
   public function getCacheTags(): array {
     return Cache::mergeTags(parent::getCacheTags(), [
       'config:mel_guide.settings',
+      'config:myeventlane_help_assistant.settings',
       'mel_guide:assets',
     ]);
   }
@@ -95,6 +96,7 @@ final class MelGuideBlock extends BlockBase implements ContainerFactoryPluginInt
       '#message' => $variables['message'],
       '#image_url' => $variables['image_url'],
       '#image_alt' => $variables['image_alt'],
+      '#actions' => $variables['actions'],
       '#position' => $variables['position'],
       '#attached' => [
         'library' => ['mel_guide/guide'],

--- a/web/modules/custom/mel_guide/src/Service/MelGuideContext.php
+++ b/web/modules/custom/mel_guide/src/Service/MelGuideContext.php
@@ -7,10 +7,13 @@ namespace Drupal\mel_guide\Service;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\State\StateInterface;
+use Drupal\Core\Url;
 use Drupal\file\FileInterface;
 use Drupal\media\MediaInterface;
 use Drupal\node\NodeInterface;
@@ -42,6 +45,8 @@ final class MelGuideContext {
     private readonly EntityRepositoryInterface $entityRepository,
     private readonly FileSystemInterface $fileSystem,
     private readonly FileUrlGeneratorInterface $fileUrlGenerator,
+    private readonly ModuleHandlerInterface $moduleHandler,
+    private readonly AccountProxyInterface $currentUser,
   ) {}
 
   /**
@@ -72,12 +77,53 @@ final class MelGuideContext {
       'image_url' => $image['url'],
       'cache_tags' => $image['cache_tags'],
       'image_alt' => $this->resolveImageAlt($state),
+      'actions' => $this->resolveActions(),
       'appearance_delay' => (int) $config->get('appearance_delay'),
       'max_messages_per_session' => (int) $config->get('max_messages_per_session'),
       'hide_days_after_dismiss' => (int) $config->get('hide_days_after_dismiss'),
       'debug_force_display' => (bool) $config->get('debug_force_display'),
       'position' => $this->resolvePosition(),
     ];
+  }
+
+  /**
+   * Resolves safe, route-backed guide actions for the current visitor.
+   *
+   * @return array<string, string>
+   *   Action URLs keyed by action name.
+   */
+  private function resolveActions(): array {
+    $actions = [];
+
+    try {
+      $events_url = Url::fromRoute('view.upcoming_events.page_events');
+      if ($events_url->access($this->currentUser)) {
+        $actions['events'] = $events_url->toString();
+      }
+    }
+    catch (\Throwable) {
+      // Fail closed when the configured discovery route is unavailable.
+    }
+
+    if (!$this->moduleHandler->moduleExists('myeventlane_help_centre')
+      || !$this->moduleHandler->moduleExists('myeventlane_help_assistant')
+      || !(bool) $this->configFactory->get('myeventlane_help_assistant.settings')->get('enabled')) {
+      return $actions;
+    }
+
+    try {
+      $help_url = Url::fromRoute('myeventlane_help_centre.home', [], [
+        'fragment' => 'mel-help-assistant',
+      ]);
+      if ($help_url->access($this->currentUser)) {
+        $actions['help'] = $help_url->toString();
+      }
+    }
+    catch (\Throwable) {
+      // Fail closed rather than render an inaccessible Help Assistant link.
+    }
+
+    return $actions;
   }
 
   /**

--- a/web/modules/custom/mel_guide/templates/mel-guide.html.twig
+++ b/web/modules/custom/mel_guide/templates/mel-guide.html.twig
@@ -8,11 +8,21 @@
   <div class="mel-guide__panel" data-mel-guide-panel hidden>
     <div{{ bubble_attributes }}>
       <p class="mel-guide__message">{{ message }}</p>
-      <div class="mel-guide__actions">
+      <nav class="mel-guide__actions" aria-label="{{ 'MEL guide actions'|t }}">
+        {% if actions.events %}
+          <a class="mel-guide__action mel-guide__action--primary" href="{{ actions.events }}">
+            {{ 'Browse events'|t }}
+          </a>
+        {% endif %}
+        {% if actions.help %}
+          <a class="mel-guide__action mel-guide__action--secondary" href="{{ actions.help }}">
+            {{ 'Ask MEL for help'|t }}
+          </a>
+        {% endif %}
         <button type="button" class="mel-guide__action mel-guide__action--hide" data-mel-guide-hide>
           {{ 'Hide MEL'|t }}
         </button>
-      </div>
+      </nav>
     </div>
     <button
       type="button"

--- a/web/modules/custom/mel_guide/tests/src/Unit/MelGuideActionsContractTest.php
+++ b/web/modules/custom/mel_guide/tests/src/Unit/MelGuideActionsContractTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mel_guide\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Protects the MEL Guide route, accessibility, and presentation contracts.
+ */
+#[Group('mel_guide')]
+final class MelGuideActionsContractTest extends UnitTestCase {
+
+  /**
+   * Actions use existing routes and fail closed when help is unavailable.
+   */
+  public function testActionsAreRouteBackedAndAccessChecked(): void {
+    $module = dirname(__DIR__, 3);
+    $context = file_get_contents($module . '/src/Service/MelGuideContext.php');
+    $services = file_get_contents($module . '/mel_guide.services.yml');
+
+    self::assertIsString($context);
+    self::assertIsString($services);
+    self::assertStringContainsString("Url::fromRoute('view.upcoming_events.page_events')", $context);
+    self::assertStringContainsString("moduleExists('myeventlane_help_centre')", $context);
+    self::assertStringContainsString("moduleExists('myeventlane_help_assistant')", $context);
+    self::assertStringContainsString("get('myeventlane_help_assistant.settings')->get('enabled')", $context);
+    self::assertStringContainsString("Url::fromRoute('myeventlane_help_centre.home'", $context);
+    self::assertStringContainsString("'fragment' => 'mel-help-assistant'", $context);
+    self::assertSame(2, substr_count($context, "->access(\$this->currentUser)"));
+    self::assertStringContainsString("'@module_handler'", $services);
+    self::assertStringContainsString("'@current_user'", $services);
+  }
+
+  /**
+   * The guide offers keyboard-sized links without becoming another chatbot.
+   */
+  public function testActionsAreAccessibleAndNonConversational(): void {
+    $module = dirname(__DIR__, 3);
+    $root = dirname(__DIR__, 7);
+    $template = file_get_contents($module . '/templates/mel-guide.html.twig');
+    $styles = file_get_contents($module . '/css/mel-guide.css');
+    $sync = file_get_contents($root . '/config/sync/mel_guide.settings.yml');
+
+    self::assertIsString($template);
+    self::assertIsString($styles);
+    self::assertIsString($sync);
+    self::assertStringContainsString("aria-label=\"{{ 'MEL guide actions'|t }}\"", $template);
+    self::assertStringContainsString("{{ 'Browse events'|t }}", $template);
+    self::assertStringContainsString("{{ 'Ask MEL for help'|t }}", $template);
+    self::assertStringContainsString("{{ 'Hide MEL'|t }}", $template);
+    self::assertStringNotContainsString('<input', $template);
+    self::assertStringNotContainsString('<textarea', $template);
+    self::assertStringContainsString('min-height: 44px', $styles);
+    self::assertStringContainsString("welcome: \"Hi, I'm MEL. I can help you find your next event.\"", $sync);
+    self::assertStringNotContainsString('Looking for something fun?', $sync);
+  }
+
+}


### PR DESCRIPTION
## Scope

MG-2 replaces the MEL Guide's unanswered conversational prompt with useful, route-backed next steps.

- Change the homepage greeting to “Hi, I’m MEL. I can help you find your next event.”
- Add a primary **Browse events** action using the existing Events View route.
- Add **Ask MEL for help** using the existing grounded Help Assistant in the Help Centre.
- Render the Help Assistant action only when its modules are enabled, its feature is enabled, and the current visitor has route access.
- Keep **Hide MEL** as a quieter secondary control.
- Add keyboard-sized targets, focus styling, mobile-friendly stacked actions, cache coverage and regression contracts.

This does not embed a second chatbot or change MG-1 Media behaviour.

## Root cause

MEL Guide was intentionally implemented as a contextual companion rather than a chatbot, but its question-style copy implied visitors could reply. Its panel exposed only close and hide controls.

## Validation

- MEL Guide unit suite: 7 tests, 68 assertions.
- Drupal and DrupalPractice coding standards: passed for changed PHP.
- Drupal static analysis: no errors.
- PHP syntax and `git diff --check`: passed.
- Visual runtime acceptance remains pending because the active DDEV hostname serves a different checkout.

This draft PR does not authorise merge, configuration import or deployment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Visitor-facing navigation and conditional help links depend on route access and other modules’ config; changes are localized to mel_guide with access checks and cache tags, not auth or payment flows.
> 
> **Overview**
> Replaces the guide’s conversational welcome copy with **“Hi, I’m MEL. I can help you find your next event.”** and adds **actionable next steps** in the panel instead of only close/hide.
> 
> **Browse events** links to the existing upcoming events view when the visitor has route access. **Ask MEL for help** links to the Help Centre with the help-assistant fragment only when help centre and help assistant modules are enabled, the assistant is enabled in config, and the user can access that route; otherwise those links are omitted (fail closed).
> 
> The actions area is a labeled `nav` with stacked primary/secondary styling, **44px** targets, and focus styles; **Hide MEL** stays a quieter text control. Block cache tags include `myeventlane_help_assistant.settings`. Unit contract tests lock route names, access checks, and non-chatbot markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f31e5455e37dafa2a388e8d65da261ae69d33fcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->