### PR TITLE
Retire vendor settings compatibility module config

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -151,7 +151,6 @@ module:
   myeventlane_vendor_analytics: 0
   myeventlane_vendor_comms: 0
   myeventlane_vendor_nudges: 0
-  myeventlane_vendor_settings: 0
   myeventlane_venue: 0
   myeventlane_views: 0
   myeventlane_wallet: 0


### PR DESCRIPTION
## What changed

- Remove `myeventlane_vendor_settings` from synchronised enabled extensions.
- Keep the compatibility module code in place for this release.

## Why

PR #809 moved all runtime ownership into `myeventlane_vendor`. The remaining module is metadata-only and Drupal reports no dependent configuration or owned tables.

This is the first half of a two-release retirement. Removing active configuration before deleting the module code avoids the bootstrap failure that occurs when Drupal expects an enabled extension whose code is absent.

## Validation

- Verified compressed, owner-only DDEV database backup before uninstall.
- Uninstalled only `myeventlane_vendor_settings` in DDEV.
- Drupal 11.4.5 bootstrap and database connection successful.
- No pending database updates or entity-definition changes.
- `/vendor/settings` and `/vendor/settings/profile` still resolve to `myeventlane_vendor` ownership.
- Focused contract test: 5 tests, 39 assertions.
- Cache rebuild successful.
- YAML parse and focused diff checks passed.

## Deployment

Staging requires a fresh verified database backup before importing this configuration change. Code deletion remains a separate later release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single config export change for a metadata-only shim with no owned tables; vendor settings routes stay on `myeventlane_vendor` per prior migration.
> 
> **Overview**
> **Disables the legacy `myeventlane_vendor_settings` compatibility module** in exported Drupal config by removing it from `config/sync/core.extension.yml`. This is the first step of a two-release retirement after PR #809 moved vendor settings runtime to `myeventlane_vendor`.
> 
> The module’s PHP remains in the repo for this release; only the enabled-extension list changes so environments can uninstall the shim without bootstrap errors from missing code on a later delete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d97d5b1a70166cb99410b8ed284c6ef56a01bac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->