### PR TITLE
Use the configured provider on public event maps

### DIFF
--- a/web/modules/custom/myeventlane_event/tests/src/Unit/PublicEventBodyTemplateContractTest.php
+++ b/web/modules/custom/myeventlane_event/tests/src/Unit/PublicEventBodyTemplateContractTest.php
@@ -50,4 +50,18 @@ final class PublicEventBodyTemplateContractTest extends TestCase {
     self::assertLessThan($expectPosition, $highlightsPosition);
   }
 
+  public function testPublicMapUsesConfiguredProviderRenderer(): void {
+    $moduleRoot = dirname(__DIR__, 3);
+    $webRoot = dirname($moduleRoot, 3);
+    $template = (string) file_get_contents(
+      $webRoot . '/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig',
+    );
+
+    self::assertStringContainsString('myeventlane-event-map-container', $template);
+    self::assertStringContainsString('data-latitude="{{ mel_lat }}"', $template);
+    self::assertStringContainsString('data-longitude="{{ mel_lng }}"', $template);
+    self::assertStringNotContainsString('www.google.com/maps?output=embed', $template);
+    self::assertStringNotContainsString('<iframe', $template);
+  }
+
 }

--- a/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
+++ b/web/themes/custom/myeventlane_theme/src/scss/components/_event-full.scss
@@ -2033,7 +2033,7 @@
   background: colors.$mel-color-surface-alt;
 }
 
-// Google Maps iframe embed in Event Information card (no API key required).
+// Provider-aware map in the Event Information card.
 .mel-event-map-embed {
   width: 100%;
   border-radius: radii.$mel-radius-md;

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -14,7 +14,7 @@
 #}
 {{ attach_library('myeventlane_theme/myeventlane_event_full') }}
 {% set canonical_url = url('entity.node.canonical', { 'node': node.id() }, { 'absolute': true }) %}
-{# Google Maps in Event Information card uses iframe embed (no API key). JS map library only if needed elsewhere. #}
+{# Event Information map uses the provider selected by myeventlane_location. #}
 {% set mel_cta_text = (event_ui is defined and (event_ui.cta_label|default(''))|striptags|length > 0) ? event_ui.cta_label : (event_cta and event_cta.label ? event_cta.label : '') %}
 {% if mel_booking_action_label is defined and mel_booking_action_label %}
   {% set mel_cta_text = mel_booking_action_label %}
@@ -353,18 +353,6 @@
             {% set info_venue_line = has_venue_name ? node.field_venue_name.value|trim : (venue_entity_label|trim ?: mel_venue|default('')|trim) %}
             {% set location_has_markup = content.field_location is defined and content.field_location|render|striptags|trim %}
             {% if info_venue_line is not empty or info_address is not empty or has_field_location %}
-              {% set map_query = '' %}
-              {% if mel_lat is defined and mel_lng is defined and mel_lat and mel_lng %}
-                {% set map_query = mel_lat ~ ',' ~ mel_lng %}
-              {% elseif info_venue_line is not empty and info_address is not empty %}
-                {% set map_query = info_venue_line ~ ', ' ~ info_address %}
-              {% elseif info_venue_line is not empty %}
-                {% set map_query = info_venue_line %}
-              {% elseif info_address is not empty %}
-                {% set map_query = info_address %}
-              {% elseif has_field_location and content.field_location is defined %}
-                {% set map_query = content.field_location|render|striptags|trim %}
-              {% endif %}
               <div class="mel-info-row">
                 <div class="mel-info-row__label">{{ 'Location'|t }}</div>
                 <div class="mel-info-row__value mel-event-location">
@@ -380,17 +368,16 @@
                       {% endif %}
                     </div>
                   {% endif %}
-                  {% if map_query is not empty %}
+                  {% if mel_lat is defined and mel_lng is defined and mel_lat and mel_lng %}
                     <div class="mel-event-map-embed mel-mt-3">
-                      <iframe
-                        src="https://www.google.com/maps?output=embed&amp;q={{ map_query|url_encode }}"
-                        width="100%"
-                        height="200"
-                        allowfullscreen
-                        loading="lazy"
-                        referrerpolicy="no-referrer-when-downgrade"
-                        title="{{ 'Map of event location'|t }}">
-                      </iframe>
+                      <div
+                        class="mel-event-location-map myeventlane-event-map-container"
+                        data-latitude="{{ mel_lat }}"
+                        data-longitude="{{ mel_lng }}"
+                        data-title="{{ node.label }}"
+                        role="region"
+                        aria-label="{{ 'Map of event location'|t }}">
+                      </div>
                     </div>
                   {% endif %}
                 </div>


### PR DESCRIPTION
## What changed

- Replaced the canonical public event page’s hard-coded Google Maps iframe with the existing provider-aware map container.
- Passed the event latitude, longitude and title to the renderer.
- Kept venue and address content as the fallback when coordinates are unavailable.
- Added a template contract test preventing a Google-only iframe from returning.

## Why

Staging correctly selected Apple Maps and generated a valid MapKit JWT, but the public event template bypassed the location provider and always rendered `www.google.com/maps` in an iframe.

## User impact

Public event pages now follow the provider selected in `myeventlane_location.settings`. With Apple Maps selected, the existing MapKit renderer handles the embedded map.

## Validation

- PHPUnit: 3 tests, 16 assertions passed.
- Focused Drupal Check/PHPStan: no errors.
- PHP syntax and Git whitespace checks passed.
- No configuration, database, cache or staging state was changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized presentation change on the event full template; depends on existing location JS/libraries when coordinates exist, with no config or auth changes.
> 
> **Overview**
> **Public event full pages** no longer hard-code a Google Maps **iframe** in the Event Information card. The embed is replaced with the existing **`myeventlane-event-map-container`** hook (lat/lng/title data attributes) so **`myeventlane_location`**’s selected provider (e.g. Apple MapKit) can render the map.
> 
> The map block is shown only when **`mel_lat`** and **`mel_lng`** are present; address-only **`map_query`** logic used for the old iframe is removed. Venue and address copy are unchanged when coordinates are missing.
> 
> A **template contract test** asserts the provider container is used and that Google embed URLs and **`<iframe>`** maps do not return to this template. SCSS comment text is updated to describe a provider-aware map.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 829332ac60c19b4aefb25a84fdecc9a1c61be999. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->