### PR TITLE
Load MapKit credentials from the runtime environment

### DIFF
--- a/web/modules/custom/myeventlane_location/src/Service/MapKitTokenGenerator.php
+++ b/web/modules/custom/myeventlane_location/src/Service/MapKitTokenGenerator.php
@@ -124,9 +124,34 @@ final class MapKitTokenGenerator {
    */
   private function resolveCredentials(): ?array {
     $config = $this->configFactory->get('myeventlane_location.settings');
-    $team_id = (string) ($config->get('apple_maps_team_id') ?? '');
-    $key_id = (string) ($config->get('apple_maps_key_id') ?? '');
-    $private_key = (string) ($config->get('apple_maps_private_key') ?? '');
+    $team_id = $this->getEnvironmentValue('MEL_APPLE_MAPS_TEAM_ID');
+    $key_id = $this->getEnvironmentValue('MEL_APPLE_MAPS_KEY_ID');
+    $private_key = '';
+
+    if ($team_id === '') {
+      $team_id = (string) ($config->get('apple_maps_team_id') ?? '');
+    }
+    if ($key_id === '') {
+      $key_id = (string) ($config->get('apple_maps_key_id') ?? '');
+    }
+
+    $private_key_path = $this->getEnvironmentValue('MEL_APPLE_MAPS_PRIVATE_KEY_PATH');
+    if ($private_key_path !== '') {
+      if (!is_file($private_key_path) || !is_readable($private_key_path)) {
+        $this->logger->error('MapKit private key file is missing or unreadable.');
+        return NULL;
+      }
+
+      $contents = file_get_contents($private_key_path);
+      if (!is_string($contents) || $contents === '') {
+        $this->logger->error('MapKit private key file could not be read or was empty.');
+        return NULL;
+      }
+      $private_key = $contents;
+    }
+    else {
+      $private_key = (string) ($config->get('apple_maps_private_key') ?? '');
+    }
 
     if ($team_id === '' && defined('MYEVENTLANE_APPLE_MAPS_TEAM_ID')) {
       $team_id = (string) MYEVENTLANE_APPLE_MAPS_TEAM_ID;
@@ -154,6 +179,11 @@ final class MapKitTokenGenerator {
    * e.g. https://staging.myeventlane.com.au
    */
   private function resolveOrigin(): string {
+    $environment_origin = $this->getEnvironmentValue('MEL_APPLE_MAPS_ORIGIN');
+    if ($environment_origin !== '') {
+      return $environment_origin;
+    }
+
     if (defined('MYEVENTLANE_APPLE_MAPS_ORIGIN') && MYEVENTLANE_APPLE_MAPS_ORIGIN !== '') {
       return (string) MYEVENTLANE_APPLE_MAPS_ORIGIN;
     }
@@ -164,6 +194,23 @@ final class MapKitTokenGenerator {
     }
 
     return $request->getSchemeAndHttpHost();
+  }
+
+  /**
+   * Reads a non-empty runtime environment value.
+   */
+  private function getEnvironmentValue(string $name): string {
+    $value = getenv($name);
+    if (is_string($value) && $value !== '') {
+      return $value;
+    }
+    if (isset($_ENV[$name]) && is_string($_ENV[$name]) && $_ENV[$name] !== '') {
+      return $_ENV[$name];
+    }
+    if (isset($_SERVER[$name]) && is_string($_SERVER[$name]) && $_SERVER[$name] !== '') {
+      return $_SERVER[$name];
+    }
+    return '';
   }
 
   /**

--- a/web/modules/custom/myeventlane_location/tests/src/Unit/MapKitTokenGeneratorEnvironmentTest.php
+++ b/web/modules/custom/myeventlane_location/tests/src/Unit/MapKitTokenGeneratorEnvironmentTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_location\Unit;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\myeventlane_location\Service\MapKitTokenGenerator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Covers environment-owned MapKit credentials.
+ *
+ * @group myeventlane_location
+ */
+final class MapKitTokenGeneratorEnvironmentTest extends TestCase {
+
+  /**
+   * Environment variables used by this test.
+   */
+  private const ENVIRONMENT_NAMES = [
+    'MEL_APPLE_MAPS_TEAM_ID',
+    'MEL_APPLE_MAPS_KEY_ID',
+    'MEL_APPLE_MAPS_PRIVATE_KEY_PATH',
+    'MEL_APPLE_MAPS_ORIGIN',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function tearDown(): void {
+    foreach (self::ENVIRONMENT_NAMES as $name) {
+      putenv($name);
+      unset($_ENV[$name], $_SERVER[$name]);
+    }
+    parent::tearDown();
+  }
+
+  /**
+   * A missing key file keeps the provider unconfigured.
+   */
+  public function testMissingKeyFileIsRejected(): void {
+    $this->setCredentialEnvironment('/path/that/does/not/exist.p8');
+
+    self::assertFalse($this->createGenerator()->isConfigured());
+  }
+
+  /**
+   * An empty key file keeps the provider unconfigured.
+   */
+  public function testEmptyKeyFileIsRejected(): void {
+    $path = tempnam(sys_get_temp_dir(), 'mapkit-empty-');
+    self::assertIsString($path);
+
+    try {
+      $this->setCredentialEnvironment($path);
+      self::assertFalse($this->createGenerator()->isConfigured());
+    }
+    finally {
+      unlink($path);
+    }
+  }
+
+  /**
+   * An unreadable key file keeps the provider unconfigured.
+   */
+  public function testUnreadableKeyFileIsRejected(): void {
+    $path = tempnam(sys_get_temp_dir(), 'mapkit-unreadable-');
+    self::assertIsString($path);
+    self::assertNotFalse(file_put_contents($path, 'not-used'));
+    self::assertTrue(chmod($path, 0000));
+
+    try {
+      $this->setCredentialEnvironment($path);
+      self::assertFalse($this->createGenerator()->isConfigured());
+    }
+    finally {
+      chmod($path, 0600);
+      unlink($path);
+    }
+  }
+
+  /**
+   * A valid environment-owned key produces a browser-scoped JWT.
+   */
+  public function testValidKeyFileGeneratesTokenWithRequestOrigin(): void {
+    $key = openssl_pkey_new([
+      'private_key_type' => OPENSSL_KEYTYPE_EC,
+      'curve_name' => 'prime256v1',
+    ]);
+    self::assertNotFalse($key);
+    self::assertTrue(openssl_pkey_export($key, $privateKey));
+
+    $path = tempnam(sys_get_temp_dir(), 'mapkit-valid-');
+    self::assertIsString($path);
+    self::assertNotFalse(file_put_contents($path, $privateKey));
+
+    try {
+      $this->setCredentialEnvironment($path);
+      $generator = $this->createGenerator('https://staging.example.test', TRUE);
+      self::assertTrue($generator->isConfigured());
+      $token = $generator->generateToken();
+      $segments = explode('.', $token);
+
+      self::assertCount(3, $segments);
+      $payload = json_decode($this->decodeBase64Url($segments[1]), TRUE, flags: JSON_THROW_ON_ERROR);
+      self::assertSame('TEAM123456', $payload['iss']);
+      self::assertSame('https://staging.example.test', $payload['origin']);
+    }
+    finally {
+      unlink($path);
+    }
+  }
+
+  /**
+   * Creates the service with empty Drupal configuration.
+   */
+  private function createGenerator(?string $origin = NULL, bool $expectNoError = FALSE): MapKitTokenGenerator {
+    $config = $this->createMock(ImmutableConfig::class);
+    $config->method('get')->willReturn('');
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')->willReturn($config);
+
+    $logger = $this->createMock(LoggerChannelInterface::class);
+    if ($expectNoError) {
+      $logger->expects(self::never())->method('error');
+    }
+    $loggerFactory = $this->createMock(LoggerChannelFactoryInterface::class);
+    $loggerFactory->method('get')->willReturn($logger);
+
+    $requestStack = new RequestStack();
+    if ($origin !== NULL) {
+      $requestStack->push(Request::create($origin));
+    }
+
+    return new MapKitTokenGenerator($configFactory, $loggerFactory, $requestStack);
+  }
+
+  /**
+   * Sets complete non-secret identifiers and the supplied key path.
+   */
+  private function setCredentialEnvironment(string $keyPath): void {
+    $values = [
+      'MEL_APPLE_MAPS_TEAM_ID' => 'TEAM123456',
+      'MEL_APPLE_MAPS_KEY_ID' => 'KEY1234567',
+      'MEL_APPLE_MAPS_PRIVATE_KEY_PATH' => $keyPath,
+    ];
+    foreach ($values as $name => $value) {
+      putenv($name . '=' . $value);
+      $_ENV[$name] = $value;
+      $_SERVER[$name] = $value;
+    }
+  }
+
+  /**
+   * Decodes one JWT base64url segment.
+   */
+  private function decodeBase64Url(string $value): string {
+    $value .= str_repeat('=', (4 - strlen($value) % 4) % 4);
+    $decoded = base64_decode(strtr($value, '-_', '+/'), TRUE);
+    self::assertIsString($decoded);
+    return $decoded;
+  }
+
+}


### PR DESCRIPTION
## What changed

- Load MapKit Team ID and Key ID from the existing `MEL_APPLE_MAPS_*` runtime variables.
- Read the MapKit `.p8` private key from `MEL_APPLE_MAPS_PRIVATE_KEY_PATH` on the server.
- Support an optional `MEL_APPLE_MAPS_ORIGIN` override while retaining request-derived origins by default.
- Keep Drupal configuration and legacy PHP constants as fallbacks.
- Add focused tests for missing, empty, unreadable and valid private-key files, including ES256 JWT generation and the browser-origin claim.

## Why

Staging already loads the protected Apple Maps variables from `staging.env`, and the `.p8` file is valid and permission-restricted. The token generator did not read those variable names, so it reported incomplete credentials and returned no browser token.

## Security impact

The private key remains in the protected staging filesystem. Its contents are read only by the server-side token generator and are never included directly in frontend settings or committed to Git.

## Validation

- PHPUnit: 4 tests, 17 assertions passed.
- Focused Drupal Check/PHPStan: no errors in the changed service and test.
- PHP syntax and Git whitespace checks passed.
- The full location module retains 15 pre-existing static-analysis findings unrelated to this change.
- No staging configuration, provider selection or credential value was changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches server-side Apple Maps signing credentials and filesystem key reads; behavior is guarded by validation and tests but misconfigured env vars could break MapKit tokens in production.
> 
> **Overview**
> **MapKit token generation** now prefers staging-style `MEL_APPLE_MAPS_*` runtime variables before Drupal config and legacy `settings.php` constants.
> 
> Team ID and Key ID come from `MEL_APPLE_MAPS_TEAM_ID` and `MEL_APPLE_MAPS_KEY_ID` when set. The private key can be loaded from a server path via `MEL_APPLE_MAPS_PRIVATE_KEY_PATH`, with validation that the file exists, is readable, and non-empty; otherwise the previous config-stored key path still applies. The JWT **origin** claim can be overridden with `MEL_APPLE_MAPS_ORIGIN` before constants and request-derived host.
> 
> A shared `getEnvironmentValue()` helper reads non-empty values from `getenv`, `$_ENV`, and `$_SERVER`. New unit tests cover missing, empty, and unreadable key files plus successful ES256 JWT generation with the request origin in the payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a38c822ee896180f00a6c8563cfb1db796a84e0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->