### PR TITLE
Add HTML sitemap meta description

### DIFF
--- a/web/modules/custom/myeventlane_front/src/Controller/SitemapController.php
+++ b/web/modules/custom/myeventlane_front/src/Controller/SitemapController.php
@@ -33,6 +33,20 @@ final class SitemapController extends ControllerBase {
     return [
       '#theme' => 'myeventlane_front_sitemap',
       '#sections' => $this->sitemapBuilder->buildSections(),
+      '#attached' => [
+        'html_head' => [
+          [
+            [
+              '#tag' => 'meta',
+              '#attributes' => [
+                'name' => 'description',
+                'content' => 'Explore MyEventLane events, organiser resources, support, trust information and legal pages.',
+              ],
+            ],
+            'myeventlane_front_sitemap_description',
+          ],
+        ],
+      ],
       '#cache' => [
         'tags' => [
           'config:myeventlane_legal.settings',

--- a/web/modules/custom/myeventlane_front/tests/src/Unit/HtmlSitemapMetadataContractTest.php
+++ b/web/modules/custom/myeventlane_front/tests/src/Unit/HtmlSitemapMetadataContractTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_front\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects metadata on the public HTML sitemap.
+ *
+ * @group myeventlane_front
+ */
+final class HtmlSitemapMetadataContractTest extends TestCase {
+
+  /**
+   * Confirms the sitemap provides a useful search description.
+   */
+  public function testSitemapAttachesMetaDescription(): void {
+    $moduleRoot = dirname(__DIR__, 3);
+    $controller = (string) file_get_contents($moduleRoot . '/src/Controller/SitemapController.php');
+
+    self::assertStringContainsString("'name' => 'description'", $controller);
+    self::assertStringContainsString('Explore MyEventLane events, organiser resources', $controller);
+  }
+
+}


### PR DESCRIPTION
## What changed

- add a concise meta description to the human-readable `/sitemap` page
- add a focused contract test protecting the metadata

## Why

The staging SEO acceptance review confirmed that `/sitemap` rendered with a canonical URL but did not provide a meta description.

## Impact

Search and link-preview consumers receive a useful description of the public sitemap page without changing its navigation or XML sitemap behaviour.

## Validation

- PHP syntax checks passed
- Drupal coding-standard checks passed
- targeted PHPUnit: 1 test, 2 assertions passed (1 framework deprecation)
- `git diff --check` passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SEO metadata only on the HTML sitemap; no navigation, caching tags, or XML sitemap behavior changes.
> 
> **Overview**
> Adds a **meta description** to the public `/sitemap` page via `#attached` `html_head` in `SitemapController`, so search and link previews get a short summary of what the page covers (events, organiser resources, support, trust, legal).
> 
> A new **contract test** (`HtmlSitemapMetadataContractTest`) asserts the controller still includes the description meta tag and expected copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a58aeb6c2b0ceeae46a8ebe82dabea26625a1b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->