### PR TITLE
Harden legacy support search API

### DIFF
--- a/web/modules/custom/myeventlane_support/myeventlane_support.services.yml
+++ b/web/modules/custom/myeventlane_support/myeventlane_support.services.yml
@@ -1,0 +1,8 @@
+services:
+  myeventlane_support.search_request_guard:
+    class: Drupal\myeventlane_support\Service\SupportSearchRequestGuard
+    arguments: ['@flood', '@logger.channel.myeventlane_support']
+
+  logger.channel.myeventlane_support:
+    parent: logger.channel_base
+    arguments: ['myeventlane_support']

--- a/web/modules/custom/myeventlane_support/src/Controller/SupportController.php
+++ b/web/modules/custom/myeventlane_support/src/Controller/SupportController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_support\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\myeventlane_support\Service\SupportSearchRequestGuard;
 use Drupal\node\NodeInterface;
 use Drupal\views\Views;
 use Psr\Log\LoggerInterface;
@@ -22,6 +23,7 @@ final class SupportController extends ControllerBase {
   public function __construct(
     private readonly RequestStack $requestStack,
     private readonly LoggerInterface $logger,
+    private readonly SupportSearchRequestGuard $searchRequestGuard,
   ) {}
 
   /**
@@ -30,7 +32,8 @@ final class SupportController extends ControllerBase {
   public static function create(ContainerInterface $container): static {
     return new static(
       $container->get('request_stack'),
-      $container->get('logger.factory')->get('myeventlane_support'),
+      $container->get('logger.channel.myeventlane_support'),
+      $container->get('myeventlane_support.search_request_guard'),
     );
   }
 
@@ -68,13 +71,27 @@ final class SupportController extends ControllerBase {
   }
 
   /**
-   * Returns help article search hits for integrations that still call this JSON route.
+   * Returns help article search hits for integrations using this JSON route.
    */
   public function searchApi(Request $request): JsonResponse {
     $raw = (string) ($request->query->get('q') ?? '');
     $query = trim($raw);
+    if (!$this->searchRequestGuard->isAllowed($request)) {
+      $response = new JsonResponse([
+        'results' => [],
+        'error' => 'rate_limited',
+      ], 429);
+      $response->headers->set('Retry-After', '60');
+      $response->setMaxAge(0);
+      $response->headers->addCacheControlDirective('no-store');
+      return $response;
+    }
     if ($query === '') {
-      return new JsonResponse(['results' => []]);
+      $this->searchRequestGuard->record('empty_query');
+      $response = new JsonResponse(['results' => []]);
+      $response->setMaxAge(0);
+      $response->headers->addCacheControlDirective('no-store');
+      return $response;
     }
     if (mb_strlen($query) > 500) {
       $query = mb_substr($query, 0, 500);
@@ -83,7 +100,14 @@ final class SupportController extends ControllerBase {
     $view = Views::getView('mel_help_search');
     if ($view === NULL) {
       $this->logger->error('Support search API: mel_help_search view is not available.');
-      return new JsonResponse(['results' => [], 'error' => 'search_unavailable'], 503);
+      $this->searchRequestGuard->record('search_unavailable');
+      $response = new JsonResponse([
+        'results' => [],
+        'error' => 'search_unavailable',
+      ], 503);
+      $response->setMaxAge(0);
+      $response->headers->addCacheControlDirective('no-store');
+      return $response;
     }
 
     $view->setDisplay('block_search');
@@ -109,6 +133,7 @@ final class SupportController extends ControllerBase {
     }
 
     $response = new JsonResponse(['results' => $results]);
+    $this->searchRequestGuard->record('success', count($results));
     $response->setMaxAge(0);
     $response->headers->addCacheControlDirective('no-store');
     return $response;

--- a/web/modules/custom/myeventlane_support/src/Service/SupportSearchRequestGuard.php
+++ b/web/modules/custom/myeventlane_support/src/Service/SupportSearchRequestGuard.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_support\Service;
+
+use Drupal\Component\Utility\Crypt;
+use Drupal\Core\Flood\FloodInterface;
+use Drupal\Core\Site\Settings;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Applies public support-search limits and records privacy-safe usage events.
+ */
+final class SupportSearchRequestGuard {
+
+  private const BURST_EVENT = 'myeventlane_support.search_burst';
+
+  private const HOURLY_EVENT = 'myeventlane_support.search_hourly';
+
+  private const BURST_LIMIT = 60;
+
+  private const BURST_WINDOW = 60;
+
+  private const HOURLY_LIMIT = 600;
+
+  private const HOURLY_WINDOW = 3600;
+
+  public function __construct(
+    private readonly FloodInterface $flood,
+    private readonly LoggerInterface $logger,
+  ) {}
+
+  /**
+   * Returns whether this client may perform another search.
+   */
+  public function isAllowed(Request $request): bool {
+    $identifier = $this->identifier($request);
+
+    if (!$this->flood->isAllowed(self::BURST_EVENT, self::BURST_LIMIT, self::BURST_WINDOW, $identifier)) {
+      return FALSE;
+    }
+    if (!$this->flood->isAllowed(self::HOURLY_EVENT, self::HOURLY_LIMIT, self::HOURLY_WINDOW, $identifier)) {
+      return FALSE;
+    }
+
+    $this->flood->register(self::BURST_EVENT, self::BURST_WINDOW, $identifier);
+    $this->flood->register(self::HOURLY_EVENT, self::HOURLY_WINDOW, $identifier);
+    return TRUE;
+  }
+
+  /**
+   * Records an aggregate-friendly event without query text or client identity.
+   */
+  public function record(string $outcome, int $resultCount = 0): void {
+    $this->logger->info('Legacy support search API request: {outcome}; results: {result_count}.', [
+      'outcome' => $outcome,
+      'result_count' => max(0, $resultCount),
+    ]);
+  }
+
+  /**
+   * Builds an installation-specific, non-reversible flood identifier.
+   */
+  private function identifier(Request $request): string {
+    $clientIp = $request->getClientIp() ?? 'unknown';
+    return Crypt::hmacBase64('support-search|' . $clientIp, Settings::getHashSalt());
+  }
+
+}

--- a/web/modules/custom/myeventlane_support/tests/src/Unit/SupportControllerTest.php
+++ b/web/modules/custom/myeventlane_support/tests/src/Unit/SupportControllerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_support\Unit;
+
+use Drupal\Core\Flood\FloodInterface;
+use Drupal\Core\Site\Settings;
+use Drupal\myeventlane_support\Controller\SupportController;
+use Drupal\myeventlane_support\Service\SupportSearchRequestGuard;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_support\Controller\SupportController
+ *
+ * @group myeventlane_support
+ */
+final class SupportControllerTest extends TestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    new Settings(['hash_salt' => 'support-controller-test-salt']);
+  }
+
+  /**
+   * @covers ::searchApi
+   */
+  public function testEmptyQueryIsLimitedAndRecordedWithoutSearch(): void {
+    $flood = $this->createMock(FloodInterface::class);
+    $flood->expects($this->exactly(2))->method('isAllowed')->willReturn(TRUE);
+    $flood->expects($this->exactly(2))->method('register');
+
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->once())
+      ->method('info')
+      ->with(
+        'Legacy support search API request: {outcome}; results: {result_count}.',
+        ['outcome' => 'empty_query', 'result_count' => 0],
+      );
+
+    $response = $this->controller($flood, $logger)->searchApi(
+      Request::create('/support/search-api'),
+    );
+
+    $this->assertSame(200, $response->getStatusCode());
+    $this->assertSame(['results' => []], json_decode((string) $response->getContent(), TRUE));
+    $this->assertStringContainsString('no-store', (string) $response->headers->get('Cache-Control'));
+  }
+
+  /**
+   * @covers ::searchApi
+   */
+  public function testRateLimitedResponsePreservesJsonContractAndNoStore(): void {
+    $flood = $this->createMock(FloodInterface::class);
+    $flood->expects($this->once())->method('isAllowed')->willReturn(FALSE);
+    $flood->expects($this->never())->method('register');
+
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->never())->method('info');
+
+    $response = $this->controller($flood, $logger)->searchApi(
+      Request::create('/support/search-api?q=refund'),
+    );
+
+    $this->assertSame(429, $response->getStatusCode());
+    $this->assertSame('60', $response->headers->get('Retry-After'));
+    $this->assertStringContainsString('no-store', (string) $response->headers->get('Cache-Control'));
+    $this->assertSame(
+      ['results' => [], 'error' => 'rate_limited'],
+      json_decode((string) $response->getContent(), TRUE),
+    );
+  }
+
+  /**
+   * Builds a controller with isolated flood and logging collaborators.
+   */
+  private function controller(
+    FloodInterface $flood,
+    LoggerInterface $logger,
+  ): SupportController {
+    return new SupportController(
+      new RequestStack(),
+      $logger,
+      new SupportSearchRequestGuard($flood, $logger),
+    );
+  }
+
+}

--- a/web/modules/custom/myeventlane_support/tests/src/Unit/SupportSearchRequestGuardTest.php
+++ b/web/modules/custom/myeventlane_support/tests/src/Unit/SupportSearchRequestGuardTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_support\Unit;
+
+use Drupal\Core\Flood\FloodInterface;
+use Drupal\Core\Site\Settings;
+use Drupal\myeventlane_support\Service\SupportSearchRequestGuard;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @coversDefaultClass \Drupal\myeventlane_support\Service\SupportSearchRequestGuard
+ *
+ * @group myeventlane_support
+ */
+final class SupportSearchRequestGuardTest extends TestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    new Settings(['hash_salt' => 'support-search-test-salt']);
+  }
+
+  /**
+   * @covers ::isAllowed
+   */
+  public function testAllowedRequestRegistersBothLimitsWithHashedIdentifier(): void {
+    $flood = $this->createMock(FloodInterface::class);
+    $identifiers = [];
+    $flood->expects($this->exactly(2))
+      ->method('isAllowed')
+      ->willReturnCallback(function (string $event, int $threshold, int $window, string $identifier) use (&$identifiers): bool {
+        $identifiers[] = $identifier;
+        $this->assertNotSame('203.0.113.4', $identifier);
+        return TRUE;
+      });
+    $flood->expects($this->exactly(2))
+      ->method('register')
+      ->willReturnCallback(function (string $event, int $window, string $identifier) use (&$identifiers): void {
+        $this->assertSame($identifiers[0], $identifier);
+      });
+
+    $guard = new SupportSearchRequestGuard($flood, $this->createMock(LoggerInterface::class));
+    $request = Request::create('/support/search-api?q=refund', 'GET', [], [], [], ['REMOTE_ADDR' => '203.0.113.4']);
+
+    $this->assertTrue($guard->isAllowed($request));
+    $this->assertCount(2, $identifiers);
+    $this->assertSame($identifiers[0], $identifiers[1]);
+  }
+
+  /**
+   * @covers ::isAllowed
+   */
+  public function testBurstLimitDenialDoesNotAmplifyLoggingOrRegister(): void {
+    $flood = $this->createMock(FloodInterface::class);
+    $flood->expects($this->once())->method('isAllowed')->willReturn(FALSE);
+    $flood->expects($this->never())->method('register');
+
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->never())->method('info');
+
+    $guard = new SupportSearchRequestGuard($flood, $logger);
+    $this->assertFalse($guard->isAllowed(Request::create('/support/search-api?q=refund')));
+  }
+
+  /**
+   * @covers ::record
+   */
+  public function testUsageRecordContainsOnlyOutcomeAndResultCount(): void {
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger->expects($this->once())
+      ->method('info')
+      ->with(
+        'Legacy support search API request: {outcome}; results: {result_count}.',
+        ['outcome' => 'success', 'result_count' => 3],
+      );
+
+    $guard = new SupportSearchRequestGuard($this->createMock(FloodInterface::class), $logger);
+    $guard->record('success', 3);
+  }
+
+}


### PR DESCRIPTION
## What changed

- added per-client burst and hourly flood limits to the legacy public support search API
- returned a stable JSON 429 response with Retry-After and no-store headers
- replaced raw client identifiers with an installation-specific HMAC identifier
- added privacy-safe usage events containing only outcome and result count
- avoided logging rejected requests to prevent logging amplification
- added focused unit coverage for flood registration, hashed identifiers, empty requests and rate-limited responses

## Why

`/support/search-api` remains publicly accessible while its external consumers are unconfirmed. The endpoint previously executed a Drupal View without request-frequency controls or focused regression coverage.

This keeps the compatibility route available while reducing abuse risk and providing bounded evidence for the later retain-or-retire decision.

## Impact

- no configuration or database changes
- no module retirement
- successful response schema remains unchanged
- clients exceeding 60 requests per minute or 600 per hour receive HTTP 429

## Validation

- PHPUnit: 5 tests, 27 assertions
- Drupal coding standards
- Drupal Check/PHPStan: zero findings
- Composer validation
- PHP syntax and Git whitespace checks

Deployment, configuration reconciliation and the compatibility-period decision remain separate gates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes behavior for abusive or high-volume clients on a public endpoint; legitimate traffic within limits is unaffected, but shared NAT users could hit caps together.
> 
> **Overview**
> Adds **per-client flood limits** and **privacy-safe usage logging** to the public legacy JSON route `/support/search-api`, which still powers help search from front-end integrations.
> 
> A new `SupportSearchRequestGuard` enforces **60 requests/minute** and **600/hour** using Drupal flood, keyed by an **HMAC of client IP** (not raw IP). Over-limit callers get **HTTP 429** with `error: rate_limited`, `Retry-After: 60`, and **no-store** cache headers; successful JSON shape is unchanged.
> 
> Allowed requests log only **outcome** and **result count** (no query text); **denied requests are not logged** to avoid amplification. All search API responses now set **no-store** cache control. Unit tests cover the guard, empty-query handling, and 429 contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1474fb801c54b1c705e2194ab3498807070c646d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->