### PR TITLE
Stack public event content cards

### DIFF
--- a/web/modules/custom/myeventlane_event/tests/src/Unit/PublicEventBodyTemplateContractTest.php
+++ b/web/modules/custom/myeventlane_event/tests/src/Unit/PublicEventBodyTemplateContractTest.php
@@ -25,4 +25,29 @@ final class PublicEventBodyTemplateContractTest extends TestCase {
     self::assertStringNotContainsString('{{ content.body }}', $template);
   }
 
+  public function testPublicContentCardsUseOneOrderedColumn(): void {
+    $moduleRoot = dirname(__DIR__, 3);
+    $webRoot = dirname($moduleRoot, 3);
+    $template = (string) file_get_contents(
+      $webRoot . '/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig',
+    );
+    $styles = (string) file_get_contents(
+      $webRoot . '/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss',
+    );
+
+    self::assertStringContainsString('<div class="mel-event-full__content-grid">', $template);
+    self::assertStringNotContainsString('mel-event-full__content-grid--duo', $template);
+    self::assertStringNotContainsString('.mel-event-full__content-grid--duo', $styles);
+
+    $aboutPosition = strpos($template, "'About the Event'|t");
+    $highlightsPosition = strpos($template, "'Highlights'|t");
+    $expectPosition = strpos($template, "'What to expect'|t");
+
+    self::assertIsInt($aboutPosition);
+    self::assertIsInt($highlightsPosition);
+    self::assertIsInt($expectPosition);
+    self::assertLessThan($highlightsPosition, $aboutPosition);
+    self::assertLessThan($expectPosition, $highlightsPosition);
+  }
+
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -3089,13 +3089,6 @@ main.mel-main:has(.mel-event-full):not(:has(.mel-event-page--immersive.mel-event
   grid-template-columns: minmax(0, 1fr);
 }
 
-.mel-event-full__content-grid--duo {
-  @media (width >= 768px) {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    align-items: start;
-  }
-}
-
 .mel-event-full__content-grid > .mel-event-full__card {
   padding: var(--mel-full-card-pad, 20px);
 

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -229,7 +229,7 @@
         {% set _has_about = body_plain is not empty %}
         {% set _has_highlights = highlights|length > 0 %}
         {% if _has_about or _has_highlights or expect_text %}
-          <div class="mel-event-full__content-grid{% if _has_about and _has_highlights %} mel-event-full__content-grid--duo{% endif %}">
+          <div class="mel-event-full__content-grid">
             {% if _has_about %}
               <div class="mel-event-full__about mel-card mel-card--surface mel-event-full__card{% if not _has_highlights %} mel-event-full__about--wide{% endif %}">
                 <div class="mel-card__header">


### PR DESCRIPTION
## What changed

- stacks About the Event, Highlights and What to expect as full-width cards
- preserves their existing content order
- removes the desktop-only two-column modifier
- adds focused template and stylesheet contract coverage

## Impact

The public event content column is easier to scan and no longer gives About and Highlights unequal card widths. The ticket sidebar, mobile layout, data model and configuration are unchanged.

## Validation

- focused PHPUnit contract: 2 tests, 11 assertions
- CSS lint: passed
- Vite production build: passed
- Drupal cache rebuild: passed
- rendered DDEV HTML confirms About the Event, Highlights and What to expect in that order
- organiser visual acceptance completed in DDEV

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to the public event full template and SCSS; no booking, data, or backend logic touched.
> 
> **Overview**
> Public event full pages now render **About the Event**, **Highlights**, and **What to expect** as **full-width stacked cards** instead of putting About and Highlights side by side on desktop.
> 
> The Twig template drops the conditional `mel-event-full__content-grid--duo` class on `mel-event-full__content-grid`, and `_event-full.scss` removes the `@media (width >= 768px)` two-column rules for that modifier. Card order in the template is unchanged.
> 
> A new PHPUnit contract test in `PublicEventBodyTemplateContractTest` locks in a single-column grid (no `--duo` in template or styles) and asserts section heading order: About → Highlights → What to expect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3cd44d13ba6e7c11c1f07ece6239c0b8019d12a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->