### PR TITLE
Fix Event Studio venue replacement state

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-workspace-location.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-workspace-location.js
@@ -8,9 +8,55 @@
 (function (Drupal, once) {
   'use strict';
 
+  function setValue(field, value) {
+    if (!field) {
+      return;
+    }
+    field.value = value;
+    field.dispatchEvent(new Event('input', { bubbles: true }));
+    field.dispatchEvent(new Event('change', { bubbles: true }));
+  }
+
+  function clearCanonicalLocation(form) {
+    if (!form) {
+      return;
+    }
+    setValue(form.querySelector('input[name="mel[field_location]"]'), '');
+    setValue(form.querySelector('input[name="mel[field_location_latitude]"]'), '');
+    setValue(form.querySelector('input[name="mel[field_location_longitude]"]'), '');
+  }
+
+  function resetVenue(form) {
+    setValue(form.querySelector('input[name="mel[venue_saved]"]'), '');
+    setValue(form.querySelector('input[name="mel[venue_create_name]"]'), '');
+    setValue(form.querySelector('input[name="mel[location_search]"]'), '');
+    clearCanonicalLocation(form);
+
+    const summary = form.querySelector('[data-mel-location-summary]');
+    if (summary) {
+      summary.textContent = Drupal.t('Venue reset. Choose a new saved venue or address, then save.');
+    }
+
+    const mode = form.querySelector('input[name="mel[venue_mode]"]:checked');
+    const nextField = mode && mode.value === 'saved'
+      ? form.querySelector('input[name="mel[venue_saved]"]')
+      : form.querySelector('input[name="mel[location_search]"]');
+    if (nextField) {
+      nextField.focus();
+    }
+  }
+
   Drupal.behaviors.melEventStudioWorkspaceLocation = {
     attach(context) {
       once('mel-event-studio-workspace-location', '.mel-location-search', context).forEach((input) => {
+        let selectedValue = input.value;
+
+        input.addEventListener('input', () => {
+          if (input.value !== selectedValue) {
+            clearCanonicalLocation(input.closest('form'));
+          }
+        });
+
         input.addEventListener('place_selected', (event) => {
           const detail = event.detail || {};
           const components = detail.components || {};
@@ -43,6 +89,16 @@
           }
           if (longitudeField && detail.lng != null) {
             longitudeField.value = String(detail.lng);
+          }
+          selectedValue = input.value;
+        });
+      });
+
+      once('mel-event-studio-venue-reset', '[data-mel-reset-venue]', context).forEach((button) => {
+        button.addEventListener('click', () => {
+          const form = button.closest('form');
+          if (form) {
+            resetVenue(form);
           }
         });
       });

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAutosaveController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAutosaveController.php
@@ -404,6 +404,10 @@ final class EventStudioAutosaveController {
       'status' => FALSE,
       'field_location_latitude' => $mel['field_location_latitude'] ?? $params['field_location_latitude'] ?? NULL,
       'field_location_longitude' => $mel['field_location_longitude'] ?? $params['field_location_longitude'] ?? NULL,
+      'location_coordinates_submitted' => array_key_exists('field_location_latitude', $mel)
+      || array_key_exists('field_location_longitude', $mel)
+      || array_key_exists('field_location_latitude', $params)
+      || array_key_exists('field_location_longitude', $params),
     ];
     if ($decoded_event_highlights !== NULL) {
       $payload['event_highlights'] = $decoded_event_highlights;

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventInformationForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventInformationForm.php
@@ -191,6 +191,17 @@ final class EventInformationForm extends EventStudioBaseForm {
       ],
     ];
 
+    $form['mel']['venue_reset'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'button',
+      '#value' => $this->t('Reset venue'),
+      '#attributes' => [
+        'type' => 'button',
+        'class' => ['mel-btn', 'mel-btn--secondary'],
+        'data-mel-reset-venue' => '1',
+      ],
+    ];
+
     $form['mel']['field_location'] = [
       '#type' => 'hidden',
       '#default_value' => is_string($melDefaults['field_location'] ?? NULL) ? $melDefaults['field_location'] : '',

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
@@ -238,6 +238,7 @@ final class EventStudioForm extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state, ?NodeInterface $route_node = NULL): array {
+    $form['#attached']['library'][] = 'myeventlane_event_studio/mel_event_studio_workspace_location';
     $this->ensureInjectedServices();
     $form['#attributes']['class'][] = 'mel-event-studio-form';
     $form['#attributes']['data-mel-event-studio-form'] = '1';
@@ -796,6 +797,17 @@ final class EventStudioForm extends FormBase {
             [':input[name="mel[venue_mode]"]' => ['value' => 'create']],
           ],
         ],
+      ],
+    ];
+
+    $form['mel']['venue_reset'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'button',
+      '#value' => $this->t('Reset venue'),
+      '#attributes' => [
+        'type' => 'button',
+        'class' => ['mel-btn', 'mel-btn--secondary'],
+        'data-mel-reset-venue' => '1',
       ],
     ];
 

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
@@ -320,6 +320,8 @@ final class EventStudioMelPayloadService {
       'status' => !empty($mel['status']),
       'field_location_latitude' => $mel['field_location_latitude'] ?? NULL,
       'field_location_longitude' => $mel['field_location_longitude'] ?? NULL,
+      'location_coordinates_submitted' => array_key_exists('field_location_latitude', $mel)
+      || array_key_exists('field_location_longitude', $mel),
       'event_highlights' => $this->decodeAndNormalizeEventHighlightsFromMel($mel),
       'event_highlights_items_state' => trim((string) (($mel['event_highlights'] ?? [])['items_state'] ?? '')),
       'attendee_questions' => $attendee_questions,

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -301,6 +301,9 @@ final class EventStudioSaveService {
     $venue_for_display = NULL;
     $create_venue_name = NULL;
     $address_row_for_display = NULL;
+    $coordinate_latitude = $payload['field_location_latitude'] ?? NULL;
+    $coordinate_longitude = $payload['field_location_longitude'] ?? NULL;
+    $coordinates_submitted = !empty($payload['location_coordinates_submitted']);
 
     $skip_venue_location = $draft && (
       ($choice === 'saved' && (int) ($payload['venue_id'] ?? 0) < 1)
@@ -323,6 +326,9 @@ final class EventStudioSaveService {
       $primary = $this->venueManager->getPrimaryLocation($venue_for_display);
       $location_values = $primary ? [$this->addressFromVenueLocation($primary)] : [];
       $address_row_for_display = $location_values[0] ?? NULL;
+      $coordinate_latitude = $primary?->getLatitude();
+      $coordinate_longitude = $primary?->getLongitude();
+      $coordinates_submitted = TRUE;
     }
     elseif ($choice === 'create') {
       $create_venue_name = trim((string) ($payload['new_venue_name'] ?? ''));
@@ -373,7 +379,9 @@ final class EventStudioSaveService {
       $this->applyVenueDisplayName($node, $choice, $address_row_for_display, $venue_for_display, $create_venue_name);
     }
 
-    $this->applyOptionalCoordinates($node, $payload);
+    if ($coordinates_submitted) {
+      $this->applyCoordinates($node, $coordinate_latitude, $coordinate_longitude);
+    }
 
     $cover_media_sync = NULL;
     if ($this->shouldApplyHeroImagePayload($payload)) {
@@ -2678,14 +2686,24 @@ final class EventStudioSaveService {
     return [];
   }
 
-  private function applyOptionalCoordinates(NodeInterface $node, array $payload): void {
-    $lat = $payload['field_location_latitude'] ?? NULL;
-    $lng = $payload['field_location_longitude'] ?? NULL;
-    if ($node->hasField('field_location_latitude') && $lat !== NULL && $lat !== '') {
-      $node->set('field_location_latitude', (string) $lat);
+  /**
+   * Replaces a complete coordinate pair or clears an incomplete one.
+   */
+  private function applyCoordinates(NodeInterface $node, mixed $lat, mixed $lng): void {
+    $latitude = is_numeric($lat) ? (float) $lat : NULL;
+    $longitude = is_numeric($lng) ? (float) $lng : NULL;
+    $valid_pair = $latitude !== NULL
+      && $longitude !== NULL
+      && $latitude >= -90
+      && $latitude <= 90
+      && $longitude >= -180
+      && $longitude <= 180;
+
+    if ($node->hasField('field_location_latitude')) {
+      $node->set('field_location_latitude', $valid_pair ? (string) $latitude : NULL);
     }
-    if ($node->hasField('field_location_longitude') && $lng !== NULL && $lng !== '') {
-      $node->set('field_location_longitude', (string) $lng);
+    if ($node->hasField('field_location_longitude')) {
+      $node->set('field_location_longitude', $valid_pair ? (string) $longitude : NULL);
     }
   }
 

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioSaveServiceHeroPersistenceTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioSaveServiceHeroPersistenceTest.php
@@ -154,6 +154,56 @@ final class EventStudioSaveServiceHeroPersistenceTest extends UnitTestCase {
     ]);
   }
 
+  /**
+   * Replaces both stored coordinates when the submitted pair is valid.
+   *
+   * @covers ::applyCoordinates
+   */
+  public function testApplyCoordinatesReplacesCompletePair(): void {
+    $service = $this->buildPartialSaveService();
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('hasField')->willReturn(TRUE);
+    $node->expects($this->exactly(2))
+      ->method('set')
+      ->willReturnCallback(static function (string $field, mixed $value) use ($node): NodeInterface {
+        $expected = [
+          'field_location_latitude' => '-33.8688',
+          'field_location_longitude' => '151.2093',
+        ];
+        self::assertSame($expected[$field], $value);
+        return $node;
+      });
+
+    $method = new ReflectionMethod(EventStudioSaveService::class, 'applyCoordinates');
+    $method->setAccessible(TRUE);
+    $method->invoke($service, $node, '-33.8688', '151.2093');
+  }
+
+  /**
+   * Clears both stored coordinates when the submitted pair is incomplete.
+   *
+   * @covers ::applyCoordinates
+   */
+  public function testApplyCoordinatesClearsBothFieldsForIncompletePair(): void {
+    $service = $this->buildPartialSaveService();
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('hasField')->willReturn(TRUE);
+    $node->expects($this->exactly(2))
+      ->method('set')
+      ->willReturnCallback(static function (string $field, mixed $value) use ($node): NodeInterface {
+        self::assertContains($field, [
+          'field_location_latitude',
+          'field_location_longitude',
+        ]);
+        self::assertNull($value);
+        return $node;
+      });
+
+    $method = new ReflectionMethod(EventStudioSaveService::class, 'applyCoordinates');
+    $method->setAccessible(TRUE);
+    $method->invoke($service, $node, '-33.8688', '');
+  }
+
   private function buildPartialSaveService(): EventStudioSaveService {
     $translation = $this->createMock(TranslationInterface::class);
     $translation->method('translate')->willReturnCallback(

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioVenueResetContractTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioVenueResetContractTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the Event Studio venue replacement contract.
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventStudioVenueResetContractTest extends TestCase {
+
+  /**
+   * Both supported forms expose a non-submitting reset control.
+   */
+  public function testBothVenueFormsExposeTheResetControl(): void {
+    $module_root = dirname(__DIR__, 3);
+    $information_form = (string) file_get_contents($module_root . '/src/Form/EventInformationForm.php');
+    $legacy_form = (string) file_get_contents($module_root . '/src/Form/EventStudioForm.php');
+
+    foreach ([$information_form, $legacy_form] as $form) {
+      self::assertStringContainsString("'#value' => \$this->t('Reset venue')", $form);
+      self::assertStringContainsString("'data-mel-reset-venue' => '1'", $form);
+      self::assertStringContainsString("'type' => 'button'", $form);
+    }
+    self::assertStringContainsString('mel_event_studio_workspace_location', $legacy_form);
+  }
+
+  /**
+   * Reset invalidates the visible and canonical venue fields together.
+   */
+  public function testResetClearsAllCanonicalVenueState(): void {
+    $module_root = dirname(__DIR__, 3);
+    $script = (string) file_get_contents($module_root . '/js/mel-event-studio-workspace-location.js');
+
+    foreach ([
+      'mel[venue_saved]',
+      'mel[venue_create_name]',
+      'mel[location_search]',
+      'mel[field_location]',
+      'mel[field_location_latitude]',
+      'mel[field_location_longitude]',
+    ] as $field_name) {
+      self::assertStringContainsString($field_name, $script);
+    }
+    self::assertStringContainsString("input.addEventListener('input'", $script);
+    self::assertStringContainsString("input.addEventListener('place_selected'", $script);
+  }
+
+  /**
+   * Saved venue changes take coordinates from the selected primary location.
+   */
+  public function testSavedVenueCoordinatesComeFromItsPrimaryLocation(): void {
+    $module_root = dirname(__DIR__, 3);
+    $save_service = (string) file_get_contents($module_root . '/src/Service/EventStudioSaveService.php');
+
+    self::assertStringContainsString('$primary?->getLatitude()', $save_service);
+    self::assertStringContainsString('$primary?->getLongitude()', $save_service);
+    self::assertStringContainsString('$this->applyCoordinates(', $save_service);
+  }
+
+}


### PR DESCRIPTION
## What changed

- Adds a non-submitting Reset venue control to both Event Studio location forms.
- Clears the saved venue, new venue name, visible search, canonical address and both coordinates together.
- Invalidates stored location data when an organiser edits a previously selected address.
- Copies coordinates from the selected saved venue's primary location.
- Clears incomplete or invalid coordinate pairs instead of preserving stale map coordinates.
- Preserves unrelated autosaves by tracking whether location coordinates were submitted.
- Adds focused coordinate and venue-reset regression coverage.

## Root cause

Event Studio stored the address and coordinates separately. The save service wrote non-empty coordinates but never cleared old values. Changing an address or saved venue could therefore leave the public map pointing at the previous venue.

## User impact

Organisers can deliberately reset or replace a venue without retaining the old map position.

## Validation

- PHPUnit: 13 tests, 42 assertions.
- PHP and JavaScript syntax checks passed.
- New contract test passes Drupal coding standards.
- PHPStan reported five existing findings on unchanged lines and no new finding from this tranche.
- Diff whitespace check passed.

## Release boundary

No database update, configuration change, DDEV runtime change or deployment is included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches event location persistence and public map coordinates; behavior is scoped to explicit coordinate submission and venue saves, with regression tests added.
> 
> **Overview**
> Fixes **stale map coordinates** when organisers change or reset Event Studio venue/address data.
> 
> **UI:** Adds a non-submitting **Reset venue** button on `EventInformationForm` and `EventStudioForm`, wires the legacy form to `mel_event_studio_workspace_location`, and extends workspace location JS to clear saved venue, search, canonical address, and lat/lng together; editing the address search after a place pick clears hidden location fields until a new selection is made.
> 
> **Save path:** `EventStudioSaveService` now applies coordinates only when `location_coordinates_submitted` is set (from form/autosave payloads), uses the saved venue’s **primary location** lat/lng for saved-venue mode, and replaces `applyOptionalCoordinates` with `applyCoordinates` that writes a validated pair or **clears both** fields on incomplete/invalid input. Payload builders set the submitted flag via `array_key_exists` on coordinate keys.
> 
> **Tests:** Unit tests for `applyCoordinates` and a contract test for reset UI/JS/save behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63fc12048dbfdd8de8664ac602199d0ac89a9cac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->