### PR TITLE
Clean admin dashboard static analysis

### DIFF
--- a/.github/workflows/php-composer.yml
+++ b/.github/workflows/php-composer.yml
@@ -61,6 +61,7 @@ jobs:
           web/modules/custom/myeventlane_account
           web/modules/custom/mel_ticket
           web/modules/custom/mel_admin_dashboard
+          web/modules/custom/myeventlane_admin_dashboard
 
       - name: Report remaining Drupal check findings (informational)
         run: vendor/bin/drupal-check web/modules/custom web/themes/custom

--- a/web/modules/custom/myeventlane_admin_dashboard/src/Controller/PayoutBatchController.php
+++ b/web/modules/custom/myeventlane_admin_dashboard/src/Controller/PayoutBatchController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_admin_dashboard\Controller;
 
+use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Access\CsrfTokenGenerator;
 use Drupal\Core\Cache\Cache;
@@ -85,13 +86,12 @@ final class PayoutBatchController extends ControllerBase {
     $transaction = $this->database->startTransaction();
 
     try {
-      $rows = $this->database->select(self::TABLE, 'l')
-        ->fields('l')
+      $query = $this->database->select(self::TABLE, 'l');
+      $query->fields('l')
         ->condition('l.id', $ids, 'IN')
-        ->condition('l.status', 'unpaid')
-        ->forUpdate()
-        ->execute()
-        ->fetchAll();
+        ->condition('l.status', 'unpaid');
+      $query->forUpdate();
+      $rows = $query->execute()->fetchAll();
 
       if (empty($rows)) {
         $this->messenger()->addWarning($this->t('No unpaid payouts found in selection.'));
@@ -101,6 +101,7 @@ final class PayoutBatchController extends ControllerBase {
       // Filter out rows with existing transfer_id or non-positive net.
       $validRows = [];
       foreach ($rows as $row) {
+        /** @var object{id: int, transfer_id: string|null, net: int|float|string} $row */
         if (!empty($row->transfer_id)) {
           $this->payoutLogger->warning('Batch @bid: Ledger @lid already has transfer_id @tid. Skipping.', [
             '@bid' => $batchId,
@@ -292,7 +293,7 @@ final class PayoutBatchController extends ControllerBase {
       ->getStorage('commerce_store')
       ->load($storeId);
 
-    if (!$store) {
+    if (!$store instanceof StoreInterface) {
       return NULL;
     }
 

--- a/web/modules/custom/myeventlane_admin_dashboard/src/Controller/PayoutTransferController.php
+++ b/web/modules/custom/myeventlane_admin_dashboard/src/Controller/PayoutTransferController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_admin_dashboard\Controller;
 
+use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Access\CsrfTokenGenerator;
 use Drupal\Core\Cache\Cache;
@@ -195,12 +196,10 @@ final class PayoutTransferController extends ControllerBase {
    * Loads a ledger row with a SELECT … FOR UPDATE to prevent races.
    */
   private function loadRowForUpdate(int $ledger_id): object {
-    $row = $this->database->select(self::TABLE, 'l')
-      ->fields('l')
-      ->condition('l.id', $ledger_id)
-      ->forUpdate()
-      ->execute()
-      ->fetchObject();
+    $query = $this->database->select(self::TABLE, 'l');
+    $query->fields('l')->condition('l.id', $ledger_id);
+    $query->forUpdate();
+    $row = $query->execute()->fetchObject();
 
     if (!$row) {
       throw new NotFoundHttpException("Payout ledger entry #{$ledger_id} not found.");
@@ -217,7 +216,7 @@ final class PayoutTransferController extends ControllerBase {
       ->getStorage('commerce_store')
       ->load($storeId);
 
-    if (!$store) {
+    if (!$store instanceof StoreInterface) {
       return NULL;
     }
 

--- a/web/modules/custom/myeventlane_admin_dashboard/src/Controller/StripeWebhookController.php
+++ b/web/modules/custom/myeventlane_admin_dashboard/src/Controller/StripeWebhookController.php
@@ -14,6 +14,7 @@ use Psr\Log\LoggerInterface;
 use Stripe\Event;
 use Stripe\Exception\SignatureVerificationException;
 use Stripe\Exception\UnexpectedValueException;
+use Stripe\Transfer;
 use Stripe\Webhook;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -107,7 +108,10 @@ final class StripeWebhookController extends ControllerBase {
    * Handles transfer.paid — reconciles ledger row to 'paid'.
    */
   private function handleTransferPaid(Event $event): Response {
-    $transfer = $event->data->object;
+    $transfer = $event->data['object'] ?? NULL;
+    if (!$transfer instanceof Transfer) {
+      return $this->handleInvalidTransferPayload($event);
+    }
     $transferId = $transfer->id ?? NULL;
 
     $orderId = $this->resolveOrderId($transfer);
@@ -183,7 +187,10 @@ final class StripeWebhookController extends ControllerBase {
    * Handles transfer.failed — logs error, does NOT change ledger status.
    */
   private function handleTransferFailed(Event $event): Response {
-    $transfer = $event->data->object;
+    $transfer = $event->data['object'] ?? NULL;
+    if (!$transfer instanceof Transfer) {
+      return $this->handleInvalidTransferPayload($event);
+    }
     $transferId = $transfer->id ?? 'unknown';
     $orderId = $this->resolveOrderId($transfer);
 
@@ -199,7 +206,10 @@ final class StripeWebhookController extends ControllerBase {
    * Handles transfer.created — informational logging only.
    */
   private function handleTransferCreated(Event $event): Response {
-    $transfer = $event->data->object;
+    $transfer = $event->data['object'] ?? NULL;
+    if (!$transfer instanceof Transfer) {
+      return $this->handleInvalidTransferPayload($event);
+    }
     $transferId = $transfer->id ?? 'unknown';
 
     $this->payoutLogger->info(
@@ -225,6 +235,17 @@ final class StripeWebhookController extends ControllerBase {
   }
 
   /**
+   * Acknowledges a transfer event whose verified payload has the wrong shape.
+   */
+  private function handleInvalidTransferPayload(Event $event): Response {
+    $this->payoutLogger->error(
+      'Stripe payout webhook @type did not contain a transfer object.',
+      ['@type' => $event->type]
+    );
+    return new JsonResponse(['received' => TRUE], Response::HTTP_OK);
+  }
+
+  /**
    * Resolves order_id from a transfer object.
    *
    * Strategy:
@@ -235,7 +256,7 @@ final class StripeWebhookController extends ControllerBase {
    * empty. The order_id lives on the PaymentIntent/Charge metadata instead,
    * accessible via source_transaction.
    */
-  private function resolveOrderId(object $transfer): ?string {
+  private function resolveOrderId(Transfer $transfer): ?string {
     // 1. Direct transfer metadata (best case).
     $metadata = $transfer->metadata ?? NULL;
     if ($metadata !== NULL) {

--- a/web/modules/custom/myeventlane_admin_dashboard/src/Service/PayoutBatchWorkflowService.php
+++ b/web/modules/custom/myeventlane_admin_dashboard/src/Service/PayoutBatchWorkflowService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_admin_dashboard\Service;
 
+use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Database\Connection;
@@ -58,13 +59,12 @@ final class PayoutBatchWorkflowService {
     $transaction = $this->database->startTransaction();
 
     try {
-      $rows = $this->database->select(self::LEDGER_TABLE, 'l')
-        ->fields('l')
+      $query = $this->database->select(self::LEDGER_TABLE, 'l');
+      $query->fields('l')
         ->condition('l.id', $ids, 'IN')
-        ->condition('l.status', 'unpaid')
-        ->forUpdate()
-        ->execute()
-        ->fetchAll();
+        ->condition('l.status', 'unpaid');
+      $query->forUpdate();
+      $rows = $query->execute()->fetchAll();
 
       if (empty($rows)) {
         throw new \InvalidArgumentException('No unpaid ledger rows found for the given IDs.');
@@ -561,7 +561,7 @@ final class PayoutBatchWorkflowService {
       ->getStorage('commerce_store')
       ->load($storeId);
 
-    if (!$store) {
+    if (!$store instanceof StoreInterface) {
       return NULL;
     }
 

--- a/web/modules/custom/myeventlane_admin_dashboard/src/Service/PlatformMetricsService.php
+++ b/web/modules/custom/myeventlane_admin_dashboard/src/Service/PlatformMetricsService.php
@@ -9,6 +9,7 @@ use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\myeventlane_commerce\Service\OrderItemClassifier;
 use Psr\Log\LoggerInterface;
@@ -161,7 +162,7 @@ final class PlatformMetricsService {
       ->condition('order_id', $orderId)
       ->execute();
 
-    $this->cache->invalidateTags(self::CACHE_TAGS);
+    Cache::invalidateTags(self::CACHE_TAGS);
   }
 
   /**

--- a/web/modules/custom/myeventlane_admin_dashboard/tests/src/Kernel/RefundAnalyticsAllocationTest.php
+++ b/web/modules/custom/myeventlane_admin_dashboard/tests/src/Kernel/RefundAnalyticsAllocationTest.php
@@ -23,12 +23,14 @@ use Drupal\myeventlane_pro\Service\ProRecoveryAnalyticsService;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Kernel tests refund allocation and platform recovery analytics.
  *
  * @group myeventlane_admin_dashboard
  */
+#[RunTestsInSeparateProcesses]
 final class RefundAnalyticsAllocationTest extends KernelTestBase {
 
   /**
@@ -38,6 +40,7 @@ final class RefundAnalyticsAllocationTest extends KernelTestBase {
     'system',
     'user',
     'field',
+    'filter',
     'node',
     'options',
     'path',
@@ -476,4 +479,3 @@ final class RefundAnalyticsAllocationTest extends KernelTestBase {
   }
 
 }
-


### PR DESCRIPTION
## What changed

- preserve explicit `SELECT ... FOR UPDATE` payout locking without chaining through Drupal's narrower condition return type
- require loaded payout stores to implement Commerce `StoreInterface` before accessing fields
- require verified Stripe webhook payloads to contain a `Transfer` object before reconciliation
- use Drupal's cache-tag invalidation API for payout metric changes
- repair the existing admin-dashboard kernel-test dependencies and Drupal 11 process-isolation declaration
- add `myeventlane_admin_dashboard` to the mandatory Drupal Check gate

## Why

The module had 17 static-analysis errors caused by assumptions about database query return types, generic loaded entities, dynamic Stripe payloads, and cache APIs. Several assumptions were valid at runtime but were not guaranteed by the declared contracts. The cache invalidation call was not part of `CacheBackendInterface`.

## Impact

Payout state transitions, transfer grouping and row locking are preserved. Unexpected Stripe transfer payload shapes are logged and acknowledged without changing the payout ledger. The module must now remain clean in CI.

## Validation

- Drupal Check for `myeventlane_admin_dashboard` — zero errors
- expanded mandatory four-module Drupal Check gate — zero errors
- unit contract test — 1 test, 8 assertions
- refund and recovery kernel tests — 2 tests, 42 assertions
- PHP syntax, workflow YAML and `git diff --check` passed

The kernel suite still reports upstream Drupal Commerce and contributed-module deprecations; those are outside this bounded change.

## Boundaries

- seven files only
- no configuration or database updates
- no payout data or Stripe credentials touched
- no staging or production deployment
- main DDEV checkout and MEL Hold untouched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payout row locking, Stripe transfer reconciliation, and ledger paid-state updates; behavior is intended to stay the same but these are financially sensitive paths.
> 
> **Overview**
> Clears **drupal-check** findings in `myeventlane_admin_dashboard` and adds that module to the mandatory four-module CI gate in `.github/workflows/php-composer.yml`.
> 
> **Payout locking and stores:** Batch and single-transfer payout code, plus `PayoutBatchWorkflowService`, build `SELECT … FOR UPDATE` queries in separate steps so `forUpdate()` is not lost on Drupal’s narrower `condition()` return type. Loaded commerce stores must be `StoreInterface` before reading Stripe Connect fields.
> 
> **Stripe webhooks:** Transfer handlers read `event->data['object']` and require a `Stripe\Transfer` instance; malformed payloads are logged and acknowledged without ledger updates. `resolveOrderId` is typed to `Transfer`.
> 
> **Metrics cache:** `PlatformMetricsService::markPaid` invalidates payout metric tags via `Cache::invalidateTags()` instead of the cache backend instance.
> 
> **Tests:** `RefundAnalyticsAllocationTest` adds the `filter` module, `#[RunTestsInSeparateProcesses]`, and a small cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2efe5c64ab5cde245b9570bd0e4cf7af161b61a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->