### PR TITLE
Fix Drupal 11 static analysis contracts

### DIFF
--- a/web/modules/custom/mel_admin_dashboard/src/Service/DashboardMetricsService.php
+++ b/web/modules/custom/mel_admin_dashboard/src/Service/DashboardMetricsService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\mel_admin_dashboard\Service;
 
+use Drupal\commerce_order\Entity\OrderInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Component\Datetime\TimeInterface;
@@ -91,6 +92,9 @@ class DashboardMetricsService {
 
     $gross = 0.0;
     foreach ($orders as $order) {
+      if (!$order instanceof OrderInterface) {
+        continue;
+      }
       $total = $order->getTotalPrice();
       if ($total) {
         $gross += (float) $total->getNumber();

--- a/web/modules/custom/mel_ticket/src/Entity/TicketType.php
+++ b/web/modules/custom/mel_ticket/src/Entity/TicketType.php
@@ -12,6 +12,7 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Entity\EntityStorageException;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItem;
 
 /**
  * Ticket type (RSVP, paid, or external) owned by a vendor user.
@@ -107,7 +108,7 @@ final class TicketType extends ContentEntityBase implements TicketTypeInterface 
     }
     /** @var \Drupal\link\Plugin\Field\FieldType\LinkItem $item */
     $item = $this->get('external_url')->first();
-    return $item->getUri();
+    return (string) $item->uri;
   }
 
   /**
@@ -584,8 +585,13 @@ final class TicketType extends ContentEntityBase implements TicketTypeInterface 
 
     if ($this->hasField('sale_start') && $this->hasField('sale_end')
         && !$this->get('sale_start')->isEmpty() && !$this->get('sale_end')->isEmpty()) {
-      $start = $this->get('sale_start')->date->getTimestamp();
-      $end = $this->get('sale_end')->date->getTimestamp();
+      $start_item = $this->get('sale_start')->first();
+      $end_item = $this->get('sale_end')->first();
+      if (!$start_item instanceof DateTimeItem || !$end_item instanceof DateTimeItem) {
+        throw new EntityStorageException('Ticket sale dates must use datetime fields.');
+      }
+      $start = $start_item->date->getTimestamp();
+      $end = $end_item->date->getTimestamp();
       if ($end <= $start) {
         $violations[] = 'Sale end must be after sale start.';
       }

--- a/web/modules/custom/mel_ticket/src/Entity/TicketTypeInterface.php
+++ b/web/modules/custom/mel_ticket/src/Entity/TicketTypeInterface.php
@@ -6,11 +6,12 @@ namespace Drupal\mel_ticket\Entity;
 
 use Drupal\commerce_price\Price;
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityPublishedInterface;
 
 /**
  * Contract for MEL ticket type entities.
  */
-interface TicketTypeInterface extends ContentEntityInterface {
+interface TicketTypeInterface extends ContentEntityInterface, EntityPublishedInterface {
 
   public const LIFECYCLE_ACTIVE = 'active';
 

--- a/web/modules/custom/mel_ticket/src/Form/TicketTypeForm.php
+++ b/web/modules/custom/mel_ticket/src/Form/TicketTypeForm.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\mel_ticket\Form;
 
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\ContentEntityForm;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\mel_ticket\Entity\TicketTypeInterface;
@@ -50,11 +49,11 @@ final class TicketTypeForm extends ContentEntityForm {
           $values['event'] = ['target_id' => (int) $event->id()];
         }
         $this->entity = $this->ticketTierLifecycle->persistNewTicketType($values, $event);
-        $status = EntityInterface::SAVED_NEW;
+        $status = SAVED_NEW;
       }
       else {
         $this->ticketTierLifecycle->updateTicketType($this->entity, $event);
-        $status = EntityInterface::SAVED_UPDATED;
+        $status = SAVED_UPDATED;
       }
     }
     catch (\Throwable $e) {

--- a/web/modules/custom/myeventlane_account/myeventlane_account.module
+++ b/web/modules/custom/myeventlane_account/myeventlane_account.module
@@ -11,6 +11,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
+use Drupal\file\FileInterface;
 use Drupal\myeventlane_surface\MelCustomerRouteCatalog;
 use Drupal\node\NodeInterface;
 
@@ -158,7 +159,7 @@ function _myeventlane_account_build_avatar_vars(?string $display_name_override =
   $user = \Drupal::entityTypeManager()->getStorage('user')->load($account->id());
   if ($user && $user->hasField('user_picture') && !$user->get('user_picture')->isEmpty()) {
     $file = $user->get('user_picture')->entity;
-    if ($file && $file->getFileUri()) {
+    if ($file instanceof FileInterface && $file->getFileUri()) {
       $uri = $file->getFileUri();
       $file_system = \Drupal::service('file_system');
       $real_path = $file_system->realpath($uri);

--- a/web/modules/custom/myeventlane_account/src/Controller/MyAccountController.php
+++ b/web/modules/custom/myeventlane_account/src/Controller/MyAccountController.php
@@ -8,6 +8,7 @@ use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Url;
+use Drupal\myeventlane_account\Entity\EventReview;
 use Drupal\myeventlane_account\Service\AccountLinksService;
 use Drupal\myeventlane_account\Service\CustomerAccountHeroBuilder;
 use Drupal\myeventlane_account\Service\CustomerHubDataBuilder;
@@ -279,6 +280,9 @@ final class MyAccountController extends ControllerBase {
     $existingByEvent = [];
     if (!empty($existingIds)) {
       foreach ($reviewStorage->loadMultiple($existingIds) as $review) {
+        if (!$review instanceof EventReview) {
+          continue;
+        }
         $eid = $review->getEventId();
         if ($eid) {
           $existingByEvent[$eid] = TRUE;

--- a/web/modules/custom/myeventlane_account/src/Service/CustomerHubDataBuilder.php
+++ b/web/modules/custom/myeventlane_account/src/Service/CustomerHubDataBuilder.php
@@ -5,8 +5,12 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_account\Service;
 
 use Drupal\commerce_order\Entity\OrderItemInterface;
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Url;
+use Drupal\file\FileInterface;
+use Drupal\flag\FlaggingInterface;
 use Drupal\image\ImageStyleInterface;
 use Drupal\myeventlane_core\MelReadinessHelper;
 use Drupal\myeventlane_event_attendees\Entity\EventAttendee;
@@ -164,6 +168,9 @@ final class CustomerHubDataBuilder {
 
     $byId = [];
     foreach ($flaggingStorage->loadMultiple($flaggingIds) as $flagging) {
+      if (!$flagging instanceof FlaggingInterface) {
+        continue;
+      }
       $entity = $flagging->getFlaggable();
       if (!$entity instanceof NodeInterface || $entity->bundle() !== 'event') {
         continue;
@@ -410,6 +417,9 @@ final class CustomerHubDataBuilder {
     $attendees = !empty($attendeeIds) ? $attendeeStorage->loadMultiple($attendeeIds) : [];
 
     foreach ($attendees as $attendee) {
+      if (!$attendee instanceof EventAttendee) {
+        continue;
+      }
       $eventId = (int) $attendee->get('event')->target_id;
       if ($eventId < 1) {
         continue;
@@ -471,6 +481,9 @@ final class CustomerHubDataBuilder {
     }
 
     foreach ($orders as $order) {
+      if (!$order instanceof OrderInterface) {
+        continue;
+      }
       foreach ($order->getItems() as $orderItem) {
         if (!$orderItem->hasField('field_target_event') || $orderItem->get('field_target_event')->isEmpty()) {
           continue;
@@ -497,7 +510,7 @@ final class CustomerHubDataBuilder {
         $attendeeId = NULL;
         if (!empty($oiAttendeeIds)) {
           $oiAttendee = $attendeeStorage->load(reset($oiAttendeeIds));
-          if ($oiAttendee) {
+          if ($oiAttendee instanceof EventAttendee) {
             $ticketCode = $oiAttendee->get('ticket_code')->value ?? '';
             $attendeeId = (int) $oiAttendee->id();
           }
@@ -518,6 +531,9 @@ final class CustomerHubDataBuilder {
       $rsvps = !empty($rsvpIds) ? $rsvpStorage->loadMultiple($rsvpIds) : [];
 
       foreach ($rsvps as $rsvp) {
+        if (!$rsvp instanceof ContentEntityInterface) {
+          continue;
+        }
         if (!$rsvp->hasField('event_id') || $rsvp->get('event_id')->isEmpty()) {
           continue;
         }
@@ -585,7 +601,7 @@ final class CustomerHubDataBuilder {
     $imageUrl = '';
     if ($event->hasField('field_event_image') && !$event->get('field_event_image')->isEmpty()) {
       $file = $event->get('field_event_image')->entity;
-      if ($file && $file->getFileUri()) {
+      if ($file instanceof FileInterface && $file->getFileUri()) {
         $style = $this->getEventImageStyle();
         $imageUrl = $style ? $style->buildUrl($file->getFileUri()) : '';
       }

--- a/web/modules/custom/myeventlane_account/tests/src/Functional/CustomerSettingsSaveTest.php
+++ b/web/modules/custom/myeventlane_account/tests/src/Functional/CustomerSettingsSaveTest.php
@@ -78,6 +78,8 @@ final class CustomerSettingsSaveTest extends BrowserTestBase {
     $this->submitForm([
       'field_display_name[0][value]' => 'Customer Test',
       'field_city[0][value]' => 'Sydney',
+      // Drupal's BrowserTestBase adds this runtime-only test property.
+      // @phpstan-ignore-next-line
       'current_pass' => $account->passRaw,
       'pass[pass1]' => $password,
       'pass[pass2]' => $password,


### PR DESCRIPTION
## What changed

- tighten Drupal entity contracts in `mel_ticket`, `myeventlane_account`, and `mel_admin_dashboard`
- use the correct published, file, order, flagging, attendee, review, datetime, and content-entity types before calling type-specific methods
- use Drupal's global entity save result constants
- document the BrowserTestBase runtime password property for static analysis

## Why

Drupal Check reported real contract mismatches where code relied on concrete runtime entities while the declared type only guaranteed `EntityInterface`. This makes those assumptions explicit without changing ticketing, account, or dashboard behaviour.

## Impact

The three target modules now pass Drupal Check with zero errors. Invalid or unexpected entity types are skipped safely; incorrectly configured ticket sale date fields fail explicitly during entity validation.

This PR does not add a repository-wide PHPStan baseline or change CI enforcement. A full scan currently reports 1,609 existing findings outside this bounded cleanup and should be handled as a separate governance tranche.

## Validation

- `vendor/bin/drupal-check --memory-limit=1G web/modules/custom/myeventlane_account web/modules/custom/mel_ticket web/modules/custom/mel_admin_dashboard` — no errors
- account unit suite — 6 tests, 35 assertions
- PHP syntax checks passed for changed runtime files
- `git diff --check` passed

## Boundaries

- no configuration or database changes
- no staging or production deployment
- MEL Hold untouched
- unrelated refund work in the main DDEV checkout untouched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Contract guards and interface extensions only; no config or schema changes. Ticket sale-date validation is slightly stricter if fields are misconfigured.
> 
> **Overview**
> Aligns **mel_ticket**, **myeventlane_account**, and **mel_admin_dashboard** with Drupal Check / static analysis by making entity types explicit before type-specific calls, without changing intended runtime behavior.
> 
> **Ticket types:** `TicketTypeInterface` now extends `EntityPublishedInterface`. External URLs read via the link field’s `uri` property; sale-window validation checks `DateTimeItem` instances and throws if sale dates are not datetime fields. `TicketTypeForm` uses Drupal’s global `SAVED_NEW` / `SAVED_UPDATED` constants.
> 
> **Account hub:** Loops over loaded commerce orders, flaggings, attendees, RSVP submissions, event reviews, and file entities now guard with `OrderInterface`, `FlaggingInterface`, `EventAttendee`, `ContentEntityInterface`, `EventReview`, and `FileInterface` (skipping mismatches). Avatar and event image handling use `FileInterface` checks.
> 
> **Dashboard:** Gross revenue aggregation only calls `getTotalPrice()` on orders that are `OrderInterface`.
> 
> **Tests:** Customer settings functional test documents BrowserTestBase’s runtime `passRaw` with a PHPStan ignore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfdb20ab7f1789e39b7ecba739bce77726190276. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->