### PR TITLE
Preserve revoked Pro Boost grants

### DIFF
--- a/web/modules/custom/myeventlane_pro/src/Service/ProBoostGrantPolicy.php
+++ b/web/modules/custom/myeventlane_pro/src/Service/ProBoostGrantPolicy.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\myeventlane_pro\Service;
 
+use Drupal\myeventlane_boost\Entity\BoostEntitlementInterface;
+
 /**
  * Calculates the fixed, non-renewing Pro Boost grant window.
  */
@@ -61,6 +63,15 @@ final class ProBoostGrantPolicy {
     }
 
     return $endsAt;
+  }
+
+  /**
+   * Resolves an elapsed grant status without undoing an explicit revocation.
+   */
+  public function elapsedGrantStatus(string $existingStatus): string {
+    return $existingStatus === BoostEntitlementInterface::STATUS_REVOKED
+      ? BoostEntitlementInterface::STATUS_REVOKED
+      : BoostEntitlementInterface::STATUS_EXPIRED;
   }
 
 }

--- a/web/modules/custom/myeventlane_pro/src/Service/ProBoostProvisioner.php
+++ b/web/modules/custom/myeventlane_pro/src/Service/ProBoostProvisioner.php
@@ -276,8 +276,10 @@ final class ProBoostProvisioner {
             $existing->set('ends', $cappedEnds);
             $changed = TRUE;
           }
-          if ((string) $existing->get('status')->value !== BoostEntitlementInterface::STATUS_EXPIRED) {
-            $existing->set('status', BoostEntitlementInterface::STATUS_EXPIRED);
+          $existingStatus = (string) $existing->get('status')->value;
+          $elapsedStatus = $this->grantPolicy->elapsedGrantStatus($existingStatus);
+          if ($existingStatus !== $elapsedStatus) {
+            $existing->set('status', $elapsedStatus);
             $changed = TRUE;
           }
           if ($changed) {

--- a/web/modules/custom/myeventlane_pro/tests/src/Unit/ProBoostGrantPolicyTest.php
+++ b/web/modules/custom/myeventlane_pro/tests/src/Unit/ProBoostGrantPolicyTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\myeventlane_pro\Unit;
 
+use Drupal\myeventlane_boost\Entity\BoostEntitlementInterface;
 use Drupal\myeventlane_pro\Service\ProBoostGrantPolicy;
 use PHPUnit\Framework\TestCase;
 
@@ -98,6 +99,24 @@ final class ProBoostGrantPolicyTest extends TestCase {
     self::assertSame(
       $startsAt + (7 * 86400),
       $this->policy->cappedExistingGrantEnd($startsAt, $legacyEnd, NULL, 7),
+    );
+  }
+
+  /**
+   * Tests that expiry reconciliation never overwrites a revocation outcome.
+   */
+  public function testElapsedGrantPreservesRevokedStatus(): void {
+    self::assertSame(
+      BoostEntitlementInterface::STATUS_REVOKED,
+      $this->policy->elapsedGrantStatus(BoostEntitlementInterface::STATUS_REVOKED),
+    );
+    self::assertSame(
+      BoostEntitlementInterface::STATUS_EXPIRED,
+      $this->policy->elapsedGrantStatus(BoostEntitlementInterface::STATUS_ACTIVE),
+    );
+    self::assertSame(
+      BoostEntitlementInterface::STATUS_EXPIRED,
+      $this->policy->elapsedGrantStatus(BoostEntitlementInterface::STATUS_EXPIRED),
     );
   }
 

--- a/web/modules/custom/myeventlane_pro/tests/src/Unit/ProPostMergeReviewContractTest.php
+++ b/web/modules/custom/myeventlane_pro/tests/src/Unit/ProPostMergeReviewContractTest.php
@@ -41,7 +41,14 @@ final class ProPostMergeReviewContractTest extends TestCase {
     $provisioner = $this->moduleFile('src/Service/ProBoostProvisioner.php');
 
     self::assertStringContainsString('cappedExistingGrantEnd(', $provisioner);
-    self::assertStringContainsString('BoostEntitlementInterface::STATUS_EXPIRED', $provisioner);
+    self::assertStringContainsString('elapsedGrantStatus($existingStatus)', $provisioner);
+  }
+
+  public function testElapsedProBoostPreservesRevokedOutcome(): void {
+    $provisioner = $this->moduleFile('src/Service/ProBoostProvisioner.php');
+
+    self::assertStringContainsString('elapsedGrantStatus($existingStatus)', $provisioner);
+    self::assertStringNotContainsString("set('status', BoostEntitlementInterface::STATUS_EXPIRED)", $provisioner);
   }
 
   public function testFreeCustomerCheckoutDoesNotPromiseCardStep(): void {


### PR DESCRIPTION
## What changed

- preserves `revoked` when reconciling an elapsed Pro Boost grant
- still caps an overlong revoked grant's stored end timestamp
- transitions only active elapsed grants to `expired`
- adds policy and source-contract regression coverage

## Root cause

The elapsed-grant repair introduced in PR #830 assigned `expired` to every status other than `expired`. That could overwrite an intentional cancellation revocation, making the entitlement eligible for expiry notification processing.

## Validation

- `ProBoostGrantPolicyTest`: 8 tests, 10 assertions
- `ProPostMergeReviewContractTest`: 7 tests, 24 assertions
- PHP syntax checks passed
- `git diff --check` passed

## Expected behaviour

- revoked grants remain revoked and cannot generate late expiry messages
- active grants whose canonical window elapsed become expired
- legacy end timestamps remain capped to the configured Boost duration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow entitlement status fix with targeted tests; no auth or broad architectural changes.
> 
> **Overview**
> Fixes elapsed Pro Boost grant reconciliation so **revoked** entitlements are no longer rewritten to **expired** during sync.
> 
> Adds `ProBoostGrantPolicy::elapsedGrantStatus()` and wires `ProBoostProvisioner` to use it when capping ends on grants whose canonical window has passed. **Active** (and already **expired**) grants still resolve to **expired**; only **revoked** stays **revoked**, avoiding incorrect eligibility for boost expiry notification processing.
> 
> Unit and source-contract tests cover the new policy and assert the provisioner no longer hard-sets `STATUS_EXPIRED` on elapsed grants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7996b053f25eb548f35ff4948c1fa6055ce659bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->