### PR TITLE
Persist Stripe webhook secrets across deploys

### DIFF
--- a/web/modules/custom/myeventlane_admin_dashboard/tests/src/Unit/StripeWebhookEventContractTest.php
+++ b/web/modules/custom/myeventlane_admin_dashboard/tests/src/Unit/StripeWebhookEventContractTest.php
@@ -32,4 +32,14 @@ final class StripeWebhookEventContractTest extends TestCase {
     self::assertStringContainsString("->condition('status', 'paid')", $source);
   }
 
+  public function testWebhookSecretsUseDeploymentSafeRuntimeOverrides(): void {
+    $settings = file_get_contents(dirname(__DIR__, 6) . '/sites/default/settings.mel_shared_session.php');
+    self::assertIsString($settings);
+
+    self::assertStringContainsString("\$melGetEnv('MEL_PRO_WEBHOOK_SECRET')", $settings);
+    self::assertStringContainsString("['myeventlane_pro.settings']['subscription_webhook_secret']", $settings);
+    self::assertStringContainsString("\$melGetEnv('MEL_PAYOUT_WEBHOOK_SECRET')", $settings);
+    self::assertStringContainsString("['myeventlane_admin_dashboard.settings']['stripe_webhook_secret']", $settings);
+  }
+
 }

--- a/web/sites/default/settings.mel_shared_session.php
+++ b/web/sites/default/settings.mel_shared_session.php
@@ -143,12 +143,16 @@ $settings['reverse_proxy_trusted_headers'] =
 //   MEL_STRIPE_SECRET_KEY       — sk_test_… / sk_live_…
 //   MEL_STRIPE_PUBLISHABLE_KEY  — pk_test_… / pk_live_…
 //   MEL_STRIPE_WEBHOOK_SECRET   — whsec_… (Payment Element gateway webhook)
+//   MEL_PRO_WEBHOOK_SECRET      — whsec_… (Pro lifecycle audit webhook)
+//   MEL_PAYOUT_WEBHOOK_SECRET   — whsec_… (Connect payout ledger webhook)
 //
 // DDEV: set these in a gitignored .ddev/config.local.yaml, for example
 //   web_environment:
 //     - MEL_STRIPE_SECRET_KEY=sk_test_…
 //     - MEL_STRIPE_PUBLISHABLE_KEY=pk_test_…
 //     - MEL_STRIPE_WEBHOOK_SECRET=whsec_…
+//     - MEL_PRO_WEBHOOK_SECRET=whsec_…
+//     - MEL_PAYOUT_WEBHOOK_SECRET=whsec_…
 // then ddev restart.
 // ---------------------------------------------------------------------------
 $melGetEnv = static function (string $name): string {
@@ -227,6 +231,16 @@ if ($mel_stripe_publishable !== '') {
 $mel_stripe_webhook = $melGetEnv('MEL_STRIPE_WEBHOOK_SECRET');
 if ($mel_stripe_webhook !== '') {
   $config['commerce_payment.commerce_payment_gateway.stripe_pe_recurring']['configuration']['webhook_signing_secret'] = $mel_stripe_webhook;
+}
+
+$mel_pro_webhook = $melGetEnv('MEL_PRO_WEBHOOK_SECRET');
+if ($mel_pro_webhook !== '') {
+  $config['myeventlane_pro.settings']['subscription_webhook_secret'] = $mel_pro_webhook;
+}
+
+$mel_payout_webhook = $melGetEnv('MEL_PAYOUT_WEBHOOK_SECRET');
+if ($mel_payout_webhook !== '') {
+  $config['myeventlane_admin_dashboard.settings']['stripe_webhook_secret'] = $mel_payout_webhook;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- add protected runtime overrides for `MEL_PRO_WEBHOOK_SECRET`
- add protected runtime overrides for `MEL_PAYOUT_WEBHOOK_SECRET`
- document both variables beside the existing Stripe runtime variables
- add regression coverage proving both webhook secrets are sourced outside exported Drupal configuration

## Why

The PR #823 staging deployment ran configuration import and erased the Pro lifecycle audit webhook secret from active Drupal configuration. The recurring gateway secret survived only because it already had an environment override. Payout and Pro audit secrets need the same deployment-safe treatment.

## Impact

Future config imports will no longer silently disable the Pro audit or payout webhook signature checks when their staging or production environment variables are configured. No secret values are committed.

## Validation

- focused contract tests: 3 tests, 14 assertions passed
- PHP syntax check passed for the shared settings fragment
- diff whitespace check passed
- staging runtime environment contains both variables with owner-only permissions

## Boundaries

This does not change payment processing, subscription states, Commerce orders, MEL Hold, or any webhook event logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4791e24a14c1ef72bb91d4f2fb465d8127b61767. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->