### PR TITLE
Detach Help Centre search from core Search

### DIFF
--- a/web/modules/custom/myeventlane_governance/tests/src/Kernel/CoreSearchIndependenceContractTest.php
+++ b/web/modules/custom/myeventlane_governance/tests/src/Kernel/CoreSearchIndependenceContractTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_governance\Kernel;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Guards the public Help and Search routes against core Search dependencies.
+ */
+#[Group('myeventlane_governance')]
+final class CoreSearchIndependenceContractTest extends TestCase {
+
+  /**
+   * The Help Centre search is a Views surface and does not require core Search.
+   */
+  public function testHelpCentreSearchIsIndependentOfCoreSearch(): void {
+    $moduleDirectory = $this->customModulesDirectory() . '/myeventlane_help_centre';
+    $info = Yaml::parseFile($moduleDirectory . '/myeventlane_help_centre.info.yml');
+    $routing = Yaml::parseFile($moduleDirectory . '/myeventlane_help_centre.routing.yml');
+    $view = Yaml::parseFile($this->configSyncDirectory() . '/views.view.mel_help_search.yml');
+
+    self::assertIsArray($info);
+    self::assertIsArray($routing);
+    self::assertIsArray($view);
+    self::assertNotContains('drupal:search', $info['dependencies'] ?? []);
+    self::assertContains('drupal:views', $info['dependencies'] ?? []);
+    self::assertSame(
+      '\\Drupal\\myeventlane_help_centre\\Controller\\HelpCentreController::searchIndex',
+      $routing['myeventlane_help_centre.search']['defaults']['_controller'] ?? NULL,
+    );
+    self::assertSame('node_field_data', $view['base_table'] ?? NULL);
+    self::assertNotContains('search', $view['dependencies']['module'] ?? []);
+  }
+
+  /**
+   * Public discovery search is backed by Search API, not core Search.
+   */
+  public function testPublicSearchIsBackedBySearchApi(): void {
+    $moduleDirectory = $this->customModulesDirectory() . '/myeventlane_search';
+    $info = Yaml::parseFile($moduleDirectory . '/myeventlane_search.info.yml');
+    $routing = Yaml::parseFile($moduleDirectory . '/myeventlane_search.routing.yml');
+
+    self::assertIsArray($info);
+    self::assertIsArray($routing);
+    self::assertContains('search_api:search_api', $info['dependencies'] ?? []);
+    self::assertContains('search_api:search_api_db', $info['dependencies'] ?? []);
+    self::assertNotContains('drupal:search', $info['dependencies'] ?? []);
+    self::assertSame('/search', $routing['mel_search.view']['path'] ?? NULL);
+    self::assertSame(
+      '\\Drupal\\myeventlane_search\\Controller\\SearchController::build',
+      $routing['mel_search.view']['defaults']['_controller'] ?? NULL,
+    );
+    self::assertSame('/search/autocomplete', $routing['mel_search.autocomplete']['path'] ?? NULL);
+    self::assertSame(
+      '\\Drupal\\myeventlane_search\\Controller\\SearchAutocompleteController::autocomplete',
+      $routing['mel_search.autocomplete']['defaults']['_controller'] ?? NULL,
+    );
+  }
+
+  /**
+   * Returns the custom modules directory.
+   */
+  private function customModulesDirectory(): string {
+    return dirname(__DIR__, 4);
+  }
+
+  /**
+   * Returns the configuration synchronisation directory.
+   */
+  private function configSyncDirectory(): string {
+    return dirname(__DIR__, 7) . '/config/sync';
+  }
+
+}

--- a/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.info.yml
+++ b/web/modules/custom/myeventlane_help_centre/myeventlane_help_centre.info.yml
@@ -11,7 +11,6 @@ dependencies:
   - drupal:path_alias
   - drupal:taxonomy
   - drupal:views
-  - drupal:search
   - drupal:datetime
   - drupal:text
   - myeventlane_vendor:myeventlane_vendor

--- a/web/phpunit-governance.xml
+++ b/web/phpunit-governance.xml
@@ -52,6 +52,7 @@
       <file>modules/custom/myeventlane_commerce/tests/src/Unit/OperationalCartProjectionBuilderTest.php</file>
       <file>modules/custom/myeventlane_commerce/tests/src/Unit/OperationalOrderItemDisplayBuilderTest.php</file>
       <file>modules/custom/myeventlane_commerce/tests/src/Unit/TicketBackedOrderItemClassifierTest.php</file>
+      <file>modules/custom/myeventlane_governance/tests/src/Kernel/CoreSearchIndependenceContractTest.php</file>
       <file>modules/custom/myeventlane_governance/tests/src/Kernel/PublicRouteGovernanceTest.php</file>
       <file>modules/custom/myeventlane_governance/tests/src/Kernel/WebrootSafetyGovernanceTest.php</file>
     </testsuite>


### PR DESCRIPTION
## What changed

- remove the stale `drupal:search` dependency from MyEventLane Help Centre
- add a governance contract proving Help Centre search is Views-backed
- prove public `/search` and autocomplete remain Search API-backed
- register the contract in the existing governance suite

## Why

The core Search retirement audit found that MyEventLane's public discovery search already uses Search API and Help Centre search uses Views. The Help Centre module still declared core Search even though its current search implementation does not use it. That stale dependency must be removed and guarded before any separate retirement proposal.

## Impact

No runtime route, configuration, database schema or index is changed by this PR. Core Search remains enabled. This PR only establishes the prerequisite boundary and regression coverage.

## Validation

- focused PHPUnit contract: 2 tests, 17 assertions
- Drupal and DrupalPractice coding standards
- PHP syntax
- YAML and XML parsing
- `git diff --check`

## Release boundary

Do not combine core Search retirement with this PR. Do not merge until the complete CI governance suite passes. The later retirement must be a separate backup-protected PR with staging and MEL Hold verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit fede088a61947628ca76a5051451a1bbf91337d7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->