### PR TITLE
Persist organiser venue names

### DIFF
--- a/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-workspace-location.js
+++ b/web/modules/custom/myeventlane_event_studio/js/mel-event-studio-workspace-location.js
@@ -29,6 +29,7 @@
   function resetVenue(form) {
     setValue(form.querySelector('input[name="mel[venue_saved]"]'), '');
     setValue(form.querySelector('input[name="mel[venue_create_name]"]'), '');
+    setValue(form.querySelector('input[name="mel[venue_one_off_name]"]'), '');
     setValue(form.querySelector('input[name="mel[location_search]"]'), '');
     clearCanonicalLocation(form);
 
@@ -44,6 +45,28 @@
     if (nextField) {
       nextField.focus();
     }
+  }
+
+  function applyPlaceName(form, placeName) {
+    const mode = form.querySelector('input[name="mel[venue_mode]"]:checked');
+    if (!mode || (mode.value !== 'create' && mode.value !== 'one_off')) {
+      return;
+    }
+
+    const fieldName = mode.value === 'create' ? 'venue_create_name' : 'venue_one_off_name';
+    const field = form.querySelector(`input[name="mel[${fieldName}]"]`);
+    const cleanName = String(placeName || '').trim();
+    if (!field || !cleanName) {
+      return;
+    }
+
+    const previousAutoValue = field.dataset.melAutofilledPlaceName || '';
+    if (field.value.trim() !== '' && field.value !== previousAutoValue) {
+      return;
+    }
+
+    field.dataset.melAutofilledPlaceName = cleanName;
+    setValue(field, cleanName);
   }
 
   Drupal.behaviors.melEventStudioWorkspaceLocation = {
@@ -78,6 +101,7 @@
           if (!form) {
             return;
           }
+          applyPlaceName(form, place.name || '');
           var locationField = form.querySelector('input[name="mel[field_location]"]');
           var latitudeField = form.querySelector('input[name="mel[field_location_latitude]"]');
           var longitudeField = form.querySelector('input[name="mel[field_location_longitude]"]');

--- a/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAutosaveController.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Controller/EventStudioAutosaveController.php
@@ -381,6 +381,7 @@ final class EventStudioAutosaveController {
       'venue_choice' => $choice,
       'venue_id' => $venue_id,
       'new_venue_name' => $mel['venue_create_name'] ?? $params['venue']['create']['new_venue_name'] ?? $params['new_venue_name'] ?? '',
+      'one_off_venue_name' => trim((string) ($mel['venue_one_off_name'] ?? $params['one_off_venue_name'] ?? '')),
       'field_location' => $field_location,
       'field_event_start' => $this->normalizeDatetimeFromMelRequest($mel['start_date'] ?? $params['when']['field_event_start'] ?? $params['field_event_start'] ?? NULL),
       'field_event_end' => $this->normalizeDatetimeFromMelRequest($mel['end_date'] ?? $params['when']['field_event_end'] ?? $params['field_event_end'] ?? NULL),

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventInformationForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventInformationForm.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_event_studio\Form;
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
 use Drupal\myeventlane_event_studio\Service\EventStudioWorkspacePresentation;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -62,6 +63,25 @@ final class EventInformationForm extends EventStudioBaseForm {
     $this->messenger()->addStatus($has_location
       ? $this->t('Event information and venue saved.')
       : $this->t('Event information saved.'));
+
+    $mel = $form_state->getValue('mel');
+    $created_venue = is_array($mel) && ($mel['venue_mode'] ?? '') === 'create';
+    if ($created_venue && $saved->hasField('field_venue') && !$saved->get('field_venue')->isEmpty()) {
+      $venue_id = (int) $saved->get('field_venue')->target_id;
+      if ($venue_id > 0) {
+        $return_path = Url::fromRoute('myeventlane_event_studio.workspace_venue', [
+          'node' => $saved->id(),
+        ])->toString();
+        $this->messenger()->addStatus($this->t('Complete your new venue profile, then return to your event.'));
+        $form_state->setRedirect('myeventlane_venue.vendor_venue_edit', [
+          'myeventlane_venue' => $venue_id,
+        ], [
+          'query' => ['destination' => $return_path],
+        ]);
+        return;
+      }
+    }
+
     // Schedule / Venue / Details share this form — stay on the nav section
     // the organiser opened instead of always bouncing to Details.
     $form_state->setRedirect($this->resolveStayRouteName(), ['node' => $saved->id()]);
@@ -170,6 +190,23 @@ final class EventInformationForm extends EventStudioBaseForm {
       '#states' => [
         'visible' => [
           ':input[name="mel[venue_mode]"]' => ['value' => 'create'],
+        ],
+      ],
+    ];
+
+    $form['mel']['venue_one_off_name'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Venue or location name'),
+      '#default_value' => $melDefaults['venue_one_off_name'] ?? '',
+      '#maxlength' => 255,
+      '#description' => $this->t('Shown to attendees on the event page.'),
+      '#attributes' => ['class' => ['mel-input']],
+      '#states' => [
+        'visible' => [
+          ':input[name="mel[venue_mode]"]' => ['value' => 'one_off'],
+        ],
+        'required' => [
+          ':input[name="mel[venue_mode]"]' => ['value' => 'one_off'],
         ],
       ],
     ];

--- a/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Form/EventStudioForm.php
@@ -326,6 +326,13 @@ final class EventStudioForm extends FormBase {
       ? $event->get('field_venue')->entity
       : NULL;
 
+    $one_off_venue_name_default = '';
+    if ($venue_mode_default === 'one_off'
+      && $event->hasField('field_venue_name')
+      && !$event->get('field_venue_name')->isEmpty()) {
+      $one_off_venue_name_default = trim((string) $event->get('field_venue_name')->value);
+    }
+
     $summary = '';
     if ($event->hasField('field_event_summary') && !$event->get('field_event_summary')->isEmpty()) {
       $summary = (string) $event->get('field_event_summary')->value;
@@ -779,6 +786,23 @@ final class EventStudioForm extends FormBase {
       '#states' => [
         'visible' => [
           ':input[name="mel[venue_mode]"]' => ['value' => 'create'],
+        ],
+      ],
+    ];
+
+    $form['mel']['venue_one_off_name'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Venue or location name'),
+      '#default_value' => $one_off_venue_name_default,
+      '#maxlength' => 255,
+      '#description' => $this->t('Shown to attendees on the event page.'),
+      '#attributes' => ['class' => ['mel-input']],
+      '#states' => [
+        'visible' => [
+          ':input[name="mel[venue_mode]"]' => ['value' => 'one_off'],
+        ],
+        'required' => [
+          ':input[name="mel[venue_mode]"]' => ['value' => 'one_off'],
         ],
       ],
     ];

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelDefaultsProvider.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelDefaultsProvider.php
@@ -53,6 +53,13 @@ final class EventStudioMelDefaultsProvider {
       ? $event->get('field_venue')->entity
       : NULL;
 
+    $one_off_venue_name_default = '';
+    if ($venue_mode_default === 'one_off'
+      && $event->hasField('field_venue_name')
+      && !$event->get('field_venue_name')->isEmpty()) {
+      $one_off_venue_name_default = trim((string) $event->get('field_venue_name')->value);
+    }
+
     $summary = '';
     if ($event->hasField('field_event_summary') && !$event->get('field_event_summary')->isEmpty()) {
       $summary = (string) $event->get('field_event_summary')->value;
@@ -438,6 +445,11 @@ final class EventStudioMelDefaultsProvider {
 
     $mel['venue_create_name'] = [
       '#type' => 'textfield',
+    ];
+
+    $mel['venue_one_off_name'] = [
+      '#type' => 'textfield',
+      '#default_value' => $one_off_venue_name_default,
     ];
 
     $mel['location_search'] = [

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioMelPayloadService.php
@@ -297,6 +297,7 @@ final class EventStudioMelPayloadService {
       'venue_choice' => $choice,
       'venue_id' => $venue_id,
       'new_venue_name' => $new_name,
+      'one_off_venue_name' => trim((string) ($mel['venue_one_off_name'] ?? '')),
       'field_location' => $field_location,
       'field_event_start' => $this->normalizeDatetimeValue($mel['start_date'] ?? NULL),
       'field_event_end' => $this->normalizeDatetimeValue($mel['end_date'] ?? NULL),

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventStudioSaveService.php
@@ -367,6 +367,10 @@ final class EventStudioSaveService {
       if (!$draft && $row === NULL) {
         return $this->abortSectionScopedSave(['Location is required.'], $payload);
       }
+      $one_off_venue_name = trim((string) ($payload['one_off_venue_name'] ?? ''));
+      if (!$draft && $one_off_venue_name === '') {
+        return $this->abortSectionScopedSave(['Venue or location name is required.'], $payload);
+      }
       $location_values = $row !== NULL ? [$row] : [];
       $address_row_for_display = $row;
     }
@@ -376,7 +380,14 @@ final class EventStudioSaveService {
     }
 
     if (!$skip_venue_location) {
-      $this->applyVenueDisplayName($node, $choice, $address_row_for_display, $venue_for_display, $create_venue_name);
+      $this->applyVenueDisplayName(
+        $node,
+        $choice,
+        $address_row_for_display,
+        $venue_for_display,
+        $create_venue_name,
+        trim((string) ($payload['one_off_venue_name'] ?? '')),
+      );
     }
 
     if ($coordinates_submitted) {
@@ -748,6 +759,7 @@ final class EventStudioSaveService {
     ?array $address_row,
     ?Venue $venue = NULL,
     ?string $create_name = NULL,
+    ?string $one_off_name = NULL,
   ): void {
     if (!$node->hasField('field_venue_name')) {
       return;
@@ -760,8 +772,11 @@ final class EventStudioSaveService {
     elseif ($choice === 'create' && $create_name !== NULL) {
       $display_name = trim($create_name);
     }
-    elseif ($choice === 'one_off' && is_array($address_row)) {
-      $display_name = $this->deriveVenueDisplayNameFromAddressRow($address_row);
+    elseif ($choice === 'one_off') {
+      $display_name = trim((string) $one_off_name);
+      if ($display_name === '' && is_array($address_row)) {
+        $display_name = $this->deriveVenueDisplayNameFromAddressRow($address_row);
+      }
     }
 
     if ($display_name === '') {

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioSaveServiceHeroPersistenceTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioSaveServiceHeroPersistenceTest.php
@@ -155,6 +155,26 @@ final class EventStudioSaveServiceHeroPersistenceTest extends UnitTestCase {
   }
 
   /**
+   * @covers ::applyVenueDisplayName
+   */
+  public function testApplyVenueDisplayNameUsesExplicitOneOffName(): void {
+    $service = $this->buildPartialSaveService();
+    $node = $this->createMock(NodeInterface::class);
+    $node->method('hasField')->with('field_venue_name')->willReturn(TRUE);
+    $node->expects($this->once())
+      ->method('set')
+      ->with('field_venue_name', 'Brisbane Powerhouse');
+
+    $method = new ReflectionMethod(EventStudioSaveService::class, 'applyVenueDisplayName');
+    $method->setAccessible(TRUE);
+    $method->invoke($service, $node, 'one_off', [
+      'locality' => 'Brisbane',
+      'administrative_area' => 'QLD',
+      'address_line1' => '119 Lamington St',
+    ], NULL, NULL, '  Brisbane Powerhouse  ');
+  }
+
+  /**
    * Replaces both stored coordinates when the submitted pair is valid.
    *
    * @covers ::applyCoordinates

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioVenueNameContractTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioVenueNameContractTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_event_studio\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects venue-name capture and new-venue hand-off contracts.
+ *
+ * @group myeventlane_event_studio
+ */
+final class EventStudioVenueNameContractTest extends TestCase {
+
+  /**
+   * Both supported forms capture a one-off venue name.
+   */
+  public function testBothVenueFormsExposeOneOffVenueName(): void {
+    $module_root = dirname(__DIR__, 3);
+    $information_form = (string) file_get_contents($module_root . '/src/Form/EventInformationForm.php');
+    $legacy_form = (string) file_get_contents($module_root . '/src/Form/EventStudioForm.php');
+
+    foreach ([$information_form, $legacy_form] as $form) {
+      self::assertStringContainsString("['venue_one_off_name']", $form);
+      self::assertStringContainsString("'Venue or location name'", $form);
+      self::assertStringContainsString("'#maxlength' => 255", $form);
+    }
+  }
+
+  /**
+   * Place search fills names without replacing organiser-entered text.
+   */
+  public function testPlaceSearchPreservesManualVenueNames(): void {
+    $module_root = dirname(__DIR__, 3);
+    $script = (string) file_get_contents($module_root . '/js/mel-event-studio-workspace-location.js');
+
+    self::assertStringContainsString("mode.value === 'create' ? 'venue_create_name' : 'venue_one_off_name'", $script);
+    self::assertStringContainsString("field.dataset.melAutofilledPlaceName", $script);
+    self::assertStringContainsString("field.value.trim() !== '' && field.value !== previousAutoValue", $script);
+    self::assertStringContainsString("applyPlaceName(form, place.name || '')", $script);
+  }
+
+  /**
+   * A newly-created venue hands the organiser to its protected edit route.
+   */
+  public function testNewVenueRedirectReturnsToEventStudio(): void {
+    $module_root = dirname(__DIR__, 3);
+    $information_form = (string) file_get_contents($module_root . '/src/Form/EventInformationForm.php');
+
+    self::assertStringContainsString("'myeventlane_venue.vendor_venue_edit'", $information_form);
+    self::assertStringContainsString("'myeventlane_event_studio.workspace_venue'", $information_form);
+    self::assertStringContainsString("'query' => ['destination' => \$return_path]", $information_form);
+  }
+
+}

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioVenueResetContractTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioVenueResetContractTest.php
@@ -39,6 +39,7 @@ final class EventStudioVenueResetContractTest extends TestCase {
     foreach ([
       'mel[venue_saved]',
       'mel[venue_create_name]',
+      'mel[venue_one_off_name]',
       'mel[location_search]',
       'mel[field_location]',
       'mel[field_location_latitude]',


### PR DESCRIPTION
## What changed

- capture and persist an attendee-facing name for one-off locations
- auto-fill reusable and one-off venue names from Google or Apple place results without overwriting organiser edits
- send organisers to complete a newly-created reusable venue profile, then return to Event Studio
- add focused venue-name and redirect regression coverage

## Why

Place selection previously saved the address but did not reliably retain the place name. Newly-created reusable venues also left organisers in Event Studio without prompting them to complete the venue profile.

## Validation

- focused PHPUnit: 17 tests, 60 assertions
- JavaScript syntax check
- PHP syntax checks
- diff whitespace check
- full module suite run; 304 of 315 passed, with 11 existing unrelated failures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes event save validation and post-save redirects for venue flows; impact is localized to Event Studio location handling but affects what attendees see on listings.
> 
> **Overview**
> Adds an attendee-facing **Venue or location name** for one-off addresses in Event Studio (workspace and legacy forms), wired through autosave/save payloads into `field_venue_name` with server-side validation on non-draft saves.
> 
> Place search now **auto-fills** create and one-off name fields from Google/Apple place results without overwriting names the organiser typed manually; venue reset clears the new field too.
> 
> After saving with **Create new venue**, organisers are redirected to the vendor venue edit screen with a **destination** back to the Event Studio venue workspace instead of staying on the form.
> 
> Adds contract/unit tests for form fields, place-name JS behavior, redirect, and explicit one-off display names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce17a00c0a97d5b8747856ad28e9c99c47eb4c54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->