### PR TITLE
Clean analytics static analysis

### DIFF
--- a/.github/workflows/php-composer.yml
+++ b/.github/workflows/php-composer.yml
@@ -63,6 +63,7 @@ jobs:
           web/modules/custom/mel_admin_dashboard
           web/modules/custom/myeventlane_admin_dashboard
           web/modules/custom/myeventlane_ai
+          web/modules/custom/myeventlane_analytics
 
       - name: Report remaining Drupal check findings (informational)
         run: vendor/bin/drupal-check web/modules/custom web/themes/custom

--- a/web/modules/custom/myeventlane_analytics/src/Service/AnalyticsDataService.php
+++ b/web/modules/custom/myeventlane_analytics/src/Service/AnalyticsDataService.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_analytics\Service;
 
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_order\Entity\OrderItemInterface;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 
@@ -51,6 +53,10 @@ final class AnalyticsDataService {
 
     $grouped = [];
     foreach ($orderItems as $item) {
+      if (!$item instanceof OrderItemInterface) {
+        continue;
+      }
+
       if (!$this->orderItemClassifier->isVendorRevenueEligible($item)) {
         continue;
       }
@@ -72,7 +78,7 @@ final class AnalyticsDataService {
         continue;
       }
 
-      if (!$order || $order->getState()->getId() !== 'completed') {
+      if (!$order instanceof OrderInterface || $order->getState()->getId() !== 'completed') {
         continue;
       }
 
@@ -124,6 +130,10 @@ final class AnalyticsDataService {
     $breakdown = [];
 
     foreach ($orderItems as $item) {
+      if (!$item instanceof OrderItemInterface) {
+        continue;
+      }
+
       if (!$this->orderItemClassifier->isVendorRevenueEligible($item)) {
         continue;
       }
@@ -145,7 +155,7 @@ final class AnalyticsDataService {
         continue;
       }
 
-      if (!$order || $order->getState()->getId() !== 'completed') {
+      if (!$order instanceof OrderInterface || $order->getState()->getId() !== 'completed') {
         continue;
       }
 
@@ -206,6 +216,10 @@ final class AnalyticsDataService {
     $completed = 0;
 
     foreach ($allOrderItems as $item) {
+      if (!$item instanceof OrderItemInterface) {
+        continue;
+      }
+
       if (!$this->orderItemClassifier->isVendorRevenueEligible($item)) {
         continue;
       }
@@ -227,7 +241,7 @@ final class AnalyticsDataService {
         continue;
       }
 
-      if (!$order) {
+      if (!$order instanceof OrderInterface) {
         continue;
       }
 

--- a/web/modules/custom/myeventlane_analytics/tests/src/Kernel/Phase7/TicketsSoldKernelTest.php
+++ b/web/modules/custom/myeventlane_analytics/tests/src/Kernel/Phase7/TicketsSoldKernelTest.php
@@ -138,7 +138,7 @@ final class TicketsSoldKernelTest extends AnalyticsKernelTestBase {
     $this->assertArrayHasKey((int) $store_b->id(), $map);
 
     // 8) No whole-order totals are used: event-less paid items must not be counted.
-    $this->assertSame(2, count($rows), 'Only event-linked paid items should be counted.');
+    $this->assertCount(2, $rows, 'Only event-linked paid items should be counted.');
 
     // 3) Refunds do NOT reduce count: insert completed refund log row and re-run.
     $this->container->get('database')->insert('myeventlane_refund_log')->fields([
@@ -505,4 +505,3 @@ final class TicketsSoldKernelTest extends AnalyticsKernelTestBase {
   }
 
 }
-


### PR DESCRIPTION
## What changed

- Add explicit Drupal Commerce order-item and order type guards in `AnalyticsDataService`.
- Replace one count comparison with PHPUnit's dedicated `assertCount()` assertion.
- Add `myeventlane_analytics` to the mandatory clean-module Drupal Check gate.

## Why

Drupal entity storage exposes generic entity contracts to static analysis. The analytics service then called Commerce-specific methods without first proving the loaded entities were Commerce orders or order items. This produced 21 related findings. A separate test assertion produced the final finding.

## Impact

Valid Commerce order and order-item processing is unchanged. Unexpected entity implementations now fail closed and are skipped. The analytics module moves from 22 Drupal Check findings to zero and is protected by the mandatory CI gate.

## Validation

- `myeventlane_analytics`: Drupal Check passes with zero errors.
- Expanded mandatory six-module Drupal Check gate passes with zero errors.
- Changed PHP files pass syntax checks.
- GitHub workflow YAML parses successfully.
- Unit test passes: 1 test, 7 assertions.
- Drupal coding standards report no errors; existing line-length warnings remain.
- `git diff --check` passes.

## Known test-harness issue

The analytics kernel suite starts with a disposable database but 36 tests fail during fixture setup because the existing fixtures do not install Drupal's `filter` service required by Commerce configuration. This is independent of the three changed files and is deliberately left for a separate test-harness tranche.

## Boundaries

This PR contains three files only. It does not include configuration exports, database changes, credentials, deployment changes, the separate kernel test-harness repair, unrelated DDEV refund work, or MEL Hold changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type guards preserve normal Commerce processing paths; only unexpected entity types are skipped. CI and test-only changes carry no runtime security or data-handling risk.
> 
> **Overview**
> Adds **static-analysis-safe type guards** in `AnalyticsDataService` so loaded order items and orders are verified as `OrderItemInterface` and `OrderInterface` before Commerce-specific calls; non-matching entities are skipped (fail-closed).
> 
> **CI:** `myeventlane_analytics` is included in the mandatory **drupal-check** clean-module list in `php-composer.yml`.
> 
> **Tests:** One kernel assertion uses `assertCount()` instead of `assertSame` with `count()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a801aa3a466774690c8362c121ec421399ab3131. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->