### PR TITLE
Restore Event Studio content navigation and public descriptions

### DIFF
--- a/web/modules/custom/myeventlane_event/tests/src/Unit/PublicEventBodyTemplateContractTest.php
+++ b/web/modules/custom/myeventlane_event/tests/src/Unit/PublicEventBodyTemplateContractTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the public event description rendering contract.
+ *
+ * @group myeventlane_event
+ */
+final class PublicEventBodyTemplateContractTest extends TestCase {
+
+  public function testBodyIsRenderedOnceAndReusedForOutput(): void {
+    $moduleRoot = dirname(__DIR__, 3);
+    $webRoot = dirname($moduleRoot, 3);
+    $template = (string) file_get_contents(
+      $webRoot . '/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig',
+    );
+
+    self::assertSame(1, substr_count($template, 'content.body|render'));
+    self::assertStringContainsString('{{ body_render }}', $template);
+    self::assertStringNotContainsString('{{ content.body }}', $template);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/ContentSection.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Plugin/EventStudioSection/ContentSection.php
@@ -7,7 +7,7 @@ namespace Drupal\myeventlane_event_studio\Plugin\EventStudioSection;
 use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
 
 /**
- * Content section — nested under Details (not primary Workspace nav).
+ * Content section — public event story, highlights, and guest policies.
  */
 #[EventStudioSection(
   id: 'content',
@@ -23,6 +23,6 @@ use Drupal\myeventlane_event_studio\Attribute\EventStudioSection;
   empty_state_type: 'none',
   mobile_priority: 30,
   operationalArea: 'event',
-  navigationVisible: FALSE,
+  navigationVisible: TRUE,
 )]
 final class ContentSection extends EventStudioSectionBase {}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioManageEventIaTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioManageEventIaTest.php
@@ -69,6 +69,25 @@ final class EventStudioManageEventIaTest extends UnitTestCase {
     $this->assertStringContainsString('myeventlane_vendor.console.event_workspace', $tasks);
   }
 
+  public function testContentEditorsAreReachableFromWorkspaceNavigation(): void {
+    $section = file_get_contents(dirname(__DIR__, 3) . '/src/Plugin/EventStudioSection/ContentSection.php');
+    $form = file_get_contents(dirname(__DIR__, 3) . '/src/Form/EventStudioDescriptionForm.php');
+    $tabs = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_vendor/src/Service/VendorEventTabsService.php');
+    $fallback = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_vendor/src/Hook/VendorConsolePagePreprocess.php');
+
+    $this->assertIsString($section);
+    $this->assertStringContainsString('navigationVisible: TRUE', $section);
+    $this->assertIsString($form);
+    $this->assertStringContainsString("\$form['mel']['body']", $form);
+    $this->assertStringContainsString("\$form['mel']['event_highlights']", $form);
+    $this->assertIsString($tabs);
+    $this->assertStringContainsString("'key' => 'content'", $tabs);
+    $this->assertStringContainsString('myeventlane_event_studio.workspace_content', $tabs);
+    $this->assertIsString($fallback);
+    $this->assertStringContainsString("'key' => 'content'", $fallback);
+    $this->assertStringContainsString('myeventlane_event_studio.workspace_content', $fallback);
+  }
+
   public function testManageEventBackLinkUsesWorkspaceRoute(): void {
     $theme = file_get_contents(dirname(__DIR__, 6) . '/themes/custom/myeventlane_vendor_theme/myeventlane_vendor_theme.theme');
     $twig = file_get_contents(dirname(__DIR__, 6) . '/themes/custom/myeventlane_vendor_theme/templates/mel-event/mel-event-workspace.html.twig');

--- a/web/modules/custom/myeventlane_vendor/src/Hook/VendorConsolePagePreprocess.php
+++ b/web/modules/custom/myeventlane_vendor/src/Hook/VendorConsolePagePreprocess.php
@@ -93,6 +93,7 @@ final class VendorConsolePagePreprocess {
     $workspace_tabs = [
       ['key' => 'overview', 'route' => 'myeventlane_event_studio.workspace', 'label' => $this->t('Overview'), 'url' => Url::fromRoute('myeventlane_event_studio.workspace', ['node' => $event_id])->toString()],
       ['key' => 'details', 'route' => 'myeventlane_event_studio.workspace_information', 'label' => $this->t('Details'), 'url' => Url::fromRoute('myeventlane_event_studio.workspace_information', ['node' => $event_id])->toString()],
+      ['key' => 'content', 'route' => 'myeventlane_event_studio.workspace_content', 'label' => $this->t('Content'), 'url' => Url::fromRoute('myeventlane_event_studio.workspace_content', ['node' => $event_id])->toString()],
       ['key' => 'tickets', 'route' => 'myeventlane_event_studio.workspace_tickets', 'label' => $this->t('Ticketing'), 'url' => Url::fromRoute('myeventlane_event_studio.workspace_tickets', ['node' => $event_id])->toString()],
       ['key' => 'attendees', 'route' => 'myeventlane_event_studio.workspace_attendees', 'label' => $this->t('Attendees'), 'url' => Url::fromRoute('myeventlane_event_studio.workspace_attendees', ['node' => $event_id])->toString()],
       ['key' => 'messages', 'route' => 'myeventlane_event_studio.workspace_messaging', 'label' => $this->t('Messages'), 'url' => Url::fromRoute('myeventlane_event_studio.workspace_messaging', ['node' => $event_id])->toString()],

--- a/web/modules/custom/myeventlane_vendor/src/Service/VendorEventTabsService.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/VendorEventTabsService.php
@@ -128,6 +128,14 @@ final class VendorEventTabsService {
         'disabled_reason' => '',
       ],
       [
+        'key' => 'content',
+        'label' => (string) $t->translate('Content'),
+        'route' => 'myeventlane_event_studio.workspace_content',
+        'params' => ['node' => $id],
+        'disabled' => FALSE,
+        'disabled_reason' => '',
+      ],
+      [
         'key' => 'schedule',
         'label' => (string) $t->translate('Schedule'),
         'route' => 'myeventlane_event_studio.workspace_schedule',

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -236,7 +236,7 @@
                   <h2 class="mel-card__title">{{ 'About the Event'|t }}</h2>
                 </div>
                 <div class="mel-card__body">
-                  {{ content.body }}
+                  {{ body_render }}
                 </div>
               </div>
             {% endif %}


### PR DESCRIPTION
## What changed

- restores the Event Studio Content section to organiser navigation
- adds the Content fallback tab to the vendor event workspace
- renders the already-resolved event body on public full event pages
- adds focused regression coverage for navigation and render-once behaviour

## Root cause

The Content section was explicitly hidden from navigation even though its route and form remained functional. On the public event page, the Twig template rendered `content.body` while checking whether it was empty, then attempted to render the consumed Drupal render array a second time.

## Impact

Organisers can reach About the Event and Event Highlights from Event Studio. Genuine About content now appears on the public event page. Existing placeholder-copy filtering remains unchanged.

## Validation

- focused Event Studio navigation test: passed, 11 assertions
- public event body template contract: passed, 3 assertions
- PHP syntax checks: passed
- Drupal cache rebuild: passed
- DDEV bootstrap, database, pending updates and entity definitions: healthy
- rendered DDEV verification: Content navigation visible and event 1094 About content displayed publicly

## Known unrelated result

The wider Event Studio IA test class still contains a pre-existing failure in `testStaffShellRetiredInFavorOfEventStudioRedirects`; this change does not alter that contract.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation and Twig display fixes with targeted unit tests; no auth, commerce, or data-model changes.
> 
> **Overview**
> Restores **Event Studio Content** in organiser navigation and wires a **Content** workspace tab through vendor event tabs and console preprocess fallback, so About the Event and highlights editing is reachable again via `workspace_content`.
> 
> On public full event pages, **About the Event** now outputs the pre-rendered `body_render` string instead of `{{ content.body }}`, fixing empty descriptions when the template had already consumed the body render array for emptiness checks.
> 
> Adds regression tests for workspace Content IA and for the Twig contract (single `content.body|render`, display via `body_render`, no direct `content.body` output).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 226759377bfd7e1a776264e16a38415dc0024d8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->