### PR TITLE
Set bounded AI job retention

### DIFF
--- a/config/sync/myeventlane_ai.settings.yml
+++ b/config/sync/myeventlane_ai.settings.yml
@@ -1,6 +1,7 @@
 _core:
   default_config_hash: hLCUT-cJFQE24x2teLcXCHLoNYpZzk572muSNu-8SZ0
 enabled: true
+rate_limit_enabled: true
 provider: openai
 openai:
   endpoint: 'https://api.openai.com/v1/chat/completions'
@@ -18,5 +19,5 @@ cb_failure_threshold: 10
 cb_window_seconds: 600
 cb_cost_trip_seconds: 86400
 usage_retention_days: 7
-ai_job_retention_days: 0
-ai_job_error_retention_days: 0
+ai_job_retention_days: 7
+ai_job_error_retention_days: 14

--- a/web/modules/custom/myeventlane_ai/myeventlane_ai.services.yml
+++ b/web/modules/custom/myeventlane_ai/myeventlane_ai.services.yml
@@ -47,6 +47,10 @@ services:
     class: Drupal\myeventlane_ai\Service\AiJobCleanupService
     arguments: ['@entity_type.manager', '@logger.channel.myeventlane_ai']
 
+  myeventlane_ai.job_retention_policy:
+    class: Drupal\myeventlane_ai\Service\AiJobRetentionPolicy
+    arguments: ['@config.factory']
+
   logger.channel.myeventlane_ai:
     parent: logger.channel_base
     arguments: ['myeventlane_ai']

--- a/web/modules/custom/myeventlane_ai/src/Plugin/QueueWorker/AiJobQueueWorker.php
+++ b/web/modules/custom/myeventlane_ai/src/Plugin/QueueWorker/AiJobQueueWorker.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_ai\Plugin\QueueWorker;
 
-use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Queue\QueueWorkerBase;
 use Drupal\myeventlane_ai\Entity\AiJob;
 use Drupal\myeventlane_ai\Service\AiManager;
+use Drupal\myeventlane_ai\Service\AiJobRetentionPolicy;
 use Drupal\myeventlane_ai\Service\PromptRegistry;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -32,7 +32,7 @@ final class AiJobQueueWorker extends QueueWorkerBase implements ContainerFactory
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly AiManager $aiManager,
     private readonly PromptRegistry $promptRegistry,
-    private readonly ConfigFactoryInterface $configFactory,
+    private readonly AiJobRetentionPolicy $retentionPolicy,
     private readonly LoggerInterface $logger,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
@@ -49,7 +49,7 @@ final class AiJobQueueWorker extends QueueWorkerBase implements ContainerFactory
       $container->get('entity_type.manager'),
       $container->get('myeventlane_ai.manager'),
       $container->get('myeventlane_ai.prompt_registry'),
-      $container->get('config.factory'),
+      $container->get('myeventlane_ai.job_retention_policy'),
       $container->get('logger.channel.myeventlane_ai'),
     );
   }
@@ -83,6 +83,7 @@ final class AiJobQueueWorker extends QueueWorkerBase implements ContainerFactory
     if ($definition === NULL) {
       $job->set('status', AiJob::STATUS_ERROR);
       $job->set('error_message', 'Prompt config missing or invalid.');
+      $this->setExpiresAt($job);
       $job->save();
       return;
     }
@@ -103,10 +104,10 @@ final class AiJobQueueWorker extends QueueWorkerBase implements ContainerFactory
       $job->set('result_text', trim($result->raw));
       $job->set('model', $result->model ?? '');
       $job->set('prompt_hash', $definition->getPromptHash());
-      if ($result->token_counts !== null) {
+      if ($result->token_counts !== NULL) {
         $job->set('token_counts', json_encode($result->token_counts));
       }
-      if ($result->estimated_cost_usd !== null) {
+      if ($result->estimated_cost_usd !== NULL) {
         $job->set('estimated_cost_usd', $result->estimated_cost_usd);
       }
     }
@@ -124,21 +125,13 @@ final class AiJobQueueWorker extends QueueWorkerBase implements ContainerFactory
    * Sets expires_at when job completes (done or error).
    */
   private function setExpiresAt(AiJob $job): void {
-    $config = $this->configFactory->get('myeventlane_ai.settings');
-    $status = $job->get('status')->value;
-
-    $retention_days = match ($status) {
-      AiJob::STATUS_DONE => (int) ($config->get('ai_job_retention_days') ?? 7),
-      AiJob::STATUS_ERROR => (int) ($config->get('ai_job_error_retention_days') ?? 14),
-      default => 0,
-    };
-
-    if ($retention_days <= 0) {
-      return;
+    $expires_at = $this->retentionPolicy->expiryFor(
+      (string) $job->get('status')->value,
+      (int) $job->get('created')->value,
+    );
+    if ($expires_at > 0) {
+      $job->set('expires_at', $expires_at);
     }
-
-    $created = (int) $job->get('created')->value;
-    $job->set('expires_at', $created + ($retention_days * 86400));
   }
 
 }

--- a/web/modules/custom/myeventlane_ai/src/Service/AiJobRetentionPolicy.php
+++ b/web/modules/custom/myeventlane_ai/src/Service/AiJobRetentionPolicy.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_ai\Service;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\myeventlane_ai\Entity\AiJob;
+
+/**
+ * Calculates expiry timestamps for terminal AI job states.
+ */
+final class AiJobRetentionPolicy {
+
+  private const SECONDS_PER_DAY = 86400;
+
+  public function __construct(
+    private readonly ConfigFactoryInterface $configFactory,
+  ) {}
+
+  /**
+   * Returns an expiry timestamp, or zero for a non-terminal/disabled policy.
+   */
+  public function expiryFor(string $status, int $created): int {
+    $config = $this->configFactory->get('myeventlane_ai.settings');
+    $retention_days = match ($status) {
+      AiJob::STATUS_DONE => (int) ($config->get('ai_job_retention_days') ?? 7),
+      AiJob::STATUS_ERROR => (int) ($config->get('ai_job_error_retention_days') ?? 14),
+      default => 0,
+    };
+
+    return $retention_days > 0
+      ? $created + ($retention_days * self::SECONDS_PER_DAY)
+      : 0;
+  }
+
+}

--- a/web/modules/custom/myeventlane_ai/tests/src/Unit/AiJobRetentionPolicyTest.php
+++ b/web/modules/custom/myeventlane_ai/tests/src/Unit/AiJobRetentionPolicyTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_ai\Unit;
+
+use Drupal\Core\Config\Config;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\myeventlane_ai\Entity\AiJob;
+use Drupal\myeventlane_ai\Service\AiJobRetentionPolicy;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests AI job retention expiry calculation.
+ */
+#[Group('myeventlane_ai')]
+final class AiJobRetentionPolicyTest extends TestCase {
+
+  private const CREATED = 1_700_000_000;
+
+  /**
+   * Tests the configured expiry for successful and failed jobs.
+   */
+  public function testTerminalStatusExpiry(): void {
+    $policy = $this->policy(7, 14);
+
+    $this->assertSame(self::CREATED + (7 * 86400), $policy->expiryFor(AiJob::STATUS_DONE, self::CREATED));
+    $this->assertSame(self::CREATED + (14 * 86400), $policy->expiryFor(AiJob::STATUS_ERROR, self::CREATED));
+  }
+
+  /**
+   * Tests that active jobs never receive an expiry timestamp.
+   */
+  public function testActiveStatusHasNoExpiry(): void {
+    $policy = $this->policy(7, 14);
+
+    $this->assertSame(0, $policy->expiryFor(AiJob::STATUS_QUEUED, self::CREATED));
+    $this->assertSame(0, $policy->expiryFor(AiJob::STATUS_RUNNING, self::CREATED));
+  }
+
+  /**
+   * Tests that zero explicitly disables expiry for a terminal state.
+   */
+  public function testZeroRetentionHasNoExpiry(): void {
+    $policy = $this->policy(0, 0);
+
+    $this->assertSame(0, $policy->expiryFor(AiJob::STATUS_DONE, self::CREATED));
+    $this->assertSame(0, $policy->expiryFor(AiJob::STATUS_ERROR, self::CREATED));
+  }
+
+  /**
+   * Builds the policy with controlled retention configuration.
+   */
+  private function policy(int $done_days, int $error_days): AiJobRetentionPolicy {
+    $config = $this->createMock(Config::class);
+    $config->method('get')->willReturnMap([
+      ['ai_job_retention_days', $done_days],
+      ['ai_job_error_retention_days', $error_days],
+    ]);
+    $factory = $this->createMock(ConfigFactoryInterface::class);
+    $factory->method('get')->with('myeventlane_ai.settings')->willReturn($config);
+
+    return new AiJobRetentionPolicy($factory);
+  }
+
+}


### PR DESCRIPTION
## What changed

- explicitly enable AI rate limiting in synchronised configuration
- retain successful AI jobs for 7 days
- retain errored AI jobs for 14 days
- extract expiry calculation into a narrow, testable retention-policy service
- apply expiry to normal completion, provider errors and missing-prompt failures
- add focused tests for successful, failed, queued, running and disabled-retention states

## Why

Staging currently configures successful and failed AI jobs for infinite retention. Completed jobs can hold generated response text and operational metadata. The existing cleanup service only deletes records with a populated expiry timestamp, so new terminal jobs need an explicit bounded policy.

## Impact

After the reviewed configuration import, newly completed AI jobs will receive a 7-day expiry and newly failed jobs a 14-day expiry. Queued and running jobs remain untouched. Rate limiting is made explicit rather than relying on the current safe fallback for a missing key.

This PR does not backfill or delete existing records. It does not implement escalation-insight retention, change entity schema, process AI queues or alter MEL Hold.

## Validation

- PHPUnit: 3 tests, 12 assertions
- Drupal Check: zero findings for `myeventlane_ai`
- Drupal and DrupalPractice coding standards: clean
- Composer validation: clean
- PHP syntax and diff checks: clean

## Deployment and configuration gate

The staging deployment workflow runs a configuration import. Before deployment, review that the only intended `myeventlane_ai.settings` changes are:

- `rate_limit_enabled`: explicit `true`
- `ai_job_retention_days`: `0` to `7`
- `ai_job_error_retention_days`: `0` to `14`

Deployment and configuration import require separate explicit approval. Existing AI records must remain unchanged in this tranche.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operational retention and config-only rate-limit flag; no auth or schema changes, and existing jobs are not backfilled.
> 
> **Overview**
> **Sync config** turns on explicit `rate_limit_enabled` and sets **7-day** retention for successful AI jobs and **14-day** for failed ones (replacing `0`, which left terminal jobs without expiry and outside cleanup).
> 
> **Retention logic** moves from inline config in `AiJobQueueWorker` into **`AiJobRetentionPolicy`**, which computes `expires_at` from status and `created`. The queue worker now calls that service on **done**, **provider error**, and **missing-prompt** terminal paths; queued/running jobs still get no expiry.
> 
> **Tests** cover done/error expiry, active statuses, and zero-day (disabled) retention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 747c39cde30e86a1942887a28e9007a7e63aa617. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->