### PR TITLE
Retire universal ticket compatibility module

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -78,7 +78,6 @@ module:
   media_library: 0
   mel_guide: 0
   mel_ticket: 0
-  mel_universal_ticket: 0
   menu_link_attributes: 0
   menu_link_content: 0
   menu_ui: 0

--- a/docs/audits/custom-module-consolidation.md
+++ b/docs/audits/custom-module-consolidation.md
@@ -7,6 +7,26 @@
 
 ---
 
+## Decision update — 2026-08-09
+
+Owner review confirmed the ticket-module boundary:
+
+- Keep `mel_ticket` as the reusable ticket-type entity foundation.
+- Keep `myeventlane_tickets` as the canonical ticket runtime and operational
+  module.
+- Retire `mel_universal_ticket` through a two-release compatibility migration.
+
+The first retirement release transfers legacy field-provider metadata to
+`myeventlane_tickets`, retains the old capability-manager service ID as an
+alias, and removes `mel_universal_ticket` from exported enabled configuration.
+The module directory must remain until every deployed environment confirms the
+module is disabled and ticket/redemption field storage is intact.
+
+This decision supersedes the ticket-trio **needs owner review** entries below;
+the remaining audit counts are preserved as the original June snapshot.
+
+---
+
 ## Executive summary
 
 | Metric | Count |

--- a/docs/universal-ticket-extension.md
+++ b/docs/universal-ticket-extension.md
@@ -4,7 +4,21 @@ Phase 2A extends the existing `myeventlane_ticket` content entity into the canon
 
 ## Phase 2A Foundation Status
 
-`mel_universal_ticket` owns the universal entitlement foundation orchestration layer. It does not replace `myeventlane_tickets`; it depends on the existing ticket module and safely verifies that the capability base fields already present on `myeventlane_ticket` are installed.
+`myeventlane_tickets` owns the universal entitlement fields, services, scanner
+integration, and runtime behaviour. `mel_universal_ticket` is retained for one
+transition release as a compatibility shim so existing environments can
+transfer legacy field-provider metadata before Drupal uninstalls it.
+
+Deployment order for the transition release is mandatory:
+
+1. Run database updates, including `myeventlane_tickets_update_8011()`.
+2. Confirm the ticket and redemption-log fields identify
+   `myeventlane_tickets` as their last-installed provider.
+3. Import configuration, which disables `mel_universal_ticket`.
+4. Rebuild caches and verify ticket issue, QR, scan, download, and wallet paths.
+
+The old service ID `mel_universal_ticket.capability_manager` remains an alias of
+`mel_ticket_capability.manager`. New consumers must use the canonical service.
 
 The requested `field_*` capability names map to existing code-defined base fields on `myeventlane_ticket`:
 

--- a/web/modules/custom/mel_universal_ticket/RETIREMENT.md
+++ b/web/modules/custom/mel_universal_ticket/RETIREMENT.md
@@ -1,0 +1,22 @@
+# MEL Universal Ticket retirement
+
+`mel_universal_ticket` is a compatibility shim. Universal entitlement fields,
+services, and runtime behaviour are owned by `myeventlane_tickets`.
+
+The first retirement release deliberately keeps this directory present while
+removing the module from exported enabled configuration. Deployment must run
+database updates before configuration import so
+`myeventlane_tickets_update_8011()` can transfer any last-installed field
+providers before Drupal uninstalls this module.
+
+The compatibility service ID `mel_universal_ticket.capability_manager` remains
+an alias of `mel_ticket_capability.manager`. New consumers must use the latter.
+
+Do not delete this directory until every deployed environment confirms:
+
+1. `mel_universal_ticket` is disabled.
+2. No pending database updates remain.
+3. The ticket and redemption-log fields are still installed and identify
+   `myeventlane_tickets` as their runtime and last-installed provider.
+4. No code or configuration outside this directory references the old module
+   or service ID.

--- a/web/modules/custom/mel_universal_ticket/mel_universal_ticket.info.yml
+++ b/web/modules/custom/mel_universal_ticket/mel_universal_ticket.info.yml
@@ -1,6 +1,6 @@
 name: 'MEL Universal Ticket'
 type: module
-description: 'Extends existing MyEventLane tickets with universal entitlement foundation capabilities.'
+description: 'Compatibility shim for universal ticket capabilities now owned by MyEventLane Tickets. Do not enable on new sites.'
 core_version_requirement: ^11
 package: 'Custom'
 dependencies:

--- a/web/modules/custom/mel_universal_ticket/mel_universal_ticket.services.yml
+++ b/web/modules/custom/mel_universal_ticket/mel_universal_ticket.services.yml
@@ -1,9 +1,6 @@
 services:
   mel_universal_ticket.capability_manager:
-    class: Drupal\mel_universal_ticket\Service\UniversalTicketCapabilityManager
-    arguments:
-      - '@datetime.time'
-      - '@myeventlane_tickets.entitlement_capability_registry'
+    alias: mel_ticket_capability.manager
 
   logger.channel.mel_universal_ticket:
     class: Drupal\Core\Logger\LoggerChannel

--- a/web/modules/custom/mel_universal_ticket/src/Service/UniversalTicketCapabilityManager.php
+++ b/web/modules/custom/mel_universal_ticket/src/Service/UniversalTicketCapabilityManager.php
@@ -8,5 +8,10 @@ use Drupal\myeventlane_tickets\Service\TicketCapabilityManager;
 
 /**
  * Universal entitlement service entry point for ticket-backed capabilities.
+ *
+ * Compatibility only. New code must use TicketCapabilityManager and the
+ * mel_ticket_capability.manager service instead.
+ *
+ * @see \Drupal\myeventlane_tickets\Service\TicketCapabilityManager
  */
 final class UniversalTicketCapabilityManager extends TicketCapabilityManager {}

--- a/web/modules/custom/mel_universal_ticket/tests/src/Kernel/UniversalTicketCapabilityManagerTest.php
+++ b/web/modules/custom/mel_universal_ticket/tests/src/Kernel/UniversalTicketCapabilityManagerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\mel_universal_ticket\Kernel;
 
+use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\myeventlane_tickets\Entity\RedemptionLog;
 use Drupal\myeventlane_tickets\Entity\Ticket;
@@ -12,6 +13,7 @@ use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
@@ -19,6 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  *
  * @group mel_universal_ticket
  */
+#[RunTestsInSeparateProcesses]
 final class UniversalTicketCapabilityManagerTest extends KernelTestBase {
 
   /**
@@ -78,6 +81,7 @@ final class UniversalTicketCapabilityManagerTest extends KernelTestBase {
     $container->register('myeventlane_legal.gatekeeper', \stdClass::class);
     $container->register('myeventlane_core.domain_detector', \stdClass::class);
     $container->register('myeventlane_analytics.order_item_classifier', \stdClass::class);
+    $container->register('myeventlane_commerce.ticket_backed_order_item_classifier', \stdClass::class);
     $container->register('myeventlane_core.entity_id_normalizer', \stdClass::class);
     $container->register('myeventlane_boost.manager', \stdClass::class);
   }
@@ -87,6 +91,8 @@ final class UniversalTicketCapabilityManagerTest extends KernelTestBase {
    */
   protected function setUp(): void {
     parent::setUp();
+
+    putenv('MEL_QR_SECRET=mel-kernel-test-secret');
 
     $this->installEntitySchema('user');
     $this->installEntitySchema('node');
@@ -132,6 +138,42 @@ final class UniversalTicketCapabilityManagerTest extends KernelTestBase {
       'status' => 1,
     ]);
     $this->event->save();
+  }
+
+  /**
+   * Legacy field providers transfer without deleting field storage.
+   */
+  public function testLegacyFieldProviderTransfer(): void {
+    $update_manager = $this->container->get('entity.definition_update_manager');
+    $legacy_fields = [
+      'myeventlane_ticket' => 'entitlement_type',
+      'mel_redemption_log' => 'ip_address',
+    ];
+
+    foreach ($legacy_fields as $entity_type_id => $field_name) {
+      $definition = $update_manager->getFieldStorageDefinition($field_name, $entity_type_id);
+      $this->assertNotNull($definition);
+      $this->assertInstanceOf(BaseFieldDefinition::class, $definition);
+      $definition->setProvider('mel_universal_ticket');
+      $update_manager->updateFieldStorageDefinition($definition);
+      $this->assertSame(
+        'mel_universal_ticket',
+        $update_manager->getFieldStorageDefinition($field_name, $entity_type_id)->getProvider(),
+      );
+    }
+
+    $this->container->get('module_handler')->loadInclude('myeventlane_tickets', 'install');
+    $result = myeventlane_tickets_update_8011();
+
+    $this->assertStringContainsString('myeventlane_ticket.entitlement_type', $result);
+    $this->assertStringContainsString('mel_redemption_log.ip_address', $result);
+    foreach ($legacy_fields as $entity_type_id => $field_name) {
+      $definition = $update_manager->getFieldStorageDefinition($field_name, $entity_type_id);
+      $this->assertNotNull($definition);
+      $this->assertSame('myeventlane_tickets', $definition->getProvider());
+    }
+
+    $this->assertStringContainsString('Already owned:', myeventlane_tickets_update_8011());
   }
 
   /**

--- a/web/modules/custom/myeventlane_tickets/myeventlane_tickets.install
+++ b/web/modules/custom/myeventlane_tickets/myeventlane_tickets.install
@@ -470,3 +470,74 @@ function myeventlane_tickets_update_8010(): string {
   $config->clear('qr_secret')->save();
   return 'Removed lingering qr_secret key from myeventlane_tickets.settings.';
 }
+
+/**
+ * Transfers legacy universal-ticket field ownership to myeventlane_tickets.
+ */
+function myeventlane_tickets_update_8011(): string {
+  $update_manager = \Drupal::entityDefinitionUpdateManager();
+  $fields = [
+    'myeventlane_ticket' => [
+      'entitlement_type',
+      'redemption_limit',
+      'redemption_count',
+      'fulfilment_status',
+      'collect_window',
+      'collect_location',
+      'vehicle_registration',
+      'vendor_reference',
+      'expires_at',
+      'metadata_json',
+    ],
+    'mel_redemption_log' => [
+      'entitlement_type',
+      'ip_address',
+    ],
+  ];
+
+  $transferred = [];
+  $already_owned = [];
+  foreach ($fields as $entity_type_id => $field_names) {
+    foreach ($field_names as $field_name) {
+      $definition = $update_manager->getFieldStorageDefinition($field_name, $entity_type_id);
+      if (!$definition) {
+        throw new \RuntimeException(sprintf(
+          'Cannot retire mel_universal_ticket: installed field %s.%s is missing.',
+          $entity_type_id,
+          $field_name,
+        ));
+      }
+
+      $provider = $definition->getProvider();
+      if ($provider === 'myeventlane_tickets') {
+        $already_owned[] = $entity_type_id . '.' . $field_name;
+        continue;
+      }
+      if ($provider !== 'mel_universal_ticket') {
+        throw new \RuntimeException(sprintf(
+          'Cannot transfer %s.%s from unexpected provider %s.',
+          $entity_type_id,
+          $field_name,
+          $provider ?: '(none)',
+        ));
+      }
+      if (!$definition instanceof \Drupal\Core\Field\BaseFieldDefinition) {
+        throw new \RuntimeException(sprintf(
+          'Cannot transfer immutable field definition %s.%s.',
+          $entity_type_id,
+          $field_name,
+        ));
+      }
+
+      $definition->setProvider('myeventlane_tickets');
+      $update_manager->updateFieldStorageDefinition($definition);
+      $transferred[] = $entity_type_id . '.' . $field_name;
+    }
+  }
+
+  return sprintf(
+    'Transferred universal-ticket field ownership to myeventlane_tickets: %s. Already owned: %s.',
+    $transferred === [] ? 'none' : implode(', ', $transferred),
+    $already_owned === [] ? 'none' : implode(', ', $already_owned),
+  );
+}

--- a/web/modules/custom/myeventlane_tickets/myeventlane_tickets.services.yml
+++ b/web/modules/custom/myeventlane_tickets/myeventlane_tickets.services.yml
@@ -151,6 +151,11 @@ services:
       - '@datetime.time'
       - '@myeventlane_tickets.entitlement_capability_registry'
 
+  # Backwards-compatible service ID retained while mel_universal_ticket is
+  # retired. New consumers must use mel_ticket_capability.manager.
+  mel_universal_ticket.capability_manager:
+    alias: mel_ticket_capability.manager
+
   mel_scanner.operation_manager:
     class: Drupal\myeventlane_tickets\Service\ScannerOperationManager
     arguments:


### PR DESCRIPTION
## Summary

Begins the two-release retirement of `mel_universal_ticket` without renaming or collapsing the canonical ticket modules.

- keeps `mel_ticket` as the reusable ticket-type entity foundation
- keeps `myeventlane_tickets` as the canonical ticket runtime
- transfers legacy last-installed field-provider metadata to `myeventlane_tickets`
- retains `mel_universal_ticket.capability_manager` as a compatibility alias
- removes `mel_universal_ticket` from exported enabled configuration
- deliberately retains the old module directory for the transition release
- records the decision and deployment sequence in the architecture and audit documents

## Why

The module audit found that `mel_universal_ticket` contains only a thin capability wrapper and schema-repair hooks, while the underlying entities, fields, scanner integration and runtime services already belong to `myeventlane_tickets`.

Two `mel_redemption_log` fields on staging still record `mel_universal_ticket` as their last-installed provider. Removing the module in one step could put those fields at risk during Drupal uninstall. This PR migrates provider ownership before configuration disables the compatibility module.

## Deployment gate

Order is mandatory:

1. Create a database recovery snapshot.
2. Deploy the release with the compatibility module directory still present.
3. Run database updates, including `myeventlane_tickets_update_8011()`.
4. Verify ticket and redemption-log fields have runtime and last-installed provider `myeventlane_tickets`.
5. Import configuration to uninstall `mel_universal_ticket`.
6. Rebuild caches.
7. Verify ticket issue, QR, scan, download and wallet paths.
8. Confirm no pending database updates or unexpected configuration drift.

Do not delete the compatibility module directory in this release. Physical removal is a later PR after every environment confirms the module is disabled and field storage remains intact.

## Validation

- focused Drupal kernel suite: 6 tests, 90 assertions
- PHP syntax checks
- Drupal and DrupalPractice coding standards
- YAML parsing
- Composer validation
- MEL architecture, surface and template governance audits
- Git diff validation

The kernel suite reports existing upstream Drupal/Commerce deprecations but no failures.

## Scope protection

- no refund-work changes
- no ticket entity rename
- no Commerce model changes
- no staging deployment
- no MEL Hold changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches entity field storage ownership and module enablement order; incorrect deploy (config before `update_8011`) could risk field storage during uninstall, though the update hook and docs enforce DB updates first.
> 
> **Overview**
> Starts the **two-release retirement** of `mel_universal_ticket` while keeping `myeventlane_tickets` as the canonical ticket runtime. Exported config **drops** the module from enabled extensions; the module directory stays for one transition release.
> 
> **`myeventlane_tickets_update_8011()`** reassigns last-installed field storage providers from `mel_universal_ticket` to `myeventlane_tickets` for universal entitlement fields on `myeventlane_ticket` and redemption-log fields on `mel_redemption_log`, with hard failures if fields are missing or owned by another provider. **`mel_universal_ticket.capability_manager`** is now a **service alias** to `mel_ticket_capability.manager` in both `myeventlane_tickets` and the shim module (the shim no longer registers its own capability manager implementation).
> 
> The shim is documented as compatibility-only (`RETIREMENT.md`, updated audit and architecture docs), and kernel tests cover the provider transfer path plus existing capability behaviour.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e6a3024c8d32bdc4f7a410c8205920161100f18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->