### PR TITLE
Update Commerce PayPal to security release 2.1.3

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2217,17 +2217,17 @@
         },
         {
             "name": "drupal/commerce_paypal",
-            "version": "2.1.2",
+            "version": "2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/commerce_paypal.git",
-                "reference": "2.1.2"
+                "reference": "2.1.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/commerce_paypal-2.1.2.zip",
-                "reference": "2.1.2",
-                "shasum": "e35dca0ca7c8ac0c10f390f9eaf3502e7553e022"
+                "url": "https://ftp.drupal.org/files/projects/commerce_paypal-2.1.3.zip",
+                "reference": "2.1.3",
+                "shasum": "7fd1f8be9c04110365507273a2629e02ca52faa8"
             },
             "require": {
                 "drupal/commerce": "^2.40 || ^3",
@@ -2243,8 +2243,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.1.2",
-                    "datestamp": "1776953529",
+                    "version": "2.1.3",
+                    "datestamp": "1786557128",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
## What changed

- update `drupal/commerce_paypal` from 2.1.2 to 2.1.3 in `composer.lock`
- keep the tranche limited to the affected dependency record

## Why

Commerce PayPal 2.1.2 is affected by SA-CONTRIB-2026-095 / CVE-2026-73475, an access-bypass vulnerability. Version 2.1.3 contains the upstream security fix.

## Impact

No custom code, Drupal configuration, database schema or MEL Hold files are changed. No real payment or refund was performed during validation.

## Validation

- lockfile-controlled Composer installation completed
- `composer audit --no-dev --locked`: no security advisories found
- configuration safety check passed
- webroot safety check passed
- mandatory Drupal Check scope: zero errors
- governance audits passed
- governance test suite: 198 tests, 2,719 assertions; one existing warning and 182 deprecations reported

## Deployment verification required

- confirm the deployed release and revision
- rebuild Drupal caches
- verify bootstrap, database, pending updates, entity-definition changes and configuration status
- verify PayPal gateway visibility and a non-charge checkout path; do not perform a real payment
- confirm MEL Hold release pointer and health remain unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment-gateway code for a known access-bypass CVE; risk is limited to a patch-level dependency bump with no local code changes, but post-deploy PayPal/checkout smoke checks are still warranted.
> 
> **Overview**
> Bumps **`drupal/commerce_paypal`** in **`composer.lock`** from **2.1.2** to **2.1.3** so the installed PayPal Commerce integration picks up the upstream fix for **SA-CONTRIB-2026-095** / **CVE-2026-73475** (access bypass). No application code, config, or schema changes—only the locked package version, dist URL, git reference, and shasum for that dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b1a3ae379ec3d4ae20361fe1fd6b43f7ec16a1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->