### PR TITLE
Fix Stripe payout webhook event contract

### DIFF
--- a/web/modules/custom/myeventlane_admin_dashboard/src/Controller/StripeWebhookController.php
+++ b/web/modules/custom/myeventlane_admin_dashboard/src/Controller/StripeWebhookController.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Handles Stripe payout/transfer webhooks for ledger reconciliation.
  *
- * Listens for transfer.paid, transfer.created, and transfer.failed events
+ * Listens for Stripe's real transfer.created and transfer.reversed events
  * and reconciles the internal payout ledger accordingly. Never modifies
  * commerce_order or payment entities — only the payout ledger table.
  */
@@ -97,17 +97,16 @@ final class StripeWebhookController extends ControllerBase {
    */
   private function dispatch(Event $event): Response {
     return match ($event->type) {
-      'transfer.paid' => $this->handleTransferPaid($event),
-      'transfer.failed' => $this->handleTransferFailed($event),
       'transfer.created' => $this->handleTransferCreated($event),
+      'transfer.reversed' => $this->handleTransferReversed($event),
       default => $this->handleUnknown($event),
     };
   }
 
   /**
-   * Handles transfer.paid — reconciles ledger row to 'paid'.
+   * Reconciles a created transfer to the ledger's paid state.
    */
-  private function handleTransferPaid(Event $event): Response {
+  private function handleTransferCreated(Event $event): Response {
     $transfer = $event->data['object'] ?? NULL;
     if (!$transfer instanceof Transfer) {
       return $this->handleInvalidTransferPayload($event);
@@ -118,14 +117,14 @@ final class StripeWebhookController extends ControllerBase {
 
     if ($orderId === NULL) {
       $this->payoutLogger->error(
-        'transfer.paid webhook: Could not resolve order_id. Transfer @tid has no order_id in metadata or source charge. Skipping.',
+        'transfer.created webhook: Could not resolve order_id. Transfer @tid has no order_id in metadata or source charge. Skipping.',
         ['@tid' => $transferId ?? 'unknown']
       );
       return new JsonResponse(['received' => TRUE], Response::HTTP_OK);
     }
 
     if (!$this->database->schema()->tableExists(self::TABLE)) {
-      $this->payoutLogger->error('transfer.paid webhook: Payout ledger table does not exist.');
+      $this->payoutLogger->error('transfer.created webhook: Payout ledger table does not exist.');
       return new JsonResponse(['received' => TRUE], Response::HTTP_OK);
     }
 
@@ -137,7 +136,7 @@ final class StripeWebhookController extends ControllerBase {
 
     if (!$row) {
       $this->payoutLogger->warning(
-        'transfer.paid webhook: No ledger row for order @oid (transfer @tid). Ignoring.',
+        'transfer.created webhook: No ledger row for order @oid (transfer @tid). Ignoring.',
         ['@oid' => $orderId, '@tid' => $transferId]
       );
       return new JsonResponse(['received' => TRUE], Response::HTTP_OK);
@@ -146,13 +145,13 @@ final class StripeWebhookController extends ControllerBase {
     if ($row->status === 'paid') {
       if ($row->transfer_id === $transferId) {
         $this->payoutLogger->info(
-          'transfer.paid webhook: Ledger @lid (order @oid) already paid with same transfer @tid. Idempotent skip.',
+          'transfer.created webhook: Ledger @lid (order @oid) already paid with same transfer @tid. Idempotent skip.',
           ['@lid' => $row->id, '@oid' => $orderId, '@tid' => $transferId]
         );
       }
       else {
         $this->payoutLogger->critical(
-          'transfer.paid webhook: MISMATCH — Ledger @lid (order @oid) already paid with transfer @existing but received @incoming.',
+          'transfer.created webhook: MISMATCH — Ledger @lid (order @oid) already paid with transfer @existing but received @incoming.',
           ['@lid' => $row->id, '@oid' => $orderId, '@existing' => $row->transfer_id, '@incoming' => $transferId]
         );
       }
@@ -171,7 +170,7 @@ final class StripeWebhookController extends ControllerBase {
     Cache::invalidateTags(self::CACHE_TAGS);
 
     $this->payoutLogger->info(
-      'Payout synced from Stripe. Order @oid marked paid via transfer @tid (ledger @lid, store @sid).',
+      'Payout synced from transfer.created. Order @oid marked paid via transfer @tid (ledger @lid, store @sid).',
       [
         '@oid' => $orderId,
         '@tid' => $transferId,
@@ -184,41 +183,54 @@ final class StripeWebhookController extends ControllerBase {
   }
 
   /**
-   * Handles transfer.failed — logs error, does NOT change ledger status.
+   * Flags a fully reversed transfer for manual payout review.
    */
-  private function handleTransferFailed(Event $event): Response {
+  private function handleTransferReversed(Event $event): Response {
     $transfer = $event->data['object'] ?? NULL;
     if (!$transfer instanceof Transfer) {
       return $this->handleInvalidTransferPayload($event);
     }
     $transferId = $transfer->id ?? 'unknown';
-    $orderId = $this->resolveOrderId($transfer);
+    $amount = (int) ($transfer->amount ?? 0);
+    $amountReversed = (int) ($transfer->amount_reversed ?? 0);
+    $fullyReversed = (bool) ($transfer->reversed ?? FALSE)
+      || ($amount > 0 && $amountReversed >= $amount);
 
-    $this->payoutLogger->error(
-      'transfer.failed webhook: Transfer @tid failed. Order @oid. No ledger change applied.',
-      ['@tid' => $transferId, '@oid' => $orderId ?? 'unresolved']
-    );
-
-    return new JsonResponse(['received' => TRUE], Response::HTTP_OK);
-  }
-
-  /**
-   * Handles transfer.created — informational logging only.
-   */
-  private function handleTransferCreated(Event $event): Response {
-    $transfer = $event->data['object'] ?? NULL;
-    if (!$transfer instanceof Transfer) {
-      return $this->handleInvalidTransferPayload($event);
+    if (!$fullyReversed) {
+      $this->payoutLogger->warning(
+        'transfer.reversed webhook: Transfer @tid was partially reversed (@reversed of @amount). Ledger remains paid for manual review.',
+        ['@tid' => $transferId, '@reversed' => $amountReversed, '@amount' => $amount],
+      );
+      return new JsonResponse(['received' => TRUE], Response::HTTP_OK);
     }
-    $transferId = $transfer->id ?? 'unknown';
 
-    $this->payoutLogger->info(
-      'transfer.created webhook: Transfer @tid created (destination @dest).',
-      [
-        '@tid' => $transferId,
-        '@dest' => $transfer->destination ?? 'unknown',
-      ]
-    );
+    if (!$this->database->schema()->tableExists(self::TABLE)) {
+      $this->payoutLogger->error('transfer.reversed webhook: Payout ledger table does not exist.');
+      return new JsonResponse(['received' => TRUE], Response::HTTP_OK);
+    }
+
+    $updated = $this->database->update(self::TABLE)
+      ->fields([
+        'status' => 'pending',
+        'paid_at' => NULL,
+      ])
+      ->condition('transfer_id', $transferId)
+      ->condition('status', 'paid')
+      ->execute();
+
+    if ($updated > 0) {
+      Cache::invalidateTags(self::CACHE_TAGS);
+      $this->payoutLogger->critical(
+        'Transfer @tid was fully reversed. @count payout ledger row(s) moved to pending for manual review.',
+        ['@tid' => $transferId, '@count' => $updated],
+      );
+    }
+    else {
+      $this->payoutLogger->warning(
+        'transfer.reversed webhook: No paid payout ledger rows matched transfer @tid.',
+        ['@tid' => $transferId],
+      );
+    }
 
     return new JsonResponse(['received' => TRUE], Response::HTTP_OK);
   }

--- a/web/modules/custom/myeventlane_admin_dashboard/tests/src/Unit/StripeWebhookAuthenticationTest.php
+++ b/web/modules/custom/myeventlane_admin_dashboard/tests/src/Unit/StripeWebhookAuthenticationTest.php
@@ -54,7 +54,7 @@ final class StripeWebhookAuthenticationTest extends TestCase {
       '/admin/myeventlane/payouts/webhook',
       'POST',
       server: ['HTTP_STRIPE_SIGNATURE' => $signature],
-      content: '{"id":"evt_unsigned","type":"transfer.paid"}',
+      content: '{"id":"evt_unsigned","type":"transfer.created"}',
     );
 
     self::assertSame(Response::HTTP_BAD_REQUEST, $controller->handle($request)->getStatusCode());

--- a/web/modules/custom/myeventlane_admin_dashboard/tests/src/Unit/StripeWebhookEventContractTest.php
+++ b/web/modules/custom/myeventlane_admin_dashboard/tests/src/Unit/StripeWebhookEventContractTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_admin_dashboard\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards the Stripe Transfer webhook event contract.
+ *
+ * @group myeventlane_admin_dashboard
+ */
+final class StripeWebhookEventContractTest extends TestCase {
+
+  public function testOnlyRealStripeTransferEventsAreDispatched(): void {
+    $source = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/StripeWebhookController.php');
+    self::assertIsString($source);
+
+    self::assertStringContainsString("'transfer.created' =>", $source);
+    self::assertStringContainsString("'transfer.reversed' =>", $source);
+    self::assertStringNotContainsString("'transfer.paid' =>", $source);
+    self::assertStringNotContainsString("'transfer.failed' =>", $source);
+  }
+
+  public function testFullReversalMovesPaidLedgerRowsToManualReview(): void {
+    $source = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/StripeWebhookController.php');
+    self::assertIsString($source);
+
+    self::assertStringContainsString("'status' => 'pending'", $source);
+    self::assertStringContainsString("->condition('transfer_id', \$transferId)", $source);
+    self::assertStringContainsString("->condition('status', 'paid')", $source);
+  }
+
+}


### PR DESCRIPTION
## What changed

- replace the impossible `transfer.paid` and `transfer.failed` webhook branches with Stripe’s real `transfer.created` and `transfer.reversed` events
- reconcile a created transfer to the existing payout ledger idempotently
- move fully reversed paid ledger rows to `pending` for manual review
- leave partial reversals paid and log them for manual review, avoiding an automatic duplicate payout
- update signature-authentication coverage and add an event-contract regression test

## Why

Stripe does not emit `transfer.paid` or `transfer.failed` for Connect Transfer objects. The previous handler therefore could not perform the reconciliation it promised. Transfer creation failures are synchronous API failures; transfer lifecycle webhooks use `transfer.created` and `transfer.reversed`.

## Impact

This makes the payout webhook operationally honest and prevents a fully reversed transfer from remaining silently marked as paid. The change does not touch Commerce orders, customer ticket payments, MEL Pro billing, or MEL Hold.

## Validation

- MyEventLane admin dashboard unit suite: 5 tests, 25 assertions passed
- focused payout tests: 4 tests, 17 assertions passed
- PHP syntax checks passed
- focused PHPStan analysis passed
- staged diff whitespace check passed

## Activation note

Create the staging payout webhook for `transfer.created` and `transfer.reversed`, then install its signing secret only after this PR is merged and deployed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes payout ledger status from webhooks (financial reconciliation); scope is limited to the ledger table and correct Stripe event types reduce silent mis-reconciliation risk.
> 
> **Overview**
> Aligns the payout webhook with **Stripe Connect Transfer** events that actually fire, so ledger reconciliation can run in production.
> 
> **Event routing** drops `transfer.paid` and `transfer.failed` (not emitted for Transfer objects) in favor of **`transfer.created`** and **`transfer.reversed`**. **`transfer.created`** now carries the idempotent “mark ledger paid” logic that previously lived on the non-functional `transfer.paid` path (order resolution, mismatch logging, cache invalidation). **`transfer.reversed`** is new: fully reversed transfers reset matching **paid** ledger rows to **`pending`** and clear `paid_at`; partial reversals leave status **paid** and only log for manual review.
> 
> Tests switch the auth fixture to `transfer.created` and add **`StripeWebhookEventContractTest`** to guard dispatch keys and reversal update conditions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 223c5fb0aa17a8b5f01615e2275550ba6bc70b5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->