### PR TITLE
Align Gin settings with staging

### DIFF
--- a/config/sync/gin.settings.yml
+++ b/config/sync/gin.settings.yml
@@ -1,26 +1,29 @@
 _core:
   default_config_hash: c8aZhkIY8zHUo0_UOll4vVs_l48dHL_gBqbvfuAM0Rs
 favicon:
-  use_default: true
+  mimetype: image/png
+  path: 'public://new-fal_19_6_26_0_0.png'
+  use_default: false
 features:
   comment_user_picture: true
   comment_user_verification: true
   favicon: true
   node_user_picture: true
 logo:
-  use_default: true
+  path: 'public://myeventlane_logo_19_06_26_0_0.png'
+  use_default: false
 third_party_settings:
   shortcut:
     module_link: true
-preset_accent_color: purple
+preset_accent_color: pink
 preset_focus_color: custom
-enable_darkmode: auto
+enable_darkmode: '0'
 classic_toolbar: vertical
 secondary_toolbar_frontend: true
 high_contrast_mode: false
 accent_color: ''
 focus_color: '#f4a4c0'
 layout_density: default
-show_description_toggle: true
-show_user_theme_settings: true
+show_description_toggle: false
+show_user_theme_settings: false
 sticky_action_buttons: false


### PR DESCRIPTION
## What changed

- align the Git-tracked Gin configuration exactly with staging
- preserve staging’s custom MyEventLane logo and favicon paths
- preserve the pink accent, disabled dark mode, and disabled description and user-theme toggles

## Why

Staging active configuration and its server sync directory were aligned, but Git `main` still contained different Gin values. A later deployment could therefore restore the old repository settings and recreate configuration drift.

## Impact

Future releases will preserve the currently approved staging Gin appearance and settings. This PR changes one configuration file only and contains no database or module changes.

## Validation

- local file checksum exactly matched `/home/mel/staging/config/sync/gin.settings.yml`
- Git diff and whitespace checks passed
- staging reported no differences between active configuration and its sync directory

## Release gate

Draft only. Do not merge or deploy until required PR checks pass and deployment is separately approved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Admin theme appearance config only; no auth, data, or application logic changes.
> 
> **Overview**
> Updates `gin.settings.yml` so Git matches the approved staging Gin admin theme configuration and avoids config drift on deploy.
> 
> Switches logo and favicon from defaults to the staging custom asset paths, changes the accent preset from purple to **pink**, disables dark mode, and turns off the description and user-theme toggles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e7c668d9b429a36d6274976d9ca915969babb2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->