### PR TITLE
Clean AI static analysis

### DIFF
--- a/.github/workflows/php-composer.yml
+++ b/.github/workflows/php-composer.yml
@@ -62,6 +62,7 @@ jobs:
           web/modules/custom/mel_ticket
           web/modules/custom/mel_admin_dashboard
           web/modules/custom/myeventlane_admin_dashboard
+          web/modules/custom/myeventlane_ai
 
       - name: Report remaining Drupal check findings (informational)
         run: vendor/bin/drupal-check web/modules/custom web/themes/custom

--- a/web/modules/custom/myeventlane_ai/myeventlane_ai.install
+++ b/web/modules/custom/myeventlane_ai/myeventlane_ai.install
@@ -172,7 +172,7 @@ function myeventlane_ai_update_9006(): string {
     if ($config_factory->get($name)->isNew()) {
       $file = $extension_path . '/config/install/' . $name . '.yml';
       if (file_exists($file)) {
-        $data = \Drupal\Core\Serialization\Yaml::decode(file_get_contents($file));
+        $data = \Drupal\Component\Serialization\Yaml::decode(file_get_contents($file));
         if (is_array($data)) {
           $config_factory->getEditable($name)->setData($data)->save(TRUE);
           $installed++;

--- a/web/modules/custom/myeventlane_ai/src/Entity/AiJobAccessControlHandler.php
+++ b/web/modules/custom/myeventlane_ai/src/Entity/AiJobAccessControlHandler.php
@@ -6,8 +6,13 @@ namespace Drupal\myeventlane_ai\Entity;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityAccessControlHandler;
+use Drupal\Core\Entity\EntityHandlerInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
 /**
  * Access control for AI Job entities.
  *
@@ -16,7 +21,27 @@ use Drupal\Core\Session\AccountInterface;
  * - Vendors can view jobs when vendor_id matches their vendor.
  * - No anonymous access.
  */
-final class AiJobAccessControlHandler extends EntityAccessControlHandler {
+final class AiJobAccessControlHandler extends EntityAccessControlHandler implements EntityHandlerInterface {
+
+  /**
+   * Constructs the AI job access handler.
+   */
+  public function __construct(
+    EntityTypeInterface $entity_type,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+  ) {
+    parent::__construct($entity_type);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type): static {
+    return new static(
+      $entity_type,
+      $container->get('entity_type.manager'),
+    );
+  }
 
   /**
    * {@inheritdoc}

--- a/web/modules/custom/myeventlane_ai/src/Service/AiManager.php
+++ b/web/modules/custom/myeventlane_ai/src/Service/AiManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_ai\Service;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Site\Settings;
 use Drupal\myeventlane_ai\Provider\AiProviderInterface;
@@ -69,7 +70,10 @@ final class AiManager {
       try {
         if ($this->entityTypeManager->hasDefinition('myeventlane_vendor')) {
           $vendor = $this->entityTypeManager->getStorage('myeventlane_vendor')->load($vendor_id);
-          if (!$vendor || !$vendor->isAiEnabled()) {
+          if (!$vendor instanceof ContentEntityInterface
+            || !$vendor->hasField('ai_enabled')
+            || $vendor->get('ai_enabled')->isEmpty()
+            || !(bool) $vendor->get('ai_enabled')->value) {
             return AiResult::error('AI is disabled for this vendor.', '', $provider_name, $options['model'] ?? NULL);
           }
         }
@@ -619,22 +623,15 @@ USR;
 
     $variants = [];
     foreach ($deduped as $idx => $p) {
-      $variants[] = [
+      $variant = [
         'id' => 'v' . ($idx + 1),
         'title' => $p['title'],
         'summary' => $p['summary'],
       ];
-    }
-
-    foreach ($variants as &$variant) {
       $variant['score'] = $this->scoreVariant($variant, (string) ($payload['category'] ?? ''));
+      $variant['_ord'] = $idx;
+      $variants[] = $variant;
     }
-    unset($variant);
-
-    foreach ($variants as $i => &$variant) {
-      $variant['_ord'] = $i;
-    }
-    unset($variant);
 
     usort($variants, function (array $a, array $b): int {
       $c = ($b['score'] ?? 0) <=> ($a['score'] ?? 0);
@@ -644,16 +641,15 @@ USR;
       return ($a['_ord'] ?? 0) <=> ($b['_ord'] ?? 0);
     });
 
-    foreach ($variants as &$v) {
-      unset($v['_ord']);
+    foreach ($variants as $idx => $variant) {
+      $variants[$idx] = [
+        'id' => 'v' . ($idx + 1),
+        'title' => $variant['title'],
+        'summary' => $variant['summary'],
+        'score' => $variant['score'],
+        'best' => ($idx === 0),
+      ];
     }
-    unset($v);
-
-    foreach ($variants as $idx => &$v) {
-      $v['id'] = 'v' . ($idx + 1);
-      $v['best'] = ($idx === 0);
-    }
-    unset($v);
 
     \Drupal::logger('myeventlane_ai')->notice('AI variant scores: @scores', [
       '@scores' => json_encode(array_map(static fn(array $v): int => (int) ($v['score'] ?? 0), $variants)),


### PR DESCRIPTION
## What changed

- Correct the Drupal YAML serialisation namespace used by `myeventlane_ai`.
- Inject the entity type manager into the AI job access handler through Drupal's entity handler contract.
- Read the vendor AI opt-in through the content entity field API.
- Preserve stable variant ranking while keeping internal sort metadata out of the returned data.
- Add `myeventlane_ai` to the mandatory clean-module Drupal Check gate.

## Why

The module had five bounded Drupal 11 static-analysis errors caused by an incorrect class reference, a missing injected service, an undefined method call on a generic entity, and an inconsistent array shape during sorting.

## Impact

The AI kill switch and vendor opt-in behaviour remain unchanged. Variant ordering remains stable, and the public variant data shape is preserved. The access handler can now load vendor entities through an explicitly injected service.

## Validation

- `myeventlane_ai`: Drupal Check passes with zero errors.
- Expanded mandatory five-module Drupal Check gate passes with zero errors.
- Changed PHP files pass syntax checks.
- Workflow YAML parses successfully.
- Shipped AI prompt YAML configuration decodes successfully with Drupal's YAML component.
- `git diff --check` passes.

The module does not currently contain automated tests.

## Boundaries

This PR contains four files only. It does not include configuration exports, database changes, credentials, deployment changes, unrelated DDEV work, or MEL Hold changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are static-analysis and DI correctness fixes with equivalent runtime behavior for opt-in and variant ordering; CI scope expands only to enforce the already-fixed module.
> 
> **Overview**
> This PR clears **Drupal 11 static-analysis errors** in `myeventlane_ai` and **adds that module** to the workflow step that requires zero `drupal-check` findings alongside the other “clean” custom modules.
> 
> **Install / YAML:** Prompt config installation in `myeventlane_ai_update_9006` now decodes YAML via `Drupal\Component\Serialization\Yaml` instead of the incorrect `Core\Serialization` class.
> 
> **AI job access:** `AiJobAccessControlHandler` implements `EntityHandlerInterface`, injects `EntityTypeManagerInterface` through `createInstance()`, and uses that service in `getVendorForUser()` instead of relying on an undefined handler property.
> 
> **Vendor opt-in:** `AiManager::analyze()` checks the vendor `ai_enabled` field through `ContentEntityInterface` field APIs (empty/missing field still blocks AI), matching the intent of `Vendor::isAiEnabled()` without calling that method on a generic loaded entity.
> 
> **Event copy variants:** `finalizeScoredVariants()` still dedupes, scores, and sorts with stable tie-breaking via internal `_ord`, but rebuilds the returned variant arrays so `_ord` is not exposed in the API response; public fields remain `id`, `title`, `summary`, `score`, and `best`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad93ffc5af7e4b337e958b5659f4eba8df0d081a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->