### PR TITLE
Add seven-day Pro Boost and correct signup date

### DIFF
--- a/config/sync/myeventlane_pro.settings.yml
+++ b/config/sync/myeventlane_pro.settings.yml
@@ -4,6 +4,7 @@ trial_days: 30
 pro_price: 49
 pro_variation_sku: ''
 billing_portal_enabled: true
+pro_boost_days: 7
 abandoned_cart:
   enabled: true
   delay_wave_1: 7200

--- a/web/modules/custom/myeventlane_pro/config/install/myeventlane_pro.settings.yml
+++ b/web/modules/custom/myeventlane_pro/config/install/myeventlane_pro.settings.yml
@@ -2,6 +2,7 @@ trial_days: 30
 pro_price: 49
 pro_variation_sku: ''
 grace_days: 7
+pro_boost_days: 7
 upgrade_cta_enabled: true
 cancel_request_enabled: true
 billing_support_url: ''

--- a/web/modules/custom/myeventlane_pro/config/schema/myeventlane_pro.schema.yml
+++ b/web/modules/custom/myeventlane_pro/config/schema/myeventlane_pro.schema.yml
@@ -14,6 +14,9 @@ myeventlane_pro.settings:
     grace_days:
       type: integer
       label: 'Grace period days after payment failure'
+    pro_boost_days:
+      type: integer
+      label: 'Included Boost days per eligible event'
     upgrade_cta_enabled:
       type: boolean
       label: 'Show upgrade CTA to non-Pro organisers'

--- a/web/modules/custom/myeventlane_pro/myeventlane_pro.services.yml
+++ b/web/modules/custom/myeventlane_pro/myeventlane_pro.services.yml
@@ -71,6 +71,11 @@ services:
       - '@logger.channel.myeventlane_pro'
       - '@datetime.time'
       - '@database'
+      - '@config.factory'
+      - '@myeventlane_pro.pro_boost_grant_policy'
+
+  myeventlane_pro.pro_boost_grant_policy:
+    class: Drupal\myeventlane_pro\Service\ProBoostGrantPolicy
 
   myeventlane_pro.subscription_health:
     class: Drupal\myeventlane_pro\Service\ProSubscriptionHealthService

--- a/web/modules/custom/myeventlane_pro/src/Controller/ProBillingController.php
+++ b/web/modules/custom/myeventlane_pro/src/Controller/ProBillingController.php
@@ -100,7 +100,17 @@ final class ProBillingController implements ContainerInjectionInterface {
     }
 
     $startedDate = NULL;
-    if (method_exists($subscription, 'getStartDate')) {
+    // Commerce Recurring uses start_date for the first billing period. During
+    // a free trial that date is in the future, so it is not the date the
+    // organiser started Pro. The entity creation time is the canonical signup
+    // date for this organiser-facing label.
+    if (method_exists($subscription, 'getCreatedTime')) {
+      $created = (int) $subscription->getCreatedTime();
+      if ($created > 0) {
+        $startedDate = date('F j, Y', $created);
+      }
+    }
+    if ($startedDate === NULL && method_exists($subscription, 'getStartDate')) {
       $start = $subscription->getStartDate();
       if ($start) {
         $startedDate = $start->format('F j, Y');

--- a/web/modules/custom/myeventlane_pro/src/Form/ProSettingsForm.php
+++ b/web/modules/custom/myeventlane_pro/src/Form/ProSettingsForm.php
@@ -72,6 +72,16 @@ final class ProSettingsForm extends ConfigFormBase {
       '#max' => 30,
     ];
 
+    $form['commercial']['pro_boost_days'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Included Boost days per event'),
+      '#description' => $this->t('Each eligible event receives one non-renewing Boost while the organiser has active Pro access.'),
+      '#default_value' => $config->get('pro_boost_days') ?? 7,
+      '#min' => 1,
+      '#max' => 30,
+      '#required' => TRUE,
+    ];
+
     $form['commercial']['upgrade_cta_enabled'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Show upgrade CTA to non-Pro organisers'),
@@ -126,6 +136,7 @@ final class ProSettingsForm extends ConfigFormBase {
       ->set('pro_price', (int) ($values['pro_price'] ?? 49))
       ->set('pro_variation_sku', trim((string) ($values['pro_variation_sku'] ?? '')))
       ->set('grace_days', (int) ($commercial['grace_days'] ?? 7))
+      ->set('pro_boost_days', (int) ($commercial['pro_boost_days'] ?? 7))
       ->set('upgrade_cta_enabled', (bool) ($commercial['upgrade_cta_enabled'] ?? TRUE))
       ->set('cancel_request_enabled', (bool) ($commercial['cancel_request_enabled'] ?? TRUE))
       ->set('billing_support_url', trim((string) ($commercial['billing_support_url'] ?? '')))

--- a/web/modules/custom/myeventlane_pro/src/Service/ProBoostGrantPolicy.php
+++ b/web/modules/custom/myeventlane_pro/src/Service/ProBoostGrantPolicy.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\myeventlane_pro\Service;
+
+/**
+ * Calculates the fixed, non-renewing Pro Boost grant window.
+ */
+final class ProBoostGrantPolicy {
+
+  private const SECONDS_PER_DAY = 86400;
+
+  /**
+   * Calculates the end of a new grant, capped by the Pro active period.
+   */
+  public function newGrantEnd(int $startsAt, ?int $proActiveEnd, int $days): ?int {
+    $endsAt = $startsAt + (max(1, $days) * self::SECONDS_PER_DAY);
+    if ($proActiveEnd !== NULL) {
+      $endsAt = min($endsAt, $proActiveEnd);
+    }
+
+    return $endsAt > $startsAt ? $endsAt : NULL;
+  }
+
+  /**
+   * Reconciles a grant without extending or reviving an expired grant.
+   */
+  public function existingGrantEnd(
+    int $now,
+    int $existingStartsAt,
+    int $existingEndsAt,
+    ?int $proActiveEnd,
+    int $days,
+  ): ?int {
+    $endsAt = min(
+      $existingEndsAt,
+      $existingStartsAt + (max(1, $days) * self::SECONDS_PER_DAY),
+    );
+    if ($proActiveEnd !== NULL) {
+      $endsAt = min($endsAt, $proActiveEnd);
+    }
+
+    return $endsAt > $now ? $endsAt : NULL;
+  }
+
+}

--- a/web/modules/custom/myeventlane_pro/src/Service/ProBoostProvisioner.php
+++ b/web/modules/custom/myeventlane_pro/src/Service/ProBoostProvisioner.php
@@ -7,6 +7,7 @@ namespace Drupal\myeventlane_pro\Service;
 use Drupal\advancedqueue\Job;
 use Drupal\commerce_store\Entity\StoreInterface;
 use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\myeventlane_boost\BoostManager;
@@ -21,7 +22,7 @@ use Psr\Log\LoggerInterface;
 final class ProBoostProvisioner {
 
   private const PRO_SOURCE = 'pro';
-  private const DEFAULT_WINDOW_SECONDS = 2592000;
+  private const DEFAULT_BOOST_DAYS = 7;
   private const BOOST_SYNC_QUEUE_ID = 'pro_boost_sync';
   private const BOOST_SYNC_JOB_ID = 'pro_boost_sync_job';
 
@@ -33,6 +34,8 @@ final class ProBoostProvisioner {
     private readonly LoggerInterface $logger,
     private readonly TimeInterface $time,
     private readonly Connection $database,
+    private readonly ConfigFactoryInterface $configFactory,
+    private readonly ProBoostGrantPolicy $grantPolicy,
   ) {}
 
   /**
@@ -59,13 +62,19 @@ final class ProBoostProvisioner {
 
     $now = $this->time->getRequestTime();
     $eligibleEvents = $this->loadEligibleEventsForStore($storeId, $now);
-    $activeEnds = $this->proActiveResolver->getStoreActiveEndTimestamp($store) ?? ($now + self::DEFAULT_WINDOW_SECONDS);
+    $boostDays = max(1, (int) ($this->configFactory->get('myeventlane_pro.settings')->get('pro_boost_days') ?? self::DEFAULT_BOOST_DAYS));
+    $activeEnds = $this->proActiveResolver->getStoreActiveEndTimestamp($store);
+    $boostEnds = $this->grantPolicy->newGrantEnd($now, $activeEnds, $boostDays);
+
+    if ($boostEnds === NULL) {
+      return ['created' => 0, 'updated' => 0, 'revoked' => $this->revokeProEntitlementsForStore($store)];
+    }
 
     $created = 0;
     $updated = 0;
 
     foreach ($eligibleEvents as $event) {
-      $result = $this->upsertProEntitlement($event, (int) $owner->id(), $now, $activeEnds);
+      $result = $this->upsertProEntitlement($event, (int) $owner->id(), $now, $boostEnds, $activeEnds, $boostDays);
       if ($result === 'created') {
         $created++;
       }
@@ -233,7 +242,7 @@ final class ProBoostProvisioner {
   /**
    * Upserts a Pro-sourced entitlement for an event.
    */
-  private function upsertProEntitlement(NodeInterface $event, int $uid, int $startsAt, int $endsAt): string {
+  private function upsertProEntitlement(NodeInterface $event, int $uid, int $startsAt, int $endsAt, ?int $proActiveEnd, int $boostDays): string {
     $storage = $this->entityTypeManager->getStorage('myeventlane_boost_entitlement');
     $ids = $storage->getQuery()
       ->accessCheck(FALSE)
@@ -246,9 +255,22 @@ final class ProBoostProvisioner {
     if ($ids !== []) {
       $existing = $storage->load((int) reset($ids));
       if ($existing instanceof BoostEntitlementInterface) {
+        $existingStarts = (int) $existing->get('starts')->value;
+        $existingEnds = (int) $existing->get('ends')->value;
+        $canonicalEnds = $this->grantPolicy->existingGrantEnd(
+          $startsAt,
+          $existingStarts,
+          $existingEnds,
+          $proActiveEnd,
+          $boostDays,
+        );
+        if ($canonicalEnds === NULL) {
+          return 'none';
+        }
+
         $changed = FALSE;
-        if ((int) $existing->get('ends')->value !== $endsAt) {
-          $existing->set('ends', $endsAt);
+        if ($existingEnds !== $canonicalEnds) {
+          $existing->set('ends', $canonicalEnds);
           $changed = TRUE;
         }
         if ((string) $existing->get('status')->value !== BoostEntitlementInterface::STATUS_ACTIVE) {

--- a/web/modules/custom/myeventlane_pro/templates/vendor-pro-manage.html.twig
+++ b/web/modules/custom/myeventlane_pro/templates/vendor-pro-manage.html.twig
@@ -68,6 +68,10 @@
           <strong>{{ 'Marketing and branding tools'|t }}</strong>
           <span>{{ 'Keep your organiser identity consistent as you promote events.'|t }}</span>
         </a>
+        <a class="mel-pro-manage__benefit" href="{{ path('myeventlane_vendor.console.events') }}">
+          <strong>{{ 'A free 7-day Boost for each event'|t }}</strong>
+          <span>{{ 'Each eligible published event gets one seven-day Boost while your Pro access is active. No Boost payment is created.'|t }}</span>
+        </a>
       </div>
     </section>
 

--- a/web/modules/custom/myeventlane_pro/tests/src/Unit/ProBoostGrantPolicyTest.php
+++ b/web/modules/custom/myeventlane_pro/tests/src/Unit/ProBoostGrantPolicyTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\myeventlane_pro\Unit;
+
+use Drupal\myeventlane_pro\Service\ProBoostGrantPolicy;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the fixed Pro Boost grant policy.
+ *
+ * @group myeventlane_pro
+ */
+final class ProBoostGrantPolicyTest extends TestCase {
+
+  /**
+   * The policy under test.
+   */
+  private ProBoostGrantPolicy $policy;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->policy = new ProBoostGrantPolicy();
+  }
+
+  /**
+   * Tests the standard configured seven-day grant.
+   */
+  public function testNewGrantIsExactlySevenDays(): void {
+    $now = 1_700_000_000;
+    self::assertSame($now + (7 * 86400), $this->policy->newGrantEnd($now, NULL, 7));
+  }
+
+  /**
+   * Tests that a grant cannot outlive the Pro entitlement.
+   */
+  public function testNewGrantIsCappedByProEnd(): void {
+    $now = 1_700_000_000;
+    $proEnd = $now + 86400;
+    self::assertSame($proEnd, $this->policy->newGrantEnd($now, $proEnd, 7));
+  }
+
+  /**
+   * Tests that an ended Pro entitlement cannot create a grant.
+   */
+  public function testNewGrantIsRejectedWhenProHasEnded(): void {
+    $now = 1_700_000_000;
+    self::assertNull($this->policy->newGrantEnd($now, $now, 7));
+  }
+
+  /**
+   * Tests that legacy longer grants are shortened to the configured duration.
+   */
+  public function testLegacyLongGrantIsCappedWithoutExtension(): void {
+    $startsAt = 1_700_000_000;
+    $now = $startsAt + 3600;
+    $legacyEnd = $startsAt + (30 * 86400);
+    self::assertSame(
+      $startsAt + (7 * 86400),
+      $this->policy->existingGrantEnd($now, $startsAt, $legacyEnd, NULL, 7),
+    );
+  }
+
+  /**
+   * Tests that reconciliation cannot extend an existing shorter grant.
+   */
+  public function testRepeatedSyncDoesNotExtendExistingGrant(): void {
+    $startsAt = 1_700_000_000;
+    $existingEnd = $startsAt + (3 * 86400);
+    self::assertSame(
+      $existingEnd,
+      $this->policy->existingGrantEnd($startsAt + 3600, $startsAt, $existingEnd, NULL, 7),
+    );
+  }
+
+  /**
+   * Tests that reconciliation cannot revive an expired grant.
+   */
+  public function testExpiredGrantIsNotRevived(): void {
+    $startsAt = 1_700_000_000;
+    $existingEnd = $startsAt + (7 * 86400);
+    self::assertNull(
+      $this->policy->existingGrantEnd($existingEnd, $startsAt, $existingEnd, NULL, 7),
+    );
+  }
+
+}

--- a/web/modules/custom/myeventlane_pro/tests/src/Unit/ProManagePresentationContractTest.php
+++ b/web/modules/custom/myeventlane_pro/tests/src/Unit/ProManagePresentationContractTest.php
@@ -45,6 +45,18 @@ final class ProManagePresentationContractTest extends TestCase {
     self::assertStringContainsString('return new TrustedRedirectResponse($url);', $controller);
   }
 
+  public function testManagePageUsesSignupDateBeforeBillingPeriodStart(): void {
+    $controller = file_get_contents(dirname(__DIR__, 3) . '/src/Controller/ProBillingController.php');
+    self::assertIsString($controller);
+
+    $createdPosition = strpos($controller, "method_exists(\$subscription, 'getCreatedTime')");
+    $billingStartPosition = strpos($controller, "method_exists(\$subscription, 'getStartDate')");
+    self::assertNotFalse($createdPosition);
+    self::assertNotFalse($billingStartPosition);
+    self::assertLessThan($billingStartPosition, $createdPosition);
+    self::assertStringContainsString("\$startedDate === NULL && method_exists(\$subscription, 'getStartDate')", $controller);
+  }
+
   public function testZeroRoiUsesPlainLanguage(): void {
     $template = file_get_contents(dirname(__DIR__, 3) . '/templates/vendor-pro-manage.html.twig');
     self::assertIsString($template);


### PR DESCRIPTION
## What changed

- adds one free seven-day Boost entitlement for each eligible published event while MEL Pro is active
- prevents repeated reconciliation from extending or reviving the same Boost grant
- caps the Boost at the end of Pro access and creates no Boost payment
- shows the seven-day Boost benefit on the MEL Pro management page
- shows the organiser's actual Pro signup date instead of the future first billing-period date during a trial
- adds configuration, schema, service wiring and focused policy/presentation tests

## Why

The approved seven-day Pro Boost work existed only on a local branch and was never merged into `main`, so staging could neither display nor enforce that benefit. The management page also used Commerce Recurring's billing-period start date, which is 30 days in the future during the free trial.

## Validation

- PHP syntax checks passed for the changed PHP files
- `ProBoostGrantPolicyTest`: 6 tests, 6 assertions
- `ProManagePresentationContractTest`: 8 tests, 38 assertions
- `git diff --check` passed

## Acceptance checks after deployment

- `/vendor/pro/manage` shows “A free 7-day Boost for each event”
- a trial started on 18 August 2026 shows `Started: August 18, 2026`, not the first billing date
- each eligible published event receives one seven-day Pro Boost without a Commerce payment
- repeated queue/webhook processing does not extend the grant

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes boost entitlement duration and reconciliation for all active Pro stores; incorrect policy could shorten grants or affect event visibility, but no payment or auth paths are modified.
> 
> **Overview**
> Ships the **included Pro Boost** benefit: each eligible published event gets one **non-renewing** Boost for **`pro_boost_days`** (default 7) while Pro is active, with admin config and schema. **`ProBoostProvisioner`** no longer ties grant length to a long default Pro window; it reads config and uses new **`ProBoostGrantPolicy`** so grants are capped by Pro access end, legacy long grants can be shortened on sync, and repeated queue/webhook reconciliation **cannot extend or revive** expired grants.
> 
> The **MEL Pro manage** page lists the free Boost benefit and shows **Started** from subscription **creation time** first (so trial users see real signup, not Commerce Recurring’s future billing-period start). Unit tests cover the grant policy and the signup-date ordering contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a601599fe790fb50108845438e3a053018025b95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->