### PR TITLE
Redirect raw event URLs to aliases

### DIFF
--- a/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
+++ b/web/modules/custom/myeventlane_event/myeventlane_event.services.yml
@@ -3,6 +3,15 @@ services:
     parent: logger.channel_base
     arguments: ['myeventlane_event']
 
+  myeventlane_event.canonical_redirect_subscriber:
+    class: Drupal\myeventlane_event\EventSubscriber\EventCanonicalRedirectSubscriber
+    arguments:
+      - '@path_alias.manager'
+      - '@current_user'
+      - '@unrouted_url_assembler'
+    tags:
+      - { name: event_subscriber }
+
   myeventlane_event.stats:
     class: Drupal\myeventlane_event\Service\EventStatsService
     arguments:

--- a/web/modules/custom/myeventlane_event/src/EventSubscriber/EventCanonicalRedirectSubscriber.php
+++ b/web/modules/custom/myeventlane_event/src/EventSubscriber/EventCanonicalRedirectSubscriber.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event\EventSubscriber;
+
+use Drupal\Core\Routing\LocalRedirectResponse;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Utility\UnroutedUrlAssemblerInterface;
+use Drupal\node\NodeInterface;
+use Drupal\path_alias\AliasManagerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Redirects raw event node paths to their friendly aliases.
+ */
+final class EventCanonicalRedirectSubscriber implements EventSubscriberInterface {
+
+  public function __construct(
+    private readonly AliasManagerInterface $aliasManager,
+    private readonly AccountInterface $currentUser,
+    private readonly UnroutedUrlAssemblerInterface $unroutedUrlAssembler,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      KernelEvents::REQUEST => ['onRequest', 29],
+    ];
+  }
+
+  /**
+   * Redirects an accessible raw event node path to its current alias.
+   */
+  public function onRequest(RequestEvent $event): void {
+    if (!$event->isMainRequest() || $event->hasResponse()) {
+      return;
+    }
+
+    $request = $event->getRequest();
+    if ($request->attributes->get('_route') !== 'entity.node.canonical') {
+      return;
+    }
+
+    $node = $request->attributes->get('node');
+    if (!$node instanceof NodeInterface || $node->bundle() !== 'event') {
+      return;
+    }
+
+    $internalPath = '/node/' . $node->id();
+    if ($request->getPathInfo() !== $internalPath) {
+      return;
+    }
+
+    if (!$node->access('view', $this->currentUser)) {
+      return;
+    }
+
+    $alias = $this->aliasManager->getAliasByPath(
+      $internalPath,
+      $node->language()->getId(),
+    );
+    if ($alias === $internalPath || $alias === '') {
+      return;
+    }
+
+    $destination = $this->unroutedUrlAssembler->assemble(
+      'base:' . ltrim($alias, '/'),
+      ['query' => $request->query->all()],
+    );
+    $event->setResponse(new LocalRedirectResponse($destination, 301));
+  }
+
+}

--- a/web/modules/custom/myeventlane_event/tests/src/Unit/EventCanonicalRedirectSubscriberTest.php
+++ b/web/modules/custom/myeventlane_event/tests/src/Unit/EventCanonicalRedirectSubscriberTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event\Unit;
+
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Utility\UnroutedUrlAssemblerInterface;
+use Drupal\myeventlane_event\EventSubscriber\EventCanonicalRedirectSubscriber;
+use Drupal\node\NodeInterface;
+use Drupal\path_alias\AliasManagerInterface;
+use Drupal\Tests\UnitTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_event\EventSubscriber\EventCanonicalRedirectSubscriber
+ * @group myeventlane_event
+ */
+final class EventCanonicalRedirectSubscriberTest extends UnitTestCase {
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testRawEventPathRedirectsAndPreservesQuery(): void {
+    $aliasManager = $this->createMock(AliasManagerInterface::class);
+    $aliasManager->expects(self::once())
+      ->method('getAliasByPath')
+      ->with('/node/123', 'en')
+      ->willReturn('/events/community-market');
+
+    $assembler = $this->createMock(UnroutedUrlAssemblerInterface::class);
+    $assembler->expects(self::once())
+      ->method('assemble')
+      ->with('base:events/community-market', [
+        'query' => ['utm_source' => 'newsletter'],
+      ])
+      ->willReturn('/events/community-market?utm_source=newsletter');
+
+    $event = $this->requestEvent('/node/123?utm_source=newsletter');
+    $subscriber = new EventCanonicalRedirectSubscriber(
+      $aliasManager,
+      $this->createMock(AccountInterface::class),
+      $assembler,
+    );
+
+    $subscriber->onRequest($event);
+
+    self::assertTrue($event->hasResponse());
+    self::assertSame(301, $event->getResponse()->getStatusCode());
+    self::assertSame(
+      '/events/community-market?utm_source=newsletter',
+      $event->getResponse()->headers->get('Location'),
+    );
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testFriendlyAliasDoesNotRedirect(): void {
+    $event = $this->requestEvent('/events/community-market');
+    $subscriber = new EventCanonicalRedirectSubscriber(
+      $this->createMock(AliasManagerInterface::class),
+      $this->createMock(AccountInterface::class),
+      $this->createMock(UnroutedUrlAssemblerInterface::class),
+    );
+
+    $subscriber->onRequest($event);
+
+    self::assertFalse($event->hasResponse());
+  }
+
+  /**
+   * @covers ::onRequest
+   */
+  public function testInaccessibleEventDoesNotRedirect(): void {
+    $event = $this->requestEvent('/node/123', FALSE);
+    $aliasManager = $this->createMock(AliasManagerInterface::class);
+    $aliasManager->expects(self::never())->method('getAliasByPath');
+    $subscriber = new EventCanonicalRedirectSubscriber(
+      $aliasManager,
+      $this->createMock(AccountInterface::class),
+      $this->createMock(UnroutedUrlAssemblerInterface::class),
+    );
+
+    $subscriber->onRequest($event);
+
+    self::assertFalse($event->hasResponse());
+  }
+
+  /**
+   * Builds a canonical event request.
+   */
+  private function requestEvent(string $uri, bool $accessible = TRUE): RequestEvent {
+    $request = Request::create($uri);
+    $request->attributes->set('_route', 'entity.node.canonical');
+
+    $language = $this->createMock(LanguageInterface::class);
+    $language->method('getId')->willReturn('en');
+
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('bundle')->willReturn('event');
+    $node->method('id')->willReturn(123);
+    $node->method('language')->willReturn($language);
+    $node->method('access')->willReturn($accessible);
+    $request->attributes->set('node', $node);
+
+    return new RequestEvent(
+      $this->createMock(HttpKernelInterface::class),
+      $request,
+      HttpKernelInterface::MAIN_REQUEST,
+    );
+  }
+
+}


### PR DESCRIPTION
## What changed

- redirect literal `/node/{id}` event requests to the current friendly alias with HTTP 301
- preserve query parameters through Drupal's URL assembler
- require event view access and respect any earlier access/passcode response
- bypass friendly-alias requests to prevent redirect loops
- add focused unit coverage

## Why

Public event nodes remained directly accessible through both their raw Drupal path and friendly alias. Canonical tags reduced duplicate-indexing risk but did not enforce the required single public URL.

## Impact

Accessible event node URLs now converge on their friendly aliases. Private or inaccessible events do not gain a redirect response, and existing passcode/access handling takes precedence.

## Validation

- PHP syntax checks passed
- Drupal coding-standard checks passed
- targeted PHPUnit: 3 tests, 12 assertions passed (4 framework deprecations)
- `git diff --check` passed

## Staging acceptance

- verify an anonymous raw public event URL returns 301 to its friendly alias
- verify query parameters survive safely
- verify the final alias returns 200 with its matching canonical tag
- verify an access-controlled event is not exposed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public URL behavior for all event canonical requests at the HTTP layer; access and existing gate responses are guarded, but misconfiguration could affect SEO or redirect edge cases.
> 
> **Overview**
> Adds a **request subscriber** that issues a **301** when someone hits the literal `/node/{id}` path for an **event** node, sending them to the current path alias instead of serving duplicate public URLs.
> 
> The redirect only runs on the main request, when no response is already set (so passcode/access handling at higher priority can win), on `entity.node.canonical` with path info exactly matching `/node/{id}`, for bundles `event`, and only if the current user has **view** access. Query strings are preserved via `UnroutedUrlAssembler`. Requests that already use the friendly alias are left alone to avoid loops.
> 
> Service registration wires `path_alias.manager`, `current_user`, and `unrouted_url_assembler`. Unit tests cover redirect + query preservation, no redirect on alias paths, and no redirect when the event is not viewable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a95456c58267bcab2da4a240398b7dd8a647b47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->