### PR TITLE
Delete retired vendor settings compatibility shim

### DIFF
--- a/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorSettingsPresentationContractTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Unit/VendorSettingsPresentationContractTest.php
@@ -82,22 +82,15 @@ final class VendorSettingsPresentationContractTest extends TestCase {
   }
 
   /**
-   * Ensures the enabled compatibility module owns no runtime surface.
+   * Ensures the retired compatibility module cannot be re-enabled.
    */
-  public function testCompatibilityModuleIsMetadataOnly(): void {
+  public function testCompatibilityModuleIsRetired(): void {
     $module_root = dirname(__DIR__, 4) . '/myeventlane_vendor_settings';
-    $info = file_get_contents($module_root . '/myeventlane_vendor_settings.info.yml');
-    self::assertIsString($info);
-    self::assertStringContainsString(
-      'myeventlane_vendor:myeventlane_vendor',
-      $info,
-    );
+    self::assertFileDoesNotExist($module_root . '/myeventlane_vendor_settings.info.yml');
 
-    self::assertFileDoesNotExist($module_root . '/myeventlane_vendor_settings.routing.yml');
-    self::assertFileDoesNotExist($module_root . '/myeventlane_vendor_settings.libraries.yml');
-    self::assertSame([], glob($module_root . '/src/**/*.php') ?: []);
-    self::assertSame([], glob($module_root . '/css/*') ?: []);
-    self::assertSame([], glob($module_root . '/js/*') ?: []);
+    $extensions = file_get_contents(dirname(__DIR__, 7) . '/config/sync/core.extension.yml');
+    self::assertIsString($extensions);
+    self::assertStringNotContainsString('myeventlane_vendor_settings:', $extensions);
   }
 
 }

--- a/web/modules/custom/myeventlane_vendor_settings/myeventlane_vendor_settings.info.yml
+++ b/web/modules/custom/myeventlane_vendor_settings/myeventlane_vendor_settings.info.yml
@@ -1,8 +1,0 @@
-name: 'MEL Vendor Settings'
-type: module
-description: 'Compatibility shim for vendor settings now owned by MyEventLane Vendor.'
-core_version_requirement: ^11
-package: MEL
-lifecycle: stable
-dependencies:
-  - myeventlane_vendor:myeventlane_vendor


### PR DESCRIPTION
## What changed

- Delete the retired `myeventlane_vendor_settings` module metadata.
- Update the focused contract to prevent the extension metadata or enabled-extension entry returning.

## Why

PR #810 removed the shim from synchronised and active staging configuration. Staging then confirmed the module disabled, no `core.extension` entry, no `system.schema` record, clean configuration status and healthy organiser routes.

The module has no runtime code, routes, services, permissions, schema or dependent configuration. Its metadata can now be removed without leaving Drupal configured for a missing extension.

## Validation

- PHP syntax check passed.
- Focused contract: 5 tests, 35 assertions.
- Diff whitespace check passed.
- Staging precondition verified after PR #810 deployment.

## Deployment

No database update or configuration import is expected from this deletion-only release. Verify staging bootstrap, configuration status, organiser routes and MEL Hold after deployment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion-only cleanup with no runtime, routes, or config import expected; risk is limited to accidentally reintroducing a missing extension reference, which the updated test guards against.
> 
> **Overview**
> Removes the last on-disk trace of the **`myeventlane_vendor_settings`** compatibility module by deleting its **`myeventlane_vendor_settings.info.yml`**, after vendor settings were already owned by **`myeventlane_vendor`** and the extension was dropped from sync config in PR #810.
> 
> The presentation contract test is retargeted: instead of asserting the shim had metadata but no routes, libraries, or PHP, it now asserts the **`.info.yml` is absent** and **`config/sync/core.extension.yml`** does not enable **`myeventlane_vendor_settings`**, so the retired extension cannot creep back into the tree or config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91690264eb1ecb124e6651def20abc8140cafde6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->