### PR TITLE
Fix staging ticket schema and update settings

### DIFF
--- a/config/sync/update.settings.yml
+++ b/config/sync/update.settings.yml
@@ -2,12 +2,12 @@ _core:
   default_config_hash: cceqUa945af6yMPEeM1pWJQoA-tumoAqhThW2xGoZ04
 check:
   disabled_extensions: true
-  interval_days: 1
+  interval_days: 7
 fetch:
   url: null
   max_attempts: 2
   timeout: 30
 notification:
   emails:
-    - admin@example.com
+    - info@myeventlane.com.au
   threshold: all

--- a/web/modules/custom/mel_ticket/mel_ticket.install
+++ b/web/modules/custom/mel_ticket/mel_ticket.install
@@ -7,6 +7,7 @@ declare(strict_types=1);
  * Install and update hooks for MEL Ticket.
  */
 
+use Drupal\Core\Entity\Sql\SqlContentEntityStorage;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\user\Entity\Role;
@@ -523,6 +524,39 @@ function mel_ticket_update_9014(): string {
   }
 
   return 'Installed mel_ticket_type.field_is_best_value for best-value tickets.';
+}
+
+/**
+ * Adds the published-status lookup index to ticket types.
+ */
+function mel_ticket_update_9015(): string {
+  $entity_type_id = 'mel_ticket_type';
+  $update_manager = \Drupal::entityDefinitionUpdateManager();
+  $changes = $update_manager->getChangeList();
+
+  if (empty($changes[$entity_type_id]['entity_type'])) {
+    return 'mel_ticket_type entity storage is already aligned.';
+  }
+
+  $entity_type = \Drupal::entityTypeManager()->getDefinition($entity_type_id, FALSE);
+  if (!$entity_type) {
+    throw new \RuntimeException('mel_ticket_type entity type not found.');
+  }
+
+  $storage = \Drupal::entityTypeManager()->getStorage($entity_type_id);
+  $installed = \Drupal::service('entity.last_installed_schema.repository')
+    ->getLastInstalledDefinition($entity_type_id);
+  if ($installed
+    && $storage instanceof SqlContentEntityStorage
+    && $storage->requiresEntityDataMigration($entity_type, $installed)) {
+    throw new \RuntimeException(
+      'mel_ticket_type requires a data migration; refusing automatic schema update.'
+    );
+  }
+
+  $update_manager->updateEntityType($entity_type);
+  return 'Updated mel_ticket_type storage with the published-status lookup '
+    . 'index.';
 }
 
 /**


### PR DESCRIPTION
## What changed

- align Update Manager checks with the approved seven-day staging schedule and operational email address
- add `mel_ticket_update_9015()` to align Ticket type storage with its published-status lookup index
- refuse the entity update if Drupal reports that a data migration is required

## Why

Staging reported a Ticket type entity-definition mismatch. The deployed database is missing the declared `(status, id)` lookup index. The repository also contained Update Manager values that would overwrite the valid staging settings during the next release.

## Impact

The update hook is idempotent and limited to the Ticket type entity definition. For the observed staging state, it adds the missing index without changing ticket data. No DDEV Access Code cleanup is included.

## Validation

- PHP syntax check passed
- Drupal Check passed with zero errors for `mel_ticket`
- Drupal and DrupalPractice coding standards passed for `mel_ticket.install`
- YAML parsed with the expected values
- Git diff check passed

## Release gate

Draft only. Do not deploy until required PR checks pass and deployment is separately approved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Entity storage updates on `mel_ticket_type` can affect ticket queries and deploy behavior; the migration guard reduces risk, but `drush updb` on staging/production still needs verification.
> 
> **Overview**
> Syncs **Update Manager** config with staging operations: check interval moves from **1** to **7** days, and notification email from `admin@example.com` to `info@myeventlane.com.au`, so a future `drush cim` does not overwrite valid staging settings.
> 
> Adds **`mel_ticket_update_9015()`** to apply the missing **`mel_ticket_type`** entity storage change (published-status `(status, id)` lookup index) when Drupal reports an entity-type definition drift. The hook is idempotent if storage is already aligned, and **throws** if `requiresEntityDataMigration()` is true so automatic schema updates cannot run when ticket data would need migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7edc1b4eafa702672192199d234a0a4c9738262a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->