### PR TITLE
Secure escalation AI draft actions

### DIFF
--- a/web/modules/custom/myeventlane_ai/myeventlane_ai.services.yml
+++ b/web/modules/custom/myeventlane_ai/myeventlane_ai.services.yml
@@ -41,7 +41,7 @@ services:
 
   myeventlane_ai.job_enqueue:
     class: Drupal\myeventlane_ai\Service\AiJobEnqueueService
-    arguments: ['@entity_type.manager', '@queue']
+    arguments: ['@entity_type.manager', '@queue', '@lock', '@datetime.time']
 
   myeventlane_ai.job_cleanup:
     class: Drupal\myeventlane_ai\Service\AiJobCleanupService

--- a/web/modules/custom/myeventlane_ai/src/Service/AiJobEnqueueService.php
+++ b/web/modules/custom/myeventlane_ai/src/Service/AiJobEnqueueService.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_ai\Service;
 
+use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Lock\LockBackendInterface;
 use Drupal\Core\Queue\QueueFactory;
 use Drupal\myeventlane_ai\Entity\AiJob;
 
@@ -16,12 +18,66 @@ use Drupal\myeventlane_ai\Entity\AiJob;
  */
 final class AiJobEnqueueService {
 
+  private const DEDUP_WINDOW = 300;
+
   public const QUEUE_NAME = 'myeventlane_ai.jobs';
 
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly QueueFactory $queueFactory,
+    private readonly LockBackendInterface $lock,
+    private readonly TimeInterface $time,
   ) {}
+
+  /**
+   * Returns a recent queued/running job for the scope, or enqueues a new job.
+   */
+  public function enqueueUnique(
+    string $prompt_key,
+    ?string $prompt_version,
+    array $placeholders,
+    array $options,
+    int $requested_by_uid,
+    string $scope_id,
+    ?int $vendor_id = NULL,
+  ): AiJob {
+    $lock_name = 'myeventlane_ai.enqueue:' . hash('sha256', $prompt_key . '|' . $scope_id);
+    if (!$this->lock->acquire($lock_name, 5.0)) {
+      throw new \RuntimeException('An equivalent AI job is already being queued.');
+    }
+
+    try {
+      $storage = $this->entityTypeManager->getStorage('ai_job');
+      $ids = $storage->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('scope', $scope_id)
+        ->condition('prompt_key', $prompt_key)
+        ->condition('status', [AiJob::STATUS_QUEUED, AiJob::STATUS_RUNNING], 'IN')
+        ->condition('created', $this->time->getRequestTime() - self::DEDUP_WINDOW, '>=')
+        ->sort('created', 'DESC')
+        ->range(0, 1)
+        ->execute();
+      if ($ids !== []) {
+        $job = $storage->load((int) reset($ids));
+        if ($job instanceof AiJob) {
+          return $job;
+        }
+      }
+
+      return $this->enqueue(
+        $prompt_key,
+        $prompt_version,
+        $placeholders,
+        $options,
+        $requested_by_uid,
+        $scope_id,
+        $vendor_id,
+      );
+    }
+    finally {
+      $this->lock->release($lock_name);
+    }
+  }
 
   /**
    * Creates an ai_job (queued) and enqueues for async execution.
@@ -65,7 +121,7 @@ final class AiJobEnqueueService {
       'prompt_version' => $prompt_version,
       'prompt_hash' => $prompt_hash,
     ];
-    if ($vendor_id !== null) {
+    if ($vendor_id !== NULL) {
       $values['vendor_id'] = $vendor_id;
     }
     /** @var \Drupal\myeventlane_ai\Entity\AiJob $job */

--- a/web/modules/custom/myeventlane_escalations_ai/js/ai-assistant.js
+++ b/web/modules/custom/myeventlane_escalations_ai/js/ai-assistant.js
@@ -1,4 +1,4 @@
-(function (Drupal, once) {
+(function (Drupal, once, drupalSettings) {
   'use strict';
 
   function expandReplyShell() {
@@ -124,6 +124,34 @@
           });
         });
       });
+
+      once('mel-ai-generate', '[data-mel-ai-generate]', context).forEach(function (button) {
+        button.addEventListener('click', async function () {
+          const url = button.getAttribute('data-mel-ai-generate-url');
+          const tokenUrl = drupalSettings.myeventlaneEscalationsAi?.csrfTokenUrl || '/session/token';
+          if (!url) return;
+
+          button.disabled = true;
+          try {
+            const tokenResponse = await fetch(tokenUrl, {credentials: 'same-origin'});
+            const token = await tokenResponse.text();
+            const response = await fetch(url, {
+              method: 'POST',
+              credentials: 'same-origin',
+              headers: {
+                'Accept': 'application/json',
+                'X-CSRF-Token': token,
+                'X-Requested-With': 'XMLHttpRequest'
+              }
+            });
+            if (!response.ok) throw new Error('request_failed');
+            window.location.reload();
+          } catch (error) {
+            window.alert(Drupal.t('Could not queue an AI draft. Please try again.'));
+            button.disabled = false;
+          }
+        });
+      });
     }
   };
-})(Drupal, once);
+})(Drupal, once, drupalSettings);

--- a/web/modules/custom/myeventlane_escalations_ai/myeventlane_escalations_ai.module
+++ b/web/modules/custom/myeventlane_escalations_ai/myeventlane_escalations_ai.module
@@ -11,6 +11,7 @@ use Drupal\Component\Utility\Html;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Url;
+use Drupal\myeventlane_escalations\Entity\EscalationInterface;
 
 /**
  * Implements hook_entity_insert().
@@ -34,7 +35,7 @@ function myeventlane_escalations_ai_entity_insert(EntityInterface $entity): void
  * and the escalation is not already resolved/closed (avoid spam).
  */
 function myeventlane_escalations_ai_entity_update(EntityInterface $entity): void {
-  if ($entity->getEntityTypeId() !== 'escalation') {
+  if (!$entity instanceof EscalationInterface) {
     return;
   }
 
@@ -49,11 +50,12 @@ function myeventlane_escalations_ai_entity_update(EntityInterface $entity): void
   }
 
   // Compare current description with original to detect actual changes.
-  if (!isset($entity->original)) {
+  $original = $entity->getOriginal();
+  if (!$original instanceof EscalationInterface) {
     return;
   }
 
-  $old_desc = (string) $entity->original->get('description')->value;
+  $old_desc = (string) $original->get('description')->value;
   $new_desc = (string) $entity->get('description')->value;
 
   if ($old_desc === $new_desc) {
@@ -103,6 +105,7 @@ function myeventlane_escalations_ai_theme($existing, $type, $theme, $path) {
  * Safely decode insight payload JSON and normalise keys.
  *
  * @return array{ok: bool, data: array, error: ?string}
+ *   The decoded payload result.
  */
 function _myeventlane_escalations_ai_decode_payload(?string $json): array {
   if (!$json) {
@@ -181,6 +184,11 @@ function myeventlane_escalations_ai_entity_view(array &$build, EntityInterface $
       '#generate_url' => $generate_url,
       '#attached' => [
         'library' => ['myeventlane_escalations_ai/ai_assistant'],
+        'drupalSettings' => [
+          'myeventlaneEscalationsAi' => [
+            'csrfTokenUrl' => '/session/token',
+          ],
+        ],
       ],
       '#cache' => [
         'contexts' => ['user.permissions'],
@@ -191,7 +199,7 @@ function myeventlane_escalations_ai_entity_view(array &$build, EntityInterface $
 }
 
 /**
- * Builds a themed AI insight card render array from an EscalationAiInsight entity.
+ * Builds a themed AI insight card render array from an insight entity.
  *
  * @param \Drupal\myeventlane_escalations_ai\Entity\EscalationAiInsight $insight
  *   The AI insight entity.

--- a/web/modules/custom/myeventlane_escalations_ai/myeventlane_escalations_ai.routing.yml
+++ b/web/modules/custom/myeventlane_escalations_ai/myeventlane_escalations_ai.routing.yml
@@ -2,8 +2,14 @@ myeventlane_escalations_ai.generate_draft:
   path: '/admin/myeventlane/escalations/{escalation}/ai/draft'
   defaults:
     _controller: '\Drupal\myeventlane_escalations_ai\Controller\EscalationAiController::generateDraft'
+  methods: [POST]
   requirements:
     _permission: 'generate escalation ai drafts'
+    _custom_access: 'myeventlane_escalations_ai.access::draftAccess'
+    _csrf_request_header_token: 'TRUE'
     escalation: '\d+'
   options:
     _admin_route: TRUE
+    parameters:
+      escalation:
+        type: entity:escalation

--- a/web/modules/custom/myeventlane_escalations_ai/myeventlane_escalations_ai.services.yml
+++ b/web/modules/custom/myeventlane_escalations_ai/myeventlane_escalations_ai.services.yml
@@ -5,7 +5,15 @@ services:
 
   myeventlane_escalations_ai.job_enqueuer:
     class: Drupal\myeventlane_escalations_ai\Service\EscalationAiJobEnqueuer
-    arguments: ['@queue', '@logger.channel.myeventlane_escalations_ai']
+    arguments: ['@queue', '@myeventlane_escalations_ai.dedup_store', '@lock', '@logger.channel.myeventlane_escalations_ai']
+
+  myeventlane_escalations_ai.dedup_store:
+    class: Drupal\Core\KeyValueStore\KeyValueStoreExpirableInterface
+    factory: ['@keyvalue.expirable', 'get']
+    arguments: ['myeventlane_escalations_ai.dedup']
+
+  myeventlane_escalations_ai.access:
+    class: Drupal\myeventlane_escalations_ai\Access\EscalationAiAccess
 
   logger.channel.myeventlane_escalations_ai:
     parent: logger.channel_base

--- a/web/modules/custom/myeventlane_escalations_ai/src/Access/EscalationAiAccess.php
+++ b/web/modules/custom/myeventlane_escalations_ai/src/Access/EscalationAiAccess.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_escalations_ai\Access;
+
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\myeventlane_escalations\Entity\EscalationInterface;
+
+/**
+ * Enforces access to the escalation used for an AI action.
+ */
+final class EscalationAiAccess {
+
+  /**
+   * Checks whether the account may view the target escalation.
+   */
+  public function draftAccess(AccountInterface $account, EscalationInterface $escalation): AccessResultInterface {
+    return $escalation->access('view', $account, TRUE);
+  }
+
+}

--- a/web/modules/custom/myeventlane_escalations_ai/src/Controller/EscalationAiController.php
+++ b/web/modules/custom/myeventlane_escalations_ai/src/Controller/EscalationAiController.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_escalations_ai\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\myeventlane_escalations\Entity\EscalationInterface;
 use Drupal\myeventlane_escalations_ai\Service\EscalationAiJobEnqueuer;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
  * Staff actions for AI generation.
@@ -22,40 +23,34 @@ final class EscalationAiController extends ControllerBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container): self {
-    $instance = new self(
+    return new self(
       $container->get('myeventlane_escalations_ai.job_enqueuer'),
     );
-    $instance->redirectDestination = $container->get('redirect.destination');
-    return $instance;
   }
 
   /**
    * Enqueue a reply_suggestion job for this escalation.
    *
-   * @param int $escalation
-   *   The escalation entity ID from the route.
+   * @param \Drupal\myeventlane_escalations\Entity\EscalationInterface $escalation
+   *   The escalation entity from the route.
    *
-   * @return \Symfony\Component\HttpFoundation\RedirectResponse
-   *   Redirect back to the escalation view.
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   Queue result for the calling interface.
    */
-  public function generateDraft(int $escalation): RedirectResponse {
-    $storage = $this->entityTypeManager()->getStorage('escalation');
-    $entity = $storage->load($escalation);
+  public function generateDraft(EscalationInterface $escalation): JsonResponse {
+    $queued = $this->jobEnqueuer->enqueue(
+      (int) $escalation->id(),
+      'reply_suggestion',
+      (int) $this->currentUser()->id(),
+    );
 
-    if (!$entity) {
-      $this->messenger()->addError($this->t('Escalation not found.'));
-      return new RedirectResponse('/admin/myeventlane/escalations');
-    }
-
-    $this->jobEnqueuer->enqueue((int) $escalation, 'reply_suggestion', (int) $this->currentUser()->id());
-    $this->messenger()->addStatus($this->t('AI reply draft queued. It will appear in the AI Insights panel after cron/queue runs.'));
-
-    $destination = $this->getRedirectDestination()->get();
-    $target = '/admin/myeventlane/escalations/' . $escalation;
-    if ($destination) {
-      $target .= '?' . $destination;
-    }
-    return new RedirectResponse($target);
+    return new JsonResponse([
+      'ok' => TRUE,
+      'queued' => $queued,
+      'message' => $queued
+        ? $this->t('AI reply draft queued.')
+        : $this->t('An AI reply draft is already queued.'),
+    ], $queued ? 202 : 200);
   }
 
 }

--- a/web/modules/custom/myeventlane_escalations_ai/src/Service/EscalationAiJobEnqueuer.php
+++ b/web/modules/custom/myeventlane_escalations_ai/src/Service/EscalationAiJobEnqueuer.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_escalations_ai\Service;
 
+use Drupal\Core\KeyValueStore\KeyValueStoreExpirableInterface;
+use Drupal\Core\Lock\LockBackendInterface;
 use Drupal\Core\Queue\QueueFactory;
 use Psr\Log\LoggerInterface;
 
@@ -12,6 +14,8 @@ use Psr\Log\LoggerInterface;
  */
 final class EscalationAiJobEnqueuer {
 
+  private const DEDUP_TTL = 300;
+
   /**
    * Queue name for escalation AI jobs.
    */
@@ -19,6 +23,8 @@ final class EscalationAiJobEnqueuer {
 
   public function __construct(
     private readonly QueueFactory $queueFactory,
+    private readonly KeyValueStoreExpirableInterface $dedupStore,
+    private readonly LockBackendInterface $lock,
     private readonly LoggerInterface $logger,
   ) {}
 
@@ -34,7 +40,24 @@ final class EscalationAiJobEnqueuer {
    * @param array $metadata
    *   Optional metadata to include in the queue item (e.g. hours_remaining).
    */
-  public function enqueue(int $escalation_id, string $task, ?int $requested_by_uid = NULL, array $metadata = []): void {
+  public function enqueue(int $escalation_id, string $task, ?int $requested_by_uid = NULL, array $metadata = []): bool {
+    $dedup_key = $task . ':' . $escalation_id;
+    $lock_name = 'myeventlane_escalations_ai.enqueue:' . $dedup_key;
+    if (!$this->lock->acquire($lock_name, 5.0)) {
+      return FALSE;
+    }
+
+    try {
+      if ($this->dedupStore->has($dedup_key)) {
+        return FALSE;
+      }
+
+      $this->dedupStore->setWithExpire($dedup_key, time(), self::DEDUP_TTL);
+    }
+    finally {
+      $this->lock->release($lock_name);
+    }
+
     $queue = $this->queueFactory->get(self::QUEUE_NAME, TRUE);
 
     $item = [
@@ -50,6 +73,8 @@ final class EscalationAiJobEnqueuer {
       'task' => $task,
       'id' => $escalation_id,
     ]);
+
+    return TRUE;
   }
 
 }

--- a/web/modules/custom/myeventlane_escalations_ai/templates/myeventlane-escalations-ai-panel.html.twig
+++ b/web/modules/custom/myeventlane_escalations_ai/templates/myeventlane-escalations-ai-panel.html.twig
@@ -13,9 +13,12 @@
 
   {% if generate_url %}
     <div class="mel-ai-assistant__cta">
-      <a class="mel-button mel-button--secondary" href="{{ generate_url }}">
+      <button type="button"
+              class="mel-button mel-button--secondary"
+              data-mel-ai-generate
+              data-mel-ai-generate-url="{{ generate_url }}">
         Generate AI reply draft
-      </a>
+      </button>
       <p class="mel-ai-assistant__cta-note">
         Suggestions only. Nothing is auto-sent or auto-applied.
       </p>

--- a/web/modules/custom/myeventlane_escalations_ai/tests/src/Unit/EscalationAiJobEnqueuerTest.php
+++ b/web/modules/custom/myeventlane_escalations_ai/tests/src/Unit/EscalationAiJobEnqueuerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_escalations_ai\Unit;
+
+use Drupal\Core\KeyValueStore\KeyValueStoreExpirableInterface;
+use Drupal\Core\Lock\LockBackendInterface;
+use Drupal\Core\Queue\QueueFactory;
+use Drupal\Core\Queue\QueueInterface;
+use Drupal\myeventlane_escalations_ai\Service\EscalationAiJobEnqueuer;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests short-lived duplicate suppression before queue writes.
+ */
+#[Group('myeventlane_escalations_ai')]
+final class EscalationAiJobEnqueuerTest extends TestCase {
+
+  /**
+   * Tests that an active marker prevents another queue write.
+   */
+  public function testDuplicateIsNotQueued(): void {
+    $queueFactory = $this->createMock(QueueFactory::class);
+    $queueFactory->expects($this->never())->method('get');
+    $store = $this->createMock(KeyValueStoreExpirableInterface::class);
+    $store->expects($this->once())->method('has')->with('reply_suggestion:42')->willReturn(TRUE);
+    $lock = $this->createMock(LockBackendInterface::class);
+    $lock->method('acquire')->willReturn(TRUE);
+    $lock->expects($this->once())->method('release');
+
+    $service = new EscalationAiJobEnqueuer(
+      $queueFactory,
+      $store,
+      $lock,
+      $this->createMock(LoggerInterface::class),
+    );
+
+    $this->assertFalse($service->enqueue(42, 'reply_suggestion', 1));
+  }
+
+  /**
+   * Tests that the first request is marked and queued.
+   */
+  public function testFirstRequestIsQueuedAndMarked(): void {
+    $queue = $this->createMock(QueueInterface::class);
+    $queue->expects($this->once())->method('createItem')->with($this->callback(
+      static fn (array $item): bool => $item['escalation_id'] === 42 && $item['task'] === 'reply_suggestion',
+    ));
+    $queueFactory = $this->createMock(QueueFactory::class);
+    $queueFactory->method('get')->willReturn($queue);
+    $store = $this->createMock(KeyValueStoreExpirableInterface::class);
+    $store->method('has')->willReturn(FALSE);
+    $store->expects($this->once())->method('setWithExpire')->with(
+      'reply_suggestion:42',
+      $this->callback(static fn (mixed $value): bool => is_int($value)),
+      300,
+    );
+    $lock = $this->createMock(LockBackendInterface::class);
+    $lock->method('acquire')->willReturn(TRUE);
+
+    $service = new EscalationAiJobEnqueuer(
+      $queueFactory,
+      $store,
+      $lock,
+      $this->createMock(LoggerInterface::class),
+    );
+
+    $this->assertTrue($service->enqueue(42, 'reply_suggestion', 1));
+  }
+
+}

--- a/web/modules/custom/myeventlane_escalations_ai/tests/src/Unit/EscalationAiRouteSecurityTest.php
+++ b/web/modules/custom/myeventlane_escalations_ai/tests/src/Unit/EscalationAiRouteSecurityTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_escalations_ai\Unit;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Guards the escalation AI action route security contract.
+ */
+#[Group('myeventlane_escalations_ai')]
+final class EscalationAiRouteSecurityTest extends TestCase {
+
+  /**
+   * Tests the method, CSRF, permission and object-access route requirements.
+   */
+  public function testDraftRoutesRequirePostCsrfAndObjectAccess(): void {
+    $root = dirname(__DIR__, 3);
+    $routes = [
+      Yaml::parseFile($root . '/myeventlane_escalations_ai.routing.yml')['myeventlane_escalations_ai.generate_draft'],
+      Yaml::parseFile($root . '/../myeventlane_escalations_ai_draft/myeventlane_escalations_ai_draft.routing.yml')['myeventlane_escalations_ai_draft.generate'],
+    ];
+
+    foreach ($routes as $route) {
+      $this->assertSame(['POST'], $route['methods'] ?? NULL);
+      $this->assertSame('TRUE', $route['requirements']['_csrf_request_header_token'] ?? NULL);
+      $this->assertSame('generate escalation ai drafts', $route['requirements']['_permission'] ?? NULL);
+      $this->assertNotEmpty($route['requirements']['_custom_access'] ?? NULL);
+      $this->assertSame('entity:escalation', $route['options']['parameters']['escalation']['type'] ?? NULL);
+    }
+  }
+
+}

--- a/web/modules/custom/myeventlane_escalations_ai_draft/js/escalation-ai-draft.js
+++ b/web/modules/custom/myeventlane_escalations_ai_draft/js/escalation-ai-draft.js
@@ -10,6 +10,10 @@
   const POLL_INTERVAL = 1500;
   const MAX_POLLS = 20;
 
+  function getCsrfTokenUrl() {
+    return drupalSettings.myeventlaneEscalationsAiDraft?.csrfTokenUrl || '/session/token';
+  }
+
   const TEXTAREA_SELECTORS = [
     '#mel-reply-textarea',
     '[data-mel-reply-textarea="true"]',
@@ -145,10 +149,13 @@
       btn.textContent = Drupal.t('Generating…');
 
       try {
+        const tokenResponse = await fetch(getCsrfTokenUrl(), {credentials: 'same-origin'});
+        const csrfToken = await tokenResponse.text();
         const res = await fetch(getDraftUrl(escalationId), {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
+            'X-CSRF-Token': csrfToken,
             'X-Requested-With': 'XMLHttpRequest',
           },
           credentials: 'same-origin',

--- a/web/modules/custom/myeventlane_escalations_ai_draft/myeventlane_escalations_ai_draft.module
+++ b/web/modules/custom/myeventlane_escalations_ai_draft/myeventlane_escalations_ai_draft.module
@@ -48,6 +48,11 @@ function myeventlane_escalations_ai_draft_entity_view_alter(
     '#weight' => 50,
     '#attached' => [
       'library' => ['myeventlane_escalations_ai_draft/escalation_ai_draft'],
+      'drupalSettings' => [
+        'myeventlaneEscalationsAiDraft' => [
+          'csrfTokenUrl' => '/session/token',
+        ],
+      ],
     ],
     '#cache' => [
       'contexts' => ['user.permissions'],
@@ -63,7 +68,7 @@ function myeventlane_escalations_ai_draft_entity_view_alter(
  * and portal reply form).
  */
 function myeventlane_escalations_ai_draft_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
-  // Phase 4 hard isolation: do not touch core login render tree (remove after confirm).
+  // Phase 4 hard isolation: do not touch the core login render tree.
   if ($form_id === 'user_login_form') {
     return;
   }

--- a/web/modules/custom/myeventlane_escalations_ai_draft/myeventlane_escalations_ai_draft.routing.yml
+++ b/web/modules/custom/myeventlane_escalations_ai_draft/myeventlane_escalations_ai_draft.routing.yml
@@ -4,11 +4,13 @@ myeventlane_escalations_ai_draft.generate:
   path: '/admin/myeventlane/escalations/{escalation}/ai/instant-draft'
   defaults:
     _controller: '\Drupal\myeventlane_escalations_ai_draft\Controller\EscalationAiDraftController::generate'
+  methods: [POST]
   requirements:
     _permission: 'generate escalation ai drafts'
     _custom_access: 'myeventlane_escalations_ai_draft.access::draftAccess'
+    _csrf_request_header_token: 'TRUE'
   options:
     _admin_route: TRUE
     parameters:
       escalation:
-        type: integer
+        type: entity:escalation

--- a/web/modules/custom/myeventlane_escalations_ai_draft/myeventlane_escalations_ai_draft.services.yml
+++ b/web/modules/custom/myeventlane_escalations_ai_draft/myeventlane_escalations_ai_draft.services.yml
@@ -1,8 +1,6 @@
 services:
   myeventlane_escalations_ai_draft.access:
     class: Drupal\myeventlane_escalations_ai_draft\Access\EscalationAiDraftAccess
-    arguments:
-      - '@entity_type.manager'
 
   myeventlane_escalations_ai_draft.context_builder:
     class: Drupal\myeventlane_escalations_ai_draft\Service\EscalationDraftContextBuilder

--- a/web/modules/custom/myeventlane_escalations_ai_draft/src/Access/EscalationAiDraftAccess.php
+++ b/web/modules/custom/myeventlane_escalations_ai_draft/src/Access/EscalationAiDraftAccess.php
@@ -6,8 +6,8 @@ namespace Drupal\myeventlane_escalations_ai_draft\Access;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Access\AccessResultInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\myeventlane_escalations\Entity\EscalationInterface;
 
 /**
  * Access check for escalation AI draft route.
@@ -16,24 +16,15 @@ use Drupal\Core\Session\AccountInterface;
  */
 final class EscalationAiDraftAccess {
 
-  public function __construct(
-    private readonly EntityTypeManagerInterface $entityTypeManager,
-  ) {}
-
   /**
    * Checks access to the AI draft generation endpoint.
    */
-  public function draftAccess(AccountInterface $account, int $escalation): AccessResultInterface {
+  public function draftAccess(AccountInterface $account, EscalationInterface $escalation): AccessResultInterface {
     if (!$account->hasPermission('generate escalation ai drafts')) {
       return AccessResult::forbidden()->cachePerUser();
     }
 
-    $entity = $this->entityTypeManager->getStorage('escalation')->load($escalation);
-    if (!$entity) {
-      return AccessResult::forbidden('Escalation not found.');
-    }
-
-    return AccessResult::allowed()->addCacheableDependency($entity)->cachePerUser();
+    return $escalation->access('view', $account, TRUE);
   }
 
 }

--- a/web/modules/custom/myeventlane_escalations_ai_draft/src/Controller/EscalationAiDraftController.php
+++ b/web/modules/custom/myeventlane_escalations_ai_draft/src/Controller/EscalationAiDraftController.php
@@ -6,6 +6,7 @@ namespace Drupal\myeventlane_escalations_ai_draft\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\myeventlane_ai\Service\AiJobEnqueueService;
+use Drupal\myeventlane_escalations\Entity\EscalationInterface;
 use Drupal\myeventlane_escalations_ai_draft\Service\EscalationDraftContextBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -36,12 +37,13 @@ final class EscalationAiDraftController extends ControllerBase {
   /**
    * Starts draft generation. Returns job_id for polling.
    */
-  public function generate(Request $request, int $escalation): JsonResponse {
+  public function generate(Request $request, EscalationInterface $escalation): JsonResponse {
     if (!$request->isMethod('POST')) {
       return new JsonResponse(['error' => 'Method not allowed'], 405);
     }
 
-    $context = $this->contextBuilder->build($escalation);
+    $escalation_id = (int) $escalation->id();
+    $context = $this->contextBuilder->build($escalation_id);
     if (isset($context['error'])) {
       return new JsonResponse([
         'ok' => FALSE,
@@ -81,13 +83,13 @@ final class EscalationAiDraftController extends ControllerBase {
       'playbooks' => $playbooks ?: ' (none)',
     ];
 
-    $job = $this->jobEnqueue->enqueue(
+    $job = $this->jobEnqueue->enqueueUnique(
       'escalation.draft',
       'v1',
       $placeholders,
       ['max_tokens' => 800],
       (int) $this->currentUser()->id(),
-      'escalation_draft:' . $escalation,
+      'escalation_draft:' . $escalation_id,
       NULL,
     );
 


### PR DESCRIPTION
## What changed

- make both escalation AI draft actions POST-only
- require Drupal header-token CSRF validation
- load the route parameter as an escalation entity and enforce object-level view access
- replace the state-changing queue hyperlink with a protected POST button
- add five-minute duplicate suppression for both AI queue paths
- correct entity typing in the touched escalation update hook
- add focused route-security and queue-deduplication tests

## Why

The existing actions could create AI work through GET or unprotected POST requests. They checked a broad permission but did not verify access to the specific escalation, and repeated requests could create duplicate jobs.

## Impact

Staff retain both AI drafting workflows. Requests now require an authenticated same-origin CSRF token, permission to generate drafts and access to the target escalation. No AI result is automatically sent or applied.

No schema update, configuration import or stored-data cleanup is included. AI retention policy and orphaned historical jobs remain a separate approval gate.

## Validation

- PHPUnit: 3 tests, 22 assertions
- Drupal Check: zero findings across `myeventlane_ai`, `myeventlane_escalations_ai` and `myeventlane_escalations_ai_draft`
- Drupal and DrupalPractice coding standards: clean
- Composer validation: clean
- PHP syntax and JavaScript syntax: clean
- no real AI request was made

## Deployment checks required

- rebuild Drupal caches
- verify both compiled routes accept POST only and require CSRF
- verify unauthorised and cross-escalation requests are denied
- verify an authorised staff user can queue each draft workflow
- do not allow the queue worker to make a real provider request during automated verification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication/authorization for state-changing AI job creation (CSRF, permissions, and escalation object access). Incorrect access checks could allow unauthorized draft generation or block legitimate staff actions.
> 
> **Overview**
> Hardens both staff escalation AI draft workflows so queueing can no longer happen via unprotected GET/POST requests.
> 
> Both draft routes are now **POST-only**, require a **CSRF header token**, load `{escalation}` as an entity, and enforce **object-level view access** in addition to the generate permission. The insights panel CTA switches from a link to a JS-driven POST button; the instant-draft client also sends the CSRF token.
> 
> Adds **5-minute duplicate suppression** on both queue paths: lock + recent-job reuse via `enqueueUnique()` in `AiJobEnqueueService`, and lock + expirable key-value markers in `EscalationAiJobEnqueuer`. Includes focused route-security and enqueue-dedup unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3740e570b361d6fe71561ecca44bfc4f16bdd6ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->