### PR TITLE
Clear stale payout replay guard

### DIFF
--- a/web/modules/custom/myeventlane_admin_dashboard/src/Controller/StripeWebhookController.php
+++ b/web/modules/custom/myeventlane_admin_dashboard/src/Controller/StripeWebhookController.php
@@ -175,6 +175,7 @@ final class StripeWebhookController extends ControllerBase {
       ->fields([
         'status' => 'paid',
         'transfer_id' => $transferId,
+        'reversed_transfer_id' => NULL,
         'paid_at' => $this->time->getRequestTime(),
       ])
       ->condition('order_id', $orderId)

--- a/web/modules/custom/myeventlane_admin_dashboard/tests/src/Unit/StripeWebhookEventContractTest.php
+++ b/web/modules/custom/myeventlane_admin_dashboard/tests/src/Unit/StripeWebhookEventContractTest.php
@@ -50,6 +50,7 @@ final class StripeWebhookEventContractTest extends TestCase {
     self::assertStringContainsString("(\$row->reversed_transfer_id ?? NULL) === \$transferId", $source);
     self::assertStringContainsString("->isNull('reversed_transfer_id')", $source);
     self::assertStringContainsString("->condition('reversed_transfer_id', \$transferId, '<>')", $source);
+    self::assertStringContainsString("'reversed_transfer_id' => NULL", $source);
   }
 
   /**


### PR DESCRIPTION
## What changed

- clear `reversed_transfer_id` when a different replacement `transfer.created` event is successfully recorded
- add a regression assertion for the replay-guard invariant

## Root cause

The replacement transfer webhook updated the active transfer ID and paid state but left the previous reversed transfer ID behind. Manual replacement paths already cleared that stale guard.

## Impact

The ledger retains the reversal guard while rejecting the original reversed transfer, then clears it once a legitimate replacement transfer has passed the replay checks and is recorded.

## Validation

- Drupal Check: no errors
- PHPUnit: 7 tests, 37 assertions
- Drupal and DrupalPractice coding standards
- `git diff --check`

Addresses the medium-severity Cursor Bugbot finding reported against PR #825.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Stripe payout ledger reconciliation logic; the change is small and aligns webhook handling with existing manual payout controllers.
> 
> **Overview**
> **Clears the payout ledger replay guard when a replacement `transfer.created` webhook is applied**, matching behavior already used on manual payout paths.
> 
> On successful `transfer.created` reconciliation, the ledger update now sets **`reversed_transfer_id` to `NULL`** alongside `status`, `transfer_id`, and `paid_at`. Previously, a new transfer could be recorded as paid while the old reversed transfer ID stayed set, leaving a stale guard after legitimate replacement transfers.
> 
> A **contract test** asserts the webhook controller still includes `'reversed_transfer_id' => NULL` in that update path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fedf92af59eef567f2542ab1a0374c0869c0b94c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->