### PR TITLE
Fix MEL Pro post-merge billing review findings

### DIFF
--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/OrganiserCheckoutContext.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/OrganiserCheckoutContext.php
@@ -104,7 +104,9 @@ final class OrganiserCheckoutContext {
       ],
       'trust_chips' => [
         ['text' => $trialText],
-        ['text' => (string) $this->t('@price per month after the trial', ['@price' => $monthlyPrice])],
+        ['text' => $trialApplies
+          ? (string) $this->t('@price per month after the trial', ['@price' => $monthlyPrice])
+          : (string) $this->t('@price per month from today', ['@price' => $monthlyPrice])],
         ['text' => (string) $this->t('Self-service cancellation before renewal')],
       ],
       'step_buyer' => [
@@ -185,8 +187,10 @@ final class OrganiserCheckoutContext {
       }
       if ($eventTitle === '' && $item->hasField('field_target_event') && !$item->get('field_target_event')->isEmpty()) {
         $event = $item->get('field_target_event')->entity;
-        $eventTitle = (string) $event->label();
-        $eventId = (int) $event->id();
+        if ($event !== NULL) {
+          $eventTitle = (string) $event->label();
+          $eventId = (int) $event->id();
+        }
       }
     }
     $total = $order->getTotalPrice();

--- a/web/modules/custom/myeventlane_checkout_flow/tests/src/Unit/OrganiserCheckoutContextTest.php
+++ b/web/modules/custom/myeventlane_checkout_flow/tests/src/Unit/OrganiserCheckoutContextTest.php
@@ -63,6 +63,41 @@ final class OrganiserCheckoutContextTest extends UnitTestCase {
   /**
    * @covers ::build
    */
+  public function testProWithoutTrialDoesNotPromisePaymentAfterTrial(): void {
+    $variation = $this->createMock(ProductVariationInterface::class);
+    $variation->method('bundle')->willReturn('mel_pro_subscription_variation');
+    $variation->method('getPrice')->willReturn(new Price('49.00', 'AUD'));
+
+    $item = $this->createMock(OrderItemInterface::class);
+    $item->method('getPurchasedEntity')->willReturn($variation);
+
+    $order = $this->createMock(OrderInterface::class);
+    $order->method('getItems')->willReturn([$item]);
+    $order->method('getTotalPrice')->willReturn(new Price('49.00', 'AUD'));
+
+    $config = $this->createMock(ImmutableConfig::class);
+    $config->method('get')->with('configuration.trial_interval.number')->willReturn(30);
+    $configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $configFactory->method('get')->willReturn($config);
+
+    $formatter = $this->createMock(CurrencyFormatterInterface::class);
+    $formatter->method('format')->willReturn('A$49.00');
+
+    $context = new OrganiserCheckoutContext(
+      $configFactory,
+      $formatter,
+      $this->getStringTranslationStub(),
+    );
+    $copy = json_encode($context->build($order), JSON_THROW_ON_ERROR);
+
+    $this->assertStringContainsString('No free trial is applied', $copy);
+    $this->assertStringContainsString('A$49.00 per month from today', $copy);
+    $this->assertStringNotContainsString('per month after the trial', $copy);
+  }
+
+  /**
+   * @covers ::build
+   */
   public function testCustomerOrderIsNotRelabelledAsOrganiserPurchase(): void {
     $variation = $this->createMock(ProductVariationInterface::class);
     $variation->method('bundle')->willReturn('ticket_variation');

--- a/web/modules/custom/myeventlane_messaging/src/EventSubscriber/OrderPlacedSubscriber.php
+++ b/web/modules/custom/myeventlane_messaging/src/EventSubscriber/OrderPlacedSubscriber.php
@@ -149,7 +149,9 @@ final class OrderPlacedSubscriber implements EventSubscriberInterface {
     $monthlyPrice = $price !== NULL
       ? $this->formatCurrency($price->getNumber(), $price->getCurrencyCode())
       : 'the displayed monthly price';
-    $trialDays = max(0, (int) $this->configFactory->get('myeventlane_pro.settings')->get('trial_days'));
+    $trialDays = max(0, (int) $this->configFactory
+      ->get('commerce_recurring.commerce_billing_schedule.mel_pro_monthly')
+      ->get('configuration.trial_interval.number'));
     $chargedToday = (float) ($order->getTotalPrice()?->getNumber() ?? 0);
     $trialApplies = $trialDays > 0 && $chargedToday <= 0.0;
 

--- a/web/modules/custom/myeventlane_messaging/tests/src/Unit/OrganiserTransactionEmailContractTest.php
+++ b/web/modules/custom/myeventlane_messaging/tests/src/Unit/OrganiserTransactionEmailContractTest.php
@@ -20,7 +20,9 @@ final class OrganiserTransactionEmailContractTest extends TestCase {
     self::assertStringContainsString('isProOnlyOrder($order)', $subscriber);
     self::assertStringContainsString("queue('pro_subscription_started'", $subscriber);
     self::assertStringContainsString("'order:%d:pro_subscription_started'", $subscriber);
-    self::assertStringContainsString("get('trial_days')", $subscriber);
+    self::assertStringContainsString("commerce_recurring.commerce_billing_schedule.mel_pro_monthly", $subscriber);
+    self::assertStringContainsString("configuration.trial_interval.number", $subscriber);
+    self::assertStringNotContainsString("myeventlane_pro.settings')->get('trial_days", $subscriber);
     self::assertStringContainsString('{% if trial_applies %}', $template);
     self::assertStringContainsString('{{ monthly_price }} per month', $template);
     self::assertStringContainsString('Monthly until cancelled', $template);
@@ -55,6 +57,8 @@ final class OrganiserTransactionEmailContractTest extends TestCase {
     }
 
     self::assertStringContainsString("'idempotency_key' => sprintf('order:%d:%s'", $job);
+    self::assertStringContainsString('commerce_recurring.commerce_billing_schedule.mel_pro_monthly', $job);
+    self::assertStringContainsString('configuration.trial_interval.number', $job);
     self::assertStringNotContainsString('You left tickets in your cart.', $job);
   }
 

--- a/web/modules/custom/myeventlane_pro/src/Controller/ProSubscriptionWebhookController.php
+++ b/web/modules/custom/myeventlane_pro/src/Controller/ProSubscriptionWebhookController.php
@@ -77,7 +77,11 @@ final class ProSubscriptionWebhookController extends ControllerBase {
       return new Response('Missing event id', Response::HTTP_BAD_REQUEST);
     }
 
-    if (!$this->recordEventOnce($eventId, $eventType)) {
+    $recorded = $this->recordEventOnce($eventId, $eventType);
+    if ($recorded === NULL) {
+      return new Response('Webhook ledger unavailable', Response::HTTP_SERVICE_UNAVAILABLE);
+    }
+    if ($recorded === FALSE) {
       return new Response('Already processed', Response::HTTP_OK);
     }
 
@@ -91,10 +95,10 @@ final class ProSubscriptionWebhookController extends ControllerBase {
   /**
    * Records a verified event exactly once without retaining its payload.
    */
-  private function recordEventOnce(string $eventId, string $eventType): bool {
+  private function recordEventOnce(string $eventId, string $eventType): ?bool {
     if (!$this->database->schema()->tableExists('myeventlane_pro_webhook_event')) {
       $this->logger->error('Pro subscription webhook idempotency ledger is missing.');
-      return FALSE;
+      return NULL;
     }
 
     try {

--- a/web/modules/custom/myeventlane_pro/src/Form/ProSettingsForm.php
+++ b/web/modules/custom/myeventlane_pro/src/Form/ProSettingsForm.php
@@ -31,11 +31,13 @@ final class ProSettingsForm extends ConfigFormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state): array {
     $config = $this->config('myeventlane_pro.settings');
+    $trialDays = max(0, (int) $this->config('commerce_recurring.commerce_billing_schedule.mel_pro_monthly')
+      ->get('configuration.trial_interval.number'));
 
     $form['trial_days'] = [
       '#type' => 'item',
       '#title' => $this->t('Trial period'),
-      '#markup' => $this->t('30 days'),
+      '#markup' => $this->formatPlural($trialDays, '1 day', '@count days'),
       '#description' => $this->t('Controlled by the MEL Pro Commerce billing schedule so checkout and renewal use one source of truth.'),
     ];
 
@@ -121,7 +123,6 @@ final class ProSettingsForm extends ConfigFormBase {
     $values = $form_state->getValues();
     $commercial = $values['commercial'] ?? [];
     $this->config('myeventlane_pro.settings')
-      ->set('trial_days', 30)
       ->set('pro_price', (int) ($values['pro_price'] ?? 49))
       ->set('pro_variation_sku', trim((string) ($values['pro_variation_sku'] ?? '')))
       ->set('grace_days', (int) ($commercial['grace_days'] ?? 7))

--- a/web/modules/custom/myeventlane_pro/src/Plugin/AdvancedQueue/JobType/ProAbandonedCartJob.php
+++ b/web/modules/custom/myeventlane_pro/src/Plugin/AdvancedQueue/JobType/ProAbandonedCartJob.php
@@ -207,7 +207,9 @@ final class ProAbandonedCartJob extends JobTypeBase implements ContainerFactoryP
       'order_id' => (int) $order->id(),
       'step' => $step,
       'item_count' => count($order->getItems()),
-      'trial_days' => max(0, (int) $this->configFactory->get('myeventlane_pro.settings')->get('trial_days')),
+      'trial_days' => max(0, (int) $this->configFactory
+        ->get('commerce_recurring.commerce_billing_schedule.mel_pro_monthly')
+        ->get('configuration.trial_interval.number')),
       'monthly_price' => 'A$' . number_format(
         (float) ($this->configFactory->get('myeventlane_pro.settings')->get('pro_price') ?? 49),
         2,

--- a/web/modules/custom/myeventlane_pro/tests/src/Unit/ProPostMergeReviewContractTest.php
+++ b/web/modules/custom/myeventlane_pro/tests/src/Unit/ProPostMergeReviewContractTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_pro\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Protects the post-merge billing and webhook review corrections.
+ *
+ * @group myeventlane_pro
+ */
+final class ProPostMergeReviewContractTest extends TestCase {
+
+  public function testMissingWebhookLedgerReturnsRetryableFailure(): void {
+    $controller = $this->moduleFile('src/Controller/ProSubscriptionWebhookController.php');
+
+    self::assertStringContainsString("return new Response('Webhook ledger unavailable', Response::HTTP_SERVICE_UNAVAILABLE)", $controller);
+    self::assertStringContainsString('if ($recorded === NULL)', $controller);
+    self::assertStringContainsString('if ($recorded === FALSE)', $controller);
+  }
+
+  public function testSettingsDisplayReadsCanonicalBillingSchedule(): void {
+    $form = $this->moduleFile('src/Form/ProSettingsForm.php');
+
+    self::assertStringContainsString('commerce_recurring.commerce_billing_schedule.mel_pro_monthly', $form);
+    self::assertStringContainsString('configuration.trial_interval.number', $form);
+    self::assertStringNotContainsString("->set('trial_days'", $form);
+  }
+
+  public function testFreeCustomerCheckoutDoesNotPromiseCardStep(): void {
+    $theme = file_get_contents(dirname(__DIR__, 6) . '/themes/custom/myeventlane_theme/myeventlane_theme.theme');
+    self::assertIsString($theme);
+
+    self::assertStringContainsString("\$form['actions']['next']['#value'] = t('Complete booking');", $theme);
+    self::assertStringNotContainsString("? t('Continue to card details')\n              : t('Complete booking');", $theme);
+  }
+
+  public function testDeletedBoostTargetFallsBackWithoutDereference(): void {
+    $context = file_get_contents(dirname(__DIR__, 4) . '/myeventlane_checkout_flow/src/Service/OrganiserCheckoutContext.php');
+    self::assertIsString($context);
+
+    self::assertStringContainsString('if ($event !== NULL)', $context);
+    self::assertStringContainsString("\$target = \$eventTitle !== ''", $context);
+  }
+
+  private function moduleFile(string $path): string {
+    $contents = file_get_contents(dirname(__DIR__, 3) . '/' . $path);
+    self::assertIsString($contents);
+    return $contents;
+  }
+
+}

--- a/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
+++ b/web/themes/custom/myeventlane_theme/myeventlane_theme.theme
@@ -1152,9 +1152,7 @@ function myeventlane_theme_preprocess_commerce_checkout_form(array &$variables):
               : t('Start Pro trial');
           }
           else {
-            $form['actions']['next']['#value'] = $step_id === 'checkout'
-              ? t('Continue to card details')
-              : t('Complete booking');
+            $form['actions']['next']['#value'] = t('Complete booking');
           }
         }
         elseif (($variables['mel_organiser_checkout']['kind'] ?? '') === 'boost') {
@@ -4473,7 +4471,7 @@ function myeventlane_theme_form_alter(array &$form, \Drupal\Core\Form\FormStateI
       if ($key === 'next' || $label === 'Continue to payment') {
         $step_id = $form['#step_id'] ?? NULL;
         $form['actions'][$key]['#value'] = $step_id === 'checkout'
-          ? t('Continue to card details')
+          ? t('Continue')
           : t('Complete booking');
       }
       elseif ($key === 'submit' || $label === 'Submit') {


### PR DESCRIPTION
## Summary

Addresses all five medium-severity Cursor Bugbot findings that were posted after PR #821 had already merged and deployed to staging.

## Corrections

- Makes Pro trust-chip billing copy conditional so non-trial orders say the monthly charge starts today.
- Returns HTTP 503 when the durable Pro webhook ledger is unavailable, allowing Stripe to retry rather than silently dropping a verified event.
- Restores `Complete booking` for zero-total customer orders that do not require card collection.
- Uses the Commerce billing schedule `mel_pro_monthly` as the canonical trial-duration source for checkout, confirmation email, abandoned-cart email and the Pro settings display.
- Handles missing/deleted Boost event references without dereferencing a null entity.

## Validation

- Focused regression suite: 11 tests, 69 assertions — pass.
- Broader checkout, messaging and Pro suite: 76 tests, 311 assertions — all assertions pass. PHPUnit returns non-zero because an existing attendee-resolver test emits one unrelated PHP warning.
- PHP syntax checks for changed/new PHP: pass.
- PHPStan for changed custom PHP: pass with no errors.
- Drupal database updates: none pending.
- Drupal cache rebuild: pass.
- `git diff --check`: pass.
- Credential scan: no Stripe credentials in the staged diff.

## Merge gate

Keep this PR in draft until:

- Composer and gitleaks finish successfully.
- Cursor Bugbot has posted its review for commit `27388bec3`.
- Any new actionable review threads are assessed.

Once those gates pass, merge and allow the standard staging deployment to replace revision `4816c387b487e5b820d9e7d8939b41800b5b1e33`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subscription billing copy, webhook idempotency responses, and checkout payment-step labeling—important for revenue and Stripe delivery but scoped corrective changes with added tests.
> 
> **Overview**
> Follow-up fixes from post-merge Pro billing review: checkout copy, Stripe webhook handling, trial configuration, and a Boost edge case.
> 
> **Pro billing copy** now reflects whether a trial actually applies—trust chips say monthly billing starts **from today** when there is no trial, and organiser checkout/messaging/abandoned-cart jobs read trial length from the Commerce billing schedule `mel_pro_monthly` instead of `myeventlane_pro.settings` `trial_days`. The Pro settings form displays that schedule-driven trial period and no longer persists a hard-coded `trial_days` value on save.
> 
> **Stripe Pro subscription webhooks** return **503** when the idempotency ledger table is missing (so Stripe can retry) instead of treating the event as already processed; duplicate events still return 200.
> 
> **Customer checkout** no longer promises a card step for **zero-total** orders that are not Pro/RSVP-specific flows—the primary action stays **Complete booking**, and a generic Commerce checkout relabel uses **Continue** rather than **Continue to card details**.
> 
> **Boost organiser checkout** guards against a deleted/missing `field_target_event` entity so copy does not dereference null.
> 
> Regression coverage is extended in unit/contract tests for non-trial Pro copy, email/job config sources, webhook 503 behavior, theme button text, and Boost null handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27388bec31b180f389772a89cd2e613b7ab07f29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->