### PR TITLE
Prevent duplicate event cancellation refunds

### DIFF
--- a/web/modules/custom/myeventlane_refunds/src/Form/VendorCancelEventForm.php
+++ b/web/modules/custom/myeventlane_refunds/src/Form/VendorCancelEventForm.php
@@ -93,7 +93,7 @@ final class VendorCancelEventForm extends FormBase {
       '#title' => $this->t('Cancellation Action'),
       '#options' => [
         'cancel_only' => $this->t('Cancel only (send cancellation email)'),
-        'cancel_and_refund' => $this->t('Cancel and auto-refund all orders'),
+        'cancel_and_refund' => $this->t('Cancel and refund eligible paid tickets — donations are not included'),
       ],
       '#default_value' => 'cancel_only',
       '#required' => TRUE,

--- a/web/modules/custom/myeventlane_refunds/src/Plugin/QueueWorker/EventCancelRefundWorker.php
+++ b/web/modules/custom/myeventlane_refunds/src/Plugin/QueueWorker/EventCancelRefundWorker.php
@@ -8,8 +8,8 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Queue\QueueFactory;
 use Drupal\Core\Queue\QueueWorkerBase;
-use Drupal\myeventlane_refunds\Service\RefundOrderInspector;
-use Drupal\myeventlane_refunds\Service\RefundProcessor;
+use Drupal\myeventlane_refunds\Service\RefundOrderInspectorInterface;
+use Drupal\myeventlane_refunds\Service\RefundProcessorInterface;
 use Drupal\node\NodeInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -41,9 +41,9 @@ final class EventCancelRefundWorker extends QueueWorkerBase implements Container
    *   Plugin definition.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   The entity type manager.
-   * @param \Drupal\myeventlane_refunds\Service\RefundOrderInspector $orderInspector
+   * @param \Drupal\myeventlane_refunds\Service\RefundOrderInspectorInterface $orderInspector
    *   The order inspector.
-   * @param \Drupal\myeventlane_refunds\Service\RefundProcessor $refundProcessor
+   * @param \Drupal\myeventlane_refunds\Service\RefundProcessorInterface $refundProcessor
    *   The refund processor.
    * @param \Psr\Log\LoggerInterface $logger
    *   The logger.
@@ -55,8 +55,8 @@ final class EventCancelRefundWorker extends QueueWorkerBase implements Container
     string $plugin_id,
     $plugin_definition,
     private readonly EntityTypeManagerInterface $entityTypeManager,
-    private readonly RefundOrderInspector $orderInspector,
-    private readonly RefundProcessor $refundProcessor,
+    private readonly RefundOrderInspectorInterface $orderInspector,
+    private readonly RefundProcessorInterface $refundProcessor,
     private readonly LoggerInterface $logger,
     private readonly QueueFactory $queueFactory,
   ) {
@@ -145,16 +145,23 @@ final class EventCancelRefundWorker extends QueueWorkerBase implements Container
           continue;
         }
 
-        // Request full refund for tickets only (donations excluded by default).
-        $refundPayload = [
-          'refund_type' => 'full',
-          'refund_scope' => 'tickets_only',
-          'include_donation' => FALSE,
-          'reason' => 'Event cancelled',
-        ];
+        $ticketSubtotalCents = $this->orderInspector->calculateTicketSubtotalCents($order, (int) $eventId);
+        if ($ticketSubtotalCents <= 0) {
+          $this->logger->notice('EventCancelRefundWorker: Skipped order @order_id because it has no refundable ticket amount; donations are excluded.', [
+            '@order_id' => $orderId,
+          ]);
+          continue;
+        }
+
+        if ($this->orderInspector->calculateRefundableAmountCents($order) <= 0) {
+          $this->logger->notice('EventCancelRefundWorker: Skipped order @order_id because it has no refundable payment balance.', [
+            '@order_id' => $orderId,
+          ]);
+          continue;
+        }
 
         try {
-          $this->refundProcessor->requestRefund($order, $event, $vendor, $refundPayload);
+          $this->refundProcessor->requestEventCancellationRefund($order, $event, $vendor);
           $refundedCount++;
         }
         catch (\Throwable $e) {

--- a/web/modules/custom/myeventlane_refunds/src/Service/RefundOrderInspector.php
+++ b/web/modules/custom/myeventlane_refunds/src/Service/RefundOrderInspector.php
@@ -15,7 +15,7 @@ use Drupal\node\NodeInterface;
 /**
  * Inspects orders to determine refund eligibility and calculate amounts.
  */
-final class RefundOrderInspector implements RefundOrderItemsInterface {
+final class RefundOrderInspector implements RefundOrderInspectorInterface {
 
   /**
    * Donation order item bundles.

--- a/web/modules/custom/myeventlane_refunds/src/Service/RefundOrderInspectorInterface.php
+++ b/web/modules/custom/myeventlane_refunds/src/Service/RefundOrderInspectorInterface.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_refunds\Service;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+
+/**
+ * Calculates event-ticket and payment balances used by refund workflows.
+ */
+interface RefundOrderInspectorInterface extends RefundOrderItemsInterface {
+
+  /**
+   * Calculates the refund for selected attendees from one event.
+   *
+   * @param \Drupal\commerce_order\Entity\OrderInterface $order
+   *   The paid order.
+   * @param int $event_nid
+   *   The event node ID.
+   * @param list<int> $selectedAttendeeIds
+   *   Event attendee entity IDs selected for refund.
+   */
+  public function calculateSelectedAttendeeRefundCents(
+    OrderInterface $order,
+    int $event_nid,
+    array $selectedAttendeeIds,
+  ): int;
+
+  /**
+   * Calculates the ticket subtotal for one event in an order.
+   */
+  public function calculateTicketSubtotalCents(OrderInterface $order, int $event_nid): int;
+
+  /**
+   * Calculates the donation total for an order.
+   */
+  public function calculateDonationTotalCents(OrderInterface $order): int;
+
+  /**
+   * Calculates the remaining refundable payment balance for an order.
+   */
+  public function calculateRefundableAmountCents(OrderInterface $order): int;
+
+}

--- a/web/modules/custom/myeventlane_refunds/src/Service/RefundProcessor.php
+++ b/web/modules/custom/myeventlane_refunds/src/Service/RefundProcessor.php
@@ -29,7 +29,7 @@ use Psr\Log\LoggerInterface;
 /**
  * Processes refund requests and executes refunds.
  */
-final class RefundProcessor {
+final class RefundProcessor implements RefundProcessorInterface {
 
   public const STATUS_PROCESSING = 'processing';
   public const STATUS_COMPLETED = 'completed';
@@ -42,7 +42,7 @@ final class RefundProcessor {
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   The entity type manager.
-   * @param \Drupal\myeventlane_refunds\Service\RefundOrderInspector $orderInspector
+   * @param \Drupal\myeventlane_refunds\Service\RefundOrderInspectorInterface $orderInspector
    *   The order inspector.
    * @param \Drupal\myeventlane_refunds\Service\RefundAccessResolver $accessResolver
    *   The access resolver.
@@ -73,7 +73,7 @@ final class RefundProcessor {
    */
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
-    private readonly RefundOrderInspector $orderInspector,
+    private readonly RefundOrderInspectorInterface $orderInspector,
     private readonly RefundAccessResolver $accessResolver,
     private readonly BuyerRefundEligibilityService $buyerEligibility,
     private readonly RefundRequestStorage $refundRequestStorage,
@@ -326,6 +326,70 @@ final class RefundProcessor {
   }
 
   /**
+   * Requests one ticket-only refund for an event cancellation.
+   *
+   * The persistent audit-log lookup prevents later queue batches from creating
+   * another refund. The lock closes the same gap between concurrent workers.
+   */
+  public function requestEventCancellationRefund(
+    OrderInterface $order,
+    NodeInterface $event,
+    AccountInterface $account,
+  ): int {
+    $orderId = (int) $order->id();
+    $eventId = (int) $event->id();
+    $lockId = "event_cancel_refund:$eventId:$orderId";
+
+    if (!$this->lock->acquire($lockId, 30.0)) {
+      $this->lock->wait($lockId, 30);
+      if (!$this->lock->acquire($lockId, 30.0)) {
+        $existingId = $this->findEventCancellationRefundId($orderId, $eventId);
+        if ($existingId !== NULL) {
+          return $existingId;
+        }
+        throw new \RuntimeException('An event cancellation refund is already being prepared.');
+      }
+    }
+
+    try {
+      $existingId = $this->findEventCancellationRefundId($orderId, $eventId);
+      if ($existingId !== NULL) {
+        return $existingId;
+      }
+
+      return $this->requestRefund($order, $event, $account, [
+        'refund_type' => 'full',
+        'refund_scope' => 'tickets_only',
+        'include_donation' => FALSE,
+        'reason' => 'Event cancelled',
+      ]);
+    }
+    finally {
+      $this->lock->release($lockId);
+    }
+  }
+
+  /**
+   * Finds an existing cancellation refund for one order and event.
+   */
+  private function findEventCancellationRefundId(int $orderId, int $eventId): ?int {
+    $id = $this->database->select('myeventlane_refund_log', 'refund')
+      ->fields('refund', ['id'])
+      ->condition('order_id', $orderId)
+      ->condition('event_id', $eventId)
+      ->condition('refund_type', 'full')
+      ->condition('refund_scope', 'tickets_only')
+      ->condition('donation_refunded', 0)
+      ->condition('reason', 'Event cancelled')
+      ->orderBy('id', 'DESC')
+      ->range(0, 1)
+      ->execute()
+      ->fetchField();
+
+    return $id === FALSE ? NULL : (int) $id;
+  }
+
+  /**
    * Requests a refund (creates audit log, enqueues worker, runs processing now).
    *
    * @param \Drupal\commerce_order\Entity\OrderInterface $order
@@ -334,7 +398,7 @@ final class RefundProcessor {
    *   The event node.
    * @param \Drupal\Core\Session\AccountInterface $account
    *   The vendor account.
-   * @param array $refund_payload
+   * @param array $payload
    *   Refund payload with keys:
    *   - refund_type: 'full' or 'partial'
    *   - refund_scope: 'tickets_only', 'tickets_and_donation', or 'donation_only'

--- a/web/modules/custom/myeventlane_refunds/src/Service/RefundProcessorInterface.php
+++ b/web/modules/custom/myeventlane_refunds/src/Service/RefundProcessorInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_refunds\Service;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Creates and processes authorised refunds.
+ */
+interface RefundProcessorInterface {
+
+  /**
+   * Requests a refund and returns its audit-log ID.
+   *
+   * @param \Drupal\commerce_order\Entity\OrderInterface $order
+   *   The paid order.
+   * @param \Drupal\node\NodeInterface $event
+   *   The event associated with the refund.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The account authorising the refund.
+   * @param array<string, mixed> $payload
+   *   Refund scope, type, amount, and audit context.
+   */
+  public function requestRefund(
+    OrderInterface $order,
+    NodeInterface $event,
+    AccountInterface $account,
+    array $payload,
+  ): int;
+
+  /**
+   * Requests one idempotent ticket-only refund for an event cancellation.
+   *
+   * @param \Drupal\commerce_order\Entity\OrderInterface $order
+   *   The paid order.
+   * @param \Drupal\node\NodeInterface $event
+   *   The cancelled event.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The organiser who authorised the cancellation.
+   */
+  public function requestEventCancellationRefund(
+    OrderInterface $order,
+    NodeInterface $event,
+    AccountInterface $account,
+  ): int;
+
+}

--- a/web/modules/custom/myeventlane_refunds/tests/src/Kernel/EventCancelRefundWorkerTest.php
+++ b/web/modules/custom/myeventlane_refunds/tests/src/Kernel/EventCancelRefundWorkerTest.php
@@ -12,17 +12,19 @@ use Drupal\Core\Queue\QueueFactory;
 use Drupal\Core\Queue\QueueInterface;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\myeventlane_refunds\Plugin\QueueWorker\EventCancelRefundWorker;
-use Drupal\myeventlane_refunds\Service\RefundOrderInspector;
-use Drupal\myeventlane_refunds\Service\RefundProcessor;
+use Drupal\myeventlane_refunds\Service\RefundOrderInspectorInterface;
+use Drupal\myeventlane_refunds\Service\RefundProcessorInterface;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Session\AccountInterface;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Psr\Log\LoggerInterface;
 
 /**
  * Kernel tests cursor progression for EventCancelRefundWorker batching.
- *
- * @group myeventlane_refunds
  */
+#[Group('myeventlane_refunds')]
+#[RunTestsInSeparateProcesses]
 final class EventCancelRefundWorkerTest extends KernelTestBase {
 
   /**
@@ -63,9 +65,14 @@ final class EventCancelRefundWorkerTest extends KernelTestBase {
       $items = [];
       foreach ($ids as $id) {
         $state = new class {
+
+          /**
+           * Returns the completed state ID.
+           */
           public function getId(): string {
             return 'completed';
           }
+
         };
 
         $order = $this->createMock(OrderInterface::class);
@@ -73,16 +80,26 @@ final class EventCancelRefundWorkerTest extends KernelTestBase {
         $order->method('getState')->willReturn($state);
 
         $items[$id] = new class($id, $order) {
+
           public function __construct(
             private readonly int $id,
             private readonly OrderInterface $order,
           ) {}
+
+          /**
+           * Returns the parent order.
+           */
           public function getOrder(): OrderInterface {
             return $this->order;
           }
+
+          /**
+           * Returns the order item ID.
+           */
           public function id(): int {
             return $this->id;
           }
+
         };
       }
       return $items;
@@ -105,8 +122,12 @@ final class EventCancelRefundWorkerTest extends KernelTestBase {
     ]);
 
     $processedOrderIds = [];
-    $refundProcessor = $this->createMock(RefundProcessor::class);
-    $refundProcessor->method('requestRefund')->willReturnCallback(function (OrderInterface $order) use (&$processedOrderIds): int {
+    $orderInspector = $this->createMock(RefundOrderInspectorInterface::class);
+    $orderInspector->method('calculateTicketSubtotalCents')->willReturn(1000);
+    $orderInspector->method('calculateRefundableAmountCents')->willReturn(1000);
+
+    $refundProcessor = $this->createMock(RefundProcessorInterface::class);
+    $refundProcessor->method('requestEventCancellationRefund')->willReturnCallback(function (OrderInterface $order) use (&$processedOrderIds): int {
       $processedOrderIds[] = (int) $order->id();
       return (int) $order->id();
     });
@@ -125,7 +146,7 @@ final class EventCancelRefundWorkerTest extends KernelTestBase {
       'event_cancel_refund_worker',
       [],
       $entityTypeManager,
-      $this->createMock(RefundOrderInspector::class),
+      $orderInspector,
       $refundProcessor,
       $this->createMock(LoggerInterface::class),
       $queueFactory,
@@ -144,8 +165,7 @@ final class EventCancelRefundWorkerTest extends KernelTestBase {
 
     $this->assertCount(1, $queuedItems);
     $this->assertCount(65, $processedOrderIds);
-    $this->assertSame(65, count(array_unique($processedOrderIds)));
+    $this->assertCount(65, array_unique($processedOrderIds));
   }
 
 }
-

--- a/web/modules/custom/myeventlane_refunds/tests/src/Kernel/RefundProcessorLockingTest.php
+++ b/web/modules/custom/myeventlane_refunds/tests/src/Kernel/RefundProcessorLockingTest.php
@@ -48,6 +48,63 @@ final class RefundProcessorLockingTest extends KernelTestBase {
   ];
 
   /**
+   * Tests later queue batches reuse the persisted cancellation refund.
+   */
+  public function testEventCancellationRefundReusesExistingLog(): void {
+    $database = $this->container->get('database');
+    $database->schema()->createTable('myeventlane_refund_log', [
+      'fields' => [
+        'id' => ['type' => 'serial', 'not null' => TRUE],
+        'order_id' => ['type' => 'int', 'not null' => TRUE],
+        'event_id' => ['type' => 'int', 'not null' => TRUE],
+        'refund_type' => ['type' => 'varchar', 'length' => 32, 'not null' => TRUE],
+        'refund_scope' => ['type' => 'varchar', 'length' => 64, 'not null' => TRUE],
+        'donation_refunded' => ['type' => 'int', 'not null' => TRUE],
+        'reason' => ['type' => 'text', 'not null' => FALSE],
+      ],
+      'primary key' => ['id'],
+    ]);
+    $logId = (int) $database->insert('myeventlane_refund_log')->fields([
+      'order_id' => 111,
+      'event_id' => 222,
+      'refund_type' => 'full',
+      'refund_scope' => 'tickets_only',
+      'donation_refunded' => 0,
+      'reason' => 'Event cancelled',
+    ])->execute();
+
+    $order = $this->createMock(OrderInterface::class);
+    $order->method('id')->willReturn(111);
+    $event = $this->createMock(NodeInterface::class);
+    $event->method('id')->willReturn(222);
+    $account = $this->createMock(AccountInterface::class);
+
+    $lock = $this->createMock(LockBackendInterface::class);
+    $lock->expects($this->once())
+      ->method('acquire')
+      ->with('event_cancel_refund:222:111', 30.0)
+      ->willReturn(TRUE);
+    $lock->expects($this->once())
+      ->method('release')
+      ->with('event_cancel_refund:222:111')
+      ->willReturn(TRUE);
+
+    $reflection = new \ReflectionClass(RefundProcessor::class);
+    $processor = $reflection->newInstanceWithoutConstructor();
+    $reflection->getProperty('database')->setValue($processor, $database);
+    $reflection->getProperty('lock')->setValue($processor, $lock);
+
+    $this->assertSame(
+      $logId,
+      $processor->requestEventCancellationRefund($order, $event, $account),
+    );
+    $this->assertSame(
+      1,
+      (int) $database->select('myeventlane_refund_log')->countQuery()->execute()->fetchField(),
+    );
+  }
+
+  /**
    * Tests second process call is blocked by lock.
    */
   public function testProcessRefundLockPreventsSecondExecution(): void {
@@ -373,4 +430,3 @@ final class RefundProcessorLockingTest extends KernelTestBase {
   }
 
 }
-

--- a/web/modules/custom/myeventlane_refunds/tests/src/Unit/EventCancelRefundWorkerTest.php
+++ b/web/modules/custom/myeventlane_refunds/tests/src/Unit/EventCancelRefundWorkerTest.php
@@ -11,24 +11,24 @@ use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\Core\Queue\QueueFactory;
 use Drupal\Core\Queue\QueueInterface;
 use Drupal\myeventlane_refunds\Plugin\QueueWorker\EventCancelRefundWorker;
-use Drupal\myeventlane_refunds\Service\RefundOrderInspector;
-use Drupal\myeventlane_refunds\Service\RefundProcessor;
+use Drupal\myeventlane_refunds\Service\RefundOrderInspectorInterface;
+use Drupal\myeventlane_refunds\Service\RefundProcessorInterface;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Tests\UnitTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Psr\Log\LoggerInterface;
 
 /**
  * Tests cursor progression behavior for EventCancelRefundWorker.
- *
- * @group myeventlane_refunds
  */
+#[Group('myeventlane_refunds')]
 final class EventCancelRefundWorkerTest extends UnitTestCase {
 
   /**
-   * Ensures a full batch requeues with a forward-only cursor.
+   * Ensures a mixed-value full batch uses the ticket-only refund operation.
    */
-  public function testRequeuesWithForwardCursor(): void {
+  public function testRequeuesMixedOrderWithTicketOnlyRefund(): void {
     $nodeStorage = $this->createMock(EntityStorageInterface::class);
     $userStorage = $this->createMock(EntityStorageInterface::class);
     $orderItemStorage = $this->createMock(EntityStorageInterface::class);
@@ -49,9 +49,14 @@ final class EventCancelRefundWorkerTest extends UnitTestCase {
     $userStorage->method('load')->with(123)->willReturn($vendor);
 
     $orderState = new class {
+
+      /**
+       * Returns the completed state ID.
+       */
       public function getId(): string {
         return 'completed';
       }
+
     };
     $order = $this->createMock(OrderInterface::class);
     $order->method('id')->willReturn(777);
@@ -60,16 +65,26 @@ final class EventCancelRefundWorkerTest extends UnitTestCase {
     $orderItems = [];
     foreach ($orderItemIds as $orderItemId) {
       $orderItem = new class($orderItemId, $order) {
+
         public function __construct(
           private readonly int $id,
           private readonly OrderInterface $order,
         ) {}
+
+        /**
+         * Returns the parent order.
+         */
         public function getOrder(): OrderInterface {
           return $this->order;
         }
+
+        /**
+         * Returns the order item ID.
+         */
         public function id(): int {
           return $this->id;
         }
+
       };
       $orderItems[$orderItemId] = $orderItem;
     }
@@ -82,14 +97,17 @@ final class EventCancelRefundWorkerTest extends UnitTestCase {
       ['commerce_order_item', $orderItemStorage],
     ]);
 
-    $refundProcessor = $this->createMock(RefundProcessor::class);
+    $orderInspector = $this->createMock(RefundOrderInspectorInterface::class);
+    $orderInspector->method('calculateTicketSubtotalCents')->willReturn(1000);
+    $orderInspector->method('calculateRefundableAmountCents')->willReturn(1500);
+
+    $refundProcessor = $this->createMock(RefundProcessorInterface::class);
     $refundProcessor->expects($this->once())
-      ->method('requestRefund')
+      ->method('requestEventCancellationRefund')
       ->with(
         $this->isInstanceOf(OrderInterface::class),
         $this->isInstanceOf(NodeInterface::class),
         $this->isInstanceOf(AccountInterface::class),
-        $this->arrayHasKey('refund_scope')
       );
 
     $queue = $this->createMock(QueueInterface::class);
@@ -109,7 +127,7 @@ final class EventCancelRefundWorkerTest extends UnitTestCase {
       'event_cancel_refund_worker',
       [],
       $entityTypeManager,
-      $this->createMock(RefundOrderInspector::class),
+      $orderInspector,
       $refundProcessor,
       $this->createMock(LoggerInterface::class),
       $queueFactory,
@@ -122,5 +140,105 @@ final class EventCancelRefundWorkerTest extends UnitTestCase {
     ]);
   }
 
-}
+  /**
+   * Ensures donation-only orders do not create ticket refund requests.
+   */
+  public function testSkipsDonationOnlyOrder(): void {
+    $nodeStorage = $this->createMock(EntityStorageInterface::class);
+    $userStorage = $this->createMock(EntityStorageInterface::class);
+    $orderItemStorage = $this->createMock(EntityStorageInterface::class);
 
+    $query = $this->createMock(QueryInterface::class);
+    $query->method('accessCheck')->with(FALSE)->willReturnSelf();
+    $query->method('condition')->willReturnSelf();
+    $query->method('sort')->with('order_item_id', 'ASC')->willReturnSelf();
+    $query->method('range')->with(0, 50)->willReturnSelf();
+    $query->method('execute')->willReturn([1]);
+    $orderItemStorage->method('getQuery')->willReturn($query);
+
+    $event = $this->createMock(NodeInterface::class);
+    $nodeStorage->method('load')->with(99)->willReturn($event);
+    $vendor = $this->createMock(AccountInterface::class);
+    $userStorage->method('load')->with(123)->willReturn($vendor);
+
+    $orderState = new class {
+
+      /**
+       * Returns the completed state ID.
+       */
+      public function getId(): string {
+        return 'completed';
+      }
+
+    };
+    $order = $this->createMock(OrderInterface::class);
+    $order->method('id')->willReturn(495);
+    $order->method('getState')->willReturn($orderState);
+    $orderItem = new class($order) {
+
+      /**
+       * Constructs a test order item.
+       */
+      public function __construct(private readonly OrderInterface $order) {}
+
+      /**
+       * Returns the parent order.
+       */
+      public function getOrder(): OrderInterface {
+        return $this->order;
+      }
+
+      /**
+       * Returns the order item ID.
+       */
+      public function id(): int {
+        return 1;
+      }
+
+    };
+    $orderItemStorage->method('loadMultiple')->with([1])->willReturn([1 => $orderItem]);
+
+    $entityTypeManager = $this->createMock(EntityTypeManagerInterface::class);
+    $entityTypeManager->method('getStorage')->willReturnMap([
+      ['node', $nodeStorage],
+      ['user', $userStorage],
+      ['commerce_order_item', $orderItemStorage],
+    ]);
+
+    $orderInspector = $this->createMock(RefundOrderInspectorInterface::class);
+    $orderInspector->expects($this->once())
+      ->method('calculateTicketSubtotalCents')
+      ->with($order, 99)
+      ->willReturn(0);
+    $orderInspector->expects($this->never())->method('calculateRefundableAmountCents');
+
+    $refundProcessor = $this->createMock(RefundProcessorInterface::class);
+    $refundProcessor->expects($this->never())->method('requestEventCancellationRefund');
+
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->once())
+      ->method('notice')
+      ->with(
+        $this->stringContains('donations are excluded'),
+        ['@order_id' => 495],
+      );
+
+    $worker = new EventCancelRefundWorker(
+      [],
+      'event_cancel_refund_worker',
+      [],
+      $entityTypeManager,
+      $orderInspector,
+      $refundProcessor,
+      $logger,
+      $this->createMock(QueueFactory::class),
+    );
+
+    $worker->processItem([
+      'event_id' => 99,
+      'vendor_uid' => 123,
+      'last_processed_order_item_id' => 0,
+    ]);
+  }
+
+}


### PR DESCRIPTION
## What changed

- skip donation-only orders during automatic event-cancellation refunds
- route cancellation refunds through a dedicated ticket-only processor operation
- add a persistent order-and-event refund-log lookup
- protect the lookup and creation path with an order-and-event lock
- reuse an existing cancellation-refund log across later or concurrent queue batches
- introduce narrow inspector and processor interfaces for worker tests
- clarify in the organiser form that donations are not included

## Why

The cancellation worker pages through order items while tracking processed orders only inside one batch. An order with event items across multiple batches could therefore reach refund creation more than once. If other refundable value remained on the payment, a later request could consume donation or unrelated ticket funds.

## Impact

Each order and event can now create only one automatic ticket-only cancellation refund. Donation-only orders are skipped, mixed-value orders remain ticket-only, and later batches reuse the persisted audit-log record. No configuration, schema, or deployment change is included.

## Validation

- unit worker tests: 2 tests, 30 assertions
- worker kernel test: 1 test, 20 assertions
- cancellation-idempotency kernel test: 1 test, 6 assertions
- PHP syntax and diff checks passed
- directly changed worker and interface files pass Drupal and DrupalPractice coding standards
- Drupal Check improved the existing refund-module baseline from 18 findings to 16; no new finding was introduced

## Existing test debt

Two older tests in `RefundProcessorLockingTest` still mock the final `RefundAccessResolver` and cannot execute under the current PHPUnit rules. The new idempotency test in that file passes. This inherited debt is not expanded into this money-safety slice.

## Release gate

Draft only. Do not merge or deploy until required PR checks pass and deployment is separately approved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches payment refund creation for event cancellations, including locking and audit-log reuse that directly affect whether money is refunded once or more than once.
> 
> **Overview**
> Makes automatic event-cancellation refunds **idempotent** so later queue batches cannot create a second refund against the same order and event.
> 
> Adds `requestEventCancellationRefund()` with an order+event lock and a persistent `myeventlane_refund_log` lookup, so concurrent or follow-up batches reuse the existing ticket-only cancellation refund. The cancel worker now skips donation-only and zero-balance orders, and the organiser form clarifies that donations are excluded.
> 
> Also introduces narrow `RefundOrderInspectorInterface` and `RefundProcessorInterface` contracts and expands unit/kernel coverage for skip and reuse behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 765d8c3921b6b6152b60fd1ccfdfeb4df0922fc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->