### PR TITLE
Repair P1 event SEO metadata and sitemap

### DIFF
--- a/config/sync/responsive_image.styles.mel_event_hero.yml
+++ b/config/sync/responsive_image.styles.mel_event_hero.yml
@@ -8,11 +8,8 @@ id: mel_event_hero
 label: 'MyEventLane event hero'
 image_style_mappings:
   -
-    image_mapping_type: sizes
-    image_mapping:
-      sizes: 100vw
-      sizes_image_styles:
-        - mel_event_hero_featured
+    image_mapping_type: image_style
+    image_mapping: mel_event_hero_featured
     breakpoint_id: responsive_image.viewport_sizing
     multiplier: 1x
 breakpoint_group: responsive_image

--- a/docs/deploy/staging-public-discovery-seo-smoke-test.md
+++ b/docs/deploy/staging-public-discovery-seo-smoke-test.md
@@ -386,7 +386,7 @@ See [`scripts/deploy/remote-deploy.sh`](../../scripts/deploy/remote-deploy.sh) �
 | --- | --- |
 | `field_event_visibility` | Referenced in vendor/Studio PHP but **not exported** in `config/sync` — private/unlisted/passcode visibility may not be fully enforced on all discovery surfaces until audited separately |
 | Private / unlisted / passcode events | Require a dedicated visibility audit beyond this smoke test |
-| `simple_sitemap` | Not installed or configured in `config/sync` — no automated sitemap generation in repo; see [STAGING_INDEXING_PROTECTION.md](../operations/STAGING_INDEXING_PROTECTION.md) |
+| XML sitemap | Custom `/sitemap.xml` generation is owned by `XmlSitemapController`; verify that future public events passing `PublicEventVisibility::isSeoIndexable()` appear after deploy. `simple_sitemap` is not installed. |
 | Per-environment aliases | Existing nodes/terms need Pathauto generation on **each** environment after deploy |
 | Default CI deploy skips `cim` | Until workflow passes `RUN_CIM=1`, operators must run config import manually for this release |
 | Full checkout payment | Out of scope — booking **entry** only |

--- a/web/modules/custom/myeventlane_event/myeventlane_event.module
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.module
@@ -1820,6 +1820,45 @@ function myeventlane_event_get_event_card_view_modes(): array {
 }
 
 /**
+ * Implements hook_metatags_alter().
+ */
+function myeventlane_event_metatags_alter(array &$metatags): void {
+  if (\Drupal::routeMatch()->getRouteName() !== 'entity.node.canonical') {
+    return;
+  }
+
+  $node = \Drupal::routeMatch()->getParameter('node');
+  if (!$node instanceof NodeInterface || $node->bundle() !== 'event') {
+    return;
+  }
+
+  $description = '';
+  foreach (['field_event_summary', 'field_event_intro', 'body'] as $field_name) {
+    if ($node->hasField($field_name) && !$node->get($field_name)->isEmpty()) {
+      $description = trim(strip_tags((string) $node->get($field_name)->value));
+      if ($description !== '') {
+        break;
+      }
+    }
+  }
+
+  if ($description === '') {
+    $description = $node->label();
+  }
+
+  if (str_contains($description, '[date]') && $node->hasField('field_event_start') && !$node->get('field_event_start')->isEmpty()) {
+    try {
+      $event_date = new \DateTimeImmutable((string) $node->get('field_event_start')->value, new \DateTimeZone('Australia/Sydney'));
+      $description = str_replace('[date]', $event_date->format('j F Y'), $description);
+    }
+    catch (\Exception) {
+    }
+  }
+
+  $metatags['description'] = Unicode::truncate($description, 160, TRUE, TRUE);
+}
+
+/**
  * Implements hook_page_attachments().
  *
  * Open Graph markup for canonical event pages without requiring metatag
@@ -1838,7 +1877,7 @@ function myeventlane_event_page_attachments(array &$attachments): void {
   }
 
   $canonical = $node->toUrl()->setAbsolute()->toString();
-  $title = Html::escape($node->label());
+  $title = $node->label();
 
   $description = '';
   if ($node->hasField('field_event_summary') && !$node->get('field_event_summary')->isEmpty()) {
@@ -1864,7 +1903,16 @@ function myeventlane_event_page_attachments(array &$attachments): void {
     $description = $node->label();
   }
 
-  $description = Html::escape(Unicode::truncate($description, 300, TRUE, TRUE));
+  if (str_contains($description, '[date]') && $node->hasField('field_event_start') && !$node->get('field_event_start')->isEmpty()) {
+    try {
+      $event_date = new \DateTimeImmutable((string) $node->get('field_event_start')->value, new \DateTimeZone('Australia/Sydney'));
+      $description = str_replace('[date]', $event_date->format('j F Y'), $description);
+    }
+    catch (\Exception) {
+    }
+  }
+
+  $description = Unicode::truncate($description, 300, TRUE, TRUE);
 
   $attachments['#cache']['tags'][] = 'node:' . (int) $node->id();
 
@@ -1898,7 +1946,7 @@ function myeventlane_event_page_attachments(array &$attachments): void {
       '#tag' => 'meta',
       '#attributes' => [
         'property' => 'og:url',
-        'content' => Html::escape($canonical),
+        'content' => $canonical,
       ],
     ],
     'mel_event_og_url',
@@ -1921,7 +1969,7 @@ function myeventlane_event_page_attachments(array &$attachments): void {
         '#tag' => 'meta',
         '#attributes' => [
           'property' => 'og:site_name',
-          'content' => Html::escape($site_name),
+          'content' => $site_name,
         ],
       ],
       'mel_event_og_site_name',
@@ -1935,7 +1983,7 @@ function myeventlane_event_page_attachments(array &$attachments): void {
     $file_entity = $node->get('field_event_image')->entity;
     if ($file_entity instanceof FileInterface) {
       $uri = $file_entity->getFileUri();
-      $absolute = Html::escape($urls->generateAbsoluteString($uri));
+      $absolute = $urls->generateAbsoluteString($uri);
       $attachments['#attached']['html_head'][] = [
         [
           '#tag' => 'meta',
@@ -1946,7 +1994,49 @@ function myeventlane_event_page_attachments(array &$attachments): void {
         ],
         'mel_event_og_image',
       ];
+
+      $alt = trim((string) ($node->get('field_event_image')->alt ?? ''));
+      $attachments['#attached']['html_head'][] = [
+        [
+          '#tag' => 'meta',
+          '#attributes' => [
+            'property' => 'og:image:alt',
+            'content' => $alt !== '' ? $alt : $node->label(),
+          ],
+        ],
+        'mel_event_og_image_alt',
+      ];
     }
+  }
+
+  foreach ([
+    'twitter:card' => 'summary_large_image',
+    'twitter:title' => $title,
+    'twitter:description' => $description,
+  ] as $name => $content) {
+    $attachments['#attached']['html_head'][] = [
+      [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'name' => $name,
+          'content' => $content,
+        ],
+      ],
+      'mel_event_' . str_replace(':', '_', $name),
+    ];
+  }
+
+  if (isset($absolute)) {
+    $attachments['#attached']['html_head'][] = [
+      [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'name' => 'twitter:image',
+          'content' => $absolute,
+        ],
+      ],
+      'mel_event_twitter_image',
+    ];
   }
 
   if (\Drupal::hasService('myeventlane_event.structured_data_builder')) {

--- a/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
@@ -255,6 +255,7 @@ services:
       - '@myeventlane_event.public_visibility'
       - '@myeventlane_event.booking_flow_resolver'
       - '@myeventlane_event.ticket_type_manager'
+      - '@file_url_generator'
 
   myeventlane_event.event_card_view_model:
     class: Drupal\myeventlane_event\EventCard\EventCardViewModel

--- a/web/modules/custom/myeventlane_event/src/Service/EventStructuredDataBuilder.php
+++ b/web/modules/custom/myeventlane_event/src/Service/EventStructuredDataBuilder.php
@@ -6,7 +6,9 @@ namespace Drupal\myeventlane_event\Service;
 
 use Drupal\address\Plugin\Field\FieldType\AddressItem;
 use Drupal\commerce_price\Price;
+use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\Core\Url;
+use Drupal\file\FileInterface;
 use Drupal\myeventlane_event_state\Service\EventStateResolver;
 use Drupal\node\NodeInterface;
 
@@ -21,12 +23,14 @@ final class EventStructuredDataBuilder {
     private readonly PublicEventVisibility $publicEventVisibility,
     private readonly BookingFlowResolver $bookingFlowResolver,
     private readonly TicketTypeManager $ticketTypeManager,
+    private readonly FileUrlGeneratorInterface $fileUrlGenerator,
   ) {}
 
   /**
    * Returns render-safe JSON-LD data, or NULL when the event is not public SEO.
    *
    * @return array<string, mixed>|null
+   *   The schema data, or NULL when the event must not be indexed.
    */
   public function build(NodeInterface $event): ?array {
     if (!$this->publicEventVisibility->isSeoIndexable($event)) {
@@ -47,22 +51,33 @@ final class EventStructuredDataBuilder {
     }
 
     if ($event->hasField('field_event_start') && !$event->get('field_event_start')->isEmpty()) {
-      $start = $event->get('field_event_start')->date;
+      $start = $this->formatFieldValue((string) $event->get('field_event_start')->value);
       if ($start !== NULL) {
-        $data['startDate'] = $this->formatTimestamp($start->getTimestamp());
+        $data['startDate'] = $start;
       }
     }
 
     if ($event->hasField('field_event_end') && !$event->get('field_event_end')->isEmpty()) {
-      $end = $event->get('field_event_end')->date;
+      $end = $this->formatFieldValue((string) $event->get('field_event_end')->value);
       if ($end !== NULL) {
-        $data['endDate'] = $this->formatTimestamp($end->getTimestamp());
+        $data['endDate'] = $end;
       }
     }
 
     $location = $this->resolveLocation($event);
     if ($location !== NULL) {
       $data['location'] = $location;
+      $data['eventAttendanceMode'] = 'https://schema.org/OfflineEventAttendanceMode';
+    }
+
+    $image = $this->resolveImage($event);
+    if ($image !== NULL) {
+      $data['image'] = $image;
+    }
+
+    $organizer = $this->resolveOrganizer($event);
+    if ($organizer !== NULL) {
+      $data['organizer'] = $organizer;
     }
 
     $offer = $this->resolveOffer($event);
@@ -73,6 +88,9 @@ final class EventStructuredDataBuilder {
     return array_filter($data, static fn (mixed $value): bool => $value !== NULL && $value !== '');
   }
 
+  /**
+   * Resolves the schema.org lifecycle status.
+   */
   private function resolveEventStatus(NodeInterface $event): string {
     if ($event->hasField('field_event_state') && !$event->get('field_event_state')->isEmpty()) {
       $state = (string) $event->get('field_event_state')->value;
@@ -84,21 +102,74 @@ final class EventStructuredDataBuilder {
     return 'https://schema.org/EventScheduled';
   }
 
+  /**
+   * Resolves plain event copy for search metadata.
+   */
   private function resolveDescription(NodeInterface $event): string {
+    $description = '';
     if ($event->hasField('field_event_summary') && !$event->get('field_event_summary')->isEmpty()) {
-      return trim(strip_tags((string) $event->get('field_event_summary')->value));
+      $description = trim(strip_tags((string) $event->get('field_event_summary')->value));
     }
-    if ($event->hasField('field_event_intro') && !$event->get('field_event_intro')->isEmpty()) {
-      return trim(strip_tags((string) $event->get('field_event_intro')->value));
+    elseif ($event->hasField('field_event_intro') && !$event->get('field_event_intro')->isEmpty()) {
+      $description = trim(strip_tags((string) $event->get('field_event_intro')->value));
     }
-    if ($event->hasField('body') && !$event->get('body')->isEmpty()) {
-      return trim(strip_tags((string) $event->get('body')->value));
+    elseif ($event->hasField('body') && !$event->get('body')->isEmpty()) {
+      $description = trim(strip_tags((string) $event->get('body')->value));
     }
-    return '';
+
+    if ($description !== '' && str_contains($description, '[date]') && $event->hasField('field_event_start') && !$event->get('field_event_start')->isEmpty()) {
+      $start = $this->parseFieldValue((string) $event->get('field_event_start')->value);
+      if ($start !== NULL) {
+        $description = str_replace('[date]', $start->format('j F Y'), $description);
+      }
+    }
+
+    return $description;
   }
 
   /**
+   * Resolves the canonical event image URL.
+   */
+  private function resolveImage(NodeInterface $event): ?string {
+    if (!$event->hasField('field_event_image') || $event->get('field_event_image')->isEmpty()) {
+      return NULL;
+    }
+
+    $file = $event->get('field_event_image')->entity;
+    if (!$file instanceof FileInterface) {
+      return NULL;
+    }
+
+    return $this->fileUrlGenerator->generateAbsoluteString($file->getFileUri());
+  }
+
+  /**
+   * Resolves the public event organiser.
+   *
+   * @return array<string, string>|null
+   *   The schema.org organiser, or NULL when none is available.
+   */
+  private function resolveOrganizer(NodeInterface $event): ?array {
+    if (!$event->hasField('field_event_vendor') || $event->get('field_event_vendor')->isEmpty()) {
+      return NULL;
+    }
+
+    $vendor = $event->get('field_event_vendor')->entity;
+    if ($vendor === NULL || trim((string) $vendor->label()) === '') {
+      return NULL;
+    }
+
+    return [
+      '@type' => 'Organization',
+      'name' => trim((string) $vendor->label()),
+    ];
+  }
+
+  /**
+   * Resolves the physical event location.
+   *
    * @return array<string, mixed>|null
+   *   The schema.org place, or NULL when no location is available.
    */
   private function resolveLocation(NodeInterface $event): ?array {
     $name = '';
@@ -135,7 +206,10 @@ final class EventStructuredDataBuilder {
   }
 
   /**
+   * Resolves the public booking offer.
+   *
    * @return array<string, mixed>|null
+   *   The schema.org offer, or NULL when booking is unavailable.
    */
   private function resolveOffer(NodeInterface $event): ?array {
     $mode = $this->bookingFlowResolver->getBookingMode($event);
@@ -180,6 +254,9 @@ final class EventStructuredDataBuilder {
     return $offer;
   }
 
+  /**
+   * Resolves schema.org ticket availability.
+   */
   private function resolveOfferAvailability(NodeInterface $event): string {
     if ($this->bookingFlowResolver->getAvailabilityState($event) === BookingFlowResolver::AVAILABILITY_SOLD_OUT) {
       return 'https://schema.org/SoldOut';
@@ -188,9 +265,33 @@ final class EventStructuredDataBuilder {
     return 'https://schema.org/InStock';
   }
 
-  private function formatTimestamp(int $timestamp): string {
-    $utc = (new \DateTimeImmutable('@' . $timestamp))->setTimezone(new \DateTimeZone('UTC'));
-    return $utc->setTimezone(new \DateTimeZone(self::DISPLAY_TIMEZONE))->format(\DateTimeInterface::ATOM);
+  /**
+   * Formats a stored event wall-clock value with its Sydney offset.
+   */
+  private function formatFieldValue(string $value): ?string {
+    return $this->parseFieldValue($value)?->format(\DateTimeInterface::ATOM);
+  }
+
+  /**
+   * Parses a stored event wall-clock value in the display timezone.
+   */
+  private function parseFieldValue(string $value): ?\DateTimeImmutable {
+    if ($value === '') {
+      return NULL;
+    }
+
+    $timezone = new \DateTimeZone(self::DISPLAY_TIMEZONE);
+    $date = \DateTimeImmutable::createFromFormat('!Y-m-d\\TH:i:s', $value, $timezone);
+    if ($date !== FALSE) {
+      return $date;
+    }
+
+    try {
+      return new \DateTimeImmutable($value, $timezone);
+    }
+    catch (\Exception) {
+      return NULL;
+    }
   }
 
 }

--- a/web/modules/custom/myeventlane_event/tests/src/Unit/EventStructuredDataBuilderTest.php
+++ b/web/modules/custom/myeventlane_event/tests/src/Unit/EventStructuredDataBuilderTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event\Unit;
+
+use Drupal\myeventlane_event\Service\EventStructuredDataBuilder;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_event\Service\EventStructuredDataBuilder
+ * @group myeventlane_event
+ */
+final class EventStructuredDataBuilderTest extends UnitTestCase {
+
+  /**
+   * @covers ::formatFieldValue
+   * @dataProvider wallClockProvider
+   */
+  public function testFormatsStoredWallClockWithoutTimezoneShift(string $value, ?string $expected): void {
+    $reflection = new \ReflectionClass(EventStructuredDataBuilder::class);
+    $builder = $reflection->newInstanceWithoutConstructor();
+    $method = $reflection->getMethod('formatFieldValue');
+
+    $this->assertSame($expected, $method->invoke($builder, $value));
+  }
+
+  /**
+   * Provides stored wall-clock values and expected schema timestamps.
+   *
+   * @return array<string, array{string, string|null}>
+   *   The stored value and expected formatted value.
+   */
+  public static function wallClockProvider(): array {
+    return [
+      'standard time' => [
+        '2026-08-31T17:00:00',
+        '2026-08-31T17:00:00+10:00',
+      ],
+      'daylight saving time' => [
+        '2026-12-10T18:30:00',
+        '2026-12-10T18:30:00+11:00',
+      ],
+      'invalid value' => ['not-a-date', NULL],
+      'empty value' => ['', NULL],
+    ];
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioBrandingCropContractTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioBrandingCropContractTest.php
@@ -13,6 +13,9 @@ use PHPUnit\Framework\TestCase;
  */
 final class EventStudioBrandingCropContractTest extends TestCase {
 
+  /**
+   * Confirms Studio requires the compatible event hero crop.
+   */
   public function testBrandingUsesCompatibleRequiredEventHeroCrop(): void {
     $webRoot = dirname(__DIR__, 6);
     $cropSettings = (string) file_get_contents(
@@ -27,6 +30,9 @@ final class EventStudioBrandingCropContractTest extends TestCase {
     self::assertMatchesRegularExpression('/crop_types_required:\\s*\\n\\s*- event_hero/', $brandingDisplay);
   }
 
+  /**
+   * Confirms public and booking heroes share the canonical crop style.
+   */
   public function testPublicEventAndBookingHeroesUseCanonicalCropStyle(): void {
     $webRoot = dirname(__DIR__, 6);
     $fullDisplay = (string) file_get_contents(
@@ -41,10 +47,15 @@ final class EventStudioBrandingCropContractTest extends TestCase {
 
     self::assertStringContainsString('responsive_image_style: mel_event_hero', $fullDisplay);
     self::assertStringContainsString('image.style.mel_event_hero_featured', $responsiveStyle);
+    self::assertStringContainsString('image_mapping_type: image_style', $responsiveStyle);
+    self::assertStringNotContainsString('image_mapping_type: sizes', $responsiveStyle);
     self::assertStringContainsString('fallback_image_style: mel_event_hero_featured', $responsiveStyle);
     self::assertStringContainsString("ImageStyle::load('mel_event_hero_featured')", $bookController);
   }
 
+  /**
+   * Confirms Studio presents one clear framing workflow.
+   */
   public function testCropAreaExplainsOneFramingFlowWithoutFocalShortcuts(): void {
     $moduleRoot = dirname(__DIR__, 3);
     $form = (string) file_get_contents($moduleRoot . '/src/Form/EventBrandingForm.php');
@@ -69,6 +80,9 @@ final class EventStudioBrandingCropContractTest extends TestCase {
     self::assertStringContainsString('.mel-es-branding-crop-guidance', $styles);
   }
 
+  /**
+   * Confirms branding tools initialise the visible cropper safely.
+   */
   public function testBrandingToolsWakeVisibleCropperInStudioLayout(): void {
     $moduleRoot = dirname(__DIR__, 3);
     $script = (string) file_get_contents($moduleRoot . '/js/mel-branding-hero-tools.js');
@@ -88,6 +102,9 @@ final class EventStudioBrandingCropContractTest extends TestCase {
     self::assertStringContainsString('myeventlane_event_studio/mel_cropper_jquery_compat', $module);
   }
 
+  /**
+   * Confirms saved media and MEL Pro branding controls remain available.
+   */
   public function testBrandingOffersSavedMediaSaveActionAndProColourGuidance(): void {
     $repositoryRoot = dirname(__DIR__, 7);
     $moduleRoot = dirname(__DIR__, 3);

--- a/web/modules/custom/myeventlane_front/src/Controller/XmlSitemapController.php
+++ b/web/modules/custom/myeventlane_front/src/Controller/XmlSitemapController.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_front\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Cache\CacheableResponse;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Url;
+use Drupal\myeventlane_event\Service\PublicEventVisibility;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Serves a minimal XML sitemap for public marketing and guide URLs.
@@ -19,6 +21,7 @@ final class XmlSitemapController extends ControllerBase {
   public function __construct(
     EntityTypeManagerInterface $entityTypeManager,
     private readonly DateFormatterInterface $dateFormatter,
+    private readonly PublicEventVisibility $publicEventVisibility,
   ) {
     $this->entityTypeManager = $entityTypeManager;
   }
@@ -30,13 +33,14 @@ final class XmlSitemapController extends ControllerBase {
     return new self(
       $container->get('entity_type.manager'),
       $container->get('date.formatter'),
+      $container->get('myeventlane_event.public_visibility'),
     );
   }
 
   /**
    * Returns XML sitemap entries for key public pages.
    */
-  public function page(): Response {
+  public function page(): CacheableResponse {
     $urls = [
       $this->urlEntry(Url::fromRoute('<front>', [], ['absolute' => TRUE])->toString(), time()),
       $this->urlEntry(Url::fromRoute('myeventlane_front.organiser_hub', [], ['absolute' => TRUE])->toString(), time()),
@@ -64,6 +68,25 @@ final class XmlSitemapController extends ControllerBase {
       }
     }
 
+    $event_nids = $storage->getQuery()
+      ->accessCheck(TRUE)
+      ->condition('type', 'event')
+      ->condition('status', 1)
+      ->sort('changed', 'DESC')
+      ->range(0, 500)
+      ->execute();
+
+    if (is_array($event_nids)) {
+      $events = $storage->loadMultiple($event_nids);
+      foreach ($event_nids as $nid) {
+        if (!isset($events[$nid]) || !$this->publicEventVisibility->isSeoIndexable($events[$nid])) {
+          continue;
+        }
+        $event = $events[$nid];
+        $urls[] = $this->urlEntry($event->toUrl('canonical', ['absolute' => TRUE])->toString(), (int) $event->getChangedTime());
+      }
+    }
+
     $xml = ['<?xml version="1.0" encoding="UTF-8"?>'];
     $xml[] = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
     foreach ($urls as $entry) {
@@ -74,14 +97,23 @@ final class XmlSitemapController extends ControllerBase {
     }
     $xml[] = '</urlset>';
 
-    return new Response(implode("\n", $xml), 200, [
+    $response = new CacheableResponse(implode("\n", $xml), 200, [
       'Content-Type' => 'application/xml; charset=utf-8',
       'Cache-Control' => 'public, max-age=3600',
     ]);
+    $response->addCacheableDependency((new CacheableMetadata())
+      ->setCacheTags(['node_list'])
+      ->setCacheContexts(['url.site'])
+      ->setCacheMaxAge(3600));
+
+    return $response;
   }
 
   /**
+   * Creates one escaped sitemap URL value.
+   *
    * @return array{loc: string, lastmod: string}
+   *   The canonical location and last-modified date.
    */
   private function urlEntry(string $loc, int $changed): array {
     return [

--- a/web/modules/custom/myeventlane_front/tests/src/Unit/XmlSitemapControllerContractTest.php
+++ b/web/modules/custom/myeventlane_front/tests/src/Unit/XmlSitemapControllerContractTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_front\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects public event inclusion in the XML sitemap.
+ *
+ * @group myeventlane_front
+ */
+final class XmlSitemapControllerContractTest extends TestCase {
+
+  /**
+   * Confirms the sitemap filters events through the canonical SEO policy.
+   */
+  public function testSitemapUsesCanonicalSeoIndexableEvents(): void {
+    $moduleRoot = dirname(__DIR__, 3);
+    $controller = (string) file_get_contents($moduleRoot . '/src/Controller/XmlSitemapController.php');
+
+    $this->assertStringContainsString("->condition('type', 'event')", $controller);
+    $this->assertStringContainsString('publicEventVisibility->isSeoIndexable', $controller);
+    $this->assertStringContainsString("toUrl('canonical', ['absolute' => TRUE])", $controller);
+  }
+
+}

--- a/web/robots.txt
+++ b/web/robots.txt
@@ -76,3 +76,6 @@ Disallow: /index.php/user/login
 Disallow: /index.php/user/logout
 Disallow: /index.php/media/oembed
 Disallow: /index.php/*/media/oembed
+
+# Canonical production sitemap. Staging is protected separately by X-Robots-Tag.
+Sitemap: https://myeventlane.com.au/sitemap.xml


### PR DESCRIPTION
## What changed

- correct event JSON-LD wall-clock timestamps and add attendance mode, image and organiser data
- provide reliable event meta descriptions, Open Graph image alt text and Twitter card metadata
- include SEO-indexable public events in the custom XML sitemap
- advertise the canonical production sitemap in `robots.txt`
- repair the event hero responsive-image mapping that crashes affected event pages
- add focused unit and contract coverage

## Why

The staging SEO audit found incorrect structured event times, incomplete sharing/schema metadata, eligible events missing from the XML sitemap, and two event pages failing during responsive-image rendering.

The page failures were caused by `mel_event_hero_featured` being configured as a `sizes` mapping even though Drupal requires this single style to use an `image_style` mapping.

## Impact

Public event pages provide more accurate search and social metadata. Eligible event aliases appear in `/sitemap.xml`. The responsive-image configuration no longer triggers the observed event-page exception after configuration import.

## Validation

- PHP syntax checks passed for changed PHP files
- targeted PHPUnit: 10 tests, 63 assertions passed (4 framework deprecations)
- `git diff --check` passed
- focused coding-standard checks passed for the new service, controller and tests
- full legacy `.module` scan retains pre-existing violations outside this diff
- local DDEV runtime checks previously confirmed event pages render, JSON-LD timestamps match visible Sydney times, canonical/meta/OG/Twitter tags render, and eligible events appear in `/sitemap.xml`

## Deployment requirement

Run the staging deployment with `RUN_CIM=1` so the responsive-image repair becomes active, then perform the event-page and SEO acceptance checks on staging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public SEO metadata, sitemap contents, and event page rendering (hero config requires config import); incorrect dates or indexability filtering could affect search visibility, but scope is discovery/SEO rather than auth or payments.
> 
> **Overview**
> Repairs **P1 public SEO** gaps from the staging audit: richer event metadata, accurate structured data, sitemap coverage, and a **responsive-image config** fix that was breaking some event pages.
> 
> **Event hero config** — `mel_event_hero` switches from an invalid `sizes` mapping on a single style to `image_style` → `mel_event_hero_featured`, which stops responsive-image failures on affected canonical event pages after **`cim`**.
> 
> **JSON-LD** — `EventStructuredDataBuilder` parses stored start/end as **Sydney wall-clock** (STD/DST offsets) instead of shifting via UTC; adds **image**, **organizer**, and **offline attendance mode** when location exists; expands description sourcing and **`[date]`** token replacement.
> 
> **Meta / social** — New `hook_metatags_alter` sets truncated meta descriptions for events; canonical attachments add **`og:image:alt`**, **Twitter** card tags, shared **`[date]`** handling, and rely on render escaping instead of `Html::escape` on OG/Twitter content.
> 
> **Sitemap** — Custom `/sitemap.xml` now includes published events that pass **`PublicEventVisibility::isSeoIndexable()`** (up to 500), with cacheable XML response; **`robots.txt`** advertises the production sitemap URL.
> 
> **Tests / docs** — Unit/contract tests for wall-clock formatting, sitemap policy, and hero crop config; staging smoke-test doc updated for custom sitemap ownership.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a60e4842eca6d7395131aa0b25b0c264e78d570. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->