### PR TITLE
Retire deprecated History module

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -60,7 +60,6 @@ module:
   gin_login: 0
   gin_toolbar: 0
   help: 0
-  history: 0
   honeypot: 0
   image: 0
   image_widget_crop: 0


### PR DESCRIPTION
## What changed

- remove deprecated Drupal core History from `core.extension.yml`

## Why

History only tracks which nodes a signed-in user has viewed so Drupal can mark content as new or updated. MyEventLane has no custom code, active configuration, Views or enabled extension that depends on it.

The staging audit found 28 disposable read-tracking rows across two users and 27 nodes. These are not event, message, ticket, order, payment or operational audit records.

## Impact

The deployment configuration import will uninstall History and remove its `history` table. No MyEventLane business-history data is affected.

## Validation

- YAML parsed successfully
- History is absent from the module list
- Git diff check passed
- exactly one line removed from one configuration file

## Required deployment gates

1. Take and verify a staging database backup before deployment.
2. Deploy through the normal release workflow with configuration import enabled.
3. Confirm History is uninstalled and the `history` table is absent.
4. Confirm configuration status contains no new unexpected drift.
5. Verify Drupal bootstrap, database health and key public routes.
6. Verify MEL Hold remains on its existing release and its page, CSS and JavaScript assets return HTTP 200.

## Release boundary

Draft only. Do not combine Contact, core Search or Stable 9 retirement with this PR. Do not merge or deploy without separate approval.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line config change to disable an unused core module; no application code or business data paths are modified.
> 
> **Overview**
> Removes the **Drupal core History** module from exported config by deleting the `history: 0` entry in `core.extension.yml`. On deploy with config import, History will be **uninstalled** and its `history` table dropped.
> 
> That module only tracked per-user node view timestamps for “new/updated” markers—not event, order, or operational audit data. No custom modules or active config in sync reference it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cabc966b9d58d866d81e41e50504bf9f793b970f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->