### PR TITLE
Fix staging domain redirect policy

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -181,7 +181,7 @@ jobs:
             'MEL_PUBLIC_DOMAIN="https://staging.myeventlane.com.au" \' \
             'MEL_VENDOR_DOMAIN="https://vendor.staging.myeventlane.com.au" \' \
             'MEL_ADMIN_DOMAIN="https://admin.staging.myeventlane.com.au" \' \
-            'MEL_FORCE_DOMAIN_REDIRECTS=1 \' \
+            'MEL_FORCE_DOMAIN_REDIRECTS=0 \' \
             'MEL_REVISION="${{ github.sha }}" \' \
             'MEL_DEPLOY_TIME_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \' \
             'MEL_RELEASE_IDENTIFIER="${{ github.run_id }}.${{ github.run_attempt }}" \' \

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -138,6 +138,9 @@ jobs:
       - name: Test deploy config-status parser
         run: bash scripts/deploy/test-config-status-parser.sh
 
+      - name: Test deploy domain redirect policy
+        run: bash scripts/deploy/test-domain-redirect-policy.sh
+
       - name: Set artifact metadata
         id: meta
         run: echo "artifact_name=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"

--- a/scripts/deploy/remote-deploy.sh
+++ b/scripts/deploy/remote-deploy.sh
@@ -933,7 +933,7 @@ declare(strict_types=1);
 \$config['myeventlane_core.domain_settings']['admin_domain'] =
   \$melGetEnv('MEL_ADMIN_DOMAIN') ?: '${admin}';
 \$config['myeventlane_core.domain_settings']['force_redirects'] =
-  \$melGetEnv('MEL_FORCE_DOMAIN_REDIRECTS') !== '0';
+  \$melGetEnv('MEL_FORCE_DOMAIN_REDIRECTS') === '1';
 PHP
 
   echo "Wrote domain overrides to $dst (${mode})"
@@ -1094,7 +1094,7 @@ fi
 #   MEL_PUBLIC_DOMAIN=https://staging.myeventlane.com.au
 #   MEL_VENDOR_DOMAIN=https://vendor.staging.myeventlane.com.au
 #   MEL_ADMIN_DOMAIN=https://admin.staging.myeventlane.com.au
-#   MEL_FORCE_DOMAIN_REDIRECTS=1   — required on staging (VendorDomainSubscriber redirects)
+#   MEL_FORCE_DOMAIN_REDIRECTS=0   — required until cross-subdomain auth is proven reliable
 #
 # Production example:
 #   MEL_PUBLIC_DOMAIN=https://myeventlane.com.au
@@ -1119,18 +1119,20 @@ if (\$k === 'force_redirects') {
 
 mel_verify_domain_environment() {
   local mode="$1"
-  local pub vendor admin failures=0
+  local pub vendor admin expected_force failures=0
 
   case "$mode" in
     production)
       pub='https://myeventlane.com.au'
       vendor='https://vendor.myeventlane.com.au'
       admin='https://admin.myeventlane.com.au'
+      expected_force='1'
       ;;
     staging)
       pub='https://staging.myeventlane.com.au'
       vendor='https://vendor.staging.myeventlane.com.au'
       admin='https://admin.staging.myeventlane.com.au'
+      expected_force='0'
       ;;
     *)
       return 0
@@ -1157,9 +1159,9 @@ mel_verify_domain_environment() {
   actual="$(mel_domain_effective force_redirects)"
   local force_rc=$?
   set -e
-  if [ "$force_rc" -ne 0 ] || [ "$actual" != "1" ]; then
-    echo "ERROR: effective force_redirects is '${actual:-<empty>}' (expected 1)." >&2
-    echo "Set MEL_FORCE_DOMAIN_REDIRECTS=1 in the PHP-FPM / host environment." >&2
+  if [ "$force_rc" -ne 0 ] || [ "$actual" != "$expected_force" ]; then
+    echo "ERROR: effective force_redirects is '${actual:-<empty>}' (expected ${expected_force} for ${mode})." >&2
+    echo "Set MEL_FORCE_DOMAIN_REDIRECTS=${expected_force} in the PHP-FPM / host environment." >&2
     failures=$((failures + 1))
   fi
 

--- a/scripts/deploy/test-domain-redirect-policy.sh
+++ b/scripts/deploy/test-domain-redirect-policy.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+DEPLOY="$ROOT/scripts/deploy/remote-deploy.sh"
+STAGING_WORKFLOW="$ROOT/.github/workflows/deploy-staging.yml"
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+  local description="$3"
+
+  if ! grep -Fq -- "$expected" "$file"; then
+    echo "FAIL: $description" >&2
+    echo "Expected to find: $expected" >&2
+    exit 1
+  fi
+  echo "PASS: $description"
+}
+
+assert_contains \
+  "$STAGING_WORKFLOW" \
+  "MEL_FORCE_DOMAIN_REDIRECTS=0" \
+  "staging workflow explicitly disables forced cross-domain redirects"
+
+assert_contains \
+  "$DEPLOY" \
+  '\$melGetEnv('\''MEL_FORCE_DOMAIN_REDIRECTS'\'') === '\''1'\'';' \
+  "generated shared settings fail closed unless redirects are explicitly enabled"
+
+assert_contains \
+  "$DEPLOY" \
+  "expected_force='0'" \
+  "staging deployment verification requires redirects to remain disabled"
+
+assert_contains \
+  "$DEPLOY" \
+  "expected_force='1'" \
+  "production deployment verification retains its existing redirect requirement"
+
+echo "OK: deploy domain redirect policy tests passed"


### PR DESCRIPTION
## What changed

- disable forced cross-domain redirects explicitly in the staging deployment workflow
- generate shared domain settings with redirects disabled unless `MEL_FORCE_DOMAIN_REDIRECTS=1`
- require redirects off during staging deployment verification while retaining the production requirement
- add a mandatory regression check for the deployment policy

## Why

Authenticated create-event login entered a redirect loop between the public staging host and `vendor.staging.myeventlane.com.au`. Login succeeded on the public host, but the vendor host treated the next request as anonymous and redirected back to login. The staging-only operational mitigation disabled forced domain redirects; this change prevents a future deployment from overwriting that mitigation.

## Impact

Staging vendor routes remain on the public staging hostname until cross-subdomain authentication is repaired and verified separately. Production redirect policy is unchanged.

## Validation

- `bash -n scripts/deploy/remote-deploy.sh`
- `bash scripts/deploy/test-domain-redirect-policy.sh`
- `bash scripts/deploy/test-config-status-parser.sh`
- parsed both changed GitHub workflow files as YAML
- `git diff --check`

No merge or deployment is included in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes domain redirect defaults and staging deploy verification for auth-related cross-host routing. Production still requires redirects enabled, but unset env vars now disable redirects instead of enabling them.
> 
> **Overview**
> Locks in a staging mitigation for vendor login redirect loops by setting **`MEL_FORCE_DOMAIN_REDIRECTS=0`** in the staging deploy workflow, so vendor routes stay on the public staging host until cross-subdomain auth is fixed.
> 
> Also flips generated shared settings to **fail closed**: `force_redirects` is now true only when the env var is explicitly `1` (was previously true unless set to `0`). Staging deploy verification now requires redirects off; production still requires them on.
> 
> Adds a CI regression check (`test-domain-redirect-policy.sh`) so future deploys cannot silently re-enable the staging redirect policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b84267467f72324c3bce90ffc8ada8e350e87750. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->