### PR TITLE
Hotfix: stage legacy check-in retirement safely

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -99,6 +99,7 @@ module:
   myeventlane_checkout_flow: 0
   myeventlane_checkout_paragraph: 0
   myeventlane_commerce: 0
+  myeventlane_checkin: 0
   myeventlane_core: 0
   myeventlane_dashboard: 0
   myeventlane_demo: 0

--- a/web/modules/custom/myeventlane_checkin/RETIREMENT.md
+++ b/web/modules/custom/myeventlane_checkin/RETIREMENT.md
@@ -1,7 +1,10 @@
 # MyEventLane Check-in retirement
 
-This directory is retained temporarily so deployments can uninstall the former
-`myeventlane_checkin` extension cleanly.
+This directory and its empty extension are retained temporarily while active
+environments shed role configuration dependencies on `myeventlane_checkin`.
+Keep the shim enabled during this transition: uninstalling an extension in the
+same configuration import can delete and recreate dependent roles, removing
+existing user-role assignments.
 
 The canonical organiser check-in surface is Door Mode, owned by
 `myeventlane_event_attendees` and implemented through
@@ -9,5 +12,6 @@ The canonical organiser check-in surface is Door Mode, owned by
 as access-controlled redirects in `myeventlane_event_attendees.routing.yml`.
 
 The legacy toggle and search mutation surfaces are intentionally not retained.
-Do not enable this compatibility shim on new installations. Physical removal
-is a separate release gate after staging acceptance.
+Do not enable this compatibility shim on new installations. Disabling and
+physical removal are separate release gates after every active environment has
+imported the cleaned role configuration.

--- a/web/modules/custom/myeventlane_event_attendees/tests/src/Unit/LegacyCheckinRetirementContractTest.php
+++ b/web/modules/custom/myeventlane_event_attendees/tests/src/Unit/LegacyCheckinRetirementContractTest.php
@@ -38,13 +38,13 @@ final class LegacyCheckinRetirementContractTest extends TestCase {
   }
 
   /**
-   * Active configuration no longer enables or depends on the retired module.
+   * Transition config keeps the empty shim while removing role dependencies.
    */
-  public function testActiveConfigurationRemovesLegacyModule(): void {
+  public function testActiveConfigurationSafelyStagesLegacyModuleRemoval(): void {
     $repository_root = dirname(__DIR__, 7);
     $extension_config = file_get_contents($repository_root . '/config/sync/core.extension.yml');
     $this->assertNotFalse($extension_config);
-    $this->assertStringNotContainsString('myeventlane_checkin:', $extension_config);
+    $this->assertStringContainsString('  myeventlane_checkin: 0', $extension_config);
 
     foreach (['anonymous', 'authenticated', 'vendor'] as $role) {
       $role_config = file_get_contents($repository_root . "/config/sync/user.role.{$role}.yml");


### PR DESCRIPTION
## Purpose
Prevent Drupal configuration import from deleting and recreating the vendor role while retiring the legacy check-in module.

## Change
- keep the empty `myeventlane_checkin` compatibility shim enabled for this transition release
- retain removal of legacy routes, permissions, and role dependencies
- document the required two-release retirement sequence
- update the retirement contract test

## Incident evidence
PR #784 correctly ran update 8003 before config import, but the subsequent module uninstall still deleted and recreated `user.role.vendor`, removing 24 staging user-role assignments. Those exact assignments were restored from the pre-deployment snapshot and verified.

## Validation
- PHP syntax check passed
- transition contract assertions passed
- full CI required before merge and staging redeploy

## Deployment gate
Draft until CI passes. Staging only. MEL Hold is out of scope and must remain unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deployment/config-import behavior around module enablement and role config; incorrect sequencing could still affect user-role assignments, but the change is a deliberate safeguard against a known staging incident.
> 
> **Overview**
> **Re-enables the empty `myeventlane_checkin` compatibility shim** in synced `core.extension.yml` so config import does not uninstall the extension in the same pass as cleaned role config—a sequence that had deleted and recreated `user.role.vendor` and stripped staging user-role assignments.
> 
> **Retirement docs** (`RETIREMENT.md`) now spell out that the shim must stay enabled until every active environment has imported role config without `myeventlane_checkin` dependencies; disabling and removing the directory are separate release gates.
> 
> **Contract test** `testActiveConfigurationRemovesLegacyModule` is renamed to `testActiveConfigurationSafelyStagesLegacyModuleRemoval` and now expects `myeventlane_checkin: 0` in extensions while still asserting anonymous, authenticated, and vendor roles omit legacy check-in permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bd0f3926de88531f524addfe6709d9c3e8c2a8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->