### PR TITLE
Enforce static analysis for clean modules

### DIFF
--- a/.github/workflows/php-composer.yml
+++ b/.github/workflows/php-composer.yml
@@ -55,7 +55,14 @@ jobs:
       - name: Run Composer security audit
         run: composer audit --no-dev
 
-      - name: Run Drupal check (optional)
+      - name: Enforce Drupal check for clean modules
+        run: >-
+          vendor/bin/drupal-check --memory-limit=1G
+          web/modules/custom/myeventlane_account
+          web/modules/custom/mel_ticket
+          web/modules/custom/mel_admin_dashboard
+
+      - name: Report remaining Drupal check findings (informational)
         run: vendor/bin/drupal-check web/modules/custom web/themes/custom
         continue-on-error: true
 


### PR DESCRIPTION
## What changed

- add a mandatory Drupal Check step for `myeventlane_account`, `mel_ticket`, and `mel_admin_dashboard`
- give the mandatory analysis an explicit 1 GB memory limit
- retain the repository-wide custom code scan as informational

## Why

These three modules were cleaned in PR #787, but the existing CI step used `continue-on-error: true`. A regression in a cleaned module therefore would not fail the build.

This change establishes a ratchet: code that is clean must stay clean, while unresolved findings elsewhere remain visible without blocking unrelated delivery.

## Impact

Pull requests and pushes to `main` will fail the PHP Composer workflow if any of the three governed modules introduces a Drupal Check error.

This PR does not create or accept a repository-wide baseline. The remaining repository findings stay outside this bounded tranche.

## Validation

- exact mandatory Drupal Check command passed with zero errors across 37 files
- workflow YAML syntax parsed successfully
- `git diff --check` passed

## Boundaries

- one workflow file only
- no Drupal configuration or database changes
- no runtime deployment required for activation beyond merging the workflow
- staging, production, the main DDEV checkout, and MEL Hold untouched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only `.github/workflows/php-composer.yml` changes; no application runtime, config, or database impact. Risk is limited to CI failing when those three modules introduce static-analysis errors.
> 
> **Overview**
> **CI ratchet for three custom modules** that were already cleaned: the PHP Composer workflow now runs a **blocking** `drupal-check` step (with `--memory-limit=1G`) on `myeventlane_account`, `mel_ticket`, and `mel_admin_dashboard`. Any new Drupal Check error in those paths fails the job.
> 
> The **repository-wide** scan of `web/modules/custom` and `web/themes/custom` remains, but is renamed and kept **informational** via `continue-on-error: true`, so other modules can still show findings without blocking unrelated work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 063e47d743f852838029f57761ce35a049f69e8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->