### PR TITLE
Fix payout reversal recovery

### DIFF
--- a/web/modules/custom/myeventlane_admin_dashboard/myeventlane_admin_dashboard.install
+++ b/web/modules/custom/myeventlane_admin_dashboard/myeventlane_admin_dashboard.install
@@ -68,6 +68,12 @@ function myeventlane_admin_dashboard_schema(): array {
         'not null' => FALSE,
         'description' => 'Stripe transfer ID when paid.',
       ],
+      'reversed_transfer_id' => [
+        'type' => 'varchar',
+        'length' => 128,
+        'not null' => FALSE,
+        'description' => 'Most recently fully reversed Stripe transfer ID, retained as a replay guard.',
+      ],
       'paid_at' => [
         'type' => 'int',
         'unsigned' => TRUE,
@@ -365,4 +371,21 @@ function myeventlane_admin_dashboard_update_10005(): void {
   $data = $file_storage->read('views.view.vendor_orders');
   \Drupal::service('config.storage')->write('views.view.vendor_orders', $data);
   $view_storage->resetCache();
+}
+
+/**
+ * Adds a durable replay guard for fully reversed Stripe transfers.
+ */
+function myeventlane_admin_dashboard_update_10006(): void {
+  $schema = \Drupal::database()->schema();
+  if (!$schema->tableExists('myeventlane_payout_ledger') || $schema->fieldExists('myeventlane_payout_ledger', 'reversed_transfer_id')) {
+    return;
+  }
+
+  $full = myeventlane_admin_dashboard_schema();
+  $schema->addField(
+    'myeventlane_payout_ledger',
+    'reversed_transfer_id',
+    $full['myeventlane_payout_ledger']['fields']['reversed_transfer_id'],
+  );
 }

--- a/web/modules/custom/myeventlane_admin_dashboard/src/Controller/PayoutActionController.php
+++ b/web/modules/custom/myeventlane_admin_dashboard/src/Controller/PayoutActionController.php
@@ -67,6 +67,7 @@ final class PayoutActionController extends ControllerBase {
     ];
     if ($transferId !== NULL) {
       $fields['transfer_id'] = $transferId;
+      $fields['reversed_transfer_id'] = NULL;
     }
 
     $this->database->update(self::TABLE)

--- a/web/modules/custom/myeventlane_admin_dashboard/src/Controller/PayoutTransferController.php
+++ b/web/modules/custom/myeventlane_admin_dashboard/src/Controller/PayoutTransferController.php
@@ -130,13 +130,13 @@ final class PayoutTransferController extends ControllerBase {
         ->fields([
           'status' => 'paid',
           'transfer_id' => $transfer->id,
+          'reversed_transfer_id' => NULL,
           'paid_at' => $this->time->getRequestTime(),
         ])
         ->condition('id', $ledger_id)
         ->execute();
 
       // Transaction commits when $transaction goes out of scope.
-
       Cache::invalidateTags(self::CACHE_TAGS);
 
       $this->payoutLogger->info(
@@ -228,6 +228,9 @@ final class PayoutTransferController extends ControllerBase {
     return $accountId !== '' ? $accountId : NULL;
   }
 
+  /**
+   * Validates the payout action CSRF token.
+   */
   private function validateCsrf(Request $request): void {
     $token = $request->request->get('token', '');
     if (!$this->csrfToken->validate((string) $token, 'payout_action')) {
@@ -235,11 +238,17 @@ final class PayoutTransferController extends ControllerBase {
     }
   }
 
+  /**
+   * Extracts the supported payout reporting window.
+   */
   private function extractDays(Request $request): int {
     $days = (int) $request->request->get('days', 30);
     return in_array($days, [7, 30, 90], TRUE) ? $days : 30;
   }
 
+  /**
+   * Redirects to the payout ledger for the selected reporting window.
+   */
   private function redirectToPayouts(int $days): RedirectResponse {
     $url = Url::fromRoute('myeventlane_admin_dashboard.payouts', [], [
       'query' => ['days' => $days],

--- a/web/modules/custom/myeventlane_admin_dashboard/src/Controller/StripeWebhookController.php
+++ b/web/modules/custom/myeventlane_admin_dashboard/src/Controller/StripeWebhookController.php
@@ -158,14 +158,36 @@ final class StripeWebhookController extends ControllerBase {
       return new JsonResponse(['received' => TRUE], Response::HTTP_OK);
     }
 
-    $this->database->update(self::TABLE)
+    if (($row->reversed_transfer_id ?? NULL) === $transferId) {
+      $this->payoutLogger->warning(
+        'transfer.created webhook: Transfer @tid was already fully reversed for ledger @lid (order @oid). Replay skipped.',
+        ['@tid' => $transferId, '@lid' => $row->id, '@oid' => $orderId],
+      );
+      return new JsonResponse(['received' => TRUE], Response::HTTP_OK);
+    }
+
+    $update = $this->database->update(self::TABLE);
+    $notReversed = $update->orConditionGroup()
+      ->isNull('reversed_transfer_id')
+      ->condition('reversed_transfer_id', $transferId, '<>');
+
+    $updated = $update
       ->fields([
         'status' => 'paid',
         'transfer_id' => $transferId,
         'paid_at' => $this->time->getRequestTime(),
       ])
       ->condition('order_id', $orderId)
+      ->condition($notReversed)
       ->execute();
+
+    if ($updated === 0) {
+      $this->payoutLogger->warning(
+        'transfer.created webhook: Ledger @lid (order @oid) changed before transfer @tid could be applied. Replay skipped.',
+        ['@lid' => $row->id, '@oid' => $orderId, '@tid' => $transferId],
+      );
+      return new JsonResponse(['received' => TRUE], Response::HTTP_OK);
+    }
 
     Cache::invalidateTags(self::CACHE_TAGS);
 
@@ -211,7 +233,9 @@ final class StripeWebhookController extends ControllerBase {
 
     $updated = $this->database->update(self::TABLE)
       ->fields([
-        'status' => 'pending',
+        'status' => 'unpaid',
+        'transfer_id' => NULL,
+        'reversed_transfer_id' => $transferId,
         'paid_at' => NULL,
       ])
       ->condition('transfer_id', $transferId)
@@ -221,7 +245,7 @@ final class StripeWebhookController extends ControllerBase {
     if ($updated > 0) {
       Cache::invalidateTags(self::CACHE_TAGS);
       $this->payoutLogger->critical(
-        'Transfer @tid was fully reversed. @count payout ledger row(s) moved to pending for manual review.',
+        'Transfer @tid was fully reversed. @count payout ledger row(s) moved to unpaid for manual recovery.',
         ['@tid' => $transferId, '@count' => $updated],
       );
     }

--- a/web/modules/custom/myeventlane_admin_dashboard/tests/src/Unit/StripeWebhookEventContractTest.php
+++ b/web/modules/custom/myeventlane_admin_dashboard/tests/src/Unit/StripeWebhookEventContractTest.php
@@ -13,6 +13,9 @@ use PHPUnit\Framework\TestCase;
  */
 final class StripeWebhookEventContractTest extends TestCase {
 
+  /**
+   * Confirms that only real Stripe Transfer event types are dispatched.
+   */
   public function testOnlyRealStripeTransferEventsAreDispatched(): void {
     $source = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/StripeWebhookController.php');
     self::assertIsString($source);
@@ -23,15 +26,35 @@ final class StripeWebhookEventContractTest extends TestCase {
     self::assertStringNotContainsString("'transfer.failed' =>", $source);
   }
 
+  /**
+   * Confirms that a full reversal restores manual payout recovery.
+   */
   public function testFullReversalMovesPaidLedgerRowsToManualReview(): void {
     $source = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/StripeWebhookController.php');
     self::assertIsString($source);
 
-    self::assertStringContainsString("'status' => 'pending'", $source);
+    self::assertStringContainsString("'status' => 'unpaid'", $source);
+    self::assertStringContainsString("'transfer_id' => NULL", $source);
+    self::assertStringContainsString("'reversed_transfer_id' => \$transferId", $source);
     self::assertStringContainsString("->condition('transfer_id', \$transferId)", $source);
     self::assertStringContainsString("->condition('status', 'paid')", $source);
   }
 
+  /**
+   * Confirms that a delayed created event cannot undo a full reversal.
+   */
+  public function testCreatedReplayCannotRepayReversedTransfer(): void {
+    $source = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/StripeWebhookController.php');
+    self::assertIsString($source);
+
+    self::assertStringContainsString("(\$row->reversed_transfer_id ?? NULL) === \$transferId", $source);
+    self::assertStringContainsString("->isNull('reversed_transfer_id')", $source);
+    self::assertStringContainsString("->condition('reversed_transfer_id', \$transferId, '<>')", $source);
+  }
+
+  /**
+   * Confirms that webhook secrets are supplied through runtime overrides.
+   */
   public function testWebhookSecretsUseDeploymentSafeRuntimeOverrides(): void {
     $settings = file_get_contents(dirname(__DIR__, 6) . '/sites/default/settings.mel_shared_session.php');
     self::assertIsString($settings);


### PR DESCRIPTION
## What changed

- restore fully reversed payouts to `unpaid` so staff can recover them through the payout UI
- clear the active transfer ID while retaining the reversed ID in a dedicated replay-guard field
- prevent duplicate, delayed, or concurrent `transfer.created` delivery from marking a reversed payout paid again
- clear the replay guard when a genuine replacement transfer is recorded
- add update hook `myeventlane_admin_dashboard_update_10006()` for existing installations

## Root cause

The payout webhook moved a fully reversed ledger row to `pending` but retained its active transfer ID. That state is reserved for payout batches, so the row became operationally locked. A later delivery of the original `transfer.created` event could then move the row back to `paid`.

## Impact

Fully reversed transfers return to a recoverable unpaid state. The original reversed transfer cannot be replayed, while a genuine replacement transfer can still be created and reconciled.

## Validation

- PHPUnit: 7 tests, 36 assertions
- Drupal and DrupalPractice coding standards
- PHP syntax checks
- `git diff --check`

Addresses the two high-severity Cursor Bugbot findings reported against PR #823.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes Stripe webhook reconciliation and payout ledger state for money movement; incorrect replay or status logic could mis-pay vendors or block legitimate recovery.
> 
> **Overview**
> Fixes payout recovery after a **full Stripe transfer reversal** by changing ledger behavior so reversed rows are **`unpaid`** (not `pending`), **clearing `transfer_id`**, and storing the reversed ID in a new **`reversed_transfer_id`** column (schema + `update_10006`).
> 
> **`transfer.reversed`** now writes that replay guard; **`transfer.created`** skips when the event matches a stored reversed ID and only applies paid updates when `reversed_transfer_id` is null or differs from the incoming transfer, with logging when no row updates. **Manual mark-paid** and **Stripe transfer creation** clear `reversed_transfer_id` when recording a replacement transfer.
> 
> Unit contract tests were extended to assert the unpaid reversal shape and replay protection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8b39b368e3a57e3fa4632d577b2a5a8382d0d29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->