### PR TITLE
Preserve MEL Guide config parity on save

### DIFF
--- a/web/modules/custom/mel_guide/src/Form/MelGuideSettingsForm.php
+++ b/web/modules/custom/mel_guide/src/Form/MelGuideSettingsForm.php
@@ -15,6 +15,7 @@ use Drupal\Core\State\StateInterface;
 use Drupal\file\FileInterface;
 use Drupal\file\FileUsage\FileUsageInterface;
 use Drupal\mel_guide\Service\MelGuideAssetMediaManager;
+use Drupal\mel_guide\Service\MelGuideAssetSubmissionResolver;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -391,25 +392,29 @@ final class MelGuideSettingsForm extends ConfigFormBase {
       foreach (self::ASSET_KEYS as $key) {
         $failed_key = $key;
         $upload = $states_input[$key]['upload'] ?? [];
-        $new_fid = is_array($upload) && !empty($upload[0]) ? (int) $upload[0] : 0;
+        $submitted_fid = is_array($upload) && !empty($upload[0]) ? (int) $upload[0] : 0;
         $old_fid = (int) (($config->get('asset_fids') ?? [])[$key] ?? 0);
-
-        if ($new_fid === 0 && $old_fid > 0) {
-          $old_file = $storage->load($old_fid);
-          if (!$old_file instanceof FileInterface) {
-            // An unavailable legacy file cannot appear in managed_file, so an
-            // empty submission is not evidence that the editor removed it.
-            // Retain the rollback ID while the editable path fallback renders.
-            $new_fid = $old_fid;
-          }
-        }
+        $old_file = $old_fid > 0 ? $storage->load($old_fid) : NULL;
+        $stored_uuid = is_string($stored_media_uuids[$key] ?? NULL)
+          ? $stored_media_uuids[$key]
+          : NULL;
+        $stored_media_fid = $this->assetMediaManager->getFileId($stored_uuid);
+        $selection = MelGuideAssetSubmissionResolver::resolve(
+          $submitted_fid,
+          $old_fid,
+          $stored_media_fid,
+          $old_file instanceof FileInterface,
+        );
+        $new_fid = $selection['fid'];
 
         if ($new_fid > 0) {
-          $stored_uuid = is_string($stored_media_uuids[$key] ?? NULL)
-            ? $stored_media_uuids[$key]
-            : NULL;
-          $stored_media_fid = $this->assetMediaManager->getFileId($stored_uuid);
-          if ($new_fid === $old_fid) {
+          if ($selection['preserve_media']) {
+            // The managed_file input displays the Media file ID, which may
+            // differ by environment from the configuration rollback ID.
+            // Preserve both without treating an unchanged input as a replace.
+            $asset_media_uuids[$key] = $stored_uuid;
+          }
+          elseif (!$selection['capture']) {
             // Preserve a valid prior capture, but never recapture unchanged
             // legacy assets merely because unrelated settings were submitted.
             $asset_media_uuids[$key] = $stored_media_fid === $new_fid

--- a/web/modules/custom/mel_guide/src/Service/MelGuideAssetSubmissionResolver.php
+++ b/web/modules/custom/mel_guide/src/Service/MelGuideAssetSubmissionResolver.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\mel_guide\Service;
+
+/**
+ * Distinguishes managed-file display IDs from configuration rollback IDs.
+ */
+final class MelGuideAssetSubmissionResolver {
+
+  /**
+   * Resolves the rollback FID and required Media action for an asset input.
+   *
+   * @return array{fid: int, preserve_media: bool, capture: bool}
+   *   The rollback FID to persist and the required Media action.
+   */
+  public static function resolve(
+    int $submitted_fid,
+    int $configured_fid,
+    ?int $stored_media_fid,
+    bool $configured_file_exists,
+  ): array {
+    if ($submitted_fid === 0) {
+      if ($configured_fid > 0 && !$configured_file_exists && ($stored_media_fid ?? 0) <= 0) {
+        // An unavailable legacy file cannot appear in managed_file, so an
+        // empty submission alone is not evidence that the editor removed it.
+        return [
+          'fid' => $configured_fid,
+          'preserve_media' => FALSE,
+          'capture' => FALSE,
+        ];
+      }
+
+      return [
+        'fid' => 0,
+        'preserve_media' => FALSE,
+        'capture' => FALSE,
+      ];
+    }
+
+    if ($stored_media_fid === $submitted_fid) {
+      return [
+        'fid' => $configured_fid > 0 ? $configured_fid : $submitted_fid,
+        'preserve_media' => TRUE,
+        'capture' => FALSE,
+      ];
+    }
+
+    if ($submitted_fid === $configured_fid) {
+      return [
+        'fid' => $configured_fid,
+        'preserve_media' => FALSE,
+        'capture' => FALSE,
+      ];
+    }
+
+    return [
+      'fid' => $submitted_fid,
+      'preserve_media' => FALSE,
+      'capture' => TRUE,
+    ];
+  }
+
+}

--- a/web/modules/custom/mel_guide/tests/src/Unit/MelGuideMediaContractTest.php
+++ b/web/modules/custom/mel_guide/tests/src/Unit/MelGuideMediaContractTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\mel_guide\Unit;
 
+use Drupal\mel_guide\Service\MelGuideAssetSubmissionResolver;
 use Drupal\Tests\UnitTestCase;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -98,11 +99,9 @@ final class MelGuideMediaContractTest extends UnitTestCase {
     $form = file_get_contents($module . '/src/Form/MelGuideSettingsForm.php');
 
     self::assertIsString($form);
-    self::assertStringContainsString('if ($new_fid === $old_fid)', $form);
+    self::assertStringContainsString('MelGuideAssetSubmissionResolver::resolve(', $form);
     self::assertStringContainsString('never recapture unchanged', $form);
-    self::assertStringContainsString('if ($new_fid === 0 && $old_fid > 0)', $form);
-    self::assertStringContainsString('empty submission is not evidence that the editor removed it', $form);
-    self::assertStringContainsString('$new_fid = $old_fid;', $form);
+    self::assertStringContainsString('$submitted_fid', $form);
     self::assertStringContainsString('$this->database->startTransaction()', $form);
     self::assertStringContainsString('$transaction->rollBack()', $form);
     self::assertStringContainsString('unset($transaction)', $form);
@@ -112,6 +111,72 @@ final class MelGuideMediaContractTest extends UnitTestCase {
     self::assertNotFalse($capture_position);
     self::assertNotFalse($usage_position);
     self::assertLessThan($usage_position, $capture_position);
+  }
+
+  /**
+   * An unchanged Media-resolved input retains config and Media provenance.
+   */
+  public function testUnchangedMediaInputRetainsRollbackFid(): void {
+    self::assertSame([
+      'fid' => 585,
+      'preserve_media' => TRUE,
+      'capture' => FALSE,
+    ], self::resolveAsset(443, 585, 443, FALSE));
+  }
+
+  /**
+   * Clearing a displayed Media asset remains a deliberate removal.
+   */
+  public function testDisplayedMediaCanBeRemoved(): void {
+    self::assertSame([
+      'fid' => 0,
+      'preserve_media' => FALSE,
+      'capture' => FALSE,
+    ], self::resolveAsset(0, 585, 443, FALSE));
+  }
+
+  /**
+   * Selecting a different file requests capture and persists its FID.
+   */
+  public function testReplacementFileIsCaptured(): void {
+    self::assertSame([
+      'fid' => 777,
+      'preserve_media' => FALSE,
+      'capture' => TRUE,
+    ], self::resolveAsset(777, 585, 443, FALSE));
+  }
+
+  /**
+   * A missing legacy-only asset is retained when the input cannot display it.
+   */
+  public function testUnavailableLegacyOnlyAssetIsRetained(): void {
+    self::assertSame([
+      'fid' => 585,
+      'preserve_media' => FALSE,
+      'capture' => FALSE,
+    ], self::resolveAsset(0, 585, 0, FALSE));
+  }
+
+  /**
+   * Invokes the form's deterministic asset decision without constructing it.
+   *
+   * @return array{fid: int, preserve_media: bool, capture: bool}
+   *   The resolved asset decision.
+   */
+  private static function resolveAsset(
+    int $submitted_fid,
+    int $configured_fid,
+    ?int $stored_media_fid,
+    bool $configured_file_exists,
+  ): array {
+    $module = dirname(__DIR__, 3);
+    require_once $module . '/src/Service/MelGuideAssetSubmissionResolver.php';
+    return MelGuideAssetSubmissionResolver::resolve(
+      $submitted_fid,
+      $configured_fid,
+      $stored_media_fid,
+      $configured_file_exists,
+    );
   }
 
 }


### PR DESCRIPTION
## What changed

- distinguish Media-resolved managed-file IDs from configuration rollback IDs
- preserve an unchanged environment-local Media UUID without recapture or file-usage changes
- retain deliberate removal and genuine replacement behaviour
- add behavioural coverage for unchanged, removal, replacement and unavailable legacy cases

## Root cause

The admin form displays the file ID resolved from environment-local Media state. On staging that ID differs from the configuration-managed rollback file ID. An unchanged save therefore looked like a replacement and wrote the staging file ID into active configuration, creating drift.

## Validation

- MEL Guide unit suite: 11 tests, 70 assertions
- PHP syntax checks
- Drupal and DrupalPractice coding standards
- git diff integrity

## Scope

No configuration export, schema update, Media migration, file deletion, organiser workflow or production deployment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how admin saves persist `asset_fids` and Media state—important for cross-environment parity—but logic is isolated and covered by unit tests with no auth or payment impact.
> 
> **Overview**
> Fixes **config drift** when admins save MEL Guide settings without changing character images: the managed-file widget shows the **Media-resolved file ID**, which can differ per environment from the **rollback `asset_fids`** in config, so a no-op save was treated as a replacement and wrote the local FID into active configuration.
> 
> Introduces **`MelGuideAssetSubmissionResolver`** to decide the persisted rollback FID, whether to **preserve** the stored Media UUID without recapture, and whether to **capture** a new upload. **`MelGuideSettingsForm`** uses that result instead of inline FID comparisons, including a **`preserve_media`** path that keeps both config rollback ID and environment-local Media provenance on unchanged saves.
> 
> Unit coverage in **`MelGuideMediaContractTest`** exercises unchanged Media input, deliberate removal, replacement capture, and unavailable legacy-only retention; the form contract test now asserts resolver usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d042871424f44a1cc2a340603a46ec6389c50cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->