### PR TITLE
Redirect legacy own-user profiles to My Account

### DIFF
--- a/config/sync/flag.flag.following.yml
+++ b/config/sync/flag.flag.following.yml
@@ -26,7 +26,7 @@ flag_type: 'entity:user'
 link_type: ajax_link
 flagTypeConfig:
   show_in_links: {  }
-  show_as_field: true
+  show_as_field: false
   show_on_form: false
   show_contextual_link: false
   extra_permissions: {  }

--- a/web/modules/custom/myeventlane_account/src/EventSubscriber/CustomerAccountRouteRedirectSubscriber.php
+++ b/web/modules/custom/myeventlane_account/src/EventSubscriber/CustomerAccountRouteRedirectSubscriber.php
@@ -62,10 +62,6 @@ final class CustomerAccountRouteRedirectSubscriber implements EventSubscriberInt
       return;
     }
 
-    if ($this->currentUser->hasPermission('administer users')) {
-      return;
-    }
-
     if ($route === 'entity.user.edit_form') {
       $request = $event->getRequest();
       $query = [];

--- a/web/modules/custom/myeventlane_account/tests/src/Unit/LegacyUserProfileRouteContractTest.php
+++ b/web/modules/custom/myeventlane_account/tests/src/Unit/LegacyUserProfileRouteContractTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_account\Unit;
+
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Protects the private account and public organiser profile boundary.
+ *
+ * @group myeventlane_account
+ */
+final class LegacyUserProfileRouteContractTest extends UnitTestCase {
+
+  /**
+   * Confirms own user routes do not expose an administrator-only bypass.
+   */
+  public function testOwnUserRoutesRedirectRegardlessOfAdministratorRole(): void {
+    $root = dirname(__DIR__, 3);
+    $accountSubscriber = file_get_contents($root . '/src/EventSubscriber/CustomerAccountRouteRedirectSubscriber.php');
+    $surfaceSubscriber = file_get_contents(dirname($root) . '/myeventlane_surface/src/EventSubscriber/SurfaceRouteSubscriber.php');
+    $following = file_get_contents(dirname($root, 4) . '/config/sync/flag.flag.following.yml');
+
+    self::assertIsString($accountSubscriber);
+    self::assertStringNotContainsString("hasPermission('administer users')", $accountSubscriber);
+    self::assertStringContainsString("'myeventlane_account.dashboard'", $accountSubscriber);
+
+    self::assertIsString($surfaceSubscriber);
+    self::assertStringNotContainsString("hasPermission('administer users')", $surfaceSubscriber);
+    self::assertStringContainsString("'myeventlane_account.dashboard'", $surfaceSubscriber);
+
+    self::assertIsString($following);
+    self::assertStringContainsString('show_as_field: false', $following);
+  }
+
+}

--- a/web/modules/custom/myeventlane_surface/src/EventSubscriber/SurfaceRouteSubscriber.php
+++ b/web/modules/custom/myeventlane_surface/src/EventSubscriber/SurfaceRouteSubscriber.php
@@ -80,11 +80,6 @@ final class SurfaceRouteSubscriber implements EventSubscriberInterface {
       return;
     }
 
-    // Staff managing /admin/people must reach core user view/edit routes for any account.
-    if ($this->currentUser->hasPermission('administer users')) {
-      return;
-    }
-
     try {
       $route_parameters = [];
       if ($needs_user_parameter) {


### PR DESCRIPTION
## What changed

- redirects a signed-in person’s own legacy Drupal user profile to `/my-account`, including administrators viewing themselves
- preserves administrator access to other user records through `/admin/people`
- removes the legacy user-to-user follow field from user profile rendering without deleting follow data or organiser-follow functionality
- adds a focused contract test for the account and public organiser profile boundary

## Why

The friendly user alias rendered Drupal’s sparse internal account page inside the public MyEventLane theme. It was not the governed public organiser profile and created a confusing, poorly styled duplicate identity surface.

## Impact

People now land on the canonical private My Account experience. Public organiser identity remains owned by explicitly published `/vendor/{id}` profiles. Anonymous access to user profiles remains denied.

## Validation

- PHP syntax and diff checks passed
- focused PHPUnit test passed: 1 test, 8 assertions
- local DDEV cache rebuild passed
- browser acceptance confirmed `/Anna` redirects to `/my-account`
- administrator access to another user remains available and the legacy follow action is absent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request-time redirects for administrators on their own profile and alters flag display config; scope is bounded to own-user routes and profile field rendering, not cross-user admin workflows.
> 
> **Overview**
> Signed-in users viewing **their own** legacy Drupal user profile or edit routes are always redirected to the My Account hub (`/my-account` and settings), including users with **administer users**. The previous administrator-only bypass on `CustomerAccountRouteRedirectSubscriber` and `SurfaceRouteSubscriber` is removed so the private account surface stays canonical.
> 
> The **following** flag config sets `show_as_field: false`, so user-to-user follow controls no longer render on legacy user profile fields (follow data and organiser flows are unchanged).
> 
> A **contract unit test** locks in: no `hasPermission('administer users')` escape in those subscribers, dashboard redirect targets, and the follow field visibility setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a0a990acfbc4a38acea5e199e2f206a510e9a30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->