### PR TITLE
Add organiser GST liability and invoicing

### DIFF
--- a/config/sync/commerce_order.commerce_order_item_type.boost.yml
+++ b/config/sync/commerce_order.commerce_order_item_type.boost.yml
@@ -1,7 +1,12 @@
 uuid: ec48b58b-74af-42ba-aa99-335c59be3cd6
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - commerce_tax
+third_party_settings:
+  commerce_tax:
+    taxable_type: events
 id: boost
 label: Boost
 traits: {  }

--- a/config/sync/commerce_order.commerce_order_item_type.platform_donation.yml
+++ b/config/sync/commerce_order.commerce_order_item_type.platform_donation.yml
@@ -1,9 +1,14 @@
 uuid: d7ef4fe3-33d1-448b-b314-e01faf8f3976
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - commerce_tax
+third_party_settings:
+  commerce_tax:
+    taxable_type: events
 id: platform_donation
-label: 'Platform Donation'
+label: 'MyEventLane Contribution'
 traits: {  }
 locked: false
 purchasableEntityType: null

--- a/config/sync/commerce_order.commerce_order_item_type.recurring_product_variation.yml
+++ b/config/sync/commerce_order.commerce_order_item_type.recurring_product_variation.yml
@@ -2,10 +2,15 @@ uuid: 082a2e94-93da-4667-90fb-9ce61abfb825
 langcode: en
 status: true
 dependencies:
+  module:
+    - commerce_tax
   enforced:
     module:
       - commerce_product
       - commerce_recurring
+third_party_settings:
+  commerce_tax:
+    taxable_type: events
 _core:
   default_config_hash: Q21JtNYYWL-eIfxaX1rm-NvSqPqdDymrDrN08f_QC7M
 label: 'Recurring (Product variation)'

--- a/config/sync/commerce_order.commerce_order_item_type.recurring_standalone.yml
+++ b/config/sync/commerce_order.commerce_order_item_type.recurring_standalone.yml
@@ -2,9 +2,14 @@ uuid: e9b442c1-76c0-4538-895e-13ce3c8d3658
 langcode: en
 status: true
 dependencies:
+  module:
+    - commerce_tax
   enforced:
     module:
       - commerce_recurring
+third_party_settings:
+  commerce_tax:
+    taxable_type: events
 _core:
   default_config_hash: iFZgD_z6PSZqyLy65J_OLjA_nnGu-lvKxgPr0BNiCCI
 label: 'Recurring (Standalone)'

--- a/config/sync/commerce_order.commerce_order_type.platform_donation.yml
+++ b/config/sync/commerce_order.commerce_order_type.platform_donation.yml
@@ -14,7 +14,7 @@ third_party_settings:
   commerce_checkout:
     checkout_flow: default
 id: platform_donation
-label: 'Platform Donation'
+label: 'MyEventLane Contribution'
 traits: {  }
 locked: false
 workflow: order_default
@@ -24,4 +24,4 @@ refresh_mode: always
 refresh_frequency: 1
 sendReceipt: true
 receiptBcc: ''
-receiptSubject: 'Thank you for your donation to MyEventLane'
+receiptSubject: 'Receipt for your MyEventLane contribution'

--- a/config/sync/field.field.myeventlane_vendor.myeventlane_vendor.field_acnc_status.yml
+++ b/config/sync/field.field.myeventlane_vendor.myeventlane_vendor.field_acnc_status.yml
@@ -1,0 +1,21 @@
+uuid: 75110b4f-7b54-4181-a0c9-0c1526e9450f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.myeventlane_vendor.field_acnc_status
+  module:
+    - myeventlane_vendor
+id: myeventlane_vendor.myeventlane_vendor.field_acnc_status
+field_name: field_acnc_status
+entity_type: myeventlane_vendor
+bundle: myeventlane_vendor
+label: 'Charity status'
+description: 'ACNC registration is recorded separately from GST registration.'
+required: false
+translatable: false
+default_value:
+  - { value: not_applicable }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.field.myeventlane_vendor.myeventlane_vendor.field_dgr_status.yml
+++ b/config/sync/field.field.myeventlane_vendor.myeventlane_vendor.field_dgr_status.yml
@@ -1,0 +1,21 @@
+uuid: aa6921c5-dd60-41fa-a8ed-7896e738ac01
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.myeventlane_vendor.field_dgr_status
+  module:
+    - myeventlane_vendor
+id: myeventlane_vendor.myeventlane_vendor.field_dgr_status
+field_name: field_dgr_status
+entity_type: myeventlane_vendor
+bundle: myeventlane_vendor
+label: 'DGR endorsement'
+description: 'DGR endorsement affects gift deductibility; it does not determine GST registration.'
+required: false
+translatable: false
+default_value:
+  - { value: not_endorsed }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.field.myeventlane_vendor.myeventlane_vendor.field_gst_effective_date.yml
+++ b/config/sync/field.field.myeventlane_vendor.myeventlane_vendor.field_gst_effective_date.yml
@@ -1,0 +1,20 @@
+uuid: fb051ecd-9d60-46cb-ae08-593e80433e7c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.myeventlane_vendor.field_gst_effective_date
+  module:
+    - myeventlane_vendor
+id: myeventlane_vendor.myeventlane_vendor.field_gst_effective_date
+field_name: field_gst_effective_date
+entity_type: myeventlane_vendor
+bundle: myeventlane_vendor
+label: 'GST registration effective date'
+description: 'The date GST registration began. Required only when registered.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/config/sync/field.field.myeventlane_vendor.myeventlane_vendor.field_gst_registration_status.yml
+++ b/config/sync/field.field.myeventlane_vendor.myeventlane_vendor.field_gst_registration_status.yml
@@ -1,0 +1,21 @@
+uuid: 321285c8-1443-4617-845f-86b7e179a166
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.myeventlane_vendor.field_gst_registration_status
+  module:
+    - myeventlane_vendor
+id: myeventlane_vendor.myeventlane_vendor.field_gst_registration_status
+field_name: field_gst_registration_status
+entity_type: myeventlane_vendor
+bundle: myeventlane_vendor
+label: 'GST registration status'
+description: 'Whether the organiser is registered for Australian GST.'
+required: false
+translatable: false
+default_value:
+  - { value: unknown }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.field.myeventlane_vendor.myeventlane_vendor.field_tax_declaration_at.yml
+++ b/config/sync/field.field.myeventlane_vendor.myeventlane_vendor.field_tax_declaration_at.yml
@@ -1,0 +1,20 @@
+uuid: 086b4d1f-ec4b-4a13-9a09-1f206e8a553d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.myeventlane_vendor.field_tax_declaration_at
+  module:
+    - myeventlane_vendor
+id: myeventlane_vendor.myeventlane_vendor.field_tax_declaration_at
+field_name: field_tax_declaration_at
+entity_type: myeventlane_vendor
+bundle: myeventlane_vendor
+label: 'Tax declaration date'
+description: 'When the organiser last confirmed its tax details.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: timestamp

--- a/config/sync/field.field.myeventlane_vendor.myeventlane_vendor.field_tax_entity_type.yml
+++ b/config/sync/field.field.myeventlane_vendor.myeventlane_vendor.field_tax_entity_type.yml
@@ -1,0 +1,20 @@
+uuid: f9e2d031-9c96-4dd8-b0ed-762ce63256a6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.myeventlane_vendor.field_tax_entity_type
+  module:
+    - myeventlane_vendor
+id: myeventlane_vendor.myeventlane_vendor.field_tax_entity_type
+field_name: field_tax_entity_type
+entity_type: myeventlane_vendor
+bundle: myeventlane_vendor
+label: 'Organisation type'
+description: 'The legal structure responsible for ticket sales and RSVP donations.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.storage.myeventlane_vendor.field_acnc_status.yml
+++ b/config/sync/field.storage.myeventlane_vendor.field_acnc_status.yml
@@ -1,0 +1,24 @@
+uuid: 4b033b1a-c8e0-481f-b1df-4e24655313dc
+langcode: en
+status: true
+dependencies:
+  module:
+    - myeventlane_vendor
+    - options
+id: myeventlane_vendor.field_acnc_status
+field_name: field_acnc_status
+entity_type: myeventlane_vendor
+type: list_string
+settings:
+  allowed_values:
+    - { value: not_applicable, label: 'Not applicable' }
+    - { value: not_registered, label: 'Not ACNC registered' }
+    - { value: registered, label: 'ACNC registered charity' }
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.myeventlane_vendor.field_dgr_status.yml
+++ b/config/sync/field.storage.myeventlane_vendor.field_dgr_status.yml
@@ -1,0 +1,23 @@
+uuid: 15b2463d-c905-43c6-8bdf-81cb4424c740
+langcode: en
+status: true
+dependencies:
+  module:
+    - myeventlane_vendor
+    - options
+id: myeventlane_vendor.field_dgr_status
+field_name: field_dgr_status
+entity_type: myeventlane_vendor
+type: list_string
+settings:
+  allowed_values:
+    - { value: not_endorsed, label: 'Not DGR endorsed' }
+    - { value: endorsed, label: 'DGR endorsed' }
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.myeventlane_vendor.field_gst_effective_date.yml
+++ b/config/sync/field.storage.myeventlane_vendor.field_gst_effective_date.yml
@@ -1,0 +1,20 @@
+uuid: 4514bcf1-68b3-42c8-a6a4-00827f3bcd98
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - myeventlane_vendor
+id: myeventlane_vendor.field_gst_effective_date
+field_name: field_gst_effective_date
+entity_type: myeventlane_vendor
+type: datetime
+settings:
+  datetime_type: date
+module: datetime
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.myeventlane_vendor.field_gst_registration_status.yml
+++ b/config/sync/field.storage.myeventlane_vendor.field_gst_registration_status.yml
@@ -1,0 +1,24 @@
+uuid: 78653c9c-f172-4c8c-9708-fa6fa05bfb1c
+langcode: en
+status: true
+dependencies:
+  module:
+    - myeventlane_vendor
+    - options
+id: myeventlane_vendor.field_gst_registration_status
+field_name: field_gst_registration_status
+entity_type: myeventlane_vendor
+type: list_string
+settings:
+  allowed_values:
+    - { value: unknown, label: 'Not yet declared' }
+    - { value: not_registered, label: 'Not registered for GST' }
+    - { value: registered, label: 'Registered for GST' }
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.myeventlane_vendor.field_tax_declaration_at.yml
+++ b/config/sync/field.storage.myeventlane_vendor.field_tax_declaration_at.yml
@@ -1,0 +1,18 @@
+uuid: b9741598-e161-4fb0-93ec-6fb499bb0602
+langcode: en
+status: true
+dependencies:
+  module:
+    - myeventlane_vendor
+id: myeventlane_vendor.field_tax_declaration_at
+field_name: field_tax_declaration_at
+entity_type: myeventlane_vendor
+type: timestamp
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.myeventlane_vendor.field_tax_entity_type.yml
+++ b/config/sync/field.storage.myeventlane_vendor.field_tax_entity_type.yml
@@ -1,0 +1,29 @@
+uuid: 0055853c-c25a-4fff-b156-f051275005bb
+langcode: en
+status: true
+dependencies:
+  module:
+    - myeventlane_vendor
+    - options
+id: myeventlane_vendor.field_tax_entity_type
+field_name: field_tax_entity_type
+entity_type: myeventlane_vendor
+type: list_string
+settings:
+  allowed_values:
+    - { value: individual, label: Individual / sole trader }
+    - { value: company, label: Company }
+    - { value: incorporated_association, label: 'Incorporated association' }
+    - { value: unincorporated_association, label: 'Unincorporated association' }
+    - { value: trust, label: Trust }
+    - { value: charity_or_nfp, label: 'Charity or not-for-profit' }
+    - { value: government, label: Government entity }
+    - { value: other, label: Other }
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/myeventlane_messaging.template.order_invoice.yml
+++ b/config/sync/myeventlane_messaging.template.order_invoice.yml
@@ -1,10 +1,10 @@
 enabled: true
-subject: 'Tax invoice – Order #{{ order_number }}'
+subject: '{{ document_title|default("Receipt") }} – Order #{{ order_number }}'
 body_html: |
   <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; max-width: 600px; margin: 0 auto; background-color: #fef5ec; padding: 20px;">
     <div style="background-color: #ffffff; border-radius: 8px; padding: 30px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
       <div style="text-align: center; margin-bottom: 24px;">
-        <h1 style="color: #2c3e50; margin: 0; font-size: 26px;">Tax Invoice</h1>
+        <h1 style="color: #2c3e50; margin: 0; font-size: 26px;">{{ document_title|default('Receipt') }}</h1>
       </div>
 
       <p style="color: #34495e; font-size: 16px; line-height: 1.6; margin-bottom: 16px;">
@@ -12,13 +12,13 @@ body_html: |
       </p>
 
       <p style="color: #34495e; font-size: 16px; line-height: 1.6; margin-bottom: 20px;">
-        Thank you for your payment. This is your tax invoice for order <strong>#{{ order_number }}</strong>.
+        Thank you for your payment. This is your {{ document_title|default('receipt')|lower }} for order <strong>#{{ order_number }}</strong>.
       </p>
 
       <div style="margin: 16px 0; padding: 12px 16px; background-color: #f9f9f9; border-radius: 6px; font-size: 14px; color: #34495e;">
         <p style="margin: 0 0 8px; line-height: 1.5;">
           {% if vendor_name %}<strong>Supplier:</strong> {{ vendor_name }}<br>{% endif %}
-          <strong>ABN:</strong> {{ vendor_abn }}<br>
+          {% if vendor_abn %}<strong>ABN:</strong> {{ vendor_abn }}<br>{% endif %}
         </p>
         <div style="display: flex; justify-content: space-between; flex-wrap: wrap; gap: 8px;">
           <span><strong>Invoice date:</strong> {{ invoice_date }}</span>
@@ -102,7 +102,11 @@ body_html: |
         </div>
       </div>
 
-      <p class="mel-invoice__legal" style="margin: 16px 0 0; font-size: 11px; color: #7f8c8d; line-height: 1.45;">This document is a tax invoice for GST purposes.</p>
+      {% if is_tax_invoice %}
+        <p class="mel-invoice__legal" style="margin: 16px 0 0; font-size: 11px; color: #7f8c8d; line-height: 1.45;">This document is a tax invoice for GST purposes.</p>
+      {% else %}
+        <p class="mel-invoice__legal" style="margin: 16px 0 0; font-size: 11px; color: #7f8c8d; line-height: 1.45;">The supplier is not registered for GST. No GST has been charged.</p>
+      {% endif %}
 
       <div style="margin-top: 28px; padding-top: 18px; border-top: 1px solid #e0e0e0; text-align: center; color: #7f8c8d; font-size: 12px;">
         <p style="margin: 5px 0;">This email was sent to {{ order_email }}</p>

--- a/config/sync/myeventlane_messaging.template.order_receipt.yml
+++ b/config/sync/myeventlane_messaging.template.order_receipt.yml
@@ -84,10 +84,10 @@ body_html: |
 
       {% if vendor_name or order_total_gst or invoice_lines|length > 0 or invoice_fee_lines|length > 0 or invoice_tax_lines|length > 0 %}
         <div style="margin: 24px 0; padding: 20px; background-color: #ffffff; border: 1px solid #e0e0e0; border-radius: 8px;">
-          <h2 style="color: #2c3e50; margin: 0 0 16px; font-size: 20px;">Tax Invoice</h2>
+          <h2 style="color: #2c3e50; margin: 0 0 16px; font-size: 20px;">{{ document_title|default('Receipt') }}</h2>
           <p style="color: #34495e; font-size: 14px; line-height: 1.6; margin: 0 0 12px;">
             {% if vendor_name %}<strong>Supplier:</strong> {{ vendor_name }}<br>{% endif %}
-            <strong>ABN:</strong> {{ vendor_abn }}<br>
+            {% if vendor_abn %}<strong>ABN:</strong> {{ vendor_abn }}<br>{% endif %}
             <strong>Invoice #:</strong> {{ order_number }}<br>
             {% if invoice_date_short %}<strong>Date:</strong> {{ invoice_date_short }}<br>{% endif %}
           </p>
@@ -137,7 +137,11 @@ body_html: |
             <p style="margin:12px 0 0; font-size:14px; color:#34495e;"><strong>Total GST:</strong> {{ order_total_gst }}</p>
           {% endif %}
           <p style="margin:12px 0 0; font-size:16px; color:#2c3e50;"><strong>Total</strong> {{ order_total|default(total_paid) }}</p>
-          <p class="mel-invoice__legal" style="margin:16px 0 0; font-size:11px; color:#7f8c8d; line-height:1.45;">This document is a tax invoice for GST purposes.</p>
+          {% if is_tax_invoice %}
+            <p class="mel-invoice__legal" style="margin:16px 0 0; font-size:11px; color:#7f8c8d; line-height:1.45;">This document is a tax invoice for GST purposes.</p>
+          {% else %}
+            <p class="mel-invoice__legal" style="margin:16px 0 0; font-size:11px; color:#7f8c8d; line-height:1.45;">The supplier is not registered for GST. No GST has been charged.</p>
+          {% endif %}
           {% if show_includes_gst_note|default(false) %}
           <p style="color: #7f8c8d; font-size: 13px; margin: 12px 0 0 0;">All prices include GST where applicable.</p>
           {% endif %}

--- a/config/sync/myeventlane_messaging.template.refund_completed_admin.yml
+++ b/config/sync/myeventlane_messaging.template.refund_completed_admin.yml
@@ -6,6 +6,14 @@ body_html: |-
   Order: {{ order_number }}
   Amount: {{ refunded_amount }}
 
+  {% if adjustment_note_number %}
+  Adjustment note: {{ adjustment_note_number }}
+  Date: {{ adjustment_note_date }}
+  Reason: {{ adjustment_reason }}
+  Supplier: {{ supplier_name }}{% if supplier_abn %} (ABN {{ supplier_abn }}){% endif %}
+  GST adjustment: {{ gst_adjustment }}
+  {% endif %}
+
   {% if stripe_refund_id %}
   Stripe refund reference: {{ stripe_refund_id }}
   {% endif %}

--- a/config/sync/myeventlane_messaging.template.refund_completed_buyer.yml
+++ b/config/sync/myeventlane_messaging.template.refund_completed_buyer.yml
@@ -7,6 +7,16 @@ body_html: |-
 
   Amount refunded: {{ refunded_amount }}
 
+  {% if adjustment_note_number %}
+  <strong>Adjustment note {{ adjustment_note_number }}</strong><br>
+  Date: {{ adjustment_note_date }}<br>
+  Supplier: {{ supplier_name }}<br>
+  {% if supplier_abn %}ABN: {{ supplier_abn }}<br>{% endif %}
+  Original invoice: {{ order_number }}<br>
+  Reason: {{ adjustment_reason }}<br>
+  GST adjustment: {{ gst_adjustment }}
+  {% endif %}
+
   The refund should appear on your card within 2–5 business days.
 
   <a href="{{ my_tickets_url }}">View Digital Pass</a>

--- a/config/sync/myeventlane_messaging.template.refund_completed_vendor.yml
+++ b/config/sync/myeventlane_messaging.template.refund_completed_vendor.yml
@@ -5,6 +5,13 @@ body_html: |-
 
   The customer has been notified.
 
+  {% if adjustment_note_number %}
+  Adjustment note: {{ adjustment_note_number }}
+  Date: {{ adjustment_note_date }}
+  Reason: {{ adjustment_reason }}
+  GST adjustment: {{ gst_adjustment }}
+  {% endif %}
+
   {% if tickets_cancelled and tickets_cancelled > 0 %}
   Ticket access has been cancelled for {{ tickets_cancelled }} attendee(s).
   {% endif %}

--- a/web/modules/custom/myeventlane_checkout_flow/src/Controller/OrderTaxInvoicePdfController.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Controller/OrderTaxInvoicePdfController.php
@@ -89,7 +89,7 @@ final class OrderTaxInvoicePdfController extends ControllerBase {
     $order_number_raw = $commerce_order->getOrderNumber();
     $sanitized = preg_replace('/[^a-zA-Z0-9_-]/', '-', (string) ($order_number_raw ?? ''));
     $safe_slug = (is_string($sanitized) && $sanitized !== '') ? $sanitized : (string) $commerce_order->id();
-    $filename = 'tax-invoice-' . $safe_slug . '.pdf';
+    $filename = ($invoice['is_tax_invoice'] ? 'tax-invoice-' : 'receipt-') . $safe_slug . '.pdf';
 
     return new Response($dompdf->output(), 200, [
       'Content-Type' => 'application/pdf',

--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/TaxInvoicePresentationBuilder.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/TaxInvoicePresentationBuilder.php
@@ -43,8 +43,6 @@ final class TaxInvoicePresentationBuilder {
    */
   public function build(OrderInterface $order): array {
     $store = $order->getStore();
-    $taxRegistrations = $store ? array_column($store->get('tax_registrations')->getValue(), 'value') : [];
-    $isTaxInvoice = in_array('AU', $taxRegistrations, TRUE);
     $vendor_name = $store ? $store->label() : '';
     $abn = '';
     if ($store && $store->hasField('field_abn')) {
@@ -103,6 +101,9 @@ final class TaxInvoicePresentationBuilder {
       ];
     }
     $order_total_gst = $aggregated['total_formatted'];
+    // Historical documents must reflect tax recorded on this order. The
+    // organiser's current GST registration can change after the sale.
+    $isTaxInvoice = $aggregated['tax_rows'] !== [];
 
     $total_price = $order->getTotalPrice();
     $order_total = $this->formatPrice($total_price);

--- a/web/modules/custom/myeventlane_checkout_flow/src/Service/TaxInvoicePresentationBuilder.php
+++ b/web/modules/custom/myeventlane_checkout_flow/src/Service/TaxInvoicePresentationBuilder.php
@@ -28,6 +28,8 @@ final class TaxInvoicePresentationBuilder {
    * Builds presentation variables from the order store and adjustments.
    *
    * @return array{
+   *   document_title: string,
+   *   is_tax_invoice: bool,
    *   vendor_name: string,
    *   vendor_abn: string,
    *   invoice_lines: array<int, array{title: string, quantity: int, unit_price: string, line_total: string, gst: string}>,
@@ -41,13 +43,15 @@ final class TaxInvoicePresentationBuilder {
    */
   public function build(OrderInterface $order): array {
     $store = $order->getStore();
+    $taxRegistrations = $store ? array_column($store->get('tax_registrations')->getValue(), 'value') : [];
+    $isTaxInvoice = in_array('AU', $taxRegistrations, TRUE);
     $vendor_name = $store ? $store->label() : '';
     $abn = '';
     if ($store && $store->hasField('field_abn')) {
       $raw = $store->get('field_abn')->value;
       $abn = ($raw !== NULL && $raw !== '') ? trim((string) $raw) : '';
     }
-    $vendor_abn = $abn !== '' ? $abn : 'ABN not provided';
+    $vendor_abn = $abn;
 
     $invoice_lines = [];
     $invoice_lines_include_gst_column = FALSE;
@@ -109,13 +113,15 @@ final class TaxInvoicePresentationBuilder {
       : '';
 
     return [
+      'document_title' => $isTaxInvoice ? 'Tax invoice' : 'Receipt',
+      'is_tax_invoice' => $isTaxInvoice,
       'vendor_name' => $vendor_name,
       'vendor_abn' => $vendor_abn,
       'invoice_lines' => $invoice_lines,
       'invoice_lines_include_gst_column' => $invoice_lines_include_gst_column,
       'fee_lines' => $fee_lines,
-      'tax_lines' => $tax_lines,
-      'order_total_gst' => $order_total_gst,
+      'tax_lines' => $isTaxInvoice ? $tax_lines : [],
+      'order_total_gst' => $isTaxInvoice ? $order_total_gst : '',
       'order_total' => $order_total,
       'invoice_date_display' => $invoice_date_display,
     ];

--- a/web/modules/custom/myeventlane_checkout_flow/tests/src/Unit/TaxInvoiceHistoricalGstTest.php
+++ b/web/modules/custom/myeventlane_checkout_flow/tests/src/Unit/TaxInvoiceHistoricalGstTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_checkout_flow\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards historical GST presentation against mutable store registration data.
+ *
+ * @group myeventlane_checkout_flow
+ */
+final class TaxInvoiceHistoricalGstTest extends TestCase {
+
+  public function testInvoiceStatusUsesTaxRecordedOnOrder(): void {
+    $source = file_get_contents(dirname(__DIR__, 3) . '/src/Service/TaxInvoicePresentationBuilder.php');
+
+    self::assertIsString($source);
+    self::assertStringContainsString("\$isTaxInvoice = \$aggregated['tax_rows'] !== [];", $source);
+    self::assertStringNotContainsString("get('tax_registrations')", $source);
+  }
+
+}

--- a/web/modules/custom/myeventlane_donations/src/Service/PlatformDonationService.php
+++ b/web/modules/custom/myeventlane_donations/src/Service/PlatformDonationService.php
@@ -187,7 +187,7 @@ final class PlatformDonationService {
     $orderItemStorage = $this->entityTypeManager->getStorage('commerce_order_item');
     $orderItem = $orderItemStorage->create([
       'type' => 'platform_donation',
-      'title' => 'Donation to MyEventLane',
+      'title' => 'MyEventLane platform contribution (GST inclusive)',
       'unit_price' => new Price((string) $amount, 'AUD'),
       'quantity' => 1,
     ]);

--- a/web/modules/custom/myeventlane_event_studio/src/EventStudioPreprocess.php
+++ b/web/modules/custom/myeventlane_event_studio/src/EventStudioPreprocess.php
@@ -117,7 +117,10 @@ final class EventStudioPreprocess {
         $event_type = (string) $node->get('field_event_type')->value;
       }
       $is_paid = in_array($event_type, ['paid', 'both'], TRUE);
-      if ($is_paid && $this->paidPublishStripeGate->validatePaidPublishAllowed($this->currentUser, (int) $node->id()) !== NULL) {
+      $accepts_donations = $node->hasField('field_enable_donations')
+        && !$node->get('field_enable_donations')->isEmpty()
+        && (bool) $node->get('field_enable_donations')->value;
+      if (($is_paid || $accepts_donations) && $this->paidPublishStripeGate->validatePaidPublishAllowed($this->currentUser, (int) $node->id()) !== NULL) {
         $variables['mel_publish_blocked'] = TRUE;
         $variables['mel_publish_stripe_gate'] = TRUE;
       }

--- a/web/modules/custom/myeventlane_event_studio/src/EventStudioPreprocess.php
+++ b/web/modules/custom/myeventlane_event_studio/src/EventStudioPreprocess.php
@@ -120,9 +120,17 @@ final class EventStudioPreprocess {
       $accepts_donations = $node->hasField('field_enable_donations')
         && !$node->get('field_enable_donations')->isEmpty()
         && (bool) $node->get('field_enable_donations')->value;
-      if (($is_paid || $accepts_donations) && $this->paidPublishStripeGate->validatePaidPublishAllowed($this->currentUser, (int) $node->id()) !== NULL) {
-        $variables['mel_publish_blocked'] = TRUE;
-        $variables['mel_publish_stripe_gate'] = TRUE;
+      if ($is_paid || $accepts_donations) {
+        $tax_denial = $this->paidPublishStripeGate->validateTaxDeclarationAllowed($this->currentUser, (int) $node->id());
+        if ($tax_denial !== NULL) {
+          $variables['mel_publish_blocked'] = TRUE;
+          $variables['mel_publish_tax_gate'] = TRUE;
+          $variables['mel_publish_tax_message'] = $tax_denial;
+        }
+        elseif ($this->paidPublishStripeGate->validatePaidPublishAllowed($this->currentUser, (int) $node->id()) !== NULL) {
+          $variables['mel_publish_blocked'] = TRUE;
+          $variables['mel_publish_stripe_gate'] = TRUE;
+        }
       }
     }
 

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventReadinessService.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventReadinessService.php
@@ -93,10 +93,16 @@ final class EventReadinessService {
       }
     }
 
+    $accepts_payments = in_array($event_type, ['paid', 'both'], TRUE)
+      || ($event->hasField('field_enable_donations')
+        && !$event->get('field_enable_donations')->isEmpty()
+        && (bool) $event->get('field_enable_donations')->value);
     if (in_array($event_type, ['paid', 'both'], TRUE)) {
       if ($this->validatePaidTickets($event, $errors, $warnings)) {
         $completed[] = (string) $this->t('Tickets ready');
       }
+    }
+    if ($accepts_payments) {
       $stripe = $this->validateStripePublish($account, (int) $event->id(), $warnings);
       if ($stripe !== NULL) {
         $errors[] = $stripe;

--- a/web/modules/custom/myeventlane_event_studio/src/Service/EventWorkspaceOverviewBuilder.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/EventWorkspaceOverviewBuilder.php
@@ -1075,11 +1075,14 @@ final class EventWorkspaceOverviewBuilder {
   private function buildStripeHealth(AccountInterface $account, NodeInterface $event, array $eventMeta): array {
     $eventId = (int) $event->id();
     $eventType = $this->resolveEventBookingType($event, $eventMeta);
-    if (!in_array($eventType, ['paid', 'both'], TRUE)) {
+    $acceptsDonations = $event->hasField('field_enable_donations')
+      && !$event->get('field_enable_donations')->isEmpty()
+      && (bool) $event->get('field_enable_donations')->value;
+    if (!in_array($eventType, ['paid', 'both'], TRUE) && !$acceptsDonations) {
       return [
         'label' => (string) $this->t('Payments'),
         'tone' => 'muted',
-        'detail' => (string) $this->t('Payments apply when you sell paid tickets for this event.'),
+        'detail' => (string) $this->t('Payments apply when you sell tickets or accept optional donations for this event.'),
         'url' => $this->safeUrl('myeventlane_vendor.console.payments'),
       ];
     }

--- a/web/modules/custom/myeventlane_event_studio/src/Service/PublishEligibilityEvaluator.php
+++ b/web/modules/custom/myeventlane_event_studio/src/Service/PublishEligibilityEvaluator.php
@@ -82,7 +82,11 @@ final class PublishEligibilityEvaluator {
     }
 
     $eventType = $this->eventType($event);
-    if (in_array($eventType, ['paid', 'both'], TRUE)) {
+    $acceptsPayments = in_array($eventType, ['paid', 'both'], TRUE)
+      || ($event->hasField('field_enable_donations')
+        && !$event->get('field_enable_donations')->isEmpty()
+        && (bool) $event->get('field_enable_donations')->value);
+    if ($acceptsPayments) {
       $eventNodeId = $event->id() ? (int) $event->id() : NULL;
       $stripeMsg = $this->paidPublishStripeGate->validatePaidPublishAllowed($account, $eventNodeId);
       if ($stripeMsg !== NULL) {

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
@@ -671,7 +671,15 @@
               </div>
               <div class="mel-builder-card__body mel-builder-fields mel-builder-fields--stack">
               {% if mel_publish_blocked %}
-                {% if mel_publish_stripe_gate %}
+                {% if mel_publish_tax_gate %}
+                  <div class="mel-publish-warning" role="region" aria-label="{{ 'Confirm organiser tax details'|t }}">
+                    <h3 class="mel-publish-warning__title">{{ 'Confirm your legal and tax details'|t }}</h3>
+                    <p class="mel-publish-warning__lead">{{ mel_publish_tax_message }}</p>
+                    <a href="{{ path('myeventlane_vendor.console.settings_profile') }}" class="mel-btn mel-btn--primary mel-publish-warning__cta">
+                      {{ 'Open Organiser Settings'|t }}
+                    </a>
+                  </div>
+                {% elseif mel_publish_stripe_gate %}
                   <div class="mel-publish-warning mel-publish-warning--stripe" role="region" aria-label="{{ 'Finish payment setup before publishing'|t }}">
                     <h3 class="mel-publish-warning__title">{{ 'Finish payment setup before publishing'|t }}</h3>
                     <p class="mel-publish-warning__lead">{{ 'To accept event payments, finish your Stripe setup so payouts can reach your bank.'|t }}</p>

--- a/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
+++ b/web/modules/custom/myeventlane_event_studio/templates/mel-event-studio.html.twig
@@ -672,9 +672,9 @@
               <div class="mel-builder-card__body mel-builder-fields mel-builder-fields--stack">
               {% if mel_publish_blocked %}
                 {% if mel_publish_stripe_gate %}
-                  <div class="mel-publish-warning mel-publish-warning--stripe" role="region" aria-label="{{ 'Finish Stripe setup before publishing paid tickets'|t }}">
-                    <h3 class="mel-publish-warning__title">{{ 'Finish Stripe setup before publishing paid tickets'|t }}</h3>
-                    <p class="mel-publish-warning__lead">{{ 'To sell tickets, finish your Stripe setup so payouts can reach your bank.'|t }}</p>
+                  <div class="mel-publish-warning mel-publish-warning--stripe" role="region" aria-label="{{ 'Finish payment setup before publishing'|t }}">
+                    <h3 class="mel-publish-warning__title">{{ 'Finish payment setup before publishing'|t }}</h3>
+                    <p class="mel-publish-warning__lead">{{ 'To accept event payments, finish your Stripe setup so payouts can reach your bank.'|t }}</p>
                     <a href="{{ mel_stripe_connect_url }}" class="mel-btn mel-btn--primary mel-publish-warning__cta">
                       {{ 'Resume Stripe setup'|t }}
                     </a>

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioStripePublishGateAlignmentTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioStripePublishGateAlignmentTest.php
@@ -21,6 +21,8 @@ final class EventStudioStripePublishGateAlignmentTest extends UnitTestCase {
     $this->assertIsString($services);
     $this->assertStringContainsString('PaidPublishStripeGate', $preprocess);
     $this->assertStringContainsString('validatePaidPublishAllowed', $preprocess);
+    $this->assertStringContainsString('validateTaxDeclarationAllowed', $preprocess);
+    $this->assertStringContainsString('mel_publish_tax_gate', $preprocess);
     $this->assertStringNotContainsString("empty(\$flags['stripe_connected'])", $preprocess);
     $this->assertStringContainsString("'@myeventlane_vendor.paid_publish_stripe_gate'", $services);
   }
@@ -53,6 +55,8 @@ final class EventStudioStripePublishGateAlignmentTest extends UnitTestCase {
     $this->assertIsString($preprocess);
     $this->assertIsString($gate);
     $this->assertStringContainsString('Finish payment setup before publishing', $twig);
+    $this->assertStringContainsString('Confirm your legal and tax details', $twig);
+    $this->assertStringContainsString("myeventlane_vendor.console.settings_profile", $twig);
     $this->assertStringContainsString('To accept event payments, finish your Stripe setup so payouts can reach your bank.', $twig);
     $this->assertStringContainsString('Resume Stripe setup', $twig);
     $this->assertStringContainsString('mel_stripe_connect_url', $twig);

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioStripePublishGateAlignmentTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/EventStudioStripePublishGateAlignmentTest.php
@@ -36,7 +36,8 @@ final class EventStudioStripePublishGateAlignmentTest extends UnitTestCase {
     $this->assertIsString($save);
     $this->assertIsString($publish);
     $this->assertStringContainsString('validatePaidPublishAllowed', $readiness);
-    $this->assertStringContainsString("in_array(\$event_type, ['paid', 'both'], TRUE)", $readiness);
+    $this->assertStringContainsString("\$accepts_payments = in_array(\$event_type, ['paid', 'both'], TRUE)", $readiness);
+    $this->assertStringContainsString("hasField('field_enable_donations')", $readiness);
     $this->assertStringContainsString('validatePaidPublishAllowed', $evaluator);
     $this->assertStringContainsString('publishEligibilityEvaluator', $save);
     $this->assertStringNotContainsString('validatePaidPublishAllowed', $save);
@@ -51,13 +52,14 @@ final class EventStudioStripePublishGateAlignmentTest extends UnitTestCase {
     $this->assertIsString($twig);
     $this->assertIsString($preprocess);
     $this->assertIsString($gate);
-    $this->assertStringContainsString('Finish Stripe setup before publishing paid tickets', $twig);
-    $this->assertStringContainsString('To sell tickets, finish your Stripe setup so payouts can reach your bank.', $twig);
+    $this->assertStringContainsString('Finish payment setup before publishing', $twig);
+    $this->assertStringContainsString('To accept event payments, finish your Stripe setup so payouts can reach your bank.', $twig);
     $this->assertStringContainsString('Resume Stripe setup', $twig);
     $this->assertStringContainsString('mel_stripe_connect_url', $twig);
     $this->assertStringContainsString('myeventlane_vendor.stripe_connect', $preprocess);
-    $this->assertStringContainsString('To sell tickets, finish your Stripe setup so payouts can reach your bank.', $gate);
+    $this->assertStringContainsString('To accept event payments, finish your Stripe setup so payouts can reach your bank.', $gate);
     $this->assertStringContainsString("in_array(\$event_type, ['paid', 'both'], TRUE)", $preprocess);
+    $this->assertStringContainsString("\$accepts_donations", $preprocess);
   }
 
   public function testDraftSaveSkipsPublishEligibilityOnDraftPath(): void {

--- a/web/modules/custom/myeventlane_event_studio/tests/src/Unit/PublishEligibilityEvaluatorTest.php
+++ b/web/modules/custom/myeventlane_event_studio/tests/src/Unit/PublishEligibilityEvaluatorTest.php
@@ -28,6 +28,7 @@ final class PublishEligibilityEvaluatorTest extends UnitTestCase {
     $this->assertStringContainsString('validatePaidPublishAllowed', $source);
     $this->assertStringContainsString('$this->eventReadiness->evaluate', $source);
     $this->assertStringContainsString("in_array(\$eventType, ['paid', 'both'], TRUE)", $source);
+    $this->assertStringContainsString("hasField('field_enable_donations')", $source);
     $this->assertStringContainsString('catch (\\Throwable $e)', $source);
     $this->assertStringContainsString('evaluation_failed', $source);
   }

--- a/web/modules/custom/myeventlane_messaging/config/install/myeventlane_messaging.template.order_invoice.yml
+++ b/web/modules/custom/myeventlane_messaging/config/install/myeventlane_messaging.template.order_invoice.yml
@@ -1,10 +1,10 @@
 enabled: true
-subject: 'Tax invoice – Order #{{ order_number }}'
+subject: '{{ document_title|default("Receipt") }} – Order #{{ order_number }}'
 body_html: |
   <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; max-width: 600px; margin: 0 auto; background-color: #fef5ec; padding: 20px;">
     <div style="background-color: #ffffff; border-radius: 8px; padding: 30px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
       <div style="text-align: center; margin-bottom: 24px;">
-        <h1 style="color: #2c3e50; margin: 0; font-size: 26px;">Tax Invoice</h1>
+        <h1 style="color: #2c3e50; margin: 0; font-size: 26px;">{{ document_title|default('Receipt') }}</h1>
       </div>
 
       <p style="color: #34495e; font-size: 16px; line-height: 1.6; margin-bottom: 16px;">
@@ -12,13 +12,13 @@ body_html: |
       </p>
 
       <p style="color: #34495e; font-size: 16px; line-height: 1.6; margin-bottom: 20px;">
-        Thank you for your payment. This is your tax invoice for order <strong>#{{ order_number }}</strong>.
+        Thank you for your payment. This is your {{ document_title|default('receipt')|lower }} for order <strong>#{{ order_number }}</strong>.
       </p>
 
       <div style="margin: 16px 0; padding: 12px 16px; background-color: #f9f9f9; border-radius: 6px; font-size: 14px; color: #34495e;">
         <p style="margin: 0 0 8px; line-height: 1.5;">
           {% if vendor_name %}<strong>Supplier:</strong> {{ vendor_name }}<br>{% endif %}
-          <strong>ABN:</strong> {{ vendor_abn }}<br>
+          {% if vendor_abn %}<strong>ABN:</strong> {{ vendor_abn }}<br>{% endif %}
         </p>
         <div style="display: flex; justify-content: space-between; flex-wrap: wrap; gap: 8px;">
           <span><strong>Invoice date:</strong> {{ invoice_date }}</span>
@@ -102,7 +102,11 @@ body_html: |
         </div>
       </div>
 
-      <p class="mel-invoice__legal" style="margin: 16px 0 0; font-size: 11px; color: #7f8c8d; line-height: 1.45;">This document is a tax invoice for GST purposes.</p>
+      {% if is_tax_invoice %}
+        <p class="mel-invoice__legal" style="margin: 16px 0 0; font-size: 11px; color: #7f8c8d; line-height: 1.45;">This document is a tax invoice for GST purposes.</p>
+      {% else %}
+        <p class="mel-invoice__legal" style="margin: 16px 0 0; font-size: 11px; color: #7f8c8d; line-height: 1.45;">The supplier is not registered for GST. No GST has been charged.</p>
+      {% endif %}
 
       <div style="margin-top: 28px; padding-top: 18px; border-top: 1px solid #e0e0e0; text-align: center; color: #7f8c8d; font-size: 12px;">
         <p style="margin: 5px 0;">This email was sent to {{ order_email }}</p>

--- a/web/modules/custom/myeventlane_messaging/config/install/myeventlane_messaging.template.order_receipt.yml
+++ b/web/modules/custom/myeventlane_messaging/config/install/myeventlane_messaging.template.order_receipt.yml
@@ -84,10 +84,10 @@ body_html: |
 
       {% if vendor_name or order_total_gst or invoice_lines|length > 0 or invoice_fee_lines|length > 0 or invoice_tax_lines|length > 0 %}
         <div style="margin: 24px 0; padding: 20px; background-color: #ffffff; border: 1px solid #e0e0e0; border-radius: 8px;">
-          <h2 style="color: #2c3e50; margin: 0 0 16px; font-size: 20px;">Tax Invoice</h2>
+          <h2 style="color: #2c3e50; margin: 0 0 16px; font-size: 20px;">{{ document_title|default('Receipt') }}</h2>
           <p style="color: #34495e; font-size: 14px; line-height: 1.6; margin: 0 0 12px;">
             {% if vendor_name %}<strong>Supplier:</strong> {{ vendor_name }}<br>{% endif %}
-            <strong>ABN:</strong> {{ vendor_abn }}<br>
+            {% if vendor_abn %}<strong>ABN:</strong> {{ vendor_abn }}<br>{% endif %}
             <strong>Invoice #:</strong> {{ order_number }}<br>
             {% if invoice_date_short %}<strong>Date:</strong> {{ invoice_date_short }}<br>{% endif %}
           </p>
@@ -137,7 +137,11 @@ body_html: |
             <p style="margin:12px 0 0; font-size:14px; color:#34495e;"><strong>Total GST:</strong> {{ order_total_gst }}</p>
           {% endif %}
           <p style="margin:12px 0 0; font-size:16px; color:#2c3e50;"><strong>Total</strong> {{ order_total|default(total_paid) }}</p>
-          <p class="mel-invoice__legal" style="margin:16px 0 0; font-size:11px; color:#7f8c8d; line-height:1.45;">This document is a tax invoice for GST purposes.</p>
+          {% if is_tax_invoice %}
+            <p class="mel-invoice__legal" style="margin:16px 0 0; font-size:11px; color:#7f8c8d; line-height:1.45;">This document is a tax invoice for GST purposes.</p>
+          {% else %}
+            <p class="mel-invoice__legal" style="margin:16px 0 0; font-size:11px; color:#7f8c8d; line-height:1.45;">The supplier is not registered for GST. No GST has been charged.</p>
+          {% endif %}
           {% if show_includes_gst_note|default(false) %}
           <p style="color: #7f8c8d; font-size: 13px; margin: 12px 0 0 0;">All prices include GST where applicable.</p>
           {% endif %}

--- a/web/modules/custom/myeventlane_messaging/src/EventSubscriber/OrderPaidInvoiceSubscriber.php
+++ b/web/modules/custom/myeventlane_messaging/src/EventSubscriber/OrderPaidInvoiceSubscriber.php
@@ -137,6 +137,8 @@ final class OrderPaidInvoiceSubscriber implements EventSubscriberInterface {
       'order_total_gst' => $invoice['order_total_gst'],
       'vendor_name' => $invoice['vendor_name'],
       'vendor_abn' => $invoice['vendor_abn'],
+      'document_title' => $invoice['document_title'],
+      'is_tax_invoice' => $invoice['is_tax_invoice'],
       'invoice_date' => $this->dateFormatter->format((int) $invoice_timestamp, 'long'),
       'invoice_date_short' => $invoice['invoice_date_display'],
       'line_items' => $line_items,

--- a/web/modules/custom/myeventlane_messaging/src/Service/OrderConfirmationQueueBuilder.php
+++ b/web/modules/custom/myeventlane_messaging/src/Service/OrderConfirmationQueueBuilder.php
@@ -178,6 +178,8 @@ final class OrderConfirmationQueueBuilder {
       'show_includes_gst_note' => $pricing['show_includes_gst_note'],
       'vendor_name' => $invoice['vendor_name'],
       'vendor_abn' => $invoice['vendor_abn'],
+      'document_title' => $invoice['document_title'],
+      'is_tax_invoice' => $invoice['is_tax_invoice'],
       'order_total_gst' => $invoice['order_total_gst'],
       'order_total' => $invoice['order_total'],
       'invoice_lines' => $invoice['invoice_lines'],

--- a/web/modules/custom/myeventlane_pro/src/Controller/ProBillingController.php
+++ b/web/modules/custom/myeventlane_pro/src/Controller/ProBillingController.php
@@ -11,6 +11,7 @@ use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
@@ -207,7 +208,9 @@ final class ProBillingController implements ContainerInjectionInterface {
       return new RedirectResponse($fallback);
     }
 
-    return new RedirectResponse($url);
+    // Stripe returns an absolute external URL. Drupal deliberately rejects
+    // external targets on a normal RedirectResponse during response handling.
+    return new TrustedRedirectResponse($url);
   }
 
   /**

--- a/web/modules/custom/myeventlane_pro/tests/src/Unit/ProManagePresentationContractTest.php
+++ b/web/modules/custom/myeventlane_pro/tests/src/Unit/ProManagePresentationContractTest.php
@@ -37,6 +37,14 @@ final class ProManagePresentationContractTest extends TestCase {
     self::assertStringContainsString('We do not have a future renewal date to show', $template);
   }
 
+  public function testBillingPortalUsesTrustedExternalRedirect(): void {
+    $controller = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/ProBillingController.php');
+    self::assertIsString($controller);
+
+    self::assertStringContainsString('use Drupal\\Core\\Routing\\TrustedRedirectResponse;', $controller);
+    self::assertStringContainsString('return new TrustedRedirectResponse($url);', $controller);
+  }
+
   public function testZeroRoiUsesPlainLanguage(): void {
     $template = file_get_contents(dirname(__DIR__, 3) . '/templates/vendor-pro-manage.html.twig');
     self::assertIsString($template);

--- a/web/modules/custom/myeventlane_refunds/myeventlane_refunds.install
+++ b/web/modules/custom/myeventlane_refunds/myeventlane_refunds.install
@@ -146,6 +146,35 @@ function myeventlane_refunds_schema(): array {
         'not null' => FALSE,
         'description' => 'JSON array of attendee IDs targeted by partial ticket refund.',
       ],
+      'adjustment_note_number' => [
+        'type' => 'varchar',
+        'length' => 128,
+        'not null' => FALSE,
+        'description' => 'Immutable GST adjustment note identifier.',
+      ],
+      'gst_adjustment_cents' => [
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0,
+        'description' => 'GST reversed by this confirmed refund, in cents.',
+      ],
+      'supplier_name_snapshot' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => FALSE,
+        'description' => 'Supplier name at adjustment-note creation.',
+      ],
+      'supplier_abn_snapshot' => [
+        'type' => 'varchar',
+        'length' => 14,
+        'not null' => FALSE,
+        'description' => 'Supplier ABN at adjustment-note creation.',
+      ],
+      'adjustment_note_created' => [
+        'type' => 'int',
+        'not null' => FALSE,
+        'description' => 'Unix timestamp when the adjustment note was recorded.',
+      ],
     ],
     'primary key' => ['id'],
     'indexes' => [
@@ -156,6 +185,7 @@ function myeventlane_refunds_schema(): array {
       'idx_refund_status_event' => ['event_id', 'status'],
       'idx_retry_schedule' => ['next_attempt_at'],
       'idx_retry_of' => ['retry_of'],
+      'adjustment_note_number' => ['adjustment_note_number'],
     ],
   ];
 
@@ -769,5 +799,36 @@ function myeventlane_refunds_update_9010(): void {
     catch (\Throwable) {
       // Ignore if the index already exists with a different database name.
     }
+  }
+}
+
+/**
+ * Adds immutable GST adjustment-note fields to confirmed refund records.
+ */
+function myeventlane_refunds_update_9011(): void {
+  $schema = \Drupal::database()->schema();
+  if (!$schema->tableExists('myeventlane_refund_log')) {
+    return;
+  }
+
+  $fields = [
+    'adjustment_note_number' => ['type' => 'varchar', 'length' => 128, 'not null' => FALSE],
+    'gst_adjustment_cents' => ['type' => 'int', 'not null' => TRUE, 'default' => 0],
+    'supplier_name_snapshot' => ['type' => 'varchar', 'length' => 255, 'not null' => FALSE],
+    'supplier_abn_snapshot' => ['type' => 'varchar', 'length' => 14, 'not null' => FALSE],
+    'adjustment_note_created' => ['type' => 'int', 'not null' => FALSE],
+  ];
+  foreach ($fields as $name => $spec) {
+    if (!$schema->fieldExists('myeventlane_refund_log', $name)) {
+      $schema->addField('myeventlane_refund_log', $name, $spec);
+    }
+  }
+  if (!$schema->indexExists('myeventlane_refund_log', 'adjustment_note_number')) {
+    $schema->addIndex(
+      'myeventlane_refund_log',
+      'adjustment_note_number',
+      ['adjustment_note_number'],
+      ['fields' => ['adjustment_note_number' => $fields['adjustment_note_number']]],
+    );
   }
 }

--- a/web/modules/custom/myeventlane_refunds/myeventlane_refunds.services.yml
+++ b/web/modules/custom/myeventlane_refunds/myeventlane_refunds.services.yml
@@ -15,6 +15,10 @@ services:
     class: Drupal\myeventlane_refunds\Service\RefundRequestStorage
     arguments: ['@database', '@datetime.time']
 
+  myeventlane_refunds.adjustment_note:
+    class: Drupal\myeventlane_refunds\Service\RefundAdjustmentNoteService
+    arguments: ['@database', '@datetime.time']
+
   myeventlane_refunds.buyer_refund_access_check:
     class: Drupal\myeventlane_refunds\Access\BuyerRefundAccessCheck
     arguments:
@@ -66,4 +70,5 @@ services:
       - '@lock'
       - '@module_handler'
       - '@myeventlane_core.domain_detector'
+      - '@myeventlane_refunds.adjustment_note'
       - '@?myeventlane_notifications.refund_trigger'

--- a/web/modules/custom/myeventlane_refunds/src/Service/RefundAdjustmentNoteService.php
+++ b/web/modules/custom/myeventlane_refunds/src/Service/RefundAdjustmentNoteService.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_refunds\Service;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Database\Connection;
+
+/**
+ * Records an immutable tax adjustment snapshot after a confirmed refund.
+ */
+final class RefundAdjustmentNoteService {
+
+  public function __construct(
+    private readonly Connection $database,
+    private readonly TimeInterface $time,
+  ) {}
+
+  /**
+   * Creates the adjustment snapshot once and returns the canonical log row.
+   *
+   * @param \Drupal\commerce_order\Entity\OrderInterface $order
+   *   The order whose confirmed payment was refunded.
+   * @param array<string, mixed> $refundLog
+   *   The confirmed refund log row.
+   *
+   * @return array<string, mixed>
+   *   The canonical persisted refund log row.
+   */
+  public function record(OrderInterface $order, array $refundLog): array {
+    $logId = (int) ($refundLog['id'] ?? 0);
+    if ($logId <= 0 || (string) ($refundLog['status'] ?? '') !== RefundProcessor::STATUS_COMPLETED) {
+      return $refundLog;
+    }
+    if (!empty($refundLog['adjustment_note_number'])) {
+      return $refundLog;
+    }
+
+    $store = $order->getStore();
+    $registrations = $store ? array_column($store->get('tax_registrations')->getValue(), 'value') : [];
+    $isGstRegistered = in_array('AU', $registrations, TRUE);
+    $supplierName = $store ? trim((string) $store->label()) : '';
+    $supplierAbn = '';
+    if ($store && $store->hasField('field_abn') && !$store->get('field_abn')->isEmpty()) {
+      $supplierAbn = preg_replace('/\D+/', '', (string) $store->get('field_abn')->value) ?? '';
+    }
+
+    $refundedCents = max(0, (int) ($refundLog['actual_refunded_cents'] ?? $refundLog['amount_cents'] ?? 0));
+    $donationCents = 0;
+    if (!empty($refundLog['donation_refunded']) && $order->hasField('field_mel_donation') && !$order->get('field_mel_donation')->isEmpty()) {
+      $donationCents = (int) round(((float) $order->get('field_mel_donation')->value) * 100);
+    }
+    $gstCents = $this->calculateGstAdjustmentCents(
+      $isGstRegistered,
+      $refundedCents,
+      $donationCents,
+      (string) ($refundLog['refund_scope'] ?? ''),
+    );
+    $orderNumber = preg_replace('/[^A-Za-z0-9_-]/', '-', (string) ($order->getOrderNumber() ?: $order->id())) ?: (string) $order->id();
+    $noteNumber = sprintf('ADJ-%s-%d', $orderNumber, $logId);
+
+    $this->database->update('myeventlane_refund_log')
+      ->fields([
+        'adjustment_note_number' => $noteNumber,
+        'gst_adjustment_cents' => $gstCents,
+        'supplier_name_snapshot' => $supplierName,
+        'supplier_abn_snapshot' => $supplierAbn,
+        'adjustment_note_created' => $this->time->getRequestTime(),
+      ])
+      ->condition('id', $logId)
+      ->isNull('adjustment_note_number')
+      ->execute();
+
+    $row = $this->database->select('myeventlane_refund_log', 'r')
+      ->fields('r')
+      ->condition('id', $logId)
+      ->execute()
+      ->fetchAssoc();
+    return is_array($row) ? $row : $refundLog;
+  }
+
+  /**
+   * Excludes genuine organiser gifts from the taxable refund amount.
+   */
+  public function calculateGstAdjustmentCents(
+    bool $isGstRegistered,
+    int $refundedCents,
+    int $donationCents,
+    string $refundScope,
+  ): int {
+    if (!$isGstRegistered || $refundScope === 'donation_only') {
+      return 0;
+    }
+
+    return (int) round(max(0, $refundedCents - max(0, $donationCents)) / 11);
+  }
+
+}

--- a/web/modules/custom/myeventlane_refunds/src/Service/RefundAdjustmentNoteService.php
+++ b/web/modules/custom/myeventlane_refunds/src/Service/RefundAdjustmentNoteService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_refunds\Service;
 
 use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_price\Price;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Database\Connection;
 
@@ -39,8 +40,6 @@ final class RefundAdjustmentNoteService {
     }
 
     $store = $order->getStore();
-    $registrations = $store ? array_column($store->get('tax_registrations')->getValue(), 'value') : [];
-    $isGstRegistered = in_array('AU', $registrations, TRUE);
     $supplierName = $store ? trim((string) $store->label()) : '';
     $supplierAbn = '';
     if ($store && $store->hasField('field_abn') && !$store->get('field_abn')->isEmpty()) {
@@ -48,15 +47,28 @@ final class RefundAdjustmentNoteService {
     }
 
     $refundedCents = max(0, (int) ($refundLog['actual_refunded_cents'] ?? $refundLog['amount_cents'] ?? 0));
-    $donationCents = 0;
-    if (!empty($refundLog['donation_refunded']) && $order->hasField('field_mel_donation') && !$order->get('field_mel_donation')->isEmpty()) {
-      $donationCents = (int) round(((float) $order->get('field_mel_donation')->value) * 100);
+    $orderDonationCents = 0;
+    if ($order->hasField('field_mel_donation') && !$order->get('field_mel_donation')->isEmpty()) {
+      $orderDonationCents = (int) round(((float) $order->get('field_mel_donation')->value) * 100);
     }
+    $refundedDonationCents = !empty($refundLog['donation_refunded'])
+      ? min($orderDonationCents, $refundedCents)
+      : 0;
+    $orderTaxCents = $this->sumRecordedTaxCents($order);
+    // Untaxed sales receive the ordinary refund confirmation only. They must
+    // not be represented as GST adjustment notes.
+    if ($orderTaxCents <= 0) {
+      return $refundLog;
+    }
+    $orderGrossCents = $this->priceToCents($order->getTotalPrice());
+    $taxableOrderGrossCents = max(0, $orderGrossCents - $orderDonationCents);
+    $refundedTaxableCents = (string) ($refundLog['refund_scope'] ?? '') === 'donation_only'
+      ? 0
+      : max(0, $refundedCents - $refundedDonationCents);
     $gstCents = $this->calculateGstAdjustmentCents(
-      $isGstRegistered,
-      $refundedCents,
-      $donationCents,
-      (string) ($refundLog['refund_scope'] ?? ''),
+      $orderTaxCents,
+      $taxableOrderGrossCents,
+      $refundedTaxableCents,
     );
     $orderNumber = preg_replace('/[^A-Za-z0-9_-]/', '-', (string) ($order->getOrderNumber() ?: $order->id())) ?: (string) $order->id();
     $noteNumber = sprintf('ADJ-%s-%d', $orderNumber, $logId);
@@ -82,19 +94,48 @@ final class RefundAdjustmentNoteService {
   }
 
   /**
-   * Excludes genuine organiser gifts from the taxable refund amount.
+   * Prorates the order's recorded GST over the refunded taxable amount.
    */
   public function calculateGstAdjustmentCents(
-    bool $isGstRegistered,
-    int $refundedCents,
-    int $donationCents,
-    string $refundScope,
+    int $orderTaxCents,
+    int $orderTaxableGrossCents,
+    int $refundedTaxableCents,
   ): int {
-    if (!$isGstRegistered || $refundScope === 'donation_only') {
+    if ($orderTaxCents <= 0 || $orderTaxableGrossCents <= 0 || $refundedTaxableCents <= 0) {
       return 0;
     }
 
-    return (int) round(max(0, $refundedCents - max(0, $donationCents)) / 11);
+    return min(
+      $orderTaxCents,
+      (int) round($orderTaxCents * min($refundedTaxableCents, $orderTaxableGrossCents) / $orderTaxableGrossCents),
+    );
+  }
+
+  /**
+   * Sums tax adjustments persisted on the order and its line items.
+   */
+  private function sumRecordedTaxCents(OrderInterface $order): int {
+    $taxCents = 0;
+    foreach ($order->getAdjustments() as $adjustment) {
+      if ($adjustment->getType() === 'tax') {
+        $taxCents += $this->priceToCents($adjustment->getAmount());
+      }
+    }
+    foreach ($order->getItems() as $item) {
+      foreach ($item->getAdjustments() as $adjustment) {
+        if ($adjustment->getType() === 'tax') {
+          $taxCents += $this->priceToCents($adjustment->getAmount());
+        }
+      }
+    }
+    return max(0, $taxCents);
+  }
+
+  /**
+   * Converts a Commerce price to integer minor units.
+   */
+  private function priceToCents(?Price $price): int {
+    return $price instanceof Price ? (int) round((float) $price->getNumber() * 100) : 0;
   }
 
 }

--- a/web/modules/custom/myeventlane_refunds/src/Service/RefundProcessor.php
+++ b/web/modules/custom/myeventlane_refunds/src/Service/RefundProcessor.php
@@ -68,6 +68,8 @@ final class RefundProcessor implements RefundProcessorInterface {
    *   The module handler.
    * @param \Drupal\myeventlane_core\Service\DomainDetector $domainDetector
    *   The domain detector (for public-domain customer links).
+   * @param \Drupal\myeventlane_refunds\Service\RefundAdjustmentNoteService $adjustmentNoteService
+   *   Records immutable tax adjustment snapshots after confirmed refunds.
    * @param \Drupal\myeventlane_notifications\Service\RefundNotificationTriggerService|null $refundNotificationTrigger
    *   Optional in-app refund notifications (when myeventlane_notifications is enabled).
    */
@@ -88,6 +90,7 @@ final class RefundProcessor implements RefundProcessorInterface {
     private readonly LockBackendInterface $lock,
     private readonly ModuleHandlerInterface $moduleHandler,
     private readonly DomainDetector $domainDetector,
+    private readonly RefundAdjustmentNoteService $adjustmentNoteService,
     private readonly ?RefundNotificationTriggerService $refundNotificationTrigger = NULL,
   ) {}
 
@@ -536,6 +539,16 @@ final class RefundProcessor implements RefundProcessorInterface {
    * Attempts refund execution immediately, then falls back to queue.
    */
   public function requestRefundByLogId(int $logId): void {
+    // Do not move an already completed refund back to processing. This guard
+    // also prevents replayed queue items from repeating completion side effects.
+    $existing = $this->loadRefundLog($logId);
+    if ($existing !== NULL && (
+      (string) ($existing['status'] ?? '') === self::STATUS_COMPLETED
+      || !empty($existing['stripe_refund_id'])
+    )) {
+      return;
+    }
+
     $this->setRefundStatus($logId, self::STATUS_PROCESSING);
 
     try {
@@ -1061,6 +1074,10 @@ final class RefundProcessor implements RefundProcessorInterface {
       return;
     }
 
+    // Persist the adjustment snapshot before any hook or notification. A
+    // duplicate webhook/retry reads the same note instead of issuing another.
+    $log = $this->adjustmentNoteService->record($order, $log);
+
     $this->moduleHandler->invokeAll('myeventlane_refund_completed', [
       $order,
       $event,
@@ -1252,17 +1269,25 @@ final class RefundProcessor implements RefundProcessorInterface {
     NodeInterface $event,
     array $log,
     string $customerEmail,
-    int $ticketsCancelled = 0
+    int $ticketsCancelled = 0,
   ): void {
     $ctx = $this->buildRefundEmailContext(
       $order,
       $event,
-      (int) $log['amount_cents'],
+      (int) ($log['actual_refunded_cents'] ?? $log['amount_cents']),
       $log['currency'],
       (bool) ($log['donation_refunded'] ?? FALSE)
     );
     $ctx['stripe_refund_id'] = (string) ($log['stripe_refund_id'] ?? '');
     $ctx['tickets_cancelled'] = $ticketsCancelled;
+    $ctx['adjustment_note_number'] = (string) ($log['adjustment_note_number'] ?? '');
+    $ctx['gst_adjustment'] = strtoupper((string) ($log['currency'] ?? 'aud')) . ' ' . number_format(((int) ($log['gst_adjustment_cents'] ?? 0)) / 100, 2);
+    $ctx['supplier_name'] = (string) ($log['supplier_name_snapshot'] ?? '');
+    $ctx['supplier_abn'] = (string) ($log['supplier_abn_snapshot'] ?? '');
+    $ctx['adjustment_note_date'] = !empty($log['adjustment_note_created'])
+      ? date('j M Y', (int) $log['adjustment_note_created'])
+      : '';
+    $ctx['adjustment_reason'] = trim((string) ($log['reason'] ?? 'Refund')) ?: 'Refund';
 
     if (!empty($customerEmail)) {
       $id = $this->messagingManager->queue('refund_completed_buyer', $customerEmail, $ctx);

--- a/web/modules/custom/myeventlane_refunds/tests/src/Kernel/RefundProcessorLockingTest.php
+++ b/web/modules/custom/myeventlane_refunds/tests/src/Kernel/RefundProcessorLockingTest.php
@@ -48,6 +48,42 @@ final class RefundProcessorLockingTest extends KernelTestBase {
   ];
 
   /**
+   * Tests replayed work cannot reopen a completed refund.
+   */
+  public function testCompletedRefundReplayPreservesCanonicalState(): void {
+    $database = $this->container->get('database');
+    $database->schema()->createTable('myeventlane_refund_log', [
+      'fields' => [
+        'id' => ['type' => 'serial', 'not null' => TRUE],
+        'status' => ['type' => 'varchar', 'length' => 32, 'not null' => TRUE],
+        'stripe_refund_id' => ['type' => 'varchar', 'length' => 255, 'not null' => FALSE],
+        'updated' => ['type' => 'int', 'not null' => FALSE],
+      ],
+      'primary key' => ['id'],
+    ]);
+    $logId = (int) $database->insert('myeventlane_refund_log')->fields([
+      'status' => RefundProcessor::STATUS_COMPLETED,
+      'stripe_refund_id' => 're_test_completed',
+      'updated' => 123456,
+    ])->execute();
+
+    $reflection = new \ReflectionClass(RefundProcessor::class);
+    $processor = $reflection->newInstanceWithoutConstructor();
+    $reflection->getProperty('database')->setValue($processor, $database);
+
+    $processor->requestRefundByLogId($logId);
+
+    $row = $database->select('myeventlane_refund_log', 'r')
+      ->fields('r', ['status', 'stripe_refund_id', 'updated'])
+      ->condition('id', $logId)
+      ->execute()
+      ->fetchAssoc();
+    $this->assertSame(RefundProcessor::STATUS_COMPLETED, $row['status']);
+    $this->assertSame('re_test_completed', $row['stripe_refund_id']);
+    $this->assertSame('123456', $row['updated']);
+  }
+
+  /**
    * Tests later queue batches reuse the persisted cancellation refund.
    */
   public function testEventCancellationRefundReusesExistingLog(): void {

--- a/web/modules/custom/myeventlane_refunds/tests/src/Unit/RefundAdjustmentNoteServiceTest.php
+++ b/web/modules/custom/myeventlane_refunds/tests/src/Unit/RefundAdjustmentNoteServiceTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_refunds\Unit;
+
+require_once dirname(__DIR__, 3) . '/src/Service/RefundAdjustmentNoteService.php';
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Database\Connection;
+use Drupal\myeventlane_refunds\Service\RefundAdjustmentNoteService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests GST reversal calculations for confirmed refunds.
+ *
+ * @group myeventlane_refunds
+ */
+final class RefundAdjustmentNoteServiceTest extends TestCase {
+
+  /**
+   * Tests taxable, gift, mixed and unregistered supplier refunds.
+   */
+  public function testGstAdjustmentCalculation(): void {
+    $service = new RefundAdjustmentNoteService(
+      $this->createMock(Connection::class),
+      $this->createMock(TimeInterface::class),
+    );
+
+    self::assertSame(100, $service->calculateGstAdjustmentCents(TRUE, 1100, 0, 'tickets_only'));
+    self::assertSame(0, $service->calculateGstAdjustmentCents(TRUE, 1100, 0, 'donation_only'));
+    self::assertSame(100, $service->calculateGstAdjustmentCents(TRUE, 1600, 500, 'tickets_and_donation'));
+    self::assertSame(0, $service->calculateGstAdjustmentCents(FALSE, 1100, 0, 'tickets_only'));
+  }
+
+}

--- a/web/modules/custom/myeventlane_refunds/tests/src/Unit/RefundAdjustmentNoteServiceTest.php
+++ b/web/modules/custom/myeventlane_refunds/tests/src/Unit/RefundAdjustmentNoteServiceTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 final class RefundAdjustmentNoteServiceTest extends TestCase {
 
   /**
-   * Tests taxable, gift, mixed and unregistered supplier refunds.
+   * Tests full, partial, gift and untaxed order refunds.
    */
   public function testGstAdjustmentCalculation(): void {
     $service = new RefundAdjustmentNoteService(
@@ -27,10 +27,22 @@ final class RefundAdjustmentNoteServiceTest extends TestCase {
       $this->createMock(TimeInterface::class),
     );
 
-    self::assertSame(100, $service->calculateGstAdjustmentCents(TRUE, 1100, 0, 'tickets_only'));
-    self::assertSame(0, $service->calculateGstAdjustmentCents(TRUE, 1100, 0, 'donation_only'));
-    self::assertSame(100, $service->calculateGstAdjustmentCents(TRUE, 1600, 500, 'tickets_and_donation'));
-    self::assertSame(0, $service->calculateGstAdjustmentCents(FALSE, 1100, 0, 'tickets_only'));
+    self::assertSame(100, $service->calculateGstAdjustmentCents(100, 1100, 1100));
+    self::assertSame(50, $service->calculateGstAdjustmentCents(100, 1100, 550));
+    self::assertSame(0, $service->calculateGstAdjustmentCents(100, 1100, 0));
+    self::assertSame(0, $service->calculateGstAdjustmentCents(0, 1100, 1100));
+    self::assertSame(100, $service->calculateGstAdjustmentCents(100, 1100, 1600));
+  }
+
+  /**
+   * Ensures historical refund tax never follows mutable registration data.
+   */
+  public function testHistoricalRefundLogicDoesNotUseCurrentRegistration(): void {
+    $source = file_get_contents(dirname(__DIR__, 3) . '/src/Service/RefundAdjustmentNoteService.php');
+
+    self::assertIsString($source);
+    self::assertStringContainsString('sumRecordedTaxCents($order)', $source);
+    self::assertStringNotContainsString("get('tax_registrations')", $source);
   }
 
 }

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.install
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.install
@@ -1372,6 +1372,137 @@ function myeventlane_vendor_update_10024(): string {
 }
 
 /**
+ * Adds organiser tax declarations without rewriting legacy tax treatment.
+ */
+function myeventlane_vendor_update_10025(): string {
+  $fields = [
+    'field_tax_entity_type' => [
+      'type' => 'list_string',
+      'storage_settings' => [
+        'allowed_values' => [
+          'individual' => 'Individual / sole trader',
+          'company' => 'Company',
+          'incorporated_association' => 'Incorporated association',
+          'unincorporated_association' => 'Unincorporated association',
+          'trust' => 'Trust',
+          'charity_or_nfp' => 'Charity or not-for-profit',
+          'government' => 'Government entity',
+          'other' => 'Other',
+        ],
+      ],
+      'label' => 'Organisation type',
+    ],
+    'field_gst_registration_status' => [
+      'type' => 'list_string',
+      'storage_settings' => [
+        'allowed_values' => [
+          'unknown' => 'Not yet declared',
+          'not_registered' => 'Not registered for GST',
+          'registered' => 'Registered for GST',
+        ],
+      ],
+      'label' => 'GST registration status',
+      'default_value' => [['value' => 'unknown']],
+    ],
+    'field_gst_effective_date' => [
+      'type' => 'datetime',
+      'storage_settings' => ['datetime_type' => 'date'],
+      'label' => 'GST registration effective date',
+    ],
+    'field_acnc_status' => [
+      'type' => 'list_string',
+      'storage_settings' => [
+        'allowed_values' => [
+          'not_applicable' => 'Not applicable',
+          'not_registered' => 'Not ACNC registered',
+          'registered' => 'ACNC registered charity',
+        ],
+      ],
+      'label' => 'Charity status',
+      'default_value' => [['value' => 'not_applicable']],
+    ],
+    'field_dgr_status' => [
+      'type' => 'list_string',
+      'storage_settings' => [
+        'allowed_values' => [
+          'not_endorsed' => 'Not DGR endorsed',
+          'endorsed' => 'DGR endorsed',
+        ],
+      ],
+      'label' => 'DGR endorsement',
+      'default_value' => [['value' => 'not_endorsed']],
+    ],
+    'field_tax_declaration_at' => [
+      'type' => 'timestamp',
+      'storage_settings' => [],
+      'label' => 'Tax declaration date',
+    ],
+  ];
+
+  foreach ($fields as $fieldName => $definition) {
+    if (FieldStorageConfig::loadByName('myeventlane_vendor', $fieldName) === NULL) {
+      FieldStorageConfig::create([
+        'field_name' => $fieldName,
+        'entity_type' => 'myeventlane_vendor',
+        'type' => $definition['type'],
+        'settings' => $definition['storage_settings'],
+        'cardinality' => 1,
+        'translatable' => FALSE,
+      ])->save();
+    }
+    if (FieldConfig::loadByName('myeventlane_vendor', 'myeventlane_vendor', $fieldName) === NULL) {
+      FieldConfig::create([
+        'field_name' => $fieldName,
+        'entity_type' => 'myeventlane_vendor',
+        'bundle' => 'myeventlane_vendor',
+        'label' => $definition['label'],
+        'required' => FALSE,
+        'translatable' => FALSE,
+        'default_value' => $definition['default_value'] ?? [],
+      ])->save();
+    }
+  }
+
+  // Do not rewrite organiser registrations during deployment. The legacy data
+  // cannot distinguish a genuine registration from the previous assumption,
+  // and changing it here could alter existing invoice tax treatment. The new
+  // declaration remains pending until the organiser explicitly confirms it;
+  // saving that declaration then becomes authoritative for the linked store.
+  $storeStorage = \Drupal::entityTypeManager()->getStorage('commerce_store');
+  $storeIds = $storeStorage->getQuery()->accessCheck(FALSE)->execute();
+  $vendorStoreIds = [];
+  $vendorStorage = \Drupal::entityTypeManager()->getStorage('myeventlane_vendor');
+  $vendorIds = $vendorStorage->getQuery()->accessCheck(FALSE)->execute();
+  foreach ($vendorStorage->loadMultiple($vendorIds) as $vendor) {
+    if ($vendor->hasField('field_vendor_store') && !$vendor->get('field_vendor_store')->isEmpty()) {
+      $vendorStoreIds[] = (int) $vendor->get('field_vendor_store')->target_id;
+    }
+  }
+  $vendorStoreIds = array_values(array_unique(array_filter($vendorStoreIds)));
+  $pendingVerification = 0;
+  $platformUpdated = 0;
+  foreach ($storeStorage->loadMultiple($storeIds) as $store) {
+    // Platform-owned stores retain their AU registration. Only organiser
+    // stores linked through field_vendor_reference were incorrectly assumed.
+    $isVendorStore = in_array((int) $store->id(), $vendorStoreIds, TRUE)
+      || ($store->hasField('field_vendor_reference') && !$store->get('field_vendor_reference')->isEmpty());
+    if (!$isVendorStore) {
+      $store->set('tax_registrations', ['AU']);
+      $store->set('prices_include_tax', TRUE);
+      if ($store->hasField('field_abn')) {
+        $store->set('field_abn', '11304813593');
+      }
+      $store->save();
+      $platformUpdated++;
+      continue;
+    }
+    $pendingVerification++;
+  }
+
+  return sprintf('Added organiser tax declaration fields, configured %d platform store(s) for AU GST, and left %d organiser store registration(s) unchanged pending explicit declaration.', $platformUpdated, $pendingVerification);
+}
+
+/**
  * Renders formatted text for CK-1's byte-preserving equivalence gate.
  */
 function myeventlane_vendor_render_processed_text_for_update(

--- a/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
+++ b/web/modules/custom/myeventlane_vendor/myeventlane_vendor.services.yml
@@ -55,6 +55,9 @@ services:
       - '@entity_type.manager'
       - '@entity_field.manager'
 
+  myeventlane_vendor.organiser_tax_profile:
+    class: Drupal\myeventlane_vendor\Service\OrganiserTaxProfileManager
+
   myeventlane_vendor.organiser_media_access:
     class: Drupal\myeventlane_vendor\Service\OrganiserMediaAccess
     arguments:
@@ -107,6 +110,7 @@ services:
       - '@myeventlane_vendor.user_vendor_membership_query'
       - '@logger.channel.myeventlane_vendor'
       - '@string_translation'
+      - '@myeventlane_vendor.organiser_tax_profile'
 
   myeventlane_vendor.publish_requirements_gate:
     class: Drupal\myeventlane_vendor\Service\VendorPublishRequirementsGate
@@ -132,6 +136,7 @@ services:
       - '@logger.factory'
       - '@myeventlane_onboarding.manager'
       - '@current_user'
+      - '@myeventlane_vendor.organiser_tax_profile'
     tags:
       - { name: event_subscriber }
 

--- a/web/modules/custom/myeventlane_vendor/src/EventSubscriber/VendorStoreSubscriber.php
+++ b/web/modules/custom/myeventlane_vendor/src/EventSubscriber/VendorStoreSubscriber.php
@@ -11,6 +11,7 @@ use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\myeventlane_core\Service\OnboardingManager;
 use Drupal\myeventlane_vendor\Entity\Vendor;
+use Drupal\myeventlane_vendor\Service\OrganiserTaxProfileManager;
 use Drupal\user\UserInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -79,6 +80,7 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
     LoggerChannelFactoryInterface $logger_factory,
     OnboardingManager $onboarding_manager,
     AccountProxyInterface $current_user,
+    private readonly OrganiserTaxProfileManager $organiserTaxProfile,
   ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->loggerFactory = $logger_factory;
@@ -296,16 +298,21 @@ final class VendorStoreSubscriber implements EventSubscriberInterface {
           'organization' => $vendor->getName(),
         ],
         'billing_countries' => ['AU'],
-        // Commerce Tax: Australian GST only applies when the store is registered
-        // to collect tax in AU (see LocalTaxTypeBase::matchesRegistrations()).
-        'tax_registrations' => ['AU'],
-        // Align with Australian GST config (display inclusive) and ticket face prices.
+        // Tax registrations are populated only after the organiser declares
+        // its GST status. Do not treat every organiser as GST registered.
+        'tax_registrations' => [],
+        // Ticket prices are entered as the customer-facing amount. Commerce
+        // applies included GST only when an AU registration is declared.
         'prices_include_tax' => TRUE,
         'is_default' => FALSE,
         'status' => TRUE,
       ]);
 
       $store->set('field_vendor_reference', $vendor);
+      $this->organiserTaxProfile->syncStore($vendor, $store);
+      if ($store->hasField('field_abn') && $vendor->hasField('field_abn') && !$vendor->get('field_abn')->isEmpty()) {
+        $store->set('field_abn', (string) $vendor->get('field_abn')->value);
+      }
       $store->save();
 
       $vendor->set('field_vendor_store', $store);

--- a/web/modules/custom/myeventlane_vendor/src/Form/OrganiserProfileSettingsForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/OrganiserProfileSettingsForm.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\myeventlane_vendor\Form;
 
 use Drupal\commerce_store\Entity\StoreInterface;
+use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Access\AccessManagerInterface;
 use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
@@ -19,6 +20,7 @@ use Drupal\myeventlane_surface\MelWorkflowManager;
 use Drupal\myeventlane_vendor\Entity\Vendor;
 use Drupal\myeventlane_vendor\EventSubscriber\VendorStoreSubscriber;
 use Drupal\myeventlane_vendor\Service\CurrentVendorResolverInterface;
+use Drupal\myeventlane_vendor\Service\OrganiserTaxProfileManager;
 use Drupal\myeventlane_vendor\Service\UserVendorMembershipQuery;
 use Drupal\myeventlane_vendor\Service\VendorBrandMediaManager;
 use Drupal\myeventlane_vendor\Service\VendorImageFieldPolicy;
@@ -70,6 +72,10 @@ class OrganiserProfileSettingsForm extends FormBase {
 
   protected RouteProviderInterface $routeProvider;
 
+  protected OrganiserTaxProfileManager $organiserTaxProfile;
+
+  protected TimeInterface $time;
+
   /**
    * Captures retained direct files as reusable organiser Media.
    */
@@ -98,6 +104,8 @@ class OrganiserProfileSettingsForm extends FormBase {
     $instance->userVendorMembershipQuery = $container->get('myeventlane_vendor.user_vendor_membership_query');
     $instance->accessManager = $container->get('access_manager');
     $instance->routeProvider = $container->get('router.route_provider');
+    $instance->organiserTaxProfile = $container->get('myeventlane_vendor.organiser_tax_profile');
+    $instance->time = $container->get('datetime.time');
     $instance->brandMediaManager = $container->get('myeventlane_vendor.brand_media_manager');
     $instance->melWorkflowManager = $container->has('myeventlane_surface.workflow_manager')
       ? $container->get('myeventlane_surface.workflow_manager')
@@ -1055,6 +1063,86 @@ class OrganiserProfileSettingsForm extends FormBase {
       ];
     }
 
+    if ($vendor->hasField('field_tax_entity_type')) {
+      $form['store']['business']['tax_entity_type'] = [
+        '#type' => 'select',
+        '#title' => $this->t('Organisation type'),
+        '#options' => [
+          '' => $this->t('- Select -'),
+          'individual' => $this->t('Individual / sole trader'),
+          'company' => $this->t('Company'),
+          'incorporated_association' => $this->t('Incorporated association'),
+          'unincorporated_association' => $this->t('Unincorporated association'),
+          'trust' => $this->t('Trust'),
+          'charity_or_nfp' => $this->t('Charity or not-for-profit'),
+          'government' => $this->t('Government entity'),
+          'other' => $this->t('Other'),
+        ],
+        '#default_value' => $this->getFieldValue($vendor, 'field_tax_entity_type', ''),
+        '#required' => TRUE,
+      ];
+    }
+
+    if ($vendor->hasField('field_gst_registration_status')) {
+      $form['store']['business']['gst_registration_status'] = [
+        '#type' => 'radios',
+        '#title' => $this->t('Are you registered for GST?'),
+        '#options' => [
+          'registered' => $this->t('Yes, registered for GST'),
+          'not_registered' => $this->t('No, not registered for GST'),
+        ],
+        '#default_value' => $this->getFieldValue($vendor, 'field_gst_registration_status', ''),
+        '#description' => $this->t('Not-for-profit or charity status does not automatically exempt an organisation from GST.'),
+        '#required' => TRUE,
+      ];
+    }
+
+    if ($vendor->hasField('field_gst_effective_date')) {
+      $form['store']['business']['gst_effective_date'] = [
+        '#type' => 'date',
+        '#title' => $this->t('GST registration effective date'),
+        '#default_value' => $this->getFieldValue($vendor, 'field_gst_effective_date', ''),
+        '#states' => [
+          'visible' => [':input[name="store[business][gst_registration_status]"]' => ['value' => 'registered']],
+          'required' => [':input[name="store[business][gst_registration_status]"]' => ['value' => 'registered']],
+        ],
+      ];
+    }
+
+    if ($vendor->hasField('field_acnc_status')) {
+      $form['store']['business']['acnc_status'] = [
+        '#type' => 'select',
+        '#title' => $this->t('Charity status'),
+        '#options' => [
+          'not_applicable' => $this->t('Not applicable'),
+          'not_registered' => $this->t('Not ACNC registered'),
+          'registered' => $this->t('ACNC registered charity'),
+        ],
+        '#default_value' => $this->getFieldValue($vendor, 'field_acnc_status', 'not_applicable'),
+      ];
+    }
+
+    if ($vendor->hasField('field_dgr_status')) {
+      $form['store']['business']['dgr_status'] = [
+        '#type' => 'select',
+        '#title' => $this->t('DGR endorsement'),
+        '#options' => [
+          'not_endorsed' => $this->t('Not DGR endorsed'),
+          'endorsed' => $this->t('DGR endorsed'),
+        ],
+        '#default_value' => $this->getFieldValue($vendor, 'field_dgr_status', 'not_endorsed'),
+        '#description' => $this->t('DGR endorsement affects gift deductibility; it does not determine GST registration.'),
+      ];
+    }
+
+    $form['store']['business']['tax_declaration'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('I confirm these legal and tax details are current and accurate.'),
+      '#default_value' => $vendor->hasField('field_tax_declaration_at')
+        && !$vendor->get('field_tax_declaration_at')->isEmpty(),
+      '#required' => TRUE,
+    ];
+
     $form['store']['payments_link'] = [
       '#type' => 'link',
       '#title' => $this->t('Open Payments'),
@@ -1411,6 +1499,24 @@ class OrganiserProfileSettingsForm extends FormBase {
         }
       }
     }
+
+    $business = $form_state->getValue(['store', 'business']) ?? [];
+    $gstStatus = (string) ($business['gst_registration_status'] ?? '');
+    $abn = (string) ($business['abn'] ?? '');
+    if ($gstStatus === OrganiserTaxProfileManager::STATUS_REGISTERED) {
+      if (!$this->organiserTaxProfile->isValidAbn($abn)) {
+        $form_state->setError(
+          $form['store']['business']['abn'],
+          $this->t('Enter a valid 11-digit ABN for a GST-registered organiser.')
+        );
+      }
+      if (empty($business['gst_effective_date'])) {
+        $form_state->setError(
+          $form['store']['business']['gst_effective_date'],
+          $this->t('Enter the date your GST registration took effect.')
+        );
+      }
+    }
   }
 
   /**
@@ -1600,6 +1706,11 @@ class OrganiserProfileSettingsForm extends FormBase {
     $abn = trim((string) ($business['abn'] ?? ''));
     $abn = $abn !== '' ? (string) preg_replace('/\s+/', '', $abn) : '';
     $business_name = trim((string) ($business['business_name'] ?? ''));
+    $tax_entity_type = trim((string) ($business['tax_entity_type'] ?? ''));
+    $gst_registration_status = trim((string) ($business['gst_registration_status'] ?? ''));
+    $gst_effective_date = trim((string) ($business['gst_effective_date'] ?? ''));
+    $acnc_status = trim((string) ($business['acnc_status'] ?? 'not_applicable'));
+    $dgr_status = trim((string) ($business['dgr_status'] ?? 'not_endorsed'));
 
     // Save profile information.
     $name = $form_state->getValue(['profile', 'name']);
@@ -1792,6 +1903,24 @@ class OrganiserProfileSettingsForm extends FormBase {
     if ($vendor->hasField('field_abn')) {
       $vendor->set('field_abn', $abn !== '' ? $abn : NULL);
     }
+    if ($vendor->hasField('field_tax_entity_type')) {
+      $vendor->set('field_tax_entity_type', $tax_entity_type);
+    }
+    if ($vendor->hasField('field_gst_registration_status')) {
+      $vendor->set('field_gst_registration_status', $gst_registration_status);
+    }
+    if ($vendor->hasField('field_gst_effective_date')) {
+      $vendor->set('field_gst_effective_date', $gst_registration_status === OrganiserTaxProfileManager::STATUS_REGISTERED && $gst_effective_date !== '' ? $gst_effective_date : NULL);
+    }
+    if ($vendor->hasField('field_acnc_status')) {
+      $vendor->set('field_acnc_status', $acnc_status);
+    }
+    if ($vendor->hasField('field_dgr_status')) {
+      $vendor->set('field_dgr_status', $dgr_status);
+    }
+    if ($vendor->hasField('field_tax_declaration_at')) {
+      $vendor->set('field_tax_declaration_at', $this->time->getRequestTime());
+    }
 
     // Validate entity before persisting and store sync.
     $violations = $vendor->validate();
@@ -1882,6 +2011,7 @@ class OrganiserProfileSettingsForm extends FormBase {
       if ($business_name !== '') {
         $store->setName($business_name);
       }
+      $this->organiserTaxProfile->syncStore($vendor, $store);
       try {
         $store->save();
       }

--- a/web/modules/custom/myeventlane_vendor/src/Form/VendorOnboardProfileForm.php
+++ b/web/modules/custom/myeventlane_vendor/src/Form/VendorOnboardProfileForm.php
@@ -13,10 +13,11 @@ use Drupal\myeventlane_core\Entity\OnboardingStateInterface;
 use Drupal\myeventlane_core\Service\OnboardingManager;
 use Drupal\myeventlane_legal\Service\LegalSettingsService;
 use Drupal\myeventlane_legal\Service\LegalGatekeeper;
+use Drupal\myeventlane_vendor\Service\OrganiserTaxProfileManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Dedicated onboarding Step 2 form: organiser profile (name only).
+ * Dedicated onboarding Step 2 form: organiser profile and tax declaration.
  *
  * Organiser name and legal acceptance are stored in onboarding state `flags`
  * (aligned with myeventlane_legal VendorTermsForm). The gateway skips
@@ -54,6 +55,7 @@ final class VendorOnboardProfileForm extends FormBase {
     TimeInterface $time,
     LegalSettingsService $legal_settings,
     private readonly LegalGatekeeper $legalGatekeeper,
+    private readonly OrganiserTaxProfileManager $organiserTaxProfile,
   ) {
     $this->onboardingManager = $onboarding_manager;
     $this->currentUser = $current_user;
@@ -71,6 +73,7 @@ final class VendorOnboardProfileForm extends FormBase {
       $container->get('datetime.time'),
       $container->get('myeventlane_legal.settings'),
       $container->get('myeventlane_legal.gatekeeper'),
+      $container->get('myeventlane_vendor.organiser_tax_profile'),
     );
   }
 
@@ -128,6 +131,84 @@ final class VendorOnboardProfileForm extends FormBase {
     $form['step_content']['name']['#attributes']['placeholder'] = $this->t('Enter your organiser name');
     $form['step_content']['name']['#attributes']['autofocus'] = 'autofocus';
 
+    $form['step_content']['tax'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Legal and tax details'),
+      '#description' => $this->t('We use this information to apply GST correctly and prepare invoices and receipts.'),
+    ];
+    $form['step_content']['tax']['entity_type'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Organisation type'),
+      '#options' => [
+        '' => $this->t('- Select -'),
+        'individual' => $this->t('Individual / sole trader'),
+        'company' => $this->t('Company'),
+        'incorporated_association' => $this->t('Incorporated association'),
+        'unincorporated_association' => $this->t('Unincorporated association'),
+        'trust' => $this->t('Trust'),
+        'charity_or_nfp' => $this->t('Charity or not-for-profit'),
+        'government' => $this->t('Government entity'),
+        'other' => $this->t('Other'),
+      ],
+      '#default_value' => (string) ($flags['tax_entity_type'] ?? ''),
+      '#required' => TRUE,
+    ];
+    $form['step_content']['tax']['gst_status'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Are you registered for GST?'),
+      '#options' => [
+        OrganiserTaxProfileManager::STATUS_REGISTERED => $this->t('Yes, registered for GST'),
+        OrganiserTaxProfileManager::STATUS_NOT_REGISTERED => $this->t('No, not registered for GST'),
+      ],
+      '#default_value' => (string) ($flags['gst_registration_status'] ?? ''),
+      '#description' => $this->t('Not-for-profit or charity status does not automatically exempt an organisation from GST.'),
+      '#required' => TRUE,
+    ];
+    $form['step_content']['tax']['abn'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('ABN'),
+      '#default_value' => (string) ($flags['abn'] ?? ''),
+      '#maxlength' => 14,
+      '#description' => $this->t('Required if you are registered for GST.'),
+      '#states' => [
+        'required' => [':input[name="step_content[tax][gst_status]"]' => ['value' => OrganiserTaxProfileManager::STATUS_REGISTERED]],
+      ],
+    ];
+    $form['step_content']['tax']['gst_effective_date'] = [
+      '#type' => 'date',
+      '#title' => $this->t('GST registration effective date'),
+      '#default_value' => (string) ($flags['gst_effective_date'] ?? ''),
+      '#states' => [
+        'visible' => [':input[name="step_content[tax][gst_status]"]' => ['value' => OrganiserTaxProfileManager::STATUS_REGISTERED]],
+        'required' => [':input[name="step_content[tax][gst_status]"]' => ['value' => OrganiserTaxProfileManager::STATUS_REGISTERED]],
+      ],
+    ];
+    $form['step_content']['tax']['acnc_status'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Charity status'),
+      '#options' => [
+        'not_applicable' => $this->t('Not applicable'),
+        'not_registered' => $this->t('Not ACNC registered'),
+        'registered' => $this->t('ACNC registered charity'),
+      ],
+      '#default_value' => (string) ($flags['acnc_status'] ?? 'not_applicable'),
+    ];
+    $form['step_content']['tax']['dgr_status'] = [
+      '#type' => 'select',
+      '#title' => $this->t('DGR endorsement'),
+      '#options' => [
+        'not_endorsed' => $this->t('Not DGR endorsed'),
+        'endorsed' => $this->t('DGR endorsed'),
+      ],
+      '#default_value' => (string) ($flags['dgr_status'] ?? 'not_endorsed'),
+    ];
+    $form['step_content']['tax']['declaration'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('I confirm these legal and tax details are current and accurate.'),
+      '#default_value' => !empty($flags['tax_declaration_at']),
+      '#required' => TRUE,
+    ];
+
     $form['step_content']['actions'] = [
       '#type' => 'actions',
       '#attributes' => [
@@ -177,6 +258,19 @@ final class VendorOnboardProfileForm extends FormBase {
     if (!(bool) $form_state->getValue('terms_accepted')) {
       $form_state->setError($form['terms_accepted'], $this->t('You must agree to the Vendor Terms of Service.'));
     }
+    $tax = $form_state->getValue(['step_content', 'tax']) ?? [];
+    $gstStatus = (string) ($tax['gst_status'] ?? '');
+    if ($gstStatus === OrganiserTaxProfileManager::STATUS_REGISTERED) {
+      if (!$this->organiserTaxProfile->isValidAbn((string) ($tax['abn'] ?? ''))) {
+        $form_state->setError($form['step_content']['tax']['abn'], $this->t('Enter a valid 11-digit ABN for a GST-registered organiser.'));
+      }
+      if (empty($tax['gst_effective_date'])) {
+        $form_state->setError($form['step_content']['tax']['gst_effective_date'], $this->t('Enter the date your GST registration took effect.'));
+      }
+    }
+    if (empty($tax['declaration'])) {
+      $form_state->setError($form['step_content']['tax']['declaration'], $this->t('You must confirm that your legal and tax details are accurate.'));
+    }
   }
 
   /**
@@ -200,6 +294,16 @@ final class VendorOnboardProfileForm extends FormBase {
     $flags = is_array($flags) ? $flags : [];
 
     $flags['organiser_name'] = $name;
+    $tax = $form_state->getValue(['step_content', 'tax']) ?? [];
+    $flags['tax_entity_type'] = trim((string) ($tax['entity_type'] ?? ''));
+    $flags['gst_registration_status'] = trim((string) ($tax['gst_status'] ?? ''));
+    $flags['abn'] = preg_replace('/\D+/', '', (string) ($tax['abn'] ?? '')) ?? '';
+    $flags['gst_effective_date'] = trim((string) ($tax['gst_effective_date'] ?? ''));
+    $flags['acnc_status'] = trim((string) ($tax['acnc_status'] ?? 'not_applicable'));
+    $flags['dgr_status'] = trim((string) ($tax['dgr_status'] ?? 'not_endorsed'));
+    $flags['tax_declaration_at'] = !empty($tax['declaration'])
+      ? (int) $this->time->getRequestTime()
+      : 0;
 
     // Save checkbox value from the posted form (root-level key, not under #tree).
     $flags['terms_accepted'] = !empty($values['terms_accepted']);
@@ -238,6 +342,22 @@ final class VendorOnboardProfileForm extends FormBase {
       '@vid' => (string) $vendor->id(),
     ]);
     $vendor->setName($name);
+    $taxFieldMap = [
+      'field_tax_entity_type' => $flags['tax_entity_type'],
+      'field_gst_registration_status' => $flags['gst_registration_status'],
+      'field_gst_effective_date' => $flags['gst_registration_status'] === OrganiserTaxProfileManager::STATUS_REGISTERED
+        ? $flags['gst_effective_date']
+        : NULL,
+      'field_acnc_status' => $flags['acnc_status'],
+      'field_dgr_status' => $flags['dgr_status'],
+      'field_tax_declaration_at' => $flags['tax_declaration_at'],
+      'field_abn' => $flags['abn'] !== '' ? $flags['abn'] : NULL,
+    ];
+    foreach ($taxFieldMap as $fieldName => $value) {
+      if ($vendor->hasField($fieldName)) {
+        $vendor->set($fieldName, $value);
+      }
+    }
     if (!empty($flags['vendor_terms_accepted_at'])) {
       $this->onboardingManager->applyVendorLegalFieldsFromStateFlags($vendor, $flags);
       $this->getLogger('myeventlane_vendor')->notice(
@@ -258,7 +378,12 @@ final class VendorOnboardProfileForm extends FormBase {
     // Mark onboarding complete (profile + terms) once vendor is linked. Must run
     // after setVendorId: myeventlane_onboarding_state preSave requires vendor_id
     // when stage/complete is final (see OnboardingState::preSave()).
-    if (!empty($flags['terms_accepted']) && $name !== '' && (int) ($state->getVendorId() ?? 0) > 0) {
+    if (!empty($flags['terms_accepted'])
+      && !empty($flags['tax_declaration_at'])
+      && $flags['tax_entity_type'] !== ''
+      && in_array($flags['gst_registration_status'], [OrganiserTaxProfileManager::STATUS_REGISTERED, OrganiserTaxProfileManager::STATUS_NOT_REGISTERED], TRUE)
+      && $name !== ''
+      && (int) ($state->getVendorId() ?? 0) > 0) {
       $state->setStage('complete');
       $state->setCompleted(TRUE);
       $this->onboardingManager->persistOnboardingState($state);

--- a/web/modules/custom/myeventlane_vendor/src/Service/OrganiserTaxProfileManager.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/OrganiserTaxProfileManager.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_vendor\Service;
+
+use Drupal\commerce_store\Entity\StoreInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
+
+/**
+ * Resolves organiser tax declarations and synchronises Commerce tax state.
+ */
+final class OrganiserTaxProfileManager {
+
+  public const STATUS_UNKNOWN = 'unknown';
+  public const STATUS_NOT_REGISTERED = 'not_registered';
+  public const STATUS_REGISTERED = 'registered';
+
+  /**
+   * Returns the declared GST registration status.
+   */
+  public function getGstStatus(FieldableEntityInterface $vendor): string {
+    if (!$vendor->hasField('field_gst_registration_status') || $vendor->get('field_gst_registration_status')->isEmpty()) {
+      return self::STATUS_UNKNOWN;
+    }
+
+    $status = (string) $vendor->get('field_gst_registration_status')->value;
+    return in_array($status, [self::STATUS_NOT_REGISTERED, self::STATUS_REGISTERED], TRUE)
+      ? $status
+      : self::STATUS_UNKNOWN;
+  }
+
+  /**
+   * Whether the organiser has completed the minimum supplier declaration.
+   */
+  public function isDeclared(FieldableEntityInterface $vendor): bool {
+    $entityType = $vendor->hasField('field_tax_entity_type')
+      ? trim((string) $vendor->get('field_tax_entity_type')->value)
+      : '';
+    $declaredAt = $vendor->hasField('field_tax_declaration_at')
+      ? (int) $vendor->get('field_tax_declaration_at')->value
+      : 0;
+
+    return $entityType !== ''
+      && $this->getGstStatus($vendor) !== self::STATUS_UNKNOWN
+      && $declaredAt > 0;
+  }
+
+  /**
+   * Synchronises the vendor declaration to Commerce Tax registration state.
+   */
+  public function syncStore(FieldableEntityInterface $vendor, StoreInterface $store): bool {
+    $registrations = $this->getGstStatus($vendor) === self::STATUS_REGISTERED ? ['AU'] : [];
+    $current = array_column($store->get('tax_registrations')->getValue(), 'value');
+    $changed = $current !== $registrations;
+
+    if ($changed) {
+      $store->set('tax_registrations', $registrations);
+    }
+    if ($store->hasField('prices_include_tax') && !(bool) $store->get('prices_include_tax')->value) {
+      // Event prices are entered as the customer-facing amount. This flag is
+      // harmless for unregistered stores because no tax registration matches.
+      $store->set('prices_include_tax', TRUE);
+      $changed = TRUE;
+    }
+
+    return $changed;
+  }
+
+  /**
+   * Validates an Australian Business Number checksum.
+   */
+  public function isValidAbn(string $abn): bool {
+    $digits = preg_replace('/\D+/', '', $abn) ?? '';
+    if (strlen($digits) !== 11) {
+      return FALSE;
+    }
+
+    $weights = [10, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19];
+    $sum = ((int) $digits[0] - 1) * $weights[0];
+    for ($index = 1; $index < 11; $index++) {
+      $sum += (int) $digits[$index] * $weights[$index];
+    }
+
+    return $sum % 89 === 0;
+  }
+
+}

--- a/web/modules/custom/myeventlane_vendor/src/Service/PaidPublishStripeGate.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/PaidPublishStripeGate.php
@@ -40,15 +40,12 @@ final class PaidPublishStripeGate {
       return NULL;
     }
 
-    $vendorId = $this->resolveVendorIdForAccount($account);
-    $vendor = $vendorId !== NULL
-      ? $this->entityTypeManager->getStorage('myeventlane_vendor')->load($vendorId)
-      : NULL;
-    if (!$vendor instanceof Vendor || !$this->organiserTaxProfile->isDeclared($vendor)) {
-      $this->logBlocked((int) $account->id(), $vendorId, NULL, $eventNodeId, 'tax_declaration_incomplete');
-      return (string) $this->t('Before accepting event payments, confirm your organisation and GST details in Organiser Settings.');
+    $taxDenial = $this->validateTaxDeclarationAllowed($account, $eventNodeId);
+    if ($taxDenial !== NULL) {
+      return $taxDenial;
     }
 
+    $vendorId = $this->resolveVendorIdForAccount($account);
     $store = $this->resolveCommerceStoreForAccount($account);
     $storeId = $store instanceof StoreInterface ? (int) $store->id() : NULL;
 
@@ -81,6 +78,26 @@ final class PaidPublishStripeGate {
     }
 
     return NULL;
+  }
+
+  /**
+   * Returns a dedicated denial when organiser tax details are incomplete.
+   */
+  public function validateTaxDeclarationAllowed(AccountInterface $account, ?int $eventNodeId = NULL): ?string {
+    if ((int) $account->id() === 1 || $account->hasPermission('administer site configuration')) {
+      return NULL;
+    }
+
+    $vendorId = $this->resolveVendorIdForAccount($account);
+    $vendor = $vendorId !== NULL
+      ? $this->entityTypeManager->getStorage('myeventlane_vendor')->load($vendorId)
+      : NULL;
+    if ($vendor instanceof Vendor && $this->organiserTaxProfile->isDeclared($vendor)) {
+      return NULL;
+    }
+
+    $this->logBlocked((int) $account->id(), $vendorId, NULL, $eventNodeId, 'tax_declaration_incomplete');
+    return (string) $this->t('Before accepting event payments, confirm your organisation and GST details in Organiser Settings.');
   }
 
   private function blockedMessage(): string {

--- a/web/modules/custom/myeventlane_vendor/src/Service/PaidPublishStripeGate.php
+++ b/web/modules/custom/myeventlane_vendor/src/Service/PaidPublishStripeGate.php
@@ -27,6 +27,7 @@ final class PaidPublishStripeGate {
     private readonly UserVendorMembershipQuery $membershipQuery,
     private readonly LoggerInterface $logger,
     TranslationInterface $stringTranslation,
+    private readonly OrganiserTaxProfileManager $organiserTaxProfile,
   ) {
     $this->stringTranslation = $stringTranslation;
   }
@@ -40,6 +41,14 @@ final class PaidPublishStripeGate {
     }
 
     $vendorId = $this->resolveVendorIdForAccount($account);
+    $vendor = $vendorId !== NULL
+      ? $this->entityTypeManager->getStorage('myeventlane_vendor')->load($vendorId)
+      : NULL;
+    if (!$vendor instanceof Vendor || !$this->organiserTaxProfile->isDeclared($vendor)) {
+      $this->logBlocked((int) $account->id(), $vendorId, NULL, $eventNodeId, 'tax_declaration_incomplete');
+      return (string) $this->t('Before accepting event payments, confirm your organisation and GST details in Organiser Settings.');
+    }
+
     $store = $this->resolveCommerceStoreForAccount($account);
     $storeId = $store instanceof StoreInterface ? (int) $store->id() : NULL;
 
@@ -75,7 +84,7 @@ final class PaidPublishStripeGate {
   }
 
   private function blockedMessage(): string {
-    return (string) $this->t('To sell tickets, finish your Stripe setup so payouts can reach your bank.');
+    return (string) $this->t('To accept event payments, finish your Stripe setup so payouts can reach your bank.');
   }
 
   /**

--- a/web/modules/custom/myeventlane_vendor/tests/src/Unit/OrganiserOnboardingContractTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Unit/OrganiserOnboardingContractTest.php
@@ -39,6 +39,17 @@ final class OrganiserOnboardingContractTest extends TestCase {
     self::assertStringContainsString('?? (int) $this->time->getRequestTime()', $form);
   }
 
+  public function testTaxDeclarationIsMandatoryDuringOnboarding(): void {
+    $form = $this->read('myeventlane_vendor/src/Form/VendorOnboardProfileForm.php');
+
+    self::assertStringContainsString("['step_content']['tax']['entity_type']", $form);
+    self::assertStringContainsString("['step_content']['tax']['gst_status']", $form);
+    self::assertStringContainsString("['step_content']['tax']['declaration']", $form);
+    self::assertStringContainsString("'#required' => TRUE", $form);
+    self::assertStringContainsString("'field_tax_declaration_at'", $form);
+    self::assertStringContainsString('isValidAbn', $form);
+  }
+
   public function testStripeIsRequiredOnlyByPaidEventChecks(): void {
     $vendorGate = $this->read('myeventlane_vendor/src/Service/VendorPublishRequirementsGate.php');
     $eligibility = $this->read('myeventlane_event_studio/src/Service/PublishEligibilityEvaluator.php');

--- a/web/modules/custom/myeventlane_vendor/tests/src/Unit/OrganiserTaxProfileManagerTest.php
+++ b/web/modules/custom/myeventlane_vendor/tests/src/Unit/OrganiserTaxProfileManagerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_vendor\Unit;
+
+require_once dirname(__DIR__, 3) . '/src/Service/OrganiserTaxProfileManager.php';
+
+use Drupal\myeventlane_vendor\Service\OrganiserTaxProfileManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests organiser tax profile rules that do not require Drupal storage.
+ *
+ * @group myeventlane_vendor
+ */
+final class OrganiserTaxProfileManagerTest extends TestCase {
+
+  /**
+   * Tests valid and invalid Australian Business Number checksums.
+   */
+  public function testAbnChecksum(): void {
+    $manager = new OrganiserTaxProfileManager();
+
+    self::assertTrue($manager->isValidAbn('11 304 813 593'));
+    self::assertFalse($manager->isValidAbn('11 304 813 594'));
+    self::assertFalse($manager->isValidAbn('1234'));
+  }
+
+}

--- a/web/themes/custom/myeventlane_theme/templates/commerce/mel-tax-invoice-pdf.html.twig
+++ b/web/themes/custom/myeventlane_theme/templates/commerce/mel-tax-invoice-pdf.html.twig
@@ -11,7 +11,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>{{ 'Tax Invoice'|t }} #{% if order %}{{ order.getOrderNumber }}{% endif %}</title>
+  <title>{{ inv.document_title|default('Receipt')|t }} #{% if order %}{{ order.getOrderNumber }}{% endif %}</title>
   <style>
     body {
       font-family: DejaVu Sans, Helvetica, Arial, sans-serif;
@@ -93,10 +93,10 @@
 </head>
 <body>
   <div class="mel-pdf-shell">
-    <h1>{{ 'Tax Invoice'|t }}</h1>
+    <h1>{{ inv.document_title|default('Receipt')|t }}</h1>
     <div class="mel-pdf-meta">
       {% if inv.vendor_name is defined and inv.vendor_name %}<strong>{{ 'Supplier:'|t }}</strong> {{ inv.vendor_name }}<br />{% endif %}
-      <strong>{{ 'ABN:'|t }}</strong> {{ inv.vendor_abn|default('ABN not provided') }}<br />
+      {% if inv.vendor_abn is defined and inv.vendor_abn %}<strong>{{ 'ABN:'|t }}</strong> {{ inv.vendor_abn }}<br />{% endif %}
       {% if order %}<strong>{{ 'Invoice #:'|t }}</strong> {{ order.getOrderNumber }}<br />{% endif %}
       {% if order and order.getPlacedTime %}
         <strong>{{ 'Date:'|t }}</strong> {{ order.getPlacedTime|date('d M Y') }}
@@ -153,7 +153,11 @@
         </div>
       </div>
     {% endif %}
-    <p class="mel-invoice__legal">{{ 'This document is a tax invoice for GST purposes.'|t }}</p>
+    {% if inv.is_tax_invoice|default(false) %}
+      <p class="mel-invoice__legal">{{ 'This document is a tax invoice for GST purposes.'|t }}</p>
+    {% else %}
+      <p class="mel-invoice__legal">{{ 'The supplier is not registered for GST. No GST has been charged.'|t }}</p>
+    {% endif %}
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary

<!-- What changed and why (organiser outcome, not only technical delta). -->

## Zone map (Event Workspace — required before screenshots)

<!-- Required for any PR that changes Event Workspace / organiser Workspace UI.
     Remove only for PRs with zero Workspace UI impact (state N/A + rationale). -->

```text
Identity:   <!-- Where am I? -->
Guidance:   <!-- What should I do next? (one recommendation or omit) -->
Work:       <!-- How do I do it? -->
Outcome:    <!-- What happened? (or omit) -->
```

**Zone Gate:** If you cannot produce this map, the page has not been designed yet.  
Authority: `docs/design/vendor-studio-visual/07-workspace-zones.md`

## Vendor Studio Design System References

<!-- Required for any PR that changes Vendor Studio / organiser console experience or `docs/design/vendor-studio/`.
     Remove this section only for PRs with zero Vendor Studio impact. -->

This implementation follows:

- <!-- e.g. docs/design/vendor-studio-visual/07-workspace-zones.md -->
- <!-- e.g. docs/design/vendor-studio-visual/03-option-b5.md -->
- <!-- e.g. 02-information-architecture.md -->
- <!-- e.g. 05-component-library.md -->
- <!-- e.g. 11-design-tokens.md -->
- <!-- e.g. 16-design-review-checklist.md -->
- <!-- e.g. 21-definition-of-done.md -->
- <!-- e.g. ADR-0001 -->
- <!-- e.g. DDR-003 -->

**Build order:** PDS → Workspace Zones → Visual Language B.5 → Component Catalogue → Implementation  
**PDS home:** `docs/design/vendor-studio/` (Vendor Studio Product Design System v1.0 — FROZEN)

Please also apply the GitHub label: `design-system`

## Definition of Done / checklist

- [ ] Zone Gate map present (or N/A with rationale)
- [ ] Applicable gates in `docs/design/vendor-studio/21-definition-of-done.md`
- [ ] `docs/design/vendor-studio/16-design-review-checklist.md` completed (or N/A with rationale)
- [ ] No contradiction of higher-order PDS docs ([ADR-0001](../docs/design/vendor-studio/decisions/ADR-0001-design-authority.md))

## Test plan

- [ ] <!-- Manual / automated checks -->

## Risk

<!-- Access, Commerce, payments, cache, PII — or "None" -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes tax registration, Commerce tax application, invoice/legal copy, refund accounting, and publish gates—incorrect behaviour affects compliance and customer-facing financial documents.
> 
> **Overview**
> Introduces **explicit organiser tax declarations** (organisation type, GST registration, ACNC/DGR, declaration timestamp) on vendors, with `OrganiserTaxProfileManager` driving Commerce store `tax_registrations` only after declaration. New stores no longer default to AU GST; a deploy update adds fields without rewriting legacy organiser registrations.
> 
> **Publish and payments:** Paid events and events with optional donations must pass a **tax-declaration gate** (before Stripe) in Event Studio; copy and readiness paths are broadened from “paid tickets only” to “tickets or donations.”
> 
> **Customer documents:** Invoices, receipts, and PDFs use **`document_title` / `is_tax_invoice`** derived from **tax adjustments recorded on the order**, not the organiser’s current GST status; non-GST orders get receipt wording and omit forced ABN/GST lines. Refunds on taxed orders get **immutable GST adjustment notes** on `myeventlane_refund_log` and matching email fields.
> 
> Also tags several Commerce order item types with `commerce_tax` **events**, renames platform donation to “MyEventLane Contribution,” and fixes Pro billing portal redirects via **`TrustedRedirectResponse`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a864cb2dc186cd51abe47111842af1fb214c3a98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->