### PR TITLE
Fix Pro Boost deployment convergence

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -187,7 +187,7 @@ jobs:
             'MEL_RELEASE_IDENTIFIER="${{ github.run_id }}.${{ github.run_attempt }}" \' \
             'RUN_UPDB=1 \' \
             'RUN_CIM=1 \' \
-            'CIM_ALLOWED_DIFFERENCES="crop.type.focal_point,flag.flag.following,image.style.mel_vendor_logo,views.view.flag_followers" \' \
+            'CIM_ALLOWED_DIFFERENCES="crop.type.focal_point,flag.flag.following,image.style.mel_vendor_logo,myeventlane_pro.settings,views.view.flag_followers" \' \
             'ARTIFACT_PATH="$temp_dir" \' \
             'bash scripts/deploy/remote-deploy.sh' \
             | ssh -i ~/.ssh/id_ed25519 "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}" bash -s

--- a/scripts/deploy/test-config-status-parser.sh
+++ b/scripts/deploy/test-config-status-parser.sh
@@ -47,6 +47,12 @@ run_case 0 \
   0 \
   'gin.settings'
 
+run_case 0 \
+  "Pro settings environment override passes when explicitly allowed" \
+  $'Name,State\nmyeventlane_pro.settings,Different\n' \
+  0 \
+  'myeventlane_pro.settings'
+
 run_case 7 \
   "config status command failure is preserved" \
   $'Drush bootstrap failed\n' \
@@ -59,6 +65,12 @@ run_case 1 \
 echo "Passed: $PASSES"
 echo "Failed: $FAILS"
 if [ "$FAILS" -ne 0 ]; then
+  exit 1
+fi
+
+WORKFLOW="$ROOT/.github/workflows/deploy-staging.yml"
+if ! grep -F 'CIM_ALLOWED_DIFFERENCES=' "$WORKFLOW" | grep -Fq 'myeventlane_pro.settings'; then
+  echo "FAIL: staging workflow must allow the Pro settings object overridden by MEL_PRO_WEBHOOK_SECRET"
   exit 1
 fi
 

--- a/web/modules/custom/myeventlane_pro/src/Form/ProSettingsForm.php
+++ b/web/modules/custom/myeventlane_pro/src/Form/ProSettingsForm.php
@@ -61,6 +61,7 @@ final class ProSettingsForm extends ConfigFormBase {
       '#type' => 'details',
       '#title' => $this->t('Commercial settings'),
       '#open' => TRUE,
+      '#tree' => TRUE,
     ];
 
     $form['commercial']['grace_days'] = [

--- a/web/modules/custom/myeventlane_pro/src/Service/ProBoostGrantPolicy.php
+++ b/web/modules/custom/myeventlane_pro/src/Service/ProBoostGrantPolicy.php
@@ -33,6 +33,25 @@ final class ProBoostGrantPolicy {
     ?int $proActiveEnd,
     int $days,
   ): ?int {
+    $endsAt = $this->cappedExistingGrantEnd(
+      $existingStartsAt,
+      $existingEndsAt,
+      $proActiveEnd,
+      $days,
+    );
+
+    return $endsAt > $now ? $endsAt : NULL;
+  }
+
+  /**
+   * Returns the canonical cap even when the grant has already elapsed.
+   */
+  public function cappedExistingGrantEnd(
+    int $existingStartsAt,
+    int $existingEndsAt,
+    ?int $proActiveEnd,
+    int $days,
+  ): int {
     $endsAt = min(
       $existingEndsAt,
       $existingStartsAt + (max(1, $days) * self::SECONDS_PER_DAY),
@@ -41,7 +60,7 @@ final class ProBoostGrantPolicy {
       $endsAt = min($endsAt, $proActiveEnd);
     }
 
-    return $endsAt > $now ? $endsAt : NULL;
+    return $endsAt;
   }
 
 }

--- a/web/modules/custom/myeventlane_pro/src/Service/ProBoostProvisioner.php
+++ b/web/modules/custom/myeventlane_pro/src/Service/ProBoostProvisioner.php
@@ -265,6 +265,25 @@ final class ProBoostProvisioner {
           $boostDays,
         );
         if ($canonicalEnds === NULL) {
+          $cappedEnds = $this->grantPolicy->cappedExistingGrantEnd(
+            $existingStarts,
+            $existingEnds,
+            $proActiveEnd,
+            $boostDays,
+          );
+          $changed = FALSE;
+          if ($existingEnds !== $cappedEnds) {
+            $existing->set('ends', $cappedEnds);
+            $changed = TRUE;
+          }
+          if ((string) $existing->get('status')->value !== BoostEntitlementInterface::STATUS_EXPIRED) {
+            $existing->set('status', BoostEntitlementInterface::STATUS_EXPIRED);
+            $changed = TRUE;
+          }
+          if ($changed) {
+            $existing->save();
+            return 'updated';
+          }
           return 'none';
         }
 

--- a/web/modules/custom/myeventlane_pro/tests/src/Unit/ProBoostGrantPolicyTest.php
+++ b/web/modules/custom/myeventlane_pro/tests/src/Unit/ProBoostGrantPolicyTest.php
@@ -88,4 +88,17 @@ final class ProBoostGrantPolicyTest extends TestCase {
     );
   }
 
+  /**
+   * Tests that an elapsed legacy grant still exposes its seven-day cap.
+   */
+  public function testElapsedLegacyGrantRetainsCanonicalCapForPersistence(): void {
+    $startsAt = 1_700_000_000;
+    $legacyEnd = $startsAt + (30 * 86400);
+
+    self::assertSame(
+      $startsAt + (7 * 86400),
+      $this->policy->cappedExistingGrantEnd($startsAt, $legacyEnd, NULL, 7),
+    );
+  }
+
 }

--- a/web/modules/custom/myeventlane_pro/tests/src/Unit/ProPostMergeReviewContractTest.php
+++ b/web/modules/custom/myeventlane_pro/tests/src/Unit/ProPostMergeReviewContractTest.php
@@ -29,6 +29,21 @@ final class ProPostMergeReviewContractTest extends TestCase {
     self::assertStringNotContainsString("->set('trial_days'", $form);
   }
 
+  public function testCommercialSettingsPreserveNestedFormValues(): void {
+    $form = $this->moduleFile('src/Form/ProSettingsForm.php');
+
+    self::assertStringContainsString("'#tree' => TRUE", $form);
+    self::assertStringContainsString("\$commercial = \$values['commercial'] ?? [];", $form);
+    self::assertStringContainsString("->set('pro_boost_days', (int) (\$commercial['pro_boost_days'] ?? 7))", $form);
+  }
+
+  public function testElapsedProBoostIsCappedAndExpired(): void {
+    $provisioner = $this->moduleFile('src/Service/ProBoostProvisioner.php');
+
+    self::assertStringContainsString('cappedExistingGrantEnd(', $provisioner);
+    self::assertStringContainsString('BoostEntitlementInterface::STATUS_EXPIRED', $provisioner);
+  }
+
   public function testFreeCustomerCheckoutDoesNotPromiseCardStep(): void {
     $theme = file_get_contents(dirname(__DIR__, 6) . '/themes/custom/myeventlane_theme/myeventlane_theme.theme');
     self::assertIsString($theme);


### PR DESCRIPTION
## What changed

- allows `myeventlane_pro.settings` as a documented staging environment override during post-import config convergence
- adds deployment regression coverage for that explicit allow-list entry
- caps elapsed legacy Pro Boost grants and marks them expired instead of leaving an overlong active entitlement
- makes the Pro Commercial settings form tree-shaped so `pro_boost_days` and the other nested settings persist
- adds focused policy and contract regression tests

## Root cause

PR #829 added `pro_boost_days` to `myeventlane_pro.settings`. Staging also supplies `subscription_webhook_secret` for that config object from `MEL_PRO_WEBHOOK_SECRET`, so Drupal correctly reports the object as different after import. The deploy safety check did not yet recognise that documented environment override and rolled the release back.

Two review defects were also confirmed: elapsed legacy grants returned early without being capped, and the Commercial details element lacked `#tree` even though submission expected nested values.

## Validation

- PHP syntax checks passed for all changed PHP files
- deploy config-status parser: 6 cases passed
- `ProBoostGrantPolicyTest`: 7 tests, 7 assertions
- Pro review and management presentation contracts: 14 tests, 59 assertions
- `git diff --check` passed

## Staging acceptance

- deployment completes without treating `myeventlane_pro.settings` as unexpected drift
- `/vendor/pro/manage` shows the seven-day Boost benefit and the correct signup date
- legacy overlong Pro grants are capped and expired when their canonical window has elapsed
- saving Included Boost days persists the selected value

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches staging deploy safety checks and Pro entitlement reconciliation; incorrect allow-listing could mask real config drift, but changes are narrow and well-tested.
> 
> **Overview**
> Staging deploys were failing post-config-import because **`myeventlane_pro.settings`** legitimately differs when **`MEL_PRO_WEBHOOK_SECRET`** overrides the webhook secret. This PR adds that config object to **`CIM_ALLOWED_DIFFERENCES`** in the staging workflow and extends the deploy config-status parser tests (including a workflow grep guard) so that override stays documented and enforced.
> 
> **Pro Boost** reconciliation now caps **elapsed legacy grants** to the configured window (via new **`cappedExistingGrantEnd`**) and persists them as **expired** instead of leaving overlong active entitlements when sync would otherwise no-op. **`ProSettingsForm`** sets **`#tree` => TRUE** on Commercial settings so nested values like **`pro_boost_days`** actually save.
> 
> Unit and contract tests cover the allow-list, grant cap behavior, form tree, and provisioner expiry path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e651b83df61820378a1aebeed47c00efdd15c99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->