### PR TITLE
Normalise four staging configuration exports

### DIFF
--- a/config/sync/crop.type.focal_point.yml
+++ b/config/sync/crop.type.focal_point.yml
@@ -4,8 +4,8 @@ status: true
 dependencies: {  }
 _core:
   default_config_hash: flCi9IdafdLXlJqvoHguutUOiC05-aynK4niYN4YZ3o
-id: focal_point
 label: 'Focal point'
+id: focal_point
 description: 'Crop type used by Focal point module.'
 aspect_ratio: ''
 soft_limit_width: null

--- a/config/sync/flag.flag.following.yml
+++ b/config/sync/flag.flag.following.yml
@@ -14,7 +14,6 @@ label: Following
 bundles: {  }
 entity_type: user
 global: false
-weight: 0
 flag_short: 'Follow this user'
 flag_long: 'Click the link to follow this user'
 flag_message: 'You are following the user'
@@ -22,6 +21,7 @@ unflag_short: 'Unfollow this user'
 unflag_long: 'Click the link to unfollow this user'
 unflag_message: 'You have unfollowed the user'
 unflag_denied_text: ''
+weight: 0
 flag_type: 'entity:user'
 link_type: ajax_link
 flagTypeConfig:

--- a/config/sync/image.style.mel_vendor_logo.yml
+++ b/config/sync/image.style.mel_vendor_logo.yml
@@ -23,3 +23,4 @@ effects:
     weight: 1
     data:
       extension: webp
+pipeline: __default__

--- a/config/sync/views.view.flag_followers.yml
+++ b/config/sync/views.view.flag_followers.yml
@@ -18,90 +18,12 @@ base_table: users_field_data
 base_field: uid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access user profiles'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: full
-        options:
-          items_per_page: 10
-          offset: 0
-          id: 0
-          total_pages: null
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: '‹ Previous'
-            next: 'Next ›'
-            first: '« First'
-            last: 'Last »'
-          quantity: 9
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            name: name
-            link_flag: link_flag
-          info:
-            name:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            link_flag:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: '-1'
-          empty_table: false
-      row:
-        type: fields
+      title: Followers
       fields:
         name:
           id: name
@@ -110,6 +32,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: name
+          plugin_id: field
           label: Username
           exclude: false
           alter:
@@ -165,9 +90,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: user
-          entity_field: name
-          plugin_id: field
         count:
           id: count
           table: flag_counts
@@ -175,6 +97,7 @@ display:
           relationship: flag_relationship
           group_type: group
           admin_label: ''
+          plugin_id: numeric
           label: Followers
           exclude: false
           alter:
@@ -224,7 +147,6 @@ display:
           format_plural_string: !!binary MQNAY291bnQ=
           prefix: ''
           suffix: ''
-          plugin_id: numeric
         link_flag:
           id: link_flag
           table: flagging
@@ -232,6 +154,8 @@ display:
           relationship: flag_relationship
           group_type: group
           admin_label: ''
+          entity_type: flagging
+          plugin_id: flag_link
           label: ''
           exclude: false
           alter:
@@ -273,24 +197,44 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          entity_type: flagging
-          plugin_id: flag_link
-      filters:
-        status:
-          value: '1'
-          table: users_field_data
-          field: status
-          plugin_id: boolean
-          entity_type: user
-          entity_field: status
-          id: status
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
           expose:
-            operator: ''
-          group: 1
-      sorts: {  }
-      title: Followers
-      header: {  }
-      footer: {  }
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access user profiles'
+      cache:
+        type: tag
+        options: {  }
       empty:
         area:
           id: area
@@ -299,12 +243,67 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: text
           empty: true
-          tokenize: false
           content:
             value: 'You are not following any users. :-('
             format: basic_html
-          plugin_id: text
+          tokenize: false
+      sorts: {  }
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: users_field_data
+          field: status
+          entity_type: user
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            name: name
+            link_flag: link_flag
+          default: '-1'
+          info:
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            link_flag:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
       relationships:
         flag_relationship:
           id: flag_relationship
@@ -313,12 +312,13 @@ display:
           relationship: none
           group_type: group
           admin_label: Flags
+          entity_type: user
+          plugin_id: flag_relationship
           required: true
           flag: following
           user_scope: current
-          entity_type: user
-          plugin_id: flag_relationship
-      arguments: {  }
+      header: {  }
+      footer: {  }
       display_extenders: {  }
     cache_metadata:
       max-age: 0
@@ -329,9 +329,9 @@ display:
         - user.permissions
       tags: {  }
   page_1:
-    display_plugin: page
     id: page_1
     display_title: Page
+    display_plugin: page
     position: 1
     display_options:
       display_extenders: {  }
@@ -340,11 +340,11 @@ display:
         type: 'default tab'
         title: Following
         description: ''
-        expanded: false
-        parent: ''
         weight: 0
-        context: '0'
+        expanded: false
         menu_name: main
+        parent: ''
+        context: '0'
       tab_options:
         type: normal
         title: Followers


### PR DESCRIPTION
## What changed

Normalised exactly four configuration exports to Drupal's current canonical representation:

- `crop.type.focal_point`
- `flag.flag.following`
- `image.style.mel_vendor_logo`
- `views.view.flag_followers`

The first, second and fourth files contain ordering-only changes. The image style now explicitly records Drupal's default `pipeline: __default__` value.

## Why

Staging briefly reported these four items as different after deployment. Read-only comparison showed that active staging configuration matched Drupal's canonical export, while the repository retained older serialisation order and omitted the image pipeline default. This caused repeat-drift risk.

## Impact

- No configuration values or follower records are removed.
- No schema, database or content changes are included.
- Vendor-logo and follower functionality remain enabled.
- Contact module retirement is explicitly out of scope.

## Validation

- Semantic YAML comparison passed for all four files.
- Byte-for-byte parity with the reviewed canonical staging exports passed.
- Legacy user-profile follower contract: 1 test, 8 assertions passed.
- Composer validation passed.
- Configuration, webroot and raw-card-data safety checks passed.
- Final worktree and diff scope confirmed clean and limited to four files.

## Release boundary

Do not merge or deploy until CI passes and a separate approval is given. Contact retirement must remain a separate PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config serialization/order cleanup only; no schema, content, or behavioral changes.
> 
> **Overview**
> Aligns four Drupal config exports with the current canonical staging representation to stop false config drift after deploy.
> 
> **Ordering-only** updates in `crop.type.focal_point`, `flag.flag.following`, and `views.view.flag_followers` (no value changes).
> 
> Adds the explicit default `pipeline: __default__` on `image.style.mel_vendor_logo`, matching other image styles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 094a91042a8a1e572146828da2e73e7597c226b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->