### PR TITLE
Harden deploy config-status parsing

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -135,6 +135,9 @@ jobs:
           test -f web/themes/custom/myeventlane_vendor_theme/dist/main.js
           test -f web/themes/custom/myeventlane_vendor_theme/dist/vendor-wizard.css
 
+      - name: Test deploy config-status parser
+        run: bash scripts/deploy/test-config-status-parser.sh
+
       - name: Set artifact metadata
         id: meta
         run: echo "artifact_name=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"

--- a/scripts/deploy/remote-deploy.sh
+++ b/scripts/deploy/remote-deploy.sh
@@ -1,6 +1,76 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+mel_verify_config_status_output() {
+  local output="$1"
+  local command_rc="$2"
+  local allowed_differences="${3:-}"
+  local config_names unexpected=""
+
+  if [ "$command_rc" -ne 0 ]; then
+    echo "ERROR: config:status command failed with exit code ${command_rc}." >&2
+    printf '%s\n' "$output" >&2
+    return "$command_rc"
+  fi
+
+  # Drush may emit notices before the CSV header. Start parsing only after the
+  # exact Name,State header so notices and the header itself never become
+  # configuration names. A missing header is unsafe because the output shape
+  # cannot be verified.
+  if ! config_names="$(printf '%s\n' "$output" | awk -F',' '
+    BEGIN { header_seen = 0 }
+    {
+      gsub(/\r$/, "", $0)
+      name = $1
+      state = $2
+      gsub(/^"|"$/, "", name)
+      gsub(/^"|"$/, "", state)
+      if (name == "Name" && state == "State") {
+        header_seen = 1
+        next
+      }
+      if (header_seen && NF >= 2 && name != "" && state != "") {
+        print name
+      }
+    }
+    END { if (!header_seen) exit 2 }
+  ')"; then
+    echo "ERROR: config:status did not return the expected Name,State CSV header." >&2
+    printf '%s\n' "$output" >&2
+    return 1
+  fi
+
+  while IFS= read -r config_name; do
+    [ -n "$config_name" ] || continue
+    case ",$allowed_differences," in
+      *",$config_name,"*)
+        echo "WARNING: Allowing known environment config difference: $config_name" >&2
+        ;;
+      *)
+        unexpected="${unexpected}${config_name}"$'\n'
+        ;;
+    esac
+  done <<< "$config_names"
+
+  if [ -n "$unexpected" ]; then
+    echo "ERROR: unexpected config differences remain after cim:" >&2
+    printf '%s' "$unexpected" >&2
+    printf '%s\n' "$output" >&2
+    return 1
+  fi
+}
+
+# Narrow, side-effect-free entry point used by the regression test. Production
+# deploys never set this variable.
+if [ "${MEL_TEST_CONFIG_STATUS_OUTPUT:-0}" = "1" ]; then
+  test_output="$(cat)"
+  mel_verify_config_status_output \
+    "$test_output" \
+    "${MEL_TEST_CONFIG_STATUS_RC:-0}" \
+    "${MEL_TEST_CONFIG_STATUS_ALLOWED:-}"
+  exit $?
+fi
+
 echo "=================================================="
 echo "MEL REMOTE DEPLOY WITH VALIDATION 2026-07-11"
 echo "=================================================="
@@ -1008,29 +1078,11 @@ if [ "$RUN_CIM" = "1" ]; then
   # Deploy safety: active storage must match sync after import, apart from an
   # explicit target-environment allow-list supplied by the deployment workflow.
   echo "Verifying config:status after import..."
-  CST_OUT="$(mel_drush cst --fields=name,state --format=csv --uri="$SITE_URI" 2>&1)" || true
-  CST_NAMES="$(printf '%s\n' "$CST_OUT" \
-    | awk -F',' 'NR > 1 && $1 != "" {gsub(/^"|"$/, "", $1); print $1}')"
-  CST_UNEXPECTED=""
-
-  while IFS= read -r config_name; do
-    [ -n "$config_name" ] || continue
-    case ",$CIM_ALLOWED_DIFFERENCES," in
-      *",$config_name,"*)
-        echo "WARNING: Allowing known environment config difference: $config_name" >&2
-        ;;
-      *)
-        CST_UNEXPECTED="${CST_UNEXPECTED}${config_name}"$'\n'
-        ;;
-    esac
-  done <<< "$CST_NAMES"
-
-  if [ -n "$CST_UNEXPECTED" ]; then
-    echo "ERROR: unexpected config differences remain after cim:" >&2
-    printf '%s' "$CST_UNEXPECTED" >&2
-    echo "$CST_OUT" >&2
-    exit 1
-  fi
+  set +e
+  CST_OUT="$(mel_drush cst --fields=name,state --format=csv --uri="$SITE_URI" 2>&1)"
+  CST_RC=$?
+  set -e
+  mel_verify_config_status_output "$CST_OUT" "$CST_RC" "$CIM_ALLOWED_DIFFERENCES"
 fi
 
 # ---- DOMAIN CONFIGURATION (environment; not active config / cset) ----

--- a/scripts/deploy/test-config-status-parser.sh
+++ b/scripts/deploy/test-config-status-parser.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+DEPLOY="$ROOT/scripts/deploy/remote-deploy.sh"
+PASSES=0
+FAILS=0
+
+run_case() {
+  local expected_rc="$1"
+  local name="$2"
+  local input="$3"
+  local status_rc="${4:-0}"
+  local allowed="${5:-}"
+  local output rc
+
+  set +e
+  output="$(printf '%s' "$input" | \
+    MEL_TEST_CONFIG_STATUS_OUTPUT=1 \
+    MEL_TEST_CONFIG_STATUS_RC="$status_rc" \
+    MEL_TEST_CONFIG_STATUS_ALLOWED="$allowed" \
+    bash "$DEPLOY" 2>&1)"
+  rc=$?
+  set -e
+
+  if [ "$rc" -eq "$expected_rc" ]; then
+    PASSES=$((PASSES + 1))
+    echo "PASS: $name"
+  else
+    FAILS=$((FAILS + 1))
+    echo "FAIL: $name (expected rc $expected_rc, got $rc)"
+    printf '%s\n' "$output" | sed 's/^/  /'
+  fi
+}
+
+run_case 0 \
+  "notice and CSV header are ignored when configuration is clean" \
+  $' [notice] No differences between DB and sync directory.\nName,State\n'
+
+run_case 1 \
+  "genuine unexpected configuration difference fails" \
+  $'Name,State\ngin.settings,Different\n'
+
+run_case 0 \
+  "explicitly allowed configuration difference passes" \
+  $'Name,State\ngin.settings,Different\n' \
+  0 \
+  'gin.settings'
+
+run_case 7 \
+  "config status command failure is preserved" \
+  $'Drush bootstrap failed\n' \
+  7
+
+run_case 1 \
+  "missing CSV header fails closed" \
+  $' [notice] No differences between DB and sync directory.\n'
+
+echo "Passed: $PASSES"
+echo "Failed: $FAILS"
+if [ "$FAILS" -ne 0 ]; then
+  exit 1
+fi
+
+echo "OK: deploy config-status parser tests passed"


### PR DESCRIPTION
## What changed

- Hardened the post-import `config:status` parser in `remote-deploy.sh`.
- Added a focused shell regression suite.
- Added that suite to the reusable build before artifact packaging.

## Root cause

The PR #798 deployment reached a clean Drupal configuration state, but Drush emitted a notice before its CSV output. The deploy script assumed the first line was the CSV header, then misread the actual `Name` header as a configuration difference and rolled back a healthy release.

## Behaviour after this fix

- Drush notices before the CSV header are ignored.
- The `Name,State` header is ignored.
- Genuine unexpected configuration differences remain fatal.
- Explicitly allow-listed environment differences remain supported.
- A failing Drush command preserves its non-zero exit status.
- Missing or malformed CSV headers fail closed.

## Validation

- New parser regression suite: 5/5 passed.
- Existing release-provenance suite: 17/17 passed.
- Bash syntax checks passed.
- Workflow YAML parsed successfully.
- Composer, config, webroot and raw-card-data push validation passed.

## Release boundary

This PR fixes only deployment verification. It contains no Contact retirement, Drupal configuration, schema, database or content changes. After CI passes, review the unchanged head before merge. Merging to `main` will trigger the controlled staging retry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches deploy-time config verification that can abort or accept releases; incorrect parsing could falsely fail healthy deploys or miss real config drift. Mitigated by a dedicated regression suite wired into CI.
> 
> **Overview**
> Fixes a false deploy rollback where Drush notices before `config:status` CSV output were misread as unexpected config differences.
> 
> Extracts post-`cim` verification into `mel_verify_config_status_output`, which waits for the exact `Name,State` header, ignores leading notices, preserves Drush exit codes, and fails closed if the header is missing. Allow-listed environment differences still pass.
> 
> Adds a focused shell regression suite and runs it in the reusable build before artifact packaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d62013754c7ff2fd647ed5907e3526bedeae100. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->