### PR TITLE
Add device-aware event directions link

### DIFF
--- a/web/modules/custom/myeventlane_event/tests/src/Unit/PublicEventBodyTemplateContractTest.php
+++ b/web/modules/custom/myeventlane_event/tests/src/Unit/PublicEventBodyTemplateContractTest.php
@@ -64,4 +64,28 @@ final class PublicEventBodyTemplateContractTest extends TestCase {
     self::assertStringNotContainsString('<iframe', $template);
   }
 
+  public function testPublicMapProvidesDeviceAwareDirections(): void {
+    $moduleRoot = dirname(__DIR__, 3);
+    $webRoot = dirname($moduleRoot, 3);
+    $template = (string) file_get_contents(
+      $webRoot . '/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig',
+    );
+    $script = (string) file_get_contents(
+      $webRoot . '/modules/custom/myeventlane_location/js/event-map.js',
+    );
+
+    self::assertStringContainsString('data-mel-directions-link', $template);
+    self::assertStringContainsString('maps.apple.com/directions?destination=', $template);
+    self::assertStringContainsString('www.google.com/maps/dir/?api=1', $template);
+    self::assertStringContainsString('dir_action=navigate', $template);
+    self::assertStringContainsString("{{ 'Get directions'|t }}", $template);
+
+    self::assertStringContainsString('/iPad|iPhone|iPod/i', $script);
+    self::assertStringContainsString("platform === 'MacIntel'", $script);
+    self::assertStringContainsString('/Android/i', $script);
+    self::assertStringContainsString("provider === 'apple_maps'", $script);
+    self::assertStringContainsString('link.dataset.appleDirectionsUrl', $script);
+    self::assertStringContainsString('link.dataset.googleDirectionsUrl', $script);
+  }
+
 }

--- a/web/modules/custom/myeventlane_location/js/event-map.js
+++ b/web/modules/custom/myeventlane_location/js/event-map.js
@@ -7,12 +7,44 @@
   'use strict';
 
   /**
+   * Selects the directions provider for the current device.
+   *
+   * Mobile devices use their native maps provider where possible. Desktop
+   * devices follow the configured event map provider.
+   */
+  function configureDirectionsLinks(provider) {
+    const userAgent = navigator.userAgent || '';
+    const platform = navigator.platform || '';
+    const isAppleMobile = /iPad|iPhone|iPod/i.test(userAgent)
+      || (platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+    const isAndroid = /Android/i.test(userAgent) || /Android/i.test(platform);
+
+    document.querySelectorAll('[data-mel-directions-link]').forEach((link) => {
+      const appleUrl = link.dataset.appleDirectionsUrl;
+      const googleUrl = link.dataset.googleDirectionsUrl;
+      let directionsUrl = googleUrl;
+
+      if (isAppleMobile) {
+        directionsUrl = appleUrl;
+      } else if (!isAndroid && provider === 'apple_maps') {
+        directionsUrl = appleUrl;
+      }
+
+      if (directionsUrl) {
+        link.href = directionsUrl;
+      }
+    });
+  }
+
+  /**
    * Initializes map rendering on Event view pages.
    */
   function initEventMap() {
     const settings = drupalSettings.myeventlaneLocation || {};
     const eventData = drupalSettings.myeventlaneLocationEvent || {};
     const provider = settings.provider || 'google_maps';
+
+    configureDirectionsLinks(provider);
 
     if (!eventData.latitude || !eventData.longitude) {
       console.warn('MyEventLane Location: Event coordinates not found.');
@@ -192,4 +224,3 @@
   }
 
 })(Drupal, drupalSettings);
-

--- a/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/node/node--event--full.html.twig
@@ -369,6 +369,7 @@
                     </div>
                   {% endif %}
                   {% if mel_lat is defined and mel_lng is defined and mel_lat and mel_lng %}
+                    {% set directions_destination = mel_lat ~ ',' ~ mel_lng %}
                     <div class="mel-event-map-embed mel-mt-3">
                       <div
                         class="mel-event-location-map myeventlane-event-map-container"
@@ -379,6 +380,16 @@
                         aria-label="{{ 'Map of event location'|t }}">
                       </div>
                     </div>
+                    <a
+                      class="mel-btn mel-btn--secondary mel-mt-3"
+                      href="https://www.google.com/maps/dir/?api=1&amp;destination={{ directions_destination|url_encode }}&amp;dir_action=navigate"
+                      data-mel-directions-link
+                      data-apple-directions-url="https://maps.apple.com/directions?destination={{ directions_destination|url_encode }}"
+                      data-google-directions-url="https://www.google.com/maps/dir/?api=1&amp;destination={{ directions_destination|url_encode }}&amp;dir_action=navigate"
+                      target="_blank"
+                      rel="noopener noreferrer">
+                      {{ 'Get directions'|t }}
+                    </a>
                   {% endif %}
                 </div>
               </div>


### PR DESCRIPTION
## What changed

- Adds an accessible Get directions link beneath the public event map.
- Opens Apple Maps on iPhone and iPad.
- Opens Google Maps on Android.
- Uses the configured map provider on desktop, with a Google web fallback when JavaScript is unavailable.
- Adds focused regression coverage for the public template and device routing contract.

## Why

The provider-aware public map did not offer attendees a direct route into their preferred navigation application.

## Validation

- PHPUnit: 4 tests, 27 assertions.
- Device and provider routing simulation: 5 scenarios passed.
- PHP and JavaScript syntax checks passed.
- Diff whitespace check passed.

## Release boundary

No configuration, credentials, database changes or deployment are included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Public-facing UI and client-side link swapping only; no auth, data model, or config changes.
> 
> **Overview**
> Adds a **Get directions** control under the public event map when coordinates exist, so attendees can jump straight into navigation apps.
> 
> The Twig link ships with a **Google Maps** `href` for no-JS fallback and stores Apple/Google URLs on `data-mel-directions-link` using the event lat/lng. **`configureDirectionsLinks`** in `event-map.js` runs on init and picks the URL: **Apple Maps** on iPhone/iPad (including iPad-on-MacIntel touch detection), **Google** on Android, and on desktop the **configured map provider** (`apple_maps` vs default Google).
> 
> A new **`testPublicMapProvidesDeviceAwareDirections`** contract test locks the template markup and JS routing strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 956ca9ed5c0005f5b025750cdda914354f8434a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->