### PR TITLE
Fix GST config deployment convergence

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -138,6 +138,9 @@ jobs:
       - name: Test deploy config-status parser
         run: bash scripts/deploy/test-config-status-parser.sh
 
+      - name: Test GST config convergence
+        run: php scripts/deploy/test-gst-config-convergence.php
+
       - name: Test deploy domain redirect policy
         run: bash scripts/deploy/test-domain-redirect-policy.sh
 

--- a/config/sync/commerce_order.commerce_order_item_type.recurring_product_variation.yml
+++ b/config/sync/commerce_order.commerce_order_item_type.recurring_product_variation.yml
@@ -13,9 +13,9 @@ third_party_settings:
     taxable_type: events
 _core:
   default_config_hash: Q21JtNYYWL-eIfxaX1rm-NvSqPqdDymrDrN08f_QC7M
-label: 'Recurring (Product variation)'
 id: recurring_product_variation
-purchasableEntityType: commerce_product_variation
-orderType: recurring
+label: 'Recurring (Product variation)'
 traits: {  }
 locked: true
+purchasableEntityType: commerce_product_variation
+orderType: recurring

--- a/config/sync/commerce_order.commerce_order_item_type.recurring_standalone.yml
+++ b/config/sync/commerce_order.commerce_order_item_type.recurring_standalone.yml
@@ -12,9 +12,9 @@ third_party_settings:
     taxable_type: events
 _core:
   default_config_hash: iFZgD_z6PSZqyLy65J_OLjA_nnGu-lvKxgPr0BNiCCI
-label: 'Recurring (Standalone)'
 id: recurring_standalone
-purchasableEntityType: ''
-orderType: recurring
+label: 'Recurring (Standalone)'
 traits: {  }
 locked: true
+purchasableEntityType: ''
+orderType: recurring

--- a/config/sync/core.entity_form_display.myeventlane_vendor.myeventlane_vendor.default.yml
+++ b/config/sync/core.entity_form_display.myeventlane_vendor.myeventlane_vendor.default.yml
@@ -5,11 +5,15 @@ dependencies:
   config:
     - field.field.myeventlane_vendor.myeventlane_vendor.field_abn
     - field.field.myeventlane_vendor.myeventlane_vendor.field_accent_colour
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_acnc_status
     - field.field.myeventlane_vendor.myeventlane_vendor.field_address
     - field.field.myeventlane_vendor.myeventlane_vendor.field_banner_image
     - field.field.myeventlane_vendor.myeventlane_vendor.field_business_name
     - field.field.myeventlane_vendor.myeventlane_vendor.field_description
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_dgr_status
     - field.field.myeventlane_vendor.myeventlane_vendor.field_email
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_gst_effective_date
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_gst_registration_status
     - field.field.myeventlane_vendor.myeventlane_vendor.field_logo_image
     - field.field.myeventlane_vendor.myeventlane_vendor.field_mel_vendor_banner_media
     - field.field.myeventlane_vendor.myeventlane_vendor.field_mel_vendor_email_media
@@ -25,12 +29,20 @@ dependencies:
     - field.field.myeventlane_vendor.myeventlane_vendor.field_pref_email_digest
     - field.field.myeventlane_vendor.myeventlane_vendor.field_pref_email_on_order
     - field.field.myeventlane_vendor.myeventlane_vendor.field_pref_email_on_rsvp
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_public_profile_published
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_public_show_banner
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_public_show_description
     - field.field.myeventlane_vendor.myeventlane_vendor.field_public_show_email
     - field.field.myeventlane_vendor.myeventlane_vendor.field_public_show_location
     - field.field.myeventlane_vendor.myeventlane_vendor.field_public_show_phone
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_public_show_social_links
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_public_show_summary
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_public_show_website
     - field.field.myeventlane_vendor.myeventlane_vendor.field_social_links
     - field.field.myeventlane_vendor.myeventlane_vendor.field_summary
     - field.field.myeventlane_vendor.myeventlane_vendor.field_tagline
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_tax_declaration_at
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_tax_entity_type
     - field.field.myeventlane_vendor.myeventlane_vendor.field_vendor_bio
     - field.field.myeventlane_vendor.myeventlane_vendor.field_vendor_logo
     - field.field.myeventlane_vendor.myeventlane_vendor.field_vendor_store
@@ -40,9 +52,7 @@ dependencies:
     - field.field.myeventlane_vendor.myeventlane_vendor.field_vendor_terms_version
     - field.field.myeventlane_vendor.myeventlane_vendor.field_vendor_users
     - field.field.myeventlane_vendor.myeventlane_vendor.field_website
-    - image.style.thumbnail
   module:
-    - image
     - link
     - media_library
     - myeventlane_vendor
@@ -220,7 +230,11 @@ content:
     third_party_settings: {  }
 hidden:
   field_accent_colour: true
+  field_acnc_status: true
   field_banner_image: true
+  field_dgr_status: true
+  field_gst_effective_date: true
+  field_gst_registration_status: true
   field_logo_image: true
   field_msg_accent_color: true
   field_msg_footer: true
@@ -241,6 +255,8 @@ hidden:
   field_public_show_summary: true
   field_public_show_website: true
   field_tagline: true
+  field_tax_declaration_at: true
+  field_tax_entity_type: true
   field_vendor_bio: true
   field_vendor_logo: true
   field_vendor_store: true

--- a/config/sync/core.entity_view_display.myeventlane_vendor.myeventlane_vendor.default.yml
+++ b/config/sync/core.entity_view_display.myeventlane_vendor.myeventlane_vendor.default.yml
@@ -5,11 +5,15 @@ dependencies:
   config:
     - field.field.myeventlane_vendor.myeventlane_vendor.field_abn
     - field.field.myeventlane_vendor.myeventlane_vendor.field_accent_colour
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_acnc_status
     - field.field.myeventlane_vendor.myeventlane_vendor.field_address
     - field.field.myeventlane_vendor.myeventlane_vendor.field_banner_image
     - field.field.myeventlane_vendor.myeventlane_vendor.field_business_name
     - field.field.myeventlane_vendor.myeventlane_vendor.field_description
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_dgr_status
     - field.field.myeventlane_vendor.myeventlane_vendor.field_email
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_gst_effective_date
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_gst_registration_status
     - field.field.myeventlane_vendor.myeventlane_vendor.field_logo_image
     - field.field.myeventlane_vendor.myeventlane_vendor.field_mel_vendor_banner_media
     - field.field.myeventlane_vendor.myeventlane_vendor.field_mel_vendor_email_media
@@ -25,12 +29,20 @@ dependencies:
     - field.field.myeventlane_vendor.myeventlane_vendor.field_pref_email_digest
     - field.field.myeventlane_vendor.myeventlane_vendor.field_pref_email_on_order
     - field.field.myeventlane_vendor.myeventlane_vendor.field_pref_email_on_rsvp
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_public_profile_published
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_public_show_banner
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_public_show_description
     - field.field.myeventlane_vendor.myeventlane_vendor.field_public_show_email
     - field.field.myeventlane_vendor.myeventlane_vendor.field_public_show_location
     - field.field.myeventlane_vendor.myeventlane_vendor.field_public_show_phone
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_public_show_social_links
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_public_show_summary
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_public_show_website
     - field.field.myeventlane_vendor.myeventlane_vendor.field_social_links
     - field.field.myeventlane_vendor.myeventlane_vendor.field_summary
     - field.field.myeventlane_vendor.myeventlane_vendor.field_tagline
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_tax_declaration_at
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_tax_entity_type
     - field.field.myeventlane_vendor.myeventlane_vendor.field_vendor_bio
     - field.field.myeventlane_vendor.myeventlane_vendor.field_vendor_logo
     - field.field.myeventlane_vendor.myeventlane_vendor.field_vendor_store
@@ -166,7 +178,11 @@ hidden:
   created: true
   field_abn: true
   field_accent_colour: true
+  field_acnc_status: true
   field_business_name: true
+  field_dgr_status: true
+  field_gst_effective_date: true
+  field_gst_registration_status: true
   field_mel_vendor_banner_media: true
   field_mel_vendor_email_media: true
   field_mel_vendor_logo_media: true
@@ -190,6 +206,8 @@ hidden:
   field_public_show_summary: true
   field_public_show_website: true
   field_tagline: true
+  field_tax_declaration_at: true
+  field_tax_entity_type: true
   field_vendor_store: true
   field_vendor_terms_accepted_at: true
   field_vendor_terms_accepted_ip: true

--- a/config/sync/core.entity_view_display.myeventlane_vendor.myeventlane_vendor.full.yml
+++ b/config/sync/core.entity_view_display.myeventlane_vendor.myeventlane_vendor.full.yml
@@ -6,12 +6,19 @@ dependencies:
     - core.entity_view_mode.myeventlane_vendor.full
     - field.field.myeventlane_vendor.myeventlane_vendor.field_abn
     - field.field.myeventlane_vendor.myeventlane_vendor.field_accent_colour
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_acnc_status
     - field.field.myeventlane_vendor.myeventlane_vendor.field_address
     - field.field.myeventlane_vendor.myeventlane_vendor.field_banner_image
     - field.field.myeventlane_vendor.myeventlane_vendor.field_business_name
     - field.field.myeventlane_vendor.myeventlane_vendor.field_description
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_dgr_status
     - field.field.myeventlane_vendor.myeventlane_vendor.field_email
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_gst_effective_date
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_gst_registration_status
     - field.field.myeventlane_vendor.myeventlane_vendor.field_logo_image
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_mel_vendor_banner_media
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_mel_vendor_email_media
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_mel_vendor_logo_media
     - field.field.myeventlane_vendor.myeventlane_vendor.field_msg_accent_color
     - field.field.myeventlane_vendor.myeventlane_vendor.field_msg_footer
     - field.field.myeventlane_vendor.myeventlane_vendor.field_msg_from_email
@@ -23,12 +30,20 @@ dependencies:
     - field.field.myeventlane_vendor.myeventlane_vendor.field_pref_email_digest
     - field.field.myeventlane_vendor.myeventlane_vendor.field_pref_email_on_order
     - field.field.myeventlane_vendor.myeventlane_vendor.field_pref_email_on_rsvp
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_public_profile_published
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_public_show_banner
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_public_show_description
     - field.field.myeventlane_vendor.myeventlane_vendor.field_public_show_email
     - field.field.myeventlane_vendor.myeventlane_vendor.field_public_show_location
     - field.field.myeventlane_vendor.myeventlane_vendor.field_public_show_phone
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_public_show_social_links
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_public_show_summary
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_public_show_website
     - field.field.myeventlane_vendor.myeventlane_vendor.field_social_links
     - field.field.myeventlane_vendor.myeventlane_vendor.field_summary
     - field.field.myeventlane_vendor.myeventlane_vendor.field_tagline
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_tax_declaration_at
+    - field.field.myeventlane_vendor.myeventlane_vendor.field_tax_entity_type
     - field.field.myeventlane_vendor.myeventlane_vendor.field_vendor_bio
     - field.field.myeventlane_vendor.myeventlane_vendor.field_vendor_logo
     - field.field.myeventlane_vendor.myeventlane_vendor.field_vendor_store
@@ -79,11 +94,15 @@ hidden:
   created: true
   field_abn: true
   field_accent_colour: true
+  field_acnc_status: true
   field_address: true
   field_banner_image: true
   field_business_name: true
   field_description: true
+  field_dgr_status: true
   field_email: true
+  field_gst_effective_date: true
+  field_gst_registration_status: true
   field_logo_image: true
   field_mel_vendor_banner_media: true
   field_mel_vendor_email_media: true
@@ -111,6 +130,8 @@ hidden:
   field_social_links: true
   field_summary: true
   field_tagline: true
+  field_tax_declaration_at: true
+  field_tax_entity_type: true
   field_vendor_store: true
   field_vendor_terms_accepted_at: true
   field_vendor_terms_accepted_ip: true

--- a/scripts/deploy/test-gst-config-convergence.php
+++ b/scripts/deploy/test-gst-config-convergence.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+$root = dirname(__DIR__, 2);
+$autoload = getenv('MEL_VENDOR_AUTOLOAD') ?: $root . '/vendor/autoload.php';
+require $autoload;
+
+use Symfony\Component\Yaml\Yaml;
+
+$failures = [];
+
+foreach (['recurring_product_variation', 'recurring_standalone'] as $bundle) {
+  $path = $root . '/config/sync/commerce_order.commerce_order_item_type.' . $bundle . '.yml';
+  $config = Yaml::parseFile($path);
+  if (($config['third_party_settings']['commerce_tax']['taxable_type'] ?? NULL) !== 'events') {
+    $failures[] = $bundle . ' must remain taxable as events.';
+  }
+
+  $keys = array_keys($config);
+  $expectedTail = ['id', 'label', 'traits', 'locked', 'purchasableEntityType', 'orderType'];
+  if (array_slice($keys, -count($expectedTail)) !== $expectedTail) {
+    $failures[] = $bundle . ' is not in Drupal-normalised key order.';
+  }
+}
+
+$taxFields = [
+  'field_acnc_status',
+  'field_dgr_status',
+  'field_gst_effective_date',
+  'field_gst_registration_status',
+  'field_tax_declaration_at',
+  'field_tax_entity_type',
+];
+$displays = [
+  'core.entity_form_display.myeventlane_vendor.myeventlane_vendor.default',
+  'core.entity_view_display.myeventlane_vendor.myeventlane_vendor.default',
+  'core.entity_view_display.myeventlane_vendor.myeventlane_vendor.full',
+];
+
+foreach ($displays as $display) {
+  $config = Yaml::parseFile($root . '/config/sync/' . $display . '.yml');
+  $dependencies = $config['dependencies']['config'] ?? [];
+  foreach ($taxFields as $field) {
+    $fieldConfig = 'field.field.myeventlane_vendor.myeventlane_vendor.' . $field;
+    if (!in_array($fieldConfig, $dependencies, TRUE)) {
+      $failures[] = $display . ' is missing dependency ' . $fieldConfig . '.';
+    }
+    if (($config['hidden'][$field] ?? NULL) !== TRUE) {
+      $failures[] = $display . ' must explicitly hide ' . $field . '.';
+    }
+  }
+}
+
+if ($failures !== []) {
+  fwrite(STDERR, "GST config convergence test failed:\n- " . implode("\n- ", $failures) . "\n");
+  exit(1);
+}
+
+fwrite(STDOUT, "GST config convergence test passed.\n");


### PR DESCRIPTION
## What changed

- Normalised the two MEL Pro recurring order-item configuration records while retaining their `events` GST taxable type.
- Added the new organiser tax fields to the dependencies and hidden-field metadata of all affected organiser displays.
- Added a build-time regression check for the recurring GST setting, Drupal-normalised key order, and organiser display dependencies.

## Root cause

PR #827 deployed its database updates and imported configuration, but Drupal normalised five records differently from the committed YAML. The strict post-import `config:status` gate detected those differences and rolled the code release back.

## Validation

- The five committed YAML files byte-match DDEV's active configuration export.
- Two consecutive partial imports reported no changes on the second run.
- The post-import export retained GST on both Pro recurring bundles.
- `php scripts/deploy/test-gst-config-convergence.php` passed.
- `bash scripts/check-config-safety.sh` passed.
- `git diff --check` passed.

## Deployment note

The failed staging release rolled its code symlink back, but update hooks 9011 and 10025 and the configuration import had already completed. This PR contains only the convergence repair; it does not weaken the deployment drift guard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches commerce tax classification on recurring order items and tax-field display metadata; wrong YAML could still break deploy gates or tax behaviour, but changes are convergence-only with automated checks.
> 
> **Overview**
> Repairs **config sync drift** that caused staging deploys to fail the post-import `config:status` check after GST/organiser tax work landed in an earlier release.
> 
> **Commerce recurring order item types** (`recurring_product_variation`, `recurring_standalone`): committed YAML is reordered to Drupal’s normalised key sequence while keeping `commerce_tax.taxable_type: events`.
> 
> **Organiser (`myeventlane_vendor`) displays** (default form, default view, full view): sync now lists the new tax-related fields in `dependencies.config` and marks them **hidden**, matching what Drupal writes on import/export (including public-profile visibility fields where the diff added them).
> 
> **CI**: `reusable-build` runs new `scripts/deploy/test-gst-config-convergence.php`, which asserts recurring GST settings, key order, and display dependencies/hidden flags—without relaxing the deploy drift guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fe480067d9fc06a5660d4ed85e23bb1c22b93ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->