### PR TITLE
Add Event Studio SEO preview and guidance

### DIFF
--- a/web/modules/custom/myeventlane_event/tests/src/Unit/EventStructuredDataBuilderTest.php
+++ b/web/modules/custom/myeventlane_event/tests/src/Unit/EventStructuredDataBuilderTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\myeventlane_event\Unit;
 
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\myeventlane_event\Service\EventStructuredDataBuilder;
+use Drupal\node\NodeInterface;
 use Drupal\Tests\UnitTestCase;
 
 /**
@@ -44,6 +47,31 @@ final class EventStructuredDataBuilderTest extends UnitTestCase {
       'invalid value' => ['not-a-date', NULL],
       'empty value' => ['', NULL],
     ];
+  }
+
+  /**
+   * @covers ::resolveOrganizer
+   */
+  public function testOrganizerUsesReferencedPublicProfileLabel(): void {
+    $vendor = $this->createMock(EntityInterface::class);
+    $vendor->method('label')->willReturn('Westside Community Arts');
+
+    $vendorField = $this->createMock(FieldItemListInterface::class);
+    $vendorField->method('isEmpty')->willReturn(FALSE);
+    $vendorField->method('__get')->with('entity')->willReturn($vendor);
+
+    $event = $this->createMock(NodeInterface::class);
+    $event->method('hasField')->with('field_event_vendor')->willReturn(TRUE);
+    $event->method('get')->with('field_event_vendor')->willReturn($vendorField);
+
+    $reflection = new \ReflectionClass(EventStructuredDataBuilder::class);
+    $builder = $reflection->newInstanceWithoutConstructor();
+    $method = $reflection->getMethod('resolveOrganizer');
+
+    $this->assertSame([
+      '@type' => 'Organization',
+      'name' => 'Westside Community Arts',
+    ], $method->invoke($builder, $event));
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
+++ b/web/modules/custom/myeventlane_event_studio/css/mel-event-studio-shell.css
@@ -7267,6 +7267,71 @@ body.mel-vendor:has(.mel-event-studio--workspace) .mel-vendor-console.mel-vendor
   color: var(--mel-text, #1c1a22);
 }
 
+.mel-launch-centre__seo > header h3,
+.mel-launch-centre__seo > header p,
+.mel-launch-centre__seo h4,
+.mel-launch-centre__seo p {
+  margin-top: 0;
+}
+
+.mel-launch-centre__seo > header p {
+  color: var(--mel-text-muted, #5c5a66);
+}
+
+.mel-launch-centre__seo-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.mel-launch-centre__search-preview,
+.mel-launch-centre__social-preview {
+  overflow: hidden;
+  border: 1px solid var(--mel-border-soft, #e6e2ef);
+  border-radius: 0.75rem;
+  background: var(--mel-surface, #fff);
+}
+
+.mel-launch-centre__search-preview,
+.mel-launch-centre__social-copy {
+  padding: 1rem;
+}
+
+.mel-launch-centre__preview-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--mel-text-muted, #5c5a66);
+}
+
+.mel-launch-centre__preview-domain {
+  margin-bottom: 0.25rem;
+  font-size: 0.8125rem;
+  color: #3c4043;
+}
+
+.mel-launch-centre__search-preview h4 {
+  margin-bottom: 0.35rem;
+  color: #1a0dab;
+  font-size: 1.1rem;
+  font-weight: 500;
+}
+
+.mel-launch-centre__social-preview img,
+.mel-launch-centre__preview-placeholder {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1.91 / 1;
+  object-fit: cover;
+  background: var(--mel-surface-soft, #f6f4fa);
+}
+
+.mel-launch-centre__preview-placeholder {
+  display: grid;
+  place-items: center;
+  color: var(--mel-text-muted, #5c5a66);
+}
+
 .mel-launch-centre__hero-hint {
   margin-top: 0.75rem;
   padding: 0.75rem 1rem;
@@ -7459,6 +7524,10 @@ body.mel-vendor:has(.mel-event-studio--workspace) .mel-vendor-console.mel-vendor
 
   .mel-launch-centre__fix {
     width: 100%;
+  }
+
+  .mel-launch-centre__seo-grid {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
+++ b/web/modules/custom/myeventlane_event_studio/myeventlane_event_studio.services.yml
@@ -136,6 +136,13 @@ services:
       - '@?myeventlane_event_attendees.attendee_workspace_builder'
       - '@myeventlane_vendor.controller.vendor_event_orders'
       - '@myeventlane_vendor.controller.vendor_event_analytics'
+      - '@myeventlane_event_studio.seo_preview_builder'
+
+  myeventlane_event_studio.seo_preview_builder:
+    class: Drupal\myeventlane_event_studio\Service\EventSeoPreviewBuilder
+    arguments:
+      - '@config.factory'
+      - '@file_url_generator'
 
   myeventlane_event_studio.highlight_helper:
     class: Drupal\myeventlane_event_studio\Service\EventHighlightHelper

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventReadinessService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventReadinessService.php
@@ -119,12 +119,20 @@ final class EventReadinessService {
     }
     else {
       $completed[] = (string) $this->t('Cover image');
+      $alt = trim((string) ($event->get('field_event_image')->first()?->getValue()['alt'] ?? ''));
+      if ($alt === '') {
+        $warnings[] = (string) $this->t('Add descriptive alt text to the event image before publishing.');
+      }
+      elseif ($this->isWeakImageAlt($alt)) {
+        $warnings[] = (string) $this->t('Improve the event image alt text so it describes what people can see.');
+      }
     }
 
     if ($this->validateCapacities($event, $errors, $warnings)) {
       $completed[] = (string) $this->t('Capacity');
     }
 
+    $this->addSeoWarnings($event, $warnings);
     $this->addOptionalRecommendations($event, $recommendations);
     $this->mergeQuestionReadinessFindings($event, $errors, $warnings);
 
@@ -360,13 +368,42 @@ final class EventReadinessService {
       $recommendations[] = (string) $this->t('Consider enabling optional supporter donations for RSVP attendees.');
     }
 
-    if ($event->hasField('field_event_summary') && $event->get('field_event_summary')->isEmpty()) {
-      $recommendations[] = (string) $this->t('Add a short event summary so attendees understand the experience quickly.');
-    }
-
     if ($event->hasField('field_accessibility_contact') && $event->get('field_accessibility_contact')->isEmpty()) {
       $recommendations[] = (string) $this->t('Add accessibility contact details to build attendee confidence.');
     }
+  }
+
+  /**
+   * Adds non-blocking search and social preview warnings.
+   *
+   * @param \Drupal\node\NodeInterface $event
+   *   The event being checked.
+   * @param list<string> $warnings
+   *   Warning messages, passed by reference.
+   */
+  private function addSeoWarnings(NodeInterface $event, array &$warnings): void {
+    $summary = '';
+    if ($event->hasField('field_event_summary') && !$event->get('field_event_summary')->isEmpty()) {
+      $summary = trim(strip_tags((string) $event->get('field_event_summary')->value));
+    }
+    if (mb_strlen($summary) < 10) {
+      $warnings[] = (string) $this->t('Add a useful event summary for search and social previews.');
+    }
+  }
+
+  /**
+   * Determines whether alt text is an exact generic placeholder.
+   */
+  private function isWeakImageAlt(string $alt): bool {
+    $normalised = mb_strtolower(trim(preg_replace('/\s+/', ' ', $alt) ?? $alt));
+    return in_array($normalised, [
+      'image',
+      'photo',
+      'event image',
+      'event photo',
+      'cover image',
+      'cover photo',
+    ], TRUE);
   }
 
 }

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventSeoPreviewBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventSeoPreviewBuilder.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_event_studio\Service;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\File\FileUrlGeneratorInterface;
+use Drupal\file\FileInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Builds an honest preview of event search and social metadata.
+ */
+final class EventSeoPreviewBuilder {
+
+  public function __construct(
+    private readonly ConfigFactoryInterface $configFactory,
+    private readonly FileUrlGeneratorInterface $fileUrlGenerator,
+  ) {}
+
+  /**
+   * Builds preview values from the same event fields used by public metadata.
+   *
+   * @return array<string, mixed>
+   *   Search and social preview values.
+   */
+  public function build(NodeInterface $event, string $publicUrl): array {
+    $title = trim((string) $event->label());
+    $siteName = trim((string) $this->configFactory->get('system.site')->get('name')) ?: 'MyEventLane';
+    $description = $this->description($event);
+    $imageUrl = NULL;
+    $imageAlt = '';
+
+    if ($event->hasField('field_event_image') && !$event->get('field_event_image')->isEmpty()) {
+      $item = $event->get('field_event_image')->first();
+      $imageAlt = trim((string) ($item?->getValue()['alt'] ?? ''));
+      $file = $event->get('field_event_image')->entity;
+      if ($file instanceof FileInterface) {
+        $imageUrl = $this->fileUrlGenerator->generateAbsoluteString($file->getFileUri());
+      }
+    }
+
+    return [
+      'url' => $publicUrl,
+      'domain' => (string) (parse_url($publicUrl, PHP_URL_HOST) ?: $siteName),
+      'search_title' => $this->truncate($title . ' | ' . $siteName, 60),
+      'social_title' => $title,
+      'description' => $this->truncate($description, 160),
+      'image_url' => $imageUrl,
+      'image_alt' => $imageAlt !== '' ? $imageAlt : $title,
+    ];
+  }
+
+  /**
+   * Resolves the best available plain-text event description.
+   */
+  private function description(NodeInterface $event): string {
+    foreach (['field_event_summary', 'field_event_intro', 'body'] as $fieldName) {
+      if ($event->hasField($fieldName) && !$event->get($fieldName)->isEmpty()) {
+        $value = trim(preg_replace('/\s+/', ' ', strip_tags((string) $event->get($fieldName)->value)) ?? '');
+        if ($value !== '') {
+          return $value;
+        }
+      }
+    }
+    return '';
+  }
+
+  /**
+   * Truncates preview copy without splitting multibyte characters.
+   */
+  private function truncate(string $value, int $limit): string {
+    if (mb_strlen($value) <= $limit) {
+      return $value;
+    }
+    return rtrim(mb_substr($value, 0, $limit - 1)) . '…';
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSectionRenderer.php
@@ -53,6 +53,7 @@ final class EventStudioSectionRenderer {
     private readonly ?EventAttendeeWorkspaceBuilder $attendeeWorkspaceBuilder = NULL,
     private readonly ?VendorEventOrdersController $eventOrdersController = NULL,
     private readonly ?VendorEventAnalyticsController $eventAnalyticsController = NULL,
+    private readonly ?EventSeoPreviewBuilder $seoPreviewBuilder = NULL,
   ) {
     $this->stringTranslation = $stringTranslation;
   }
@@ -362,6 +363,10 @@ final class EventStudioSectionRenderer {
     $ready = $readiness->ready;
     $remaining = count($readiness->errors);
     $nid = (int) $event->id();
+    $publicPath = Url::fromRoute('entity.node.canonical', ['node' => $nid])->toString();
+    $publicUrl = $this->domainDetector instanceof DomainDetector
+      ? $this->domainDetector->absolutePublicUrl($publicPath)
+      : Url::fromUserInput('/' . ltrim($publicPath, '/'))->setAbsolute()->toString();
 
     // Readiness wins over published: live + blockers must mirror Hero Continue setup.
     $state = !$ready ? 'needs_attention' : ($published ? 'live' : 'ready');
@@ -414,6 +419,7 @@ final class EventStudioSectionRenderer {
         'settings_label' => (string) $this->t('More settings'),
       ],
       'after' => $this->launchAfterGuidance($event, $published),
+      'seo_preview' => $this->seoPreviewBuilder?->build($event, $publicUrl) ?? [],
     ];
   }
 

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-launch-centre.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio-launch-centre.html.twig
@@ -15,6 +15,7 @@
 {% set checklist = L.checklist|default({}) %}
 {% set visibility = L.visibility|default({}) %}
 {% set after = L.after|default({}) %}
+{% set seo = L.seo_preview|default({}) %}
 {% set items = checklist.items|default([]) %}
 {% set state = L.state|default('needs_attention') %}
 {% set eyebrow_repeats_headline = L.eyebrow and L.headline and L.eyebrow == L.headline %}
@@ -35,6 +36,36 @@
     <p class="mel-launch-centre__explanation" data-mel-launch-explanation{% if not L.explanation %} hidden{% endif %}>{{ L.explanation }}</p>
     <p class="mel-launch-centre__hero-hint" data-mel-launch-hero-hint{% if not L.hero_hint %} hidden{% endif %}>{{ L.hero_hint }}</p>
   </header>
+
+  {% if seo %}
+    <section class="mel-launch-centre__seo" aria-labelledby="mel-launch-seo-heading">
+      <header>
+        <h3 id="mel-launch-seo-heading">{{ 'SEO preview'|t }}</h3>
+        <p>{{ 'Check how this event may appear in search and when shared. Services may shorten the text.'|t }}</p>
+      </header>
+      <div class="mel-launch-centre__seo-grid">
+        <article class="mel-launch-centre__search-preview">
+          <p class="mel-launch-centre__preview-label">{{ 'Search result'|t }}</p>
+          <p class="mel-launch-centre__preview-domain">{{ seo.domain }}</p>
+          <h4>{{ seo.search_title }}</h4>
+          <p>{{ seo.description ?: 'Add an event summary to preview this description.'|t }}</p>
+        </article>
+        <article class="mel-launch-centre__social-preview">
+          <p class="mel-launch-centre__preview-label">{{ 'Social share'|t }}</p>
+          {% if seo.image_url %}
+            <img src="{{ seo.image_url }}" alt="{{ seo.image_alt }}" loading="lazy">
+          {% else %}
+            <div class="mel-launch-centre__preview-placeholder">{{ 'Add a cover image'|t }}</div>
+          {% endif %}
+          <div class="mel-launch-centre__social-copy">
+            <p class="mel-launch-centre__preview-domain">{{ seo.domain }}</p>
+            <h4>{{ seo.social_title }}</h4>
+            <p>{{ seo.description ?: 'Add an event summary to preview this description.'|t }}</p>
+          </div>
+        </article>
+      </div>
+    </section>
+  {% endif %}
 
   {# 4. After you publish — informational only (no Launch Success UI) #}
   <aside class="mel-launch-centre__after" data-mel-launch-after aria-labelledby="mel-launch-after-heading"{% if not after.items|default([]) %} hidden{% endif %}>

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventSeoQualityContractTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventSeoQualityContractTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Protects the Event Studio SEO preview and warning contract.
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventSeoQualityContractTest extends UnitTestCase {
+
+  /**
+   * Confirms Publishing exposes previews and non-blocking SEO guidance.
+   */
+  public function testPublishingSurfaceContainsSearchAndSocialPreviews(): void {
+    $root = dirname(__DIR__, 3);
+    $template = file_get_contents($root . '/templates/mel-event-studio-launch-centre.html.twig');
+    $readiness = file_get_contents($root . '/src/Service/EventReadinessService.php');
+
+    self::assertIsString($template);
+    self::assertStringContainsString("'SEO preview'|t", $template);
+    self::assertStringContainsString("'Search result'|t", $template);
+    self::assertStringContainsString("'Social share'|t", $template);
+
+    self::assertIsString($readiness);
+    self::assertStringContainsString('Add a useful event summary for search and social previews.', $readiness);
+    self::assertStringContainsString('Improve the event image alt text', $readiness);
+  }
+
+}


### PR DESCRIPTION
## What changed

- adds search and social snippet previews to Event Studio Publishing
- adds non-blocking launch warnings for missing or weak event summaries
- adds non-blocking warnings for missing or clearly generic event image alt text
- protects structured event organiser names as the referenced public organiser profile label

## Why

Organisers need to see how event content will appear before publishing. Existing metadata could fall back to weak copy, while the launch checklist treated summaries as optional and did not assess image alt text.

## Impact

Publishing remains available when SEO warnings are present. Organisers receive focused guidance and can preview search and social presentation without introducing separate RSVP and paid-event rules.

## Validation

- PHP syntax checks passed
- focused PHPUnit suites: 42 tests, 218 assertions
- Drupal cache rebuild passed in local DDEV
- local visual acceptance approved by the product owner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and readiness guidance only; publishing is not blocked by SEO warnings. Structured data organizer naming is covered by a focused unit test with no auth or payment changes.
> 
> **Overview**
> Event Studio **Publishing** now shows an **SEO preview** (search snippet and social share card) built from the same event fields used for public metadata, using the absolute public event URL.
> 
> Launch readiness adds **non-blocking warnings** for short or missing summaries, missing cover image alt text, and generic alt placeholders; the optional “add a summary” recommendation is removed from that path. Structured event data **organizer** names are asserted to use the referenced public organiser profile label (unit test).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 407e3e5ca67bca1bb6b4760c7665ad76cbc419d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->